### PR TITLE
fix(mf): avoid injecting shared providers into worker entrypoints

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1397,6 +1397,9 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       }
     }
     for dep in &compilation.global_entry.include_dependencies {
+      if module_graph.dependency_by_id(dep).skip_async_entrypoints() {
+        continue;
+      }
       if let Some(module) = module_graph.module_identifier_by_dependency_id(dep) {
         self
           .queue

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -71,6 +71,12 @@ pub trait Dependency:
     &DependencyType::Unknown
   }
 
+  /// Whether this dependency should be excluded when a global entry include is applied to an
+  /// async entrypoint.
+  fn skip_async_entrypoints(&self) -> bool {
+    false
+  }
+
   fn url_mode(&self) -> Option<JavascriptParserUrl> {
     None
   }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_dependency.rs
@@ -73,6 +73,11 @@ impl Dependency for ProvideSharedDependency {
     &DependencyType::ProvideSharedModule
   }
 
+  // Match webpack: global shared providers are applied to initial entrypoints only.
+  fn skip_async_entrypoints(&self) -> bool {
+    true
+  }
+
   fn category(&self) -> &DependencyCategory {
     &DependencyCategory::Esm
   }

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/index.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/index.js
@@ -1,0 +1,3 @@
+it("should exclude shared providers but retain the federation runtime in workers", () => {
+	expect(true).toBe(true);
+});

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/rspack.config.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/rspack.config.js
@@ -1,0 +1,86 @@
+const assert = require('node:assert');
+const rspack = require('@rspack/core');
+const { ModuleFederationPlugin } = rspack.container;
+
+const sharedKey = 'mf-worker-v2-provider-marker';
+const providerPattern = new RegExp(
+  `initializeSharingData\\s*=\\s*\\{\\s*scopeToSharingDataMapping\\s*:\\s*\\{\\s*(?:"default"|default)\\s*:\\s*\\[\\s*\\{\\s*name\\s*:\\s*"${sharedKey}"`,
+);
+const federationRuntimePattern = /\.federation\.instance\s*=/;
+
+class CheckWorkerSharingPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap(
+      'CheckWorkerSharingPlugin',
+      (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'CheckWorkerSharingPlugin',
+            stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          },
+          (assets) => {
+            const sources = Object.values(assets).map((asset) =>
+              String(asset.source()),
+            );
+            const workers = sources.filter(
+              (source) =>
+                source.includes('worker a') || source.includes('worker b'),
+            );
+            assert.strictEqual(
+              workers.length,
+              2,
+              'both workers should be emitted',
+            );
+
+            for (const worker of workers) {
+              assert.doesNotMatch(
+                worker,
+                providerPattern,
+                'worker entrypoints should not contain the shared provider',
+              );
+              assert.match(
+                worker,
+                federationRuntimePattern,
+                'worker entrypoints should retain the federation runtime',
+              );
+            }
+
+            assert(
+              sources.some((source) => providerPattern.test(source)),
+              'initial entrypoints should retain the shared provider',
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[id].[contenthash].js',
+  },
+  optimization: {
+    realContentHash: true,
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'host',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './shared': './shared.js',
+      },
+      shared: {
+        [sharedKey]: {
+          import: './shared.js',
+          singleton: true,
+          version: '1.0.0',
+        },
+      },
+    }),
+    new CheckWorkerSharingPlugin(),
+  ],
+};

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/shared.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/shared.js
@@ -1,0 +1,4 @@
+new Worker(new URL("./worker-a.js", import.meta.url));
+new Worker(new URL("./worker-b.js", import.meta.url));
+
+export const value = "shared";

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/test.config.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return "./main.js";
+	}
+};

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/worker-a.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/worker-a.js
@@ -1,0 +1,1 @@
+self.postMessage("worker a");

--- a/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/worker-b.js
+++ b/tests/rspack-test/configCases/container-1-5/mf-worker-real-content-hash/worker-b.js
@@ -1,0 +1,1 @@
+self.postMessage("worker b");

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/index.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/index.js
@@ -1,0 +1,3 @@
+it("should exclude shared providers from worker entrypoints", () => {
+	expect(true).toBe(true);
+});

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/rspack.config.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/rspack.config.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert');
+const rspack = require('@rspack/core');
+const { ModuleFederationPluginV1 } = rspack.container;
+
+const sharedKey = 'mf-worker-provider-marker';
+const providerPattern = new RegExp(
+  `initializeSharingData\\s*=\\s*\\{\\s*scopeToSharingDataMapping\\s*:\\s*\\{\\s*(?:"default"|default)\\s*:\\s*\\[\\s*\\{\\s*name\\s*:\\s*"${sharedKey}"`,
+);
+
+class CheckWorkerSharingPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap(
+      'CheckWorkerSharingPlugin',
+      (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'CheckWorkerSharingPlugin',
+            stage: rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+          },
+          (assets) => {
+            const sources = Object.values(assets).map((asset) =>
+              String(asset.source()),
+            );
+            const workers = sources.filter(
+              (source) =>
+                source.includes('worker a') || source.includes('worker b'),
+            );
+            assert.strictEqual(
+              workers.length,
+              2,
+              'both workers should be emitted',
+            );
+
+            for (const worker of workers) {
+              assert.doesNotMatch(
+                worker,
+                providerPattern,
+                'worker entrypoints should not contain the shared provider',
+              );
+            }
+
+            assert(
+              sources.some((source) => providerPattern.test(source)),
+              'initial entrypoints should retain the shared provider',
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[id].[contenthash].js',
+  },
+  optimization: {
+    realContentHash: true,
+  },
+  plugins: [
+    new ModuleFederationPluginV1({
+      name: 'host',
+      filename: 'remoteEntry.[contenthash].js',
+      exposes: {
+        './shared': './shared.js',
+      },
+      shared: {
+        [sharedKey]: {
+          import: './shared.js',
+          singleton: true,
+          version: '1.0.0',
+        },
+      },
+    }),
+    new CheckWorkerSharingPlugin(),
+  ],
+};

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/shared.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/shared.js
@@ -1,0 +1,4 @@
+new Worker(new URL("./worker-a.js", import.meta.url));
+new Worker(new URL("./worker-b.js", import.meta.url));
+
+export const value = "shared";

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/test.config.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return "./main.js";
+	}
+};

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/worker-a.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/worker-a.js
@@ -1,0 +1,1 @@
+self.postMessage("worker a");

--- a/tests/rspack-test/configCases/container/mf-worker-real-content-hash/worker-b.js
+++ b/tests/rspack-test/configCases/container/mf-worker-real-content-hash/worker-b.js
@@ -1,0 +1,1 @@
+self.postMessage("worker b");


### PR DESCRIPTION
## Summary

- match webpack's `ProvideShared` strategy: apply global provider registrations when seeding configured initial entrypoints, but do not replay them into worker/async entrypoints
- keep shared providers in initial entrypoints
- keep other global includes unchanged, including the Module Federation V2 runtime in workers
- add V1 and V2 regression cases covering multiple workers, `[contenthash]`, and `optimization.realContentHash`

related to https://github.com/web-infra-dev/rspack/issues/14971

## Reproduction

The issue is reproduced in [LingyuCoder/rspack-real-content-hash-mf-worker-repro](https://github.com/LingyuCoder/rspack-real-content-hash-mf-worker-repro) with `@rspack/core@2.1.8`.

The reproduction combines:

- `ModuleFederationPluginV1` with a shared provider
- an exposed/shared module that creates two workers
- `[contenthash]` chunk filenames
- `optimization.realContentHash: true`

The released binding exits with code 134 because `RealContentHashPlugin` finds a circular asset-hash dependency. With this fix, the same reproduction compiles successfully.

## Root cause

Rspack propagates global entry dependencies and includes into async entrypoints so runtime code needed by workers remains available. This behavior was introduced by [#12096](https://github.com/web-infra-dev/rspack/pull/12096).

`ProvideSharedPlugin` also registers each shared provider as a global include. Replaying that include into every worker pulls the provider module and its fallback graph into the worker chunk graph. When the provider source creates multiple workers, each worker runtime can then reference the sibling worker asset, so their content hashes depend on each other.

`RealContentHashPlugin` is correctly reporting the resulting cycle; the incorrect part is the extra `ProvideShared` edge in each worker entrypoint.

Webpack 5.109.2 does not place the host provider registration in either worker asset for the equivalent build. Rspack V1 and V2 previously did. Both Rspack implementations use `ProvideSharedDependency`, so the same propagation rule applies to both.

## Webpack strategy

Webpack scopes global shared providers to configured initial entrypoints:

1. `ProvideSharedPlugin` calls `compilation.addInclude(..., { name: undefined })`, which records each provider in `compilation.globalEntry.includeDependencies`.
2. During `Compilation.seal`, webpack combines those global includes with every configured entry in `compilation.entries` and uses them to seed the initial entrypoint chunk graph.
3. When `buildChunkGraph` later creates an entrypoint for an async dependency block, including a `new Worker(...)` block, it starts from that block's referenced modules. It does not replay `globalEntry.includeDependencies` into the async entrypoint.

Therefore, a provider configured on the host is registered in the host's initial runtime, but a worker does not automatically inherit that provider registration. Provider registration is also independent from federation runtime support: a worker may contain the federation runtime or a shared-consume fallback without containing the host's global provider.

This avoids the circular asset relationship by not creating the extra worker-to-provider chunk-graph edges in the first place. Webpack does not make real content hash tolerate or ignore such a cycle.

## Fix

Rspack still needs the global-entry propagation introduced by [#12096](https://github.com/web-infra-dev/rspack/pull/12096) for other worker runtime dependencies. This change therefore mirrors webpack's provider boundary without disabling that behavior globally: it adds a dependency-level opt-out for replaying a global include into async entrypoints and enables it only for `ProvideSharedDependency`.

As a result:

- initial entrypoints still contain the configured provider
- V1 and V2 worker entrypoints do not contain the host provider registration
- `FederationRuntimeDependency` and all other global dependencies keep the existing behavior
- V2 workers still contain the federation runtime
- `RealContentHashPlugin` is unchanged, so genuine circular asset-hash dependencies remain errors

The previous graph-ancestry and module-type heuristics are intentionally removed. Provider propagation now follows one stable rule instead of trying to infer which provider a worker might need.

## Compatibility note

Workers and worker-loaded remotes can no longer implicitly rely on providers configured only on the host compilation. A direct shared consume can still use its configured fallback import. A worker-loaded remote that uses `import: false`, strict consumption, or otherwise has no provider/fallback must provide the share through its own setup. This is the expected consequence of webpack's configured-entry-only `ProvideShared` strategy.

## Validation

- `cargo fmt --all --check`
- `cargo check -p rspack_core -p rspack_plugin_mf`
- `pnpm run build:binding:dev`
- `pnpm run test -t "mf-worker-real-content-hash"`: 4 passed across V1/V2 config and runtime-mode cases
- `pnpm test cases/worker/mf-worker/index.test.ts`: 2 passed in Chromium and incremental mode
- CodSpeed Performance Analysis: passed with no reported regressions
- V1/V2 asset assertions verify that workers omit provider registrations, initial assets retain them, and V2 workers retain the federation runtime
- the public V1 reproduction compiles successfully with the fixed binding

## Checklist

- [x] Tests updated.
- [x] Root cause and output behavior verified against webpack.
