### PR TITLE
fix: keep property name when global is used in object shorthand

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/node_stuff_plugin.rs
@@ -4,6 +4,7 @@ use rspack_core::{
   parse_resource,
 };
 use rspack_error::{Diagnostic, cyan, yellow};
+use rspack_util::SpanExt;
 use sugar_path::SugarPath;
 use swc_experimental_ecma_ast::{Expr, GetSpan, Ident, UnaryExpr};
 
@@ -237,6 +238,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for NodeStuffPlugin {
         NodeGlobalOption::True | NodeGlobalOption::Warn
       )
     {
+      if parser.in_short_hand {
+        let start = ident.span.real_lo();
+        parser.add_presentational_dependency(Box::new(ConstDependency::new(
+          (start, start).into(),
+          format!("{}: ", ident.sym).into(),
+        )));
+      }
       parser.add_presentational_dependency(Box::new(RuntimeRequirementsDependency::new(
         ident.span.into(),
         RuntimeGlobals::GLOBAL,

--- a/tests/rspack-test/configCases/module-variables/global-true/index.js
+++ b/tests/rspack-test/configCases/module-variables/global-true/index.js
@@ -3,6 +3,11 @@ it("global true", function () {
 	expect(__webpack_require__.g).not.toBe(undefined);
 });
 
+it("should keep the property name when `global` is used in shorthand", function () {
+	const obj = { global };
+	expect(obj.global).toBe(globalThis);
+});
+
 it("should polyfill `global` if `node.global` is `true`", function() {
 	class Example {
 		constructor(g = global) {


### PR DESCRIPTION
## Summary

When `node.global` is enabled, using `global` as an object shorthand such as `{ global }` was compiled to `{ __webpack_require__.g }`. That drops the property name and is a syntax error. The parser now keeps the name in the shorthand case, so the output becomes `{ global: __webpack_require__.g }`.

## Related links

Fixes #15052

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
