### PR TITLE
perf(copy-plugin): cache and order static patterns

### DIFF
--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -10,13 +10,14 @@ use std::{
 use cow_utils::CowUtils;
 use derive_more::Debug;
 use fast_glob::glob_match;
-use futures::future::{BoxFuture, join_all};
+use futures::{StreamExt, future::BoxFuture, stream::FuturesOrdered};
 use regex::Regex;
 use rspack_core::{
   AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
   CompilationProcessAssets, Filename, GlobMatchOptions, Logger, PathData, Plugin,
-  escape_glob_pattern, find_files_by_glob,
+  escape_glob_pattern, extract_glob_base_dir, find_files_by_glob,
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
+  unescape_glob_path,
 };
 use rspack_error::{Diagnostic, Error, Result, ToStringResultToRspackResultExt};
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHashDigest, RspackHasher};
@@ -24,6 +25,10 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashSet;
 use sugar_path::SugarPath;
+
+mod pattern_cache;
+
+use pattern_cache::CachedPatternResult;
 
 #[derive(Debug)]
 pub struct CopyRspackPluginOptions {
@@ -127,6 +132,16 @@ pub struct RunPatternResult {
 #[derive(Debug)]
 pub struct CopyRspackPlugin {
   pub patterns: Vec<CopyPattern>,
+  pattern_cache: Mutex<Vec<Option<CachedPatternResult>>>,
+}
+
+struct PendingPattern<'a> {
+  index: usize,
+  pattern: &'a CopyPattern,
+  cacheable: bool,
+  file_dependencies: FxDashSet<PathBuf>,
+  context_dependencies: FxDashSet<PathBuf>,
+  diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
 }
 
 static TEMPLATE_RE: LazyLock<Regex> =
@@ -140,9 +155,35 @@ fn normalize_glob_path_separators(path: &str) -> Cow<'_, str> {
   }
 }
 
+fn order_pattern_results<T>(
+  results_by_pattern: Vec<Option<Vec<T>>>,
+  mut priority: impl FnMut(usize) -> i32,
+) -> impl Iterator<Item = (usize, T)> {
+  let mut ordered_patterns = results_by_pattern
+    .into_iter()
+    .enumerate()
+    .collect::<Vec<_>>();
+  ordered_patterns.sort_unstable_by_key(|(index, _)| (priority(*index), *index));
+  ordered_patterns.into_iter().flat_map(|(index, results)| {
+    results
+      .into_iter()
+      .flatten()
+      .map(move |result| (index, result))
+  })
+}
+
 impl CopyRspackPlugin {
   pub fn new(patterns: Vec<CopyPattern>) -> Self {
-    Self::new_inner(patterns)
+    let pattern_cache = Mutex::new(vec![None; patterns.len()]);
+    Self::new_inner(patterns, pattern_cache)
+  }
+
+  fn is_cacheable(pattern: &CopyPattern) -> bool {
+    pattern.transform_fn.is_none()
+      && !matches!(pattern.to, Some(ToOption::Fn(_)))
+      && !pattern.copy_permissions.unwrap_or(false)
+      && !matches!(pattern.to_type, Some(ToType::Template))
+      && !matches!(pattern.to, Some(ToOption::String(ref to)) if TEMPLATE_RE.is_match(to))
   }
 
   fn get_content_hash(
@@ -173,14 +214,6 @@ impl CopyRspackPlugin {
     if entry.is_dir() {
       return Ok(None);
     }
-    if let Some(ignore) = &pattern.glob_options.ignore
-      && ignore
-        .iter()
-        .any(|ignore| glob_match(ignore.as_bytes(), entry.as_str().as_bytes()))
-    {
-      return Ok(None);
-    }
-
     let from = entry;
 
     logger.debug(format!("found '{from}'"));
@@ -300,7 +333,6 @@ impl CopyRspackPlugin {
     let source = if let Some(transformer) = &pattern.transform_fn {
       let mut source = RawBufferSource::from(source_vec.clone()).boxed();
       logger.debug(format!("transforming content for '{absolute_filename}'..."));
-      // TODO: support cache in the future.
       handle_transform(
         transformer,
         source_vec,
@@ -358,7 +390,7 @@ impl CopyRspackPlugin {
     }))
   }
 
-  async fn run_patter(
+  async fn run_pattern(
     compilation: &Compilation,
     pattern: &CopyPattern,
     index: usize,
@@ -366,7 +398,7 @@ impl CopyRspackPlugin {
     context_dependencies: &FxDashSet<PathBuf>,
     diagnostics: Arc<Mutex<Vec<Diagnostic>>>,
     logger: &CompilationLogger,
-  ) -> Result<Option<Vec<Option<RunPatternResult>>>> {
+  ) -> Result<Option<Vec<RunPatternResult>>> {
     let orig_from = &pattern.from;
     let normalized_orig_from = Utf8PathBuf::from(orig_from);
 
@@ -414,15 +446,16 @@ impl CopyRspackPlugin {
     // Enable copy files starts with dot
     let mut dot_enable = pattern.glob_options.dot;
 
-    /*
-     * If input is a glob query like `/a/b/**/*.js`, we need to add common directory
-     * to context_dependencies
-     */
-    let mut need_add_context_to_dependency = false;
     let glob_query = match from_type {
       FromType::Dir => {
         logger.debug(format!("added '{abs_from}' as a context dependency"));
-        context_dependencies.insert(abs_from.clone().into_std_path_buf());
+        context_dependencies.insert(
+          abs_from
+            .clone()
+            .into_std_path_buf()
+            .normalize()
+            .into_owned(),
+        );
         context = abs_from.as_path().into();
 
         if dot_enable.is_none() {
@@ -451,7 +484,6 @@ impl CopyRspackPlugin {
         escape_glob_pattern(&from)
       }
       FromType::Glob => {
-        need_add_context_to_dependency = true;
         let mut glob_query = if Path::new(orig_from).is_absolute() {
           orig_from.into()
         } else {
@@ -470,6 +502,11 @@ impl CopyRspackPlugin {
       }
     };
 
+    if matches!(from_type, FromType::Glob) {
+      let glob_base_dir = unescape_glob_path(extract_glob_base_dir(&glob_query));
+      context_dependencies.insert(PathBuf::from(glob_base_dir).normalize().into_owned());
+    }
+
     logger.log(format!("begin globbing '{glob_query}'..."));
 
     let glob_match_options = GlobMatchOptions {
@@ -485,32 +522,14 @@ impl CopyRspackPlugin {
     .await;
 
     match glob_entries {
-      Ok(entries) => {
-        let entries: Vec<_> = entries
-          .into_iter()
-          .filter(|entry| {
-            if let Some(filters) = &pattern.glob_options.ignore {
-              // If filters length is 0, exist is true by default
-              filters
-                .iter()
-                .all(|filter| !glob_match(filter.as_bytes(), entry.as_str().as_bytes()))
-            } else {
-              true
-            }
+      Ok(mut entries) => {
+        entries.retain(|entry| {
+          pattern.glob_options.ignore.as_ref().is_none_or(|filters| {
+            filters
+              .iter()
+              .all(|filter| !glob_match(filter.as_bytes(), entry.as_str().as_bytes()))
           })
-          .collect();
-
-        if need_add_context_to_dependency
-          && let Some(common_dir) = get_closest_common_parent_dir(
-            &entries.iter().map(|it| it.as_path()).collect::<Vec<_>>(),
-          )
-        {
-          // The glob common dir is derived from glob-matched entries, which keep
-          // the pattern's raw shape (e.g. a leading `./`, and `/` separators on
-          // Windows). Normalize it so the registered context dependency matches
-          // the native, normalized paths used everywhere else in the dep graph.
-          context_dependencies.insert(common_dir.into_std_path_buf().normalize().into_owned());
-        }
+        });
 
         if entries.is_empty() {
           if pattern.no_error_on_missing {
@@ -527,6 +546,7 @@ impl CopyRspackPlugin {
               "CopyRspackPlugin Error".into(),
               format!("unable to locate '{glob_query}' glob"),
             ));
+          return Ok(None);
         }
 
         let output_path = &compilation.options.output.path;
@@ -593,7 +613,7 @@ impl CopyRspackPlugin {
           return Ok(None);
         }
 
-        Ok(Some(copied_result))
+        Ok(Some(copied_result.into_iter().flatten().collect()))
       }
       Err(e) => {
         if pattern.no_error_on_missing {
@@ -625,41 +645,188 @@ impl CopyRspackPlugin {
       }
     }
   }
+
+  fn emit_pattern_results(
+    &self,
+    compilation: &mut Compilation,
+    results_by_pattern: Vec<Option<Vec<RunPatternResult>>>,
+  ) -> Vec<(Utf8PathBuf, Utf8PathBuf)> {
+    let mut permission_copies = Vec::new();
+    for (index, result) in
+      order_pattern_results(results_by_pattern, |index| self.patterns[index].priority)
+    {
+      let copy_permissions = self.patterns[index].copy_permissions.unwrap_or(false);
+      let permission_copy = copy_permissions.then(|| {
+        (
+          result.absolute_filename.clone(),
+          compilation.options.output.path.join(&result.filename),
+        )
+      });
+
+      if let Some(exist_asset) = compilation.assets_mut().get_mut(&result.filename) {
+        if !result.force {
+          continue;
+        }
+        exist_asset.set_source(Some(Arc::new(result.source)));
+        if let Some(info) = result.info {
+          set_info(&mut exist_asset.info, info);
+        }
+        exist_asset.info.source_filename = Some(result.source_filename.to_string());
+        exist_asset.info.copied = Some(true);
+      } else {
+        let mut asset_info = AssetInfo {
+          source_filename: Some(result.source_filename.to_string()),
+          copied: Some(true),
+          ..Default::default()
+        };
+
+        if let Some(info) = result.info {
+          set_info(&mut asset_info, info);
+        }
+
+        compilation.emit_asset(
+          result.filename,
+          CompilationAsset::new(Some(Arc::new(result.source)), asset_info),
+        );
+      }
+
+      if let Some(permission_copy) = permission_copy {
+        permission_copies.push(permission_copy);
+      }
+    }
+
+    permission_copies
+  }
 }
 
 #[plugin_hook(CompilationProcessAssets for CopyRspackPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_ADDITIONAL)]
 async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let logger = compilation.get_logger("rspack.CopyRspackPlugin");
   let start = logger.time("run pattern");
-  let file_dependencies = FxDashSet::default();
-  let context_dependencies = FxDashSet::default();
-  let diagnostics = Arc::new(Mutex::new(Vec::new()));
+  let mut file_dependencies = Vec::new();
+  let mut context_dependencies = Vec::new();
+  let mut diagnostics = Vec::new();
+  let cache_counter = logger.cache("copy pattern cache");
 
-  let mut copied_result: Vec<(i32, RunPatternResult)> =
-    join_all(self.patterns.iter().enumerate().map(|(index, pattern)| {
-      CopyRspackPlugin::run_patter(
-        compilation,
-        pattern,
+  let mut results_by_pattern = vec![None; self.patterns.len()];
+  let mut pending_patterns = Vec::new();
+  {
+    let mut pattern_cache = self
+      .pattern_cache
+      .lock()
+      .expect("failed to obtain lock of `pattern_cache`");
+    pattern_cache.resize_with(self.patterns.len(), || None);
+
+    for (index, pattern) in self.patterns.iter().enumerate() {
+      let cacheable = CopyRspackPlugin::is_cacheable(pattern);
+      let cached = &mut pattern_cache[index];
+
+      if cacheable
+        && (!compilation.modified_files.is_empty() || !compilation.removed_files.is_empty())
+        && let Some(cached) = cached.as_ref()
+        && !cached.is_invalidated(
+          compilation
+            .modified_files
+            .iter()
+            .chain(compilation.removed_files.iter())
+            .map(|changed| changed.as_ref()),
+        )
+      {
+        cache_counter.hit();
+        file_dependencies.extend(cached.file_dependencies.iter().cloned());
+        context_dependencies.extend(cached.context_dependencies.iter().cloned());
+        results_by_pattern[index] = Some(cached.results.clone());
+        continue;
+      }
+
+      cache_counter.miss();
+      *cached = None;
+      pending_patterns.push(PendingPattern {
         index,
-        &file_dependencies,
-        &context_dependencies,
-        diagnostics.clone(),
+        pattern,
+        cacheable,
+        file_dependencies: FxDashSet::default(),
+        context_dependencies: FxDashSet::default(),
+        diagnostics: Arc::new(Mutex::new(Vec::new())),
+      });
+    }
+  }
+  logger.cache_end(cache_counter);
+  let pending_results = pending_patterns
+    .iter()
+    .map(|pending| {
+      CopyRspackPlugin::run_pattern(
+        compilation,
+        pending.pattern,
+        pending.index,
+        &pending.file_dependencies,
+        &pending.context_dependencies,
+        pending.diagnostics.clone(),
         &logger,
       )
-    }))
-    .await
-    .into_iter()
-    .collect::<Result<Vec<_>>>()?
-    .into_iter()
-    .flatten()
-    .flat_map(|item| {
-      item
-        .into_iter()
-        .flatten()
-        .map(|item| (item.priority, item))
-        .collect::<Vec<_>>()
     })
-    .collect();
+    .collect::<FuturesOrdered<_>>()
+    .collect::<Vec<_>>()
+    .await;
+
+  let mut first_error = None;
+  if !pending_patterns.is_empty() {
+    let mut pattern_cache = self
+      .pattern_cache
+      .lock()
+      .expect("failed to obtain lock of `pattern_cache`");
+    let mut cache_updates = Vec::new();
+    for (pending, results) in pending_patterns.into_iter().zip(pending_results) {
+      let results = match results {
+        Ok(results) => results,
+        Err(error) => {
+          if first_error.is_none() {
+            first_error = Some(error);
+          }
+          continue;
+        }
+      };
+      let pattern_file_dependencies = pending.file_dependencies.into_iter().collect::<Vec<_>>();
+      let pattern_context_dependencies =
+        pending.context_dependencies.into_iter().collect::<Vec<_>>();
+      let pattern_diagnostics = std::mem::take(
+        pending
+          .diagnostics
+          .lock()
+          .expect("failed to obtain lock of `pattern_diagnostics`")
+          .deref_mut(),
+      );
+      let has_diagnostics = !pattern_diagnostics.is_empty();
+      file_dependencies.extend(pattern_file_dependencies.iter().cloned());
+      context_dependencies.extend(pattern_context_dependencies.iter().cloned());
+      diagnostics.extend(pattern_diagnostics);
+
+      if pending.cacheable
+        && !has_diagnostics
+        && let Some(results) = results.as_ref()
+      {
+        cache_updates.push((
+          pending.index,
+          CachedPatternResult {
+            results: results.clone(),
+            file_dependencies: pattern_file_dependencies,
+            context_dependencies: pattern_context_dependencies,
+          },
+        ));
+      }
+
+      results_by_pattern[pending.index] = results;
+    }
+    if first_error.is_none() {
+      for (index, cached) in cache_updates {
+        pattern_cache[index] = Some(cached);
+      }
+    }
+  }
+  if let Some(error) = first_error {
+    return Err(error);
+  }
+
   logger.time_end(start);
 
   let start = logger.time("emit assets");
@@ -669,60 +836,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   compilation
     .context_dependencies
     .extend(context_dependencies.into_iter().map(Into::into));
-  compilation.extend_diagnostics(std::mem::take(
-    diagnostics
-      .lock()
-      .expect("failed to obtain lock of `diagnostics`")
-      .deref_mut(),
-  ));
+  compilation.extend_diagnostics(diagnostics);
 
-  copied_result.sort_unstable_by_key(|a| a.0);
-
-  // Keep track of source to destination file mappings for permission copying
-  let mut permission_copies = Vec::new();
-
-  copied_result.into_iter().for_each(|(_priority, result)| {
-    let source_path = result.absolute_filename.clone();
-    let dest_path = compilation.options.output.path.join(&result.filename);
-
-    if let Some(exist_asset) = compilation.assets_mut().get_mut(&result.filename) {
-      if !result.force {
-        return;
-      }
-      exist_asset.set_source(Some(Arc::new(result.source)));
-      if let Some(info) = result.info {
-        set_info(&mut exist_asset.info, info);
-      }
-      exist_asset.info.source_filename = Some(result.source_filename.to_string());
-      exist_asset.info.copied = Some(true);
-    } else {
-      let mut asset_info = AssetInfo {
-        source_filename: Some(result.source_filename.to_string()),
-        copied: Some(true),
-        ..Default::default()
-      };
-
-      if let Some(info) = result.info {
-        set_info(&mut asset_info, info);
-      }
-
-      compilation.emit_asset(
-        result.filename,
-        CompilationAsset::new(Some(Arc::new(result.source)), asset_info),
-      );
-    }
-
-    // Store the paths for permission copying along with the pattern index
-    permission_copies.push((result.pattern_index, source_path, dest_path));
-  });
+  let permission_copies = self.emit_pattern_results(compilation, results_by_pattern);
   logger.time_end(start);
 
   // Handle permission copying after all assets are emitted
-  for (pattern_index, source_path, dest_path) in permission_copies.iter() {
-    if let Some(pattern) = self.patterns.get(*pattern_index)
-      && pattern.copy_permissions.unwrap_or(false)
-      && let Ok(Some(permissions)) = compilation.input_filesystem.permissions(source_path).await
-    {
+  for (source_path, dest_path) in permission_copies.iter() {
+    if let Ok(Some(permissions)) = compilation.input_filesystem.permissions(source_path).await {
       // Make sure the output directory exists
       if let Some(parent) = dest_path.parent() {
         compilation
@@ -769,26 +890,6 @@ impl Plugin for CopyRspackPlugin {
       .tap(process_assets::new(self));
     Ok(())
   }
-}
-
-fn get_closest_common_parent_dir(paths: &[&Utf8Path]) -> Option<Utf8PathBuf> {
-  // If there are no matching files, return `None`.
-  if paths.is_empty() {
-    return None;
-  }
-
-  // Get the first file path and use it as the initial value for the common parent directory.
-  let mut parent_dir: Utf8PathBuf = paths[0].parent()?.to_path_buf();
-
-  // Iterate over the remaining file paths, updating the common parent directory as necessary.
-  for path in paths.iter().skip(1) {
-    // Find the common parent directory between the current file path and the previous common parent directory.
-    while !path.starts_with(&parent_dir) {
-      parent_dir = parent_dir.parent()?.into();
-    }
-  }
-
-  Some(parent_dir)
 }
 
 fn set_info(target: &mut AssetInfo, info: Info) {

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -13,7 +13,7 @@ use fast_glob::glob_match;
 use futures::{StreamExt, future::BoxFuture, stream::FuturesOrdered};
 use regex::Regex;
 use rspack_core::{
-  AssetInfo, AssetInfoRelated, Compilation, CompilationAsset, CompilationLogger,
+  AssetInfo, AssetInfoRelated, CacheOptions, Compilation, CompilationAsset, CompilationLogger,
   CompilationProcessAssets, Filename, GlobMatchOptions, Logger, PathData, Plugin,
   escape_glob_pattern, extract_glob_base_dir, find_files_by_glob,
   rspack_sources::{BoxSource, RawBufferSource, SourceExt},
@@ -707,6 +707,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let mut context_dependencies = Vec::new();
   let mut diagnostics = Vec::new();
   let cache_counter = logger.cache("copy pattern cache");
+  let pattern_cache_enabled = !matches!(&compilation.options.cache, CacheOptions::Disabled);
 
   let mut results_by_pattern = vec![None; self.patterns.len()];
   let mut pending_patterns = Vec::new();
@@ -718,7 +719,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     pattern_cache.resize_with(self.patterns.len(), || None);
 
     for (index, pattern) in self.patterns.iter().enumerate() {
-      let cacheable = CopyRspackPlugin::is_cacheable(pattern);
+      let cacheable = pattern_cache_enabled && CopyRspackPlugin::is_cacheable(pattern);
       let cached = &mut pattern_cache[index];
 
       if cacheable

--- a/crates/rspack_plugin_copy/src/pattern_cache.rs
+++ b/crates/rspack_plugin_copy/src/pattern_cache.rs
@@ -1,0 +1,25 @@
+use std::path::{Path, PathBuf};
+
+use crate::RunPatternResult;
+
+#[derive(Debug, Clone)]
+pub(super) struct CachedPatternResult {
+  pub(super) results: Vec<RunPatternResult>,
+  pub(super) file_dependencies: Vec<PathBuf>,
+  pub(super) context_dependencies: Vec<PathBuf>,
+}
+
+impl CachedPatternResult {
+  pub(super) fn is_invalidated<'a>(
+    &self,
+    mut changed_paths: impl Iterator<Item = &'a Path>,
+  ) -> bool {
+    changed_paths.any(|changed| {
+      self
+        .context_dependencies
+        .iter()
+        .chain(&self.file_dependencies)
+        .any(|dependency| changed.starts_with(dependency) || dependency.starts_with(changed))
+    })
+  }
+}

--- a/tests/rspack-test/compilerCases/_copy-plugin-cache.js
+++ b/tests/rspack-test/compilerCases/_copy-plugin-cache.js
@@ -15,7 +15,7 @@ function remove(root, filename) {
 	return file;
 }
 
-function createProject(context, name, patterns) {
+function createProject(context, name, patterns, cache = true) {
 	const root = context.getDist(name);
 	fs.rmSync(root, { recursive: true, force: true });
 	write(root, "src/index.js", "module.exports = 'initial';\n");
@@ -27,7 +27,7 @@ function createProject(context, name, patterns) {
 			mode: "development",
 			target: "node",
 			devtool: false,
-			cache: true,
+			cache,
 			incremental: true,
 			entry: "./src/index.js",
 			output: { path: path.join(root, "dist"), filename: "main.js" },

--- a/tests/rspack-test/compilerCases/_copy-plugin-cache.js
+++ b/tests/rspack-test/compilerCases/_copy-plugin-cache.js
@@ -1,0 +1,118 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { CopyRspackPlugin, Stats } = require("@rspack/core");
+
+function write(root, filename, content) {
+	const file = path.join(root, filename);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+	return file;
+}
+
+function remove(root, filename) {
+	const file = path.join(root, filename);
+	fs.rmSync(file);
+	return file;
+}
+
+function createProject(context, name, patterns) {
+	const root = context.getDist(name);
+	fs.rmSync(root, { recursive: true, force: true });
+	write(root, "src/index.js", "module.exports = 'initial';\n");
+
+	return {
+		root,
+		options: {
+			context: root,
+			mode: "development",
+			target: "node",
+			devtool: false,
+			cache: true,
+			incremental: true,
+			entry: "./src/index.js",
+			output: { path: path.join(root, "dist"), filename: "main.js" },
+			plugins: [new CopyRspackPlugin({ patterns })]
+		}
+	};
+}
+
+function useRealOutputFileSystem(_context, compiler) {
+	compiler.outputFileSystem = fs;
+}
+
+function compile(compiler) {
+	return new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve(compiler._lastCompilation);
+		});
+	});
+}
+
+function rebuild(compiler, modifiedFiles = [], removedFiles = []) {
+	return new Promise((resolve, reject) => {
+		compiler.__internal__rebuild(
+			new Set(modifiedFiles),
+			new Set(removedFiles),
+			error => {
+				if (error) return reject(error);
+				const compilation = compiler._lastCompilation;
+				if (compilation.errors.length > 0) {
+					return reject(
+						new Error(new Stats(compilation).toString({ all: false, errors: true }))
+					);
+				}
+				resolve(compilation);
+			}
+		);
+	});
+}
+
+function rebuildAllowErrors(compiler, modifiedFiles = [], removedFiles = []) {
+	return new Promise((resolve, reject) => {
+		compiler.__internal__rebuild(
+			new Set(modifiedFiles),
+			new Set(removedFiles),
+			error => {
+				if (error) return reject(error);
+				resolve(compiler._lastCompilation);
+			}
+		);
+	});
+}
+
+function asset(compilation, filename) {
+	return compilation.getAsset(filename)?.source.source().toString();
+}
+
+function reusedPatterns(compilation) {
+	const logging = new Stats(compilation).toJson({
+		all: false,
+		logging: false,
+		loggingDebug: [/CopyRspackPlugin/]
+	}).logging;
+
+	const entries = Object.values(logging || {})
+		.flatMap(group => group.entries || [])
+		.map(entry => entry.message || "");
+	const summary = entries.find(message =>
+		message.startsWith("copy pattern cache: ")
+	);
+	const hits = summary?.match(/\((\d+)\/\d+\)$/);
+	return hits ? Number(hits[1]) : 0;
+}
+
+module.exports = {
+	asset,
+	compile,
+	createProject,
+	rebuild,
+	rebuildAllowErrors,
+	remove,
+	reusedPatterns,
+	useRealOutputFileSystem,
+	write
+};

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-errors.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-errors.js
@@ -1,0 +1,121 @@
+const path = require("node:path");
+const {
+	asset,
+	compile,
+	createProject,
+	rebuild,
+	rebuildAllowErrors,
+	remove,
+	reusedPatterns,
+	useRealOutputFileSystem,
+	write
+} = require("./_copy-plugin-cache");
+
+function diagnosticRecoveryCase() {
+	let root;
+	return {
+		description: "should evict an errored pattern and recover when it returns",
+		options(context) {
+			const project = createProject(context, "diagnostic-recovery", [
+				{
+					from: "assets/source/*.txt",
+					to: "copied",
+					toType: "dir"
+				}
+			]);
+			root = project.root;
+			write(root, "assets/source/one.txt", "before\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const source = path.join(root, "assets/source/one.txt");
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/assets/source/one.txt")).toBe("before\n");
+
+			remove(root, "assets/source/one.txt");
+			let failed = await rebuildAllowErrors(compiler, [], [source]);
+			expect(failed.errors.length).toBeGreaterThan(0);
+			expect(
+				failed.errors.filter(error =>
+					String(error.message ?? error).includes("unable to locate")
+				)
+			).toHaveLength(1);
+			expect(reusedPatterns(failed)).toBe(0);
+			expect(
+				asset(failed, "copied/assets/source/one.txt")
+			).toBeUndefined();
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			failed = await rebuildAllowErrors(compiler, [entry]);
+			expect(failed.errors.length).toBeGreaterThan(0);
+			expect(reusedPatterns(failed)).toBe(0);
+			expect(
+				asset(failed, "copied/assets/source/one.txt")
+			).toBeUndefined();
+
+			write(root, "assets/source/one.txt", "after\n");
+			const recovered = await rebuild(compiler, [source]);
+			expect(asset(recovered, "copied/assets/source/one.txt")).toBe(
+				"after\n"
+			);
+			expect(reusedPatterns(recovered)).toBe(0);
+		}
+	};
+}
+
+function siblingDiagnosticCase() {
+	let root;
+	return {
+		description: "should keep a successful sibling cached after another errors",
+		options(context) {
+			const project = createProject(context, "sibling-diagnostic", [
+				{
+					from: "assets/missing/*.txt",
+					to: "copied",
+					toType: "dir"
+				},
+				{
+					from: "assets/stable.txt",
+					to: "copied/stable.txt",
+					toType: "file"
+				}
+			]);
+			root = project.root;
+			write(root, "assets/missing/one.txt", "one\n");
+			write(root, "assets/stable.txt", "before\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const missing = path.join(root, "assets/missing/one.txt");
+			const stable = path.join(root, "assets/stable.txt");
+			await compile(compiler);
+			remove(root, "assets/missing/one.txt");
+			write(root, "assets/stable.txt", "after\n");
+			let failed = await rebuildAllowErrors(compiler, [stable], [missing]);
+
+			expect(failed.errors).toHaveLength(1);
+			expect(asset(failed, "copied/stable.txt")).toBe("after\n");
+			expect(reusedPatterns(failed)).toBe(0);
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			failed = await rebuildAllowErrors(compiler, [entry]);
+
+			expect(failed.errors).toHaveLength(1);
+			expect(asset(failed, "copied/stable.txt")).toBe("after\n");
+			expect(reusedPatterns(failed)).toBe(1);
+		}
+	};
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [diagnosticRecoveryCase(), siblingDiagnosticCase()];

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-invalidation.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-invalidation.js
@@ -1,0 +1,170 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+	asset,
+	compile,
+	createProject,
+	rebuild,
+	remove,
+	reusedPatterns,
+	useRealOutputFileSystem,
+	write
+} = require("./_copy-plugin-cache");
+
+function globSiblingCase() {
+	let root;
+	return {
+		description: "should track a stable glob base when a new sibling matches",
+		options(context) {
+			const project = createProject(context, "glob-sibling", [
+				{ from: "assets/*/*.txt", to: "copied", toType: "dir" }
+			]);
+			root = project.root;
+			write(root, "assets/a/one.txt", "one\n");
+			fs.mkdirSync(path.join(root, "assets/b"), {
+				recursive: true
+			});
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect([...initial.contextDependencies]).toContain(
+				path.join(root, "assets")
+			);
+			expect(asset(initial, "copied/assets/a/one.txt")).toBe("one\n");
+
+			const sibling = write(root, "assets/b/two.txt", "two\n");
+			let updated = await rebuild(compiler, [sibling]);
+			expect(reusedPatterns(updated)).toBe(0);
+			expect(asset(updated, "copied/assets/b/two.txt")).toBe("two\n");
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(1);
+			expect([...updated.contextDependencies]).toContain(
+				path.join(root, "assets")
+			);
+			expect([...updated.fileDependencies]).toEqual(
+				expect.arrayContaining([
+					path.join(root, "assets/a/one.txt"),
+					sibling
+				])
+			);
+			expect(asset(updated, "copied/assets/a/one.txt")).toBe("one\n");
+			expect(asset(updated, "copied/assets/b/two.txt")).toBe("two\n");
+		}
+	};
+}
+
+function ancestorCase(kind) {
+	let root;
+	const from =
+		kind === "file" ? "assets/nested/one.txt" : "assets/nested";
+	const emitted =
+		kind === "file" ? "copied-file/one.txt" : "copied-dir/one.txt";
+
+	return {
+		description: `should invalidate a ${kind} pattern for an ancestor event`,
+		options(context) {
+			const project = createProject(context, `ancestor-${kind}`, [
+				{
+					from,
+					to: kind === "file" ? "copied-file" : "copied-dir",
+					toType: "dir"
+				}
+			]);
+			root = project.root;
+			write(root, "assets/nested/one.txt", "before\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(asset(initial, emitted)).toBe("before\n");
+
+			write(root, "assets/nested/one.txt", "after\n");
+			const updated = await rebuild(compiler, [path.join(root, "assets")]);
+
+			expect(asset(updated, emitted)).toBe("after\n");
+			expect(reusedPatterns(updated)).toBe(0);
+		}
+	};
+}
+
+function changedAndRemovedChildrenCase() {
+	let root;
+	return {
+		description: "should invalidate modified, removed, and newly matching children",
+		options(context) {
+			const project = createProject(context, "glob-add-remove", [
+				{
+					from: "assets/glob/**/*.txt",
+					to: "copied",
+					toType: "dir",
+					noErrorOnMissing: true,
+					globOptions: { ignore: ["**/skip-*.txt"] }
+				}
+			]);
+			root = project.root;
+			write(root, "assets/glob/nested/one.txt", "one\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const one = path.join(root, "assets/glob/nested/one.txt");
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/assets/glob/nested/one.txt")).toBe(
+				"one\n"
+			);
+
+			const two = write(root, "assets/glob/nested/two.txt", "two\n");
+			let updated = await rebuild(compiler, [two]);
+			expect(asset(updated, "copied/assets/glob/nested/two.txt")).toBe(
+				"two\n"
+			);
+
+			write(root, "assets/glob/nested/two.txt", "two-edited\n");
+			updated = await rebuild(compiler, [two]);
+			expect(asset(updated, "copied/assets/glob/nested/two.txt")).toBe(
+				"two-edited\n"
+			);
+
+			remove(root, "assets/glob/nested/one.txt");
+			remove(root, "assets/glob/nested/two.txt");
+			updated = await rebuild(compiler, [], [one, two]);
+			expect(
+				asset(updated, "copied/assets/glob/nested/one.txt")
+			).toBeUndefined();
+			expect(
+				asset(updated, "copied/assets/glob/nested/two.txt")
+			).toBeUndefined();
+
+			const three = write(root, "assets/glob/other/three.txt", "three\n");
+			const ignored = write(
+				root,
+				"assets/glob/other/skip-three.txt",
+				"ignored\n"
+			);
+			updated = await rebuild(compiler, [three, ignored]);
+			expect(asset(updated, "copied/assets/glob/other/three.txt")).toBe(
+				"three\n"
+			);
+			expect(
+				asset(updated, "copied/assets/glob/other/skip-three.txt")
+			).toBeUndefined();
+		}
+	};
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+	globSiblingCase(),
+	ancestorCase("directory"),
+	ancestorCase("file"),
+	changedAndRemovedChildrenCase()
+];

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-order.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-order.js
@@ -1,0 +1,131 @@
+const {
+	asset,
+	compile,
+	createProject,
+	rebuild,
+	reusedPatterns,
+	useRealOutputFileSystem,
+	write
+} = require("./_copy-plugin-cache");
+
+function patternOrderCase() {
+	const patternCount = 64;
+	let root;
+	let files;
+	let winner;
+
+	return {
+		description: "should preserve pattern order across cache hits and misses",
+		options(context) {
+			const patterns = Array.from({ length: patternCount }, (_, index) => ({
+				from: `assets/${index}.txt`,
+				to: "copied/value.txt",
+				toType: "file",
+				force: true,
+				priority: index % 5
+			}));
+			const project = createProject(context, "mixed-cache-order", patterns);
+			root = project.root;
+			files = patterns.map((_, index) =>
+				write(root, `assets/${index}.txt`, `${index}\n`)
+			);
+			winner = Math.floor((patternCount - 5) / 5) * 5 + 4;
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/value.txt")).toBe(`${winner}\n`);
+
+			write(root, "assets/0.txt", "first-edited\n");
+			let updated = await rebuild(compiler, [files[0]]);
+			expect(reusedPatterns(updated)).toBe(patternCount - 1);
+			expect(asset(updated, "copied/value.txt")).toBe(`${winner}\n`);
+
+			write(root, `assets/${winner}.txt`, "last-edited\n");
+			updated = await rebuild(compiler, [files[winner]]);
+			expect(reusedPatterns(updated)).toBe(patternCount - 1);
+			expect(asset(updated, "copied/value.txt")).toBe("last-edited\n");
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(patternCount);
+			expect(asset(updated, "copied/value.txt")).toBe("last-edited\n");
+		}
+	};
+}
+
+function globResultOrderCase() {
+	const interleavedCount = 32;
+	const globFileCount = 64;
+	let root;
+	let patterns;
+	let interleaved;
+	let globFiles;
+
+	return {
+		description: "should preserve forced glob result order across cache states",
+		options(context) {
+			patterns = Array.from({ length: interleavedCount }, (_, index) => ({
+				from: `assets/interleaved/${index}.txt`,
+				to: `copied/interleaved-${index}.txt`,
+				toType: "file",
+				force: true,
+				priority: index % 5
+			}));
+			patterns.splice(Math.floor(interleavedCount / 2), 0, {
+				from: "assets/many/*.txt",
+				to: "copied/many.txt",
+				toType: "file",
+				force: true,
+				priority: 2
+			});
+			const project = createProject(context, "forced-glob-order", patterns);
+			root = project.root;
+			interleaved = Array.from({ length: interleavedCount }, (_, index) =>
+				write(root, `assets/interleaved/${index}.txt`, `${index}\n`)
+			);
+			globFiles = Array.from({ length: globFileCount }, (_, index) =>
+				write(
+					root,
+					`assets/many/${String(index).padStart(4, "0")}.txt`,
+					`${index}\n`
+				)
+			);
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			let updated = await compile(compiler);
+			let winner = asset(updated, "copied/many.txt");
+			expect(winner).toBeDefined();
+
+			write(root, "assets/interleaved/0.txt", "interleaved-edited\n");
+			updated = await rebuild(compiler, [interleaved[0]]);
+			expect(reusedPatterns(updated)).toBe(patterns.length - 1);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+
+			write(root, "assets/many/0000.txt", "glob-edited\n");
+			updated = await rebuild(compiler, [globFiles[0]]);
+			expect(reusedPatterns(updated)).toBe(patterns.length - 1);
+			winner = asset(updated, "copied/many.txt");
+			expect(winner).toBeDefined();
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(patterns.length);
+			expect(asset(updated, "copied/many.txt")).toBe(winner);
+		}
+	};
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [patternOrderCase(), globResultOrderCase()];

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
@@ -144,5 +144,51 @@ function emptyRebuildCase() {
 	};
 }
 
+function disabledCacheCase() {
+	let root;
+	return {
+		description: "should not store pattern results when cache is disabled",
+		options(context) {
+			const project = createProject(
+				context,
+				"cache-disabled",
+				[{ from: "assets/source", to: "copied" }],
+				false
+			);
+			root = project.root;
+			write(root, "assets/source/one.txt", "copied\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/one.txt")).toBe("copied\n");
+
+			let entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'first change';\n"
+			);
+			let updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(0);
+			expect(asset(updated, "copied/one.txt")).toBe("copied\n");
+
+			entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'second change';\n"
+			);
+			updated = await rebuild(compiler, [entry]);
+			expect(reusedPatterns(updated)).toBe(0);
+			expect(asset(updated, "copied/one.txt")).toBe("copied\n");
+		}
+	};
+}
+
 /** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
-module.exports = [cacheablePatternsCase(), separateRunsCase(), emptyRebuildCase()];
+module.exports = [
+	cacheablePatternsCase(),
+	separateRunsCase(),
+	emptyRebuildCase(),
+	disabledCacheCase()
+];

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
@@ -1,0 +1,148 @@
+const path = require("node:path");
+const {
+	asset,
+	compile,
+	createProject,
+	rebuild,
+	reusedPatterns,
+	useRealOutputFileSystem,
+	write
+} = require("./_copy-plugin-cache");
+
+function cacheablePatternsCase() {
+	let root;
+	let transformCalls = 0;
+	let destinationCalls = 0;
+
+	return {
+		description: "should only cache static patterns",
+		options(context) {
+			transformCalls = 0;
+			destinationCalls = 0;
+			const project = createProject(context, "cache-policy", [
+				{ from: "assets/static", to: "static" },
+				{
+					from: "assets/transform",
+					to: "transform",
+					transform(content) {
+						transformCalls += 1;
+						return content;
+					}
+				},
+				{
+					from: "assets/function",
+					to({ absoluteFilename }) {
+						destinationCalls += 1;
+						return `function/${path.basename(absoluteFilename)}`;
+					}
+				},
+				{ from: "assets/template", to: "template/[name][ext]" },
+				{
+					from: "assets/nested-template",
+					to: "template-path/[path][name][ext]"
+				},
+				{
+					from: "assets/permissions",
+					to: "permissions",
+					copyPermissions: true
+				}
+			]);
+			root = project.root;
+			write(root, "assets/static/one.txt", "static\n");
+			write(root, "assets/transform/one.txt", "transform\n");
+			write(root, "assets/function/one.txt", "function\n");
+			write(root, "assets/template/one.txt", "template\n");
+			write(
+				root,
+				"assets/nested-template/deep/two.txt",
+				"nested-template\n"
+			);
+			write(root, "assets/permissions/one.txt", "permissions\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(transformCalls).toBe(1);
+			expect(destinationCalls).toBe(1);
+			expect(asset(initial, "template/one.txt")).toBe("template\n");
+			expect(asset(initial, "template-path/deep/two.txt")).toBe(
+				"nested-template\n"
+			);
+
+			const entry = write(
+				root,
+				"src/index.js",
+				"module.exports = 'changed';\n"
+			);
+			const updated = await rebuild(compiler, [entry]);
+
+			expect(reusedPatterns(updated)).toBe(1);
+			expect(transformCalls).toBe(2);
+			expect(destinationCalls).toBe(2);
+			expect(asset(updated, "static/one.txt")).toBe("static\n");
+			expect(asset(updated, "transform/one.txt")).toBe("transform\n");
+			expect(asset(updated, "function/one.txt")).toBe("function\n");
+			expect(asset(updated, "template/one.txt")).toBe("template\n");
+			expect(asset(updated, "template-path/deep/two.txt")).toBe(
+				"nested-template\n"
+			);
+			expect(asset(updated, "permissions/one.txt")).toBe("permissions\n");
+		}
+	};
+}
+
+function separateRunsCase() {
+	let root;
+	return {
+		description: "should not reuse cached results across separate run calls",
+		options(context) {
+			const project = createProject(context, "run-twice", [
+				{ from: "assets/source", to: "copied" }
+			]);
+			root = project.root;
+			write(root, "assets/source/one.txt", "before\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/one.txt")).toBe("before\n");
+
+			write(root, "assets/source/one.txt", "after\n");
+			const updated = await compile(compiler);
+
+			expect(asset(updated, "copied/one.txt")).toBe("after\n");
+			expect(reusedPatterns(updated)).toBe(0);
+		}
+	};
+}
+
+function emptyRebuildCase() {
+	let root;
+	return {
+		description: "should not reuse cached results for an empty rebuild",
+		options(context) {
+			const project = createProject(context, "empty-rebuild", [
+				{ from: "assets/source", to: "copied" }
+			]);
+			root = project.root;
+			write(root, "assets/source/one.txt", "before\n");
+			return project.options;
+		},
+		compiler: useRealOutputFileSystem,
+		async build(_context, compiler) {
+			const initial = await compile(compiler);
+			expect(asset(initial, "copied/one.txt")).toBe("before\n");
+
+			write(root, "assets/source/one.txt", "after\n");
+			const updated = await rebuild(compiler);
+
+			expect(asset(updated, "copied/one.txt")).toBe("after\n");
+			expect(reusedPatterns(updated)).toBe(0);
+		}
+	};
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [cacheablePatternsCase(), separateRunsCase(), emptyRebuildCase()];


### PR DESCRIPTION
## Summary

CopyRspackPlugin currently reruns every pattern during incremental rebuilds, even when the reported file changes cannot affect most static patterns.

This PR:

- caches results and dependencies for static copy patterns
- reuses cached results only when a rebuild reports modified or removed files and none intersect the pattern dependencies
- registers a stable glob base so newly matching sibling files invalidate the correct pattern
- keeps transform, dynamic destination, template, and permission-copy patterns uncached
- preserves deterministic priority and pattern order across interleaved cache hits and misses
- keeps pattern execution and asset reads concurrent while preserving result order
- evicts stale entries before recomputation and avoids caching diagnostic or hard-error results

Empty rebuilds remain cache misses, so this change does not depend on watch invalidation provenance.

## Related links

- Split from #14844

## Testing

- `cargo test -p rspack_plugin_copy`
- `cargo clippy -p rspack_plugin_copy --all-targets -- -D warnings`
- CopyRspackPlugin cache compiler cases covering invalidation, cache policy, ordering, and error recovery
- existing CopyRspackPlugin config cases in normal and runtime modes

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
