### PR TITLE
chore(build): enable createRequire parser in Rslib builds

### DIFF
--- a/packages/rspack/rstack.browser.config.ts
+++ b/packages/rspack/rstack.browser.config.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import vm from 'node:vm';
@@ -8,8 +7,6 @@ import { define } from 'rstack';
 import { type RsbuildPlugin, rspack } from 'rstack/lib';
 import packageJson from './package.json' with { type: 'json' };
 
-const require = createRequire(import.meta.url);
-
 const bindingDir = path.resolve('../../crates/node_binding');
 const distDir = path.resolve('../rspack-browser/dist');
 
@@ -17,6 +14,7 @@ const MF_RUNTIME_CODE = await getModuleFederationRuntimeCode();
 
 // This plugin removes `createRequire` usages from the code,
 // since `createRequire` is not available in browser environment.
+// The `createRequire` parser skips dynamic calls, so this transform is still required.
 const removeCreateRequirePlugin: RsbuildPlugin = {
   name: 'remove-create-require',
   setup(api) {
@@ -133,29 +131,34 @@ define.lib({
       MF_RUNTIME_CODE: JSON.stringify(MF_RUNTIME_CODE),
     },
   },
-  resolve: {
-    alias: {
-      '../compiled/watchpack/index.js': path.dirname(
-        require.resolve('watchpack/package.json'),
-      ),
-    },
-  },
   tools: {
-    rspack: (config, { rspack }) => {
-      config.plugins.push(
-        new rspack.IgnorePlugin({
-          resourceRegExp: /(moduleFederationDefaultRuntime|inspector)/,
-        }),
-        new rspack.NormalModuleReplacementPlugin(
-          /src[/\\]loader-runner[/\\]service\.ts/,
-          path.resolve('./src/browser/service.ts'),
-        ),
-        new rspack.NormalModuleReplacementPlugin(
-          /src[/\\]builtin-plugin[/\\]lazy-compilation[/\\]middleware\.ts/,
-          path.resolve('./src/browser/middleware.ts'),
-        ),
-      );
-    },
+    rspack: [
+      {
+        module: {
+          parser: {
+            javascript: {
+              // TODO: Remove this override after upgrading Rslib, which enables the createRequire parser by default.
+              createRequire: true,
+            },
+          },
+        },
+      },
+      (config, { rspack }) => {
+        config.plugins.push(
+          new rspack.IgnorePlugin({
+            resourceRegExp: /(moduleFederationDefaultRuntime|inspector)/,
+          }),
+          new rspack.NormalModuleReplacementPlugin(
+            /src[/\\]loader-runner[/\\]service\.ts/,
+            path.resolve('./src/browser/service.ts'),
+          ),
+          new rspack.NormalModuleReplacementPlugin(
+            /src[/\\]builtin-plugin[/\\]lazy-compilation[/\\]middleware\.ts/,
+            path.resolve('./src/browser/middleware.ts'),
+          ),
+        );
+      },
+    ],
   },
 });
 

--- a/packages/rspack/rstack.config.ts
+++ b/packages/rspack/rstack.config.ts
@@ -134,7 +134,7 @@ const codmodPlugin: RsbuildPlugin = {
 
       return [
         binding.replace(
-          `__rspack_createRequire_require(process.env.RSPACK_BINDING ? process.env.RSPACK_BINDING : "@rspack/binding")`,
+          `__rspack_createRequire_require(process.env.RSPACK_BINDING || "@rspack/binding")`,
         ),
       ];
     }

--- a/packages/rspack/rstack.config.ts
+++ b/packages/rspack/rstack.config.ts
@@ -123,37 +123,20 @@ const codmodPlugin: RsbuildPlugin = {
      * Replaces `@rspack/binding` to code that reads env `RSPACK_BINDING` as the custom binding.
      */
     function replaceBinding(root: SgNode<TypesMap, Kinds>): Edit[] {
-      const edits: Edit[] = [];
-
-      // Pattern 1: let binding_namespaceObject = __rspack_createRequire_require("@rspack/binding");
-      const pattern1 = `let binding_namespaceObject = __rspack_createRequire_require("@rspack/binding");`;
-      const binding1 = root.find(pattern1);
-      if (binding1) {
-        edits.push(
-          binding1.replace(
-            `let binding_namespaceObject = __rspack_createRequire_require(process.env.RSPACK_BINDING ? process.env.RSPACK_BINDING : "@rspack/binding");`,
-          ),
-        );
-      }
-
-      // Pattern 2: let instanceBinding = Compiler_require('@rspack/binding');
-      const pattern2 = `let instanceBinding = Compiler_require('@rspack/binding');`;
-      const binding2 = root.find(pattern2);
-      if (binding2) {
-        edits.push(
-          binding2.replace(
-            `let instanceBinding = Compiler_require(process.env.RSPACK_BINDING ? process.env.RSPACK_BINDING : '@rspack/binding');`,
-          ),
-        );
-      }
-
-      if (edits.length === 0) {
+      const binding = root.find(
+        `__rspack_createRequire_require("@rspack/binding")`,
+      );
+      if (!binding) {
         throw new Error(
           'Cannot find any binding require statements to replace',
         );
       }
 
-      return edits;
+      return [
+        binding.replace(
+          `__rspack_createRequire_require(process.env.RSPACK_BINDING ? process.env.RSPACK_BINDING : "@rspack/binding")`,
+        ),
+      ];
     }
 
     api.onAfterBuild(() => {
@@ -194,6 +177,18 @@ const removeDtsExportPlugin: RsbuildPlugin = {
 };
 
 define.lib({
+  tools: {
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            // TODO: Remove this override after upgrading Rslib, which enables the createRequire parser by default.
+            createRequire: true,
+          },
+        },
+      },
+    },
+  },
   plugins: [mfRuntimePlugin, codmodPlugin, removeDtsExportPlugin],
   lib: [
     merge(commonLibConfig, {

--- a/packages/rspack/src/node/NodeWatchFileSystem.ts
+++ b/packages/rspack/src/node/NodeWatchFileSystem.ts
@@ -78,7 +78,7 @@ export default class NodeWatchFileSystem implements WatchFileSystem {
     }
 
     const oldWatcher = this.watcher;
-    const Watchpack = require('../compiled/watchpack/index.js');
+    const Watchpack = require('watchpack');
     this.watcher = new Watchpack(options);
 
     if (callbackUndelayed) {


### PR DESCRIPTION
## Summary

Rslib's `createRequire` parser resolves static requests from source, which breaks `@rspack/core`'s output-relative watchpack request and changes the generated binding require shape. This PR enables the parser in both Node and browser builds, routes watchpack through the existing compiled dependency external, and keeps the `RSPACK_BINDING` codmod compatible with the generated output. The explicit parser overrides can be removed after the next Rslib upgrade.

## Related links

- https://github.com/web-infra-dev/rslib/pull/1814
- https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/30813488415

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).