### PR TITLE
test: ensure Rsdoctor reports tree-shaken JSON sizes

### DIFF
--- a/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/data.json
+++ b/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/data.json
@@ -1,0 +1,4 @@
+{
+  "used": "kept",
+  "unused": "this property should not contribute to the reported module size"
+}

--- a/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/index.js
+++ b/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/index.js
@@ -1,0 +1,5 @@
+import { used } from './data.json';
+
+it('should use the tree-shaken JSON value', () => {
+  expect(used).toBe('kept');
+});

--- a/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/rspack.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/rspack.config.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const {
+  experiments: { RsdoctorPlugin },
+} = require('@rspack/core');
+
+const dataPath = path.join(__dirname, 'data.json');
+const generatedSource = `module.exports = ${JSON.stringify({ used: 'kept' })}`;
+const originalSourceSize =
+  'module.exports = '.length +
+  JSON.stringify(JSON.parse(fs.readFileSync(dataPath, 'utf-8'))).length;
+
+/** @type {import('@rspack/core').Configuration[]} */
+module.exports = ['source-map', 'cheap-module-source-map'].map((devtool) => ({
+  mode: 'development',
+  devtool,
+  optimization: {
+    concatenateModules: false,
+    sideEffects: false,
+    usedExports: true,
+  },
+  plugins: [
+    new RsdoctorPlugin({
+      moduleGraphFeatures: ['graph', 'sources'],
+      chunkGraphFeatures: false,
+    }),
+    {
+      apply(compiler) {
+        compiler.hooks.compilation.tap('TestPlugin', (compilation) => {
+          const hooks = RsdoctorPlugin.getCompilationHooks(compilation);
+
+          hooks.moduleSources.tap('TestPlugin', ({ jsonModuleSizes }) => {
+            const jsonModule = [...compilation.modules].find(
+              (module) => module.type === 'json',
+            );
+            const source = compilation.codeGenerationResults
+              .get(jsonModule, 'main')
+              .sources.get('javascript');
+
+            expect(source.source().toString()).toBe(generatedSource);
+            expect(source.size()).toBeLessThan(originalSourceSize);
+            expect(jsonModuleSizes).toEqual([
+              {
+                identifier: jsonModule.identifier(),
+                size: source.size(),
+              },
+            ]);
+          });
+        });
+      },
+    },
+  ],
+}));

--- a/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/test.config.js
+++ b/tests/rspack-test/configCases/rsdoctor/jsonSizeTreeShaking/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  concurrent: false,
+};


### PR DESCRIPTION
## Summary

Add an Rsdoctor config case that verifies JSON module sizes come from the generated, tree-shaken JavaScript source rather than the original JSON payload.

The case covers both `source-map` and `cheap-module-source-map`, and checks that `jsonModuleSizes` matches the final code-generation result.

## Related links

N/A

## Validation

- `pnpm run build:js`
- `pnpm run test -t "configCases/rsdoctor/jsonSizeTreeShaking"` (2 passed)
- Pre-commit Prettier and JavaScript lint checks

## Checklist

- [x] Tests updated.
- [x] Documentation not required.
