### PR TITLE
perf: limit incremental HMR asset processing

### DIFF
--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -16,6 +16,7 @@ use rspack_core::{
   NormalModuleLoader, ParserAndGenerator, ParserOptions, PathData, Plugin, RunnerContext,
   RuntimeGlobals, RuntimeModule, RuntimeModuleExt, RuntimeSpec, SourceType,
   chunk_graph_chunk::{ChunkId, ChunkIdMap, ChunkIdSet},
+  incremental::{IncrementalPasses, Mutation},
   rspack_sources::{RawStringSource, SourceExt},
 };
 use rspack_error::{Diagnostic, Result};
@@ -225,31 +226,44 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .iter()
     .map(|(k, v)| (v.clone(), *k))
     .collect();
-  let mut completely_removed_modules: HashSet<ModuleId> = Default::default();
+  let current_chunk_ukeys: ChunkIdMap<ChunkUkey> = compilation
+    .build_chunk_graph_artifact
+    .chunk_by_ukey
+    .iter()
+    .map(|(ukey, chunk)| (chunk.expect_id().clone(), *ukey))
+    .collect();
+  let completely_removed_modules: HashSet<ModuleId> = old_all_modules
+    .iter()
+    .filter(|(module_id, chunks)| !chunks.is_empty() && !all_module_ids.contains_key(*module_id))
+    .map(|(module_id, _)| module_id.clone())
+    .collect();
+  let changed_chunks = compilation
+    .incremental
+    .mutations_read(IncrementalPasses::CHUNK_ASSET)
+    .map(|mutations| {
+      mutations
+        .iter()
+        .filter_map(|mutation| match mutation {
+          Mutation::ChunkSetHashes { chunk } => Some(*chunk),
+          _ => None,
+        })
+        .collect::<HashSet<_>>()
+    });
 
   for (chunk_id, (old_runtime, old_module_ids)) in old_chunks {
-    let mut remaining_modules: HashSet<ModuleId> = Default::default();
-    for old_module_id in old_module_ids {
-      if !all_module_ids.contains_key(old_module_id) {
-        completely_removed_modules.insert(old_module_id.clone());
-      } else {
-        remaining_modules.insert(old_module_id.clone());
-      }
-    }
-
     let mut new_modules = vec![];
     let mut new_runtime_modules = vec![];
     let chunk_id = chunk_id.clone();
     let new_runtime: RuntimeSpec;
     let removed_from_runtime: RuntimeSpec;
 
-    let current_chunk = compilation
-      .build_chunk_graph_artifact
-      .chunk_by_ukey
-      .iter()
-      .find(|(_, chunk)| chunk.expect_id().eq(&chunk_id))
-      .map(|(_, chunk)| chunk);
-    let current_chunk_ukey = current_chunk.map(|c| c.ukey());
+    let current_chunk_ukey = current_chunk_ukeys.get(&chunk_id).copied();
+    let current_chunk = current_chunk_ukey.and_then(|ukey| {
+      compilation
+        .build_chunk_graph_artifact
+        .chunk_by_ukey
+        .get(&ukey)
+    });
 
     if let Some(current_chunk) = current_chunk {
       new_runtime = current_chunk
@@ -259,6 +273,14 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
         .collect();
 
       if new_runtime.is_empty() {
+        continue;
+      }
+
+      if old_runtime == &new_runtime
+        && changed_chunks
+          .as_ref()
+          .is_some_and(|chunks| !chunks.contains(&current_chunk.ukey()))
+      {
         continue;
       }
 
@@ -341,12 +363,23 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       }
     }
 
-    for old_module_id in remaining_modules {
-      let module_identifier = all_module_ids
-        .get(&old_module_id)
-        .expect("should have module");
+    for old_module_id in old_module_ids {
+      let Some(module_identifier) = all_module_ids.get(old_module_id) else {
+        continue;
+      };
+      if removed_from_runtime.is_empty()
+        && current_chunk_ukey.is_some_and(|ukey| {
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_graph
+            .is_module_in_chunk(module_identifier, ukey)
+        })
+      {
+        continue;
+      }
+
       let old_hashes = old_all_modules
-        .get(&old_module_id)
+        .get(old_module_id)
         .expect("should have module");
       let old_hash = old_hashes.get(&chunk_id);
       let runtimes = compilation

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/__snapshots__/web/0.snap.txt
@@ -1,0 +1,13 @@
+# Case process-assets-full-scan: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/__snapshots__/web/1.snap.txt
@@ -1,0 +1,98 @@
+# Case process-assets-full-scan: Step 1
+
+## Changed Files
+- leaf.js
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Manifest: a.LAST_HASH.hot-update.json, size: 25
+- Manifest: b.LAST_HASH.hot-update.json, size: 25
+- Update: a.LAST_HASH.hot-update.js, size: 404
+- Update: b.LAST_HASH.hot-update.js, size: 404
+
+## Manifest
+
+### a.LAST_HASH.hot-update.json
+
+```json
+{"c":["a"],"r":[],"m":[]}
+```
+
+
+
+### b.LAST_HASH.hot-update.json
+
+```json
+{"c":["b"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### a.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./leaf.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("a", {
+"./leaf.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  value: () => (value)
+});
+const value = "after";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### b.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./leaf.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("b", {
+"./leaf.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  value: () => (value)
+});
+const value = "after";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/b.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/b.js
@@ -1,0 +1,4 @@
+import { value } from "./leaf";
+
+globalThis.__HMR_PROCESS_ASSETS_B__ = value;
+import.meta.webpackHot.accept("./leaf");

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/index.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/index.js
@@ -1,0 +1,9 @@
+import { value } from "./leaf";
+
+it("should fall back when incremental chunk assets are disabled", async () => {
+	expect(value).toBe("before");
+	await NEXT_HMR();
+	expect(value).toBe("after");
+});
+
+import.meta.webpackHot.accept("./leaf");

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/leaf.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/leaf.js
@@ -1,0 +1,3 @@
+export const value = "before";
+---
+export const value = "after";

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/rspack.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    a: './index.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    splitChunks: false,
+  },
+  incremental: {
+    chunkAsset: false,
+  },
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/test.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["a.js"];
+	}
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-full-scan/test.filter.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-full-scan/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = ({ target }) => target === "web";

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/__snapshots__/web/0.snap.txt
@@ -1,0 +1,15 @@
+# Case process-assets-moved-module: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Bundle: runtime.js
+- Bundle: shared.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/__snapshots__/web/1.snap.txt
@@ -1,0 +1,130 @@
+# Case process-assets-moved-module: Step 1
+
+## Changed Files
+- b.js
+- shared/moving.js
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Bundle: runtime.js
+- Bundle: shared.js
+- Manifest: runtime.LAST_HASH.hot-update.json, size: 48
+- Update: a.LAST_HASH.hot-update.js, size: 292
+- Update: b.LAST_HASH.hot-update.js, size: 349
+- Update: runtime.LAST_HASH.hot-update.js, size: 184
+- Update: shared.LAST_HASH.hot-update.js, size: 297
+
+## Manifest
+
+### runtime.LAST_HASH.hot-update.json
+
+```json
+{"c":["a","b","runtime","shared"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### a.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./shared/moving.js
+
+#### Changed Runtime Modules
+
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("a", {
+"./shared/moving.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  moving: () => (moving)
+});
+const moving = "moving-after";
+
+
+},
+
+});
+```
+
+
+
+### b.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./b.js
+
+#### Changed Runtime Modules
+
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("b", {
+"./b.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+/* import */ var _shared_anchor__rspack_import_0 = __webpack_require__("./shared/anchor.js");
+
+
+globalThis.__HMR_PROCESS_ASSETS_B__ = _shared_anchor__rspack_import_0.anchor;
+
+
+},
+
+});
+```
+
+
+
+### runtime.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("runtime", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### shared.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./shared/moving.js
+
+#### Changed Runtime Modules
+
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("shared", {
+"./shared/moving.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  moving: () => (moving)
+});
+const moving = "moving-after";
+
+
+},
+
+});
+```

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/b.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/b.js
@@ -1,0 +1,8 @@
+import { anchor } from "./shared/anchor";
+import { moving } from "./shared/moving";
+
+globalThis.__HMR_PROCESS_ASSETS_B__ = anchor + moving;
+---
+import { anchor } from "./shared/anchor";
+
+globalThis.__HMR_PROCESS_ASSETS_B__ = anchor;

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/index.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/index.js
@@ -1,0 +1,10 @@
+import { anchor } from "./shared/anchor";
+import { moving } from "./shared/moving";
+
+it("should update an installed chunk when an edited module moves", async () => {
+	expect(anchor + moving).toBe("anchormoving-before");
+	await NEXT_HMR();
+	expect(anchor + moving).toBe("anchormoving-after");
+});
+
+import.meta.webpackHot.accept("./shared/moving");

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/rspack.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/rspack.config.js
@@ -1,0 +1,26 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    a: './index.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    runtimeChunk: 'single',
+    splitChunks: {
+      chunks: 'all',
+      minSize: 0,
+      cacheGroups: {
+        shared: {
+          test: /[\\/]shared[\\/]/,
+          name: 'shared',
+          minChunks: 2,
+          enforce: true,
+        },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/shared/anchor.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/shared/anchor.js
@@ -1,0 +1,1 @@
+export const anchor = "anchor";

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/shared/moving.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/shared/moving.js
@@ -1,0 +1,3 @@
+export const moving = "moving-before";
+---
+export const moving = "moving-after";

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/test.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["runtime.js", "shared.js", "a.js"];
+	}
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-moved-module/test.filter.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-moved-module/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = ({ target }) => target === "web";

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/__snapshots__/web/0.snap.txt
@@ -1,0 +1,14 @@
+# Case process-assets-removed-runtime: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Bundle: shared.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/__snapshots__/web/1.snap.txt
@@ -1,0 +1,83 @@
+# Case process-assets-removed-runtime: Step 1
+
+## Changed Files
+- a.js
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Bundle: shared.js
+- Manifest: a.LAST_HASH.hot-update.json, size: 46
+- Manifest: b.LAST_HASH.hot-update.json, size: 25
+- Update: a.LAST_HASH.hot-update.js, size: 273
+- Update: b.LAST_HASH.hot-update.js, size: 178
+
+## Manifest
+
+### a.LAST_HASH.hot-update.json
+
+```json
+{"c":["a"],"r":["shared"],"m":["./shared.js"]}
+```
+
+
+
+### b.LAST_HASH.hot-update.json
+
+```json
+{"c":["b"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### a.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./a.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+- webpack/runtime/jsonp_chunk_loading
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("a", {
+"./a.js"(module) {
+module.exports = "removed";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+// webpack/runtime/jsonp_chunk_loading
+/* runtime omitted */
+```
+
+
+
+### b.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("b", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/a.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/a.js
@@ -1,0 +1,5 @@
+module.exports = import(/* webpackChunkName: "shared" */ "./shared").then(
+	({ value }) => value
+);
+---
+module.exports = "removed";

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/b.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/b.js
@@ -1,0 +1,5 @@
+import(/* webpackChunkName: "shared" */ "./shared").then(({ value }) => {
+	globalThis.__HMR_PROCESS_ASSETS_B__ = value;
+});
+
+module.hot.accept();

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/index.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/index.js
@@ -1,0 +1,10 @@
+let active = require("./a");
+
+it("should preserve a shared chunk until its final runtime is removed", async () => {
+	expect(await active).toBe("shared");
+	await NEXT_HMR();
+	active = require("./a");
+	expect(active).toBe("removed");
+});
+
+module.hot.accept("./a");

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/rspack.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    a: './index.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    splitChunks: false,
+  },
+  incremental: {
+    buildChunkGraph: false,
+  },
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/shared.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/shared.js
@@ -1,0 +1,1 @@
+export const value = "shared";

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/test.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/test.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+	findBundle() {
+		return ["a.js"];
+	},
+	snapshotContent(content) {
+		return content.replace(
+			/\/\/ webpack\/runtime\/jsonp_chunk_loading[\s\S]*$/,
+			"// webpack/runtime/jsonp_chunk_loading\n/* runtime omitted */"
+		);
+	}
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/test.filter.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-removed-runtime/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = ({ target }) => target === "web";

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/__snapshots__/web/0.snap.txt
@@ -1,0 +1,13 @@
+# Case process-assets-stable-runtimes: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/__snapshots__/web/1.snap.txt
@@ -1,0 +1,98 @@
+# Case process-assets-stable-runtimes: Step 1
+
+## Changed Files
+- leaf.js
+
+## Asset Files
+- Bundle: a.js
+- Bundle: b.js
+- Manifest: a.LAST_HASH.hot-update.json, size: 25
+- Manifest: b.LAST_HASH.hot-update.json, size: 25
+- Update: a.LAST_HASH.hot-update.js, size: 404
+- Update: b.LAST_HASH.hot-update.js, size: 404
+
+## Manifest
+
+### a.LAST_HASH.hot-update.json
+
+```json
+{"c":["a"],"r":[],"m":[]}
+```
+
+
+
+### b.LAST_HASH.hot-update.json
+
+```json
+{"c":["b"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### a.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./leaf.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("a", {
+"./leaf.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  value: () => (value)
+});
+const value = "after";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### b.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./leaf.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("b", {
+"./leaf.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
+__webpack_require__.r(__webpack_exports__);
+__webpack_require__.d(__webpack_exports__, {
+  value: () => (value)
+});
+const value = "after";
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/b.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/b.js
@@ -1,0 +1,4 @@
+import { value } from "./leaf";
+
+globalThis.__HMR_PROCESS_ASSETS_B__ = value;
+import.meta.webpackHot.accept("./leaf");

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/index.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/index.js
@@ -1,0 +1,9 @@
+import { value } from "./leaf";
+
+it("should emit a changed shared module for every stable runtime", async () => {
+	expect(value).toBe("before");
+	await NEXT_HMR();
+	expect(value).toBe("after");
+});
+
+import.meta.webpackHot.accept("./leaf");

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/leaf.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/leaf.js
@@ -1,0 +1,3 @@
+export const value = "before";
+---
+export const value = "after";

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/rspack.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  entry: {
+    a: './index.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    splitChunks: false,
+  },
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/test.config.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	findBundle() {
+		return ["a.js"];
+	}
+};

--- a/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/test.filter.js
+++ b/tests/rspack-test/hotCases/hmr/process-assets-stable-runtimes/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = ({ target }) => target === "web";


### PR DESCRIPTION
## Summary

- Build the chunk ID index once and use `ChunkSetHashes` mutations to skip stable chunks during incremental HMR asset processing.
- Preserve removed-module, removed-runtime, moved-module, and mutation-provenance-free fallback behavior.
- Cover these boundaries through the existing HMR hot case runners and hot-update manifest snapshots, without adding a standalone test entry.

`HotModuleReplacementPlugin::process_assets` previously performed a linear chunk lookup for every recorded chunk and revisited old module/runtime memberships across stable chunks. The work therefore scaled with both chunk count and recorded memberships even when a rebuild changed only a small subset of chunks.

This change indexes chunks once and limits the expensive scan to chunks identified by incremental hash mutations. Stable memberships avoid repeated runtime and hash queries, while builds without mutation provenance retain the full-scan path for correctness. No persistent cache or per-module state is added.

The runtime-removal hot case disables incremental chunk-graph reuse so it exercises this HMR boundary independently from the async chunk-graph stack.

Checks completed: `pnpm run build:cli:dev`, `pnpm run test:unit`, focused HMR hot cases and snapshots, existing CSS HMR cases, `cargo clippy -p rspack_plugin_hmr --all-targets`, and Rust/JavaScript formatting. The workspace-wide all-features Clippy command remains blocked in `rspack_cacheable` because that feature union brings incompatible rkyv 0.7/0.8 `Archive` traits into `PortablePath`; the failure is outside this diff.

## Related links

- Extracted from #14841
- Closes #14767

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
