### PR TITLE
perf: reuse existing leaf chunk graphs

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -15,6 +15,12 @@ use crate::{
   incremental::{IncrementalPasses, Mutation},
 };
 
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+struct EntryModuleSnapshot {
+  dependencies: Vec<ModuleIdentifier>,
+  include_dependencies: Vec<ModuleIdentifier>,
+}
+
 #[derive(Debug, Default)]
 pub struct BuildChunkGraphArtifact {
   pub chunk_by_ukey: ChunkByUkey,
@@ -26,6 +32,7 @@ pub struct BuildChunkGraphArtifact {
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
   pub module_idx: IdentifierMap<(u32, u32)>,
+  entry_modules: FxIndexMap<String, EntryModuleSnapshot>,
 }
 
 impl BuildChunkGraphArtifact {
@@ -51,6 +58,11 @@ impl BuildChunkGraphArtifact {
         .keys(),
     ) {
       logger.log("entrypoints change detected, rebuilding chunk graph");
+      return false;
+    }
+
+    if self.entry_modules != Self::get_entry_modules(this_compilation) {
+      logger.log("entry modules change detected, rebuilding chunk graph");
       return false;
     }
 
@@ -180,6 +192,61 @@ impl BuildChunkGraphArtifact {
     true
   }
 
+  fn get_entry_modules(compilation: &Compilation) -> FxIndexMap<String, EntryModuleSnapshot> {
+    let module_graph = compilation.get_module_graph();
+    let global_dependencies = compilation
+      .global_entry
+      .dependencies
+      .iter()
+      .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
+      .copied()
+      .collect::<Vec<_>>();
+    let mut global_include_dependencies = compilation
+      .global_entry
+      .include_dependencies
+      .iter()
+      .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
+      .copied()
+      .collect::<Vec<_>>();
+    global_include_dependencies.sort_unstable();
+
+    compilation
+      .entries
+      .iter()
+      .map(|(name, entry)| {
+        let dependencies = global_dependencies
+          .iter()
+          .copied()
+          .chain(entry.dependencies.iter().filter_map(|dep| {
+            module_graph
+              .module_identifier_by_dependency_id(dep)
+              .copied()
+          }))
+          .collect();
+        let mut include_dependencies = entry
+          .include_dependencies
+          .iter()
+          .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
+          .copied()
+          .collect::<Vec<_>>();
+        include_dependencies.sort_unstable();
+        let include_dependencies = global_include_dependencies
+          .iter()
+          .copied()
+          .chain(include_dependencies)
+          .collect();
+
+        (
+          name.clone(),
+          EntryModuleSnapshot {
+            dependencies,
+            include_dependencies,
+          },
+        )
+      })
+      .collect()
+  }
+
   /// Reset cached chunks back to the initial render state.
   ///
   /// webpack creates fresh `Chunk` instances for every compilation, and
@@ -202,6 +269,7 @@ impl BuildChunkGraphArtifact {
     self.named_chunks.clear();
     self.set_code_splitter(Default::default());
     self.module_idx.clear();
+    self.entry_modules.clear();
   }
 }
 
@@ -249,6 +317,7 @@ where
   compilation.build_chunk_graph_artifact.reset_for_rebuild();
 
   let compilation = task(compilation).await?;
+  let entry_modules = BuildChunkGraphArtifact::get_entry_modules(compilation);
   let mg = compilation.get_module_graph();
   let mut map = IdentifierMap::default();
   for (mid, mgm) in mg.module_graph_modules() {
@@ -259,6 +328,7 @@ where
     map.insert(*mid, (pre, post));
   }
   compilation.build_chunk_graph_artifact.module_idx = map;
+  compilation.build_chunk_graph_artifact.entry_modules = entry_modules;
   Ok(())
 }
 
@@ -280,6 +350,7 @@ impl ArtifactExt for BuildChunkGraphArtifact {
       s.spawn(|_| {
         new.entrypoints.clone_from(&old.entrypoints);
         new.module_idx.clone_from(&old.module_idx);
+        new.entry_modules.clone_from(&old.entry_modules);
       });
     });
   }

--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -156,7 +156,9 @@ impl BuildChunkGraphArtifact {
         }
       });
 
-      if miss_in_previous {
+      if miss_in_previous
+        && !(outgoings.is_empty() && self.chunk_graph.try_get_module_chunks(&module).is_some())
+      {
         logger.log("new module detected, rebuilding chunk graph");
         return false;
       }

--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -9,16 +9,17 @@ use tracing::instrument;
 
 use crate::{
   ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
-  Logger, ModuleIdentifier,
+  EntryOptions, Logger, ModuleIdentifier,
   build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
   fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-struct EntryModuleSnapshot {
+struct EntrySnapshot {
   dependencies: Vec<ModuleIdentifier>,
   include_dependencies: Vec<ModuleIdentifier>,
+  options: EntryOptions,
 }
 
 #[derive(Debug, Default)]
@@ -32,7 +33,7 @@ pub struct BuildChunkGraphArtifact {
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
   pub module_idx: IdentifierMap<(u32, u32)>,
-  entry_modules: FxIndexMap<String, EntryModuleSnapshot>,
+  entry_snapshots: FxIndexMap<String, EntrySnapshot>,
 }
 
 impl BuildChunkGraphArtifact {
@@ -61,8 +62,8 @@ impl BuildChunkGraphArtifact {
       return false;
     }
 
-    if self.entry_modules != Self::get_entry_modules(this_compilation) {
-      logger.log("entry modules change detected, rebuilding chunk graph");
+    if self.entry_snapshots != Self::get_entry_snapshots(this_compilation) {
+      logger.log("entry data change detected, rebuilding chunk graph");
       return false;
     }
 
@@ -192,7 +193,7 @@ impl BuildChunkGraphArtifact {
     true
   }
 
-  fn get_entry_modules(compilation: &Compilation) -> FxIndexMap<String, EntryModuleSnapshot> {
+  fn get_entry_snapshots(compilation: &Compilation) -> FxIndexMap<String, EntrySnapshot> {
     let module_graph = compilation.get_module_graph();
     let global_dependencies = compilation
       .global_entry
@@ -238,9 +239,10 @@ impl BuildChunkGraphArtifact {
 
         (
           name.clone(),
-          EntryModuleSnapshot {
+          EntrySnapshot {
             dependencies,
             include_dependencies,
+            options: entry.options.clone(),
           },
         )
       })
@@ -269,7 +271,7 @@ impl BuildChunkGraphArtifact {
     self.named_chunks.clear();
     self.set_code_splitter(Default::default());
     self.module_idx.clear();
-    self.entry_modules.clear();
+    self.entry_snapshots.clear();
   }
 }
 
@@ -317,7 +319,7 @@ where
   compilation.build_chunk_graph_artifact.reset_for_rebuild();
 
   let compilation = task(compilation).await?;
-  let entry_modules = BuildChunkGraphArtifact::get_entry_modules(compilation);
+  let entry_snapshots = BuildChunkGraphArtifact::get_entry_snapshots(compilation);
   let mg = compilation.get_module_graph();
   let mut map = IdentifierMap::default();
   for (mid, mgm) in mg.module_graph_modules() {
@@ -328,7 +330,7 @@ where
     map.insert(*mid, (pre, post));
   }
   compilation.build_chunk_graph_artifact.module_idx = map;
-  compilation.build_chunk_graph_artifact.entry_modules = entry_modules;
+  compilation.build_chunk_graph_artifact.entry_snapshots = entry_snapshots;
   Ok(())
 }
 
@@ -350,7 +352,7 @@ impl ArtifactExt for BuildChunkGraphArtifact {
       s.spawn(|_| {
         new.entrypoints.clone_from(&old.entrypoints);
         new.module_idx.clone_from(&old.module_idx);
-        new.entry_modules.clone_from(&old.entry_modules);
+        new.entry_snapshots.clone_from(&old.entry_snapshots);
       });
     });
   }

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/child.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/child.js
@@ -1,0 +1,1 @@
+globalThis.__duplicate_entry_root__ = true;

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/index.js
@@ -1,0 +1,5 @@
+import "./child";
+
+it("should preserve a root shared by named and global entries", () => {
+  expect(globalThis.__duplicate_entry_root__).toBe(true);
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/0/leaf.js
@@ -1,0 +1,1 @@
+export const value = "before";

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/1/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/1/leaf.js
@@ -1,0 +1,1 @@
+export const value = "after";

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/2/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/2/index.js
@@ -1,0 +1,9 @@
+import "./child";
+
+it("should preserve a root shared by named and global entries", () => {
+  expect(globalThis.__duplicate_entry_root__).toBe(true);
+});
+
+it("should rebuild when the global entry changes to an existing leaf", () => {
+  expect(globalThis.__changed_global_entry_root__).toBe(true);
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/2/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/2/leaf.js
@@ -1,0 +1,3 @@
+globalThis.__changed_global_entry_root__ = true;
+
+export const value = "use-as-global-entry";

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/3/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/3/leaf.js
@@ -1,0 +1,3 @@
+globalThis.__changed_global_entry_root__ = true;
+
+export const value = "use-as-global-entry use-entry-filename";

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
@@ -25,22 +25,32 @@ module.exports = {
       apply(compiler) {
         compiler.hooks.make.tapPromise(
           'duplicate-entry-root',
-          (compilation) =>
-            new Promise((resolve, reject) => {
-              const leafSource = fs.readFileSync(
-                path.resolve(compiler.context, 'leaf.js'),
-                'utf-8',
-              );
-              const globalEntry = leafSource.includes('use-as-global-entry')
-                ? './leaf.js'
-                : './index.js';
-              compilation.addEntry(
-                compiler.context,
-                rspack.EntryPlugin.createDependency(globalEntry),
-                {},
-                (error) => (error ? reject(error) : resolve()),
-              );
-            }),
+          async (compilation) => {
+            const leafSource = fs.readFileSync(
+              path.resolve(compiler.context, 'leaf.js'),
+              'utf-8',
+            );
+            const addEntry = (request, options) =>
+              new Promise((resolve, reject) => {
+                compilation.addEntry(
+                  compiler.context,
+                  rspack.EntryPlugin.createDependency(request),
+                  options,
+                  (error) => (error ? reject(error) : resolve()),
+                );
+              });
+            const globalEntry = leafSource.includes('use-as-global-entry')
+              ? './leaf.js'
+              : './index.js';
+
+            await addEntry(globalEntry, {});
+            await addEntry('./index.js', {
+              name: 'main',
+              filename: leafSource.includes('use-entry-filename')
+                ? 'renamed.js'
+                : 'main.js',
+            });
+          },
         );
       },
     },

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
@@ -1,4 +1,6 @@
 const rspack = require('@rspack/core');
+const fs = require('fs');
+const path = require('path');
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
@@ -25,9 +27,16 @@ module.exports = {
           'duplicate-entry-root',
           (compilation) =>
             new Promise((resolve, reject) => {
+              const leafSource = fs.readFileSync(
+                path.resolve(compiler.context, 'leaf.js'),
+                'utf-8',
+              );
+              const globalEntry = leafSource.includes('use-as-global-entry')
+                ? './leaf.js'
+                : './index.js';
               compilation.addEntry(
                 compiler.context,
-                rspack.EntryPlugin.createDependency('./index.js'),
+                rspack.EntryPlugin.createDependency(globalEntry),
                 {},
                 (error) => (error ? reject(error) : resolve()),
               );

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/rspack.config.js
@@ -1,0 +1,44 @@
+const rspack = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  entry: {
+    keeper: './leaf.js',
+    main: './index.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    minimize: false,
+    splitChunks: false,
+  },
+  incremental: {
+    buildChunkGraph: true,
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.make.tapPromise(
+          'duplicate-entry-root',
+          (compilation) =>
+            new Promise((resolve, reject) => {
+              compilation.addEntry(
+                compiler.context,
+                rspack.EntryPlugin.createDependency('./index.js'),
+                {},
+                (error) => (error ? reject(error) : resolve()),
+              );
+            }),
+        );
+      },
+    },
+  ],
+  stats: {
+    preset: 'verbose',
+    logging: 'verbose',
+    loggingDebug: [/codeSplittingCache/, /incremental/],
+  },
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
@@ -1,0 +1,29 @@
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+module.exports = {
+  findBundle() {
+    return "main.js";
+  },
+  checkStats(stepName, _, stats) {
+    if (stepName === "0") {
+      assert(
+        stats.includes("<t> rebuild chunk graph"),
+        "cold build must build the chunk graph",
+      );
+    } else if (stepName === "1") {
+      assert(
+        !stats.includes("<t> rebuild chunk graph"),
+        "editing an existing leaf must reuse the chunk graph",
+      );
+      assert(
+        !stats.includes("new module detected"),
+        "an existing terminal module must not be treated as a new module",
+      );
+    } else {
+      throw new Error(`Unexpected watch step: ${stepName}`);
+    }
+    return true;
+  },
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
@@ -21,6 +21,15 @@ module.exports = {
         !stats.includes("new module detected"),
         "an existing terminal module must not be treated as a new module",
       );
+    } else if (stepName === "2") {
+      assert(
+        stats.includes("<t> rebuild chunk graph"),
+        "changing a global entry root must rebuild the chunk graph",
+      );
+      assert(
+        stats.includes("entry modules change detected"),
+        "the changed global entry root must invalidate the cached chunk graph",
+      );
     } else {
       throw new Error(`Unexpected watch step: ${stepName}`);
     }

--- a/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/existing-leaf-duplicate-root/test.config.js
@@ -3,8 +3,8 @@ function assert(condition, message) {
 }
 
 module.exports = {
-  findBundle() {
-    return "main.js";
+  findBundle(_, __, stepName) {
+    return stepName === "3" ? "renamed.js" : "main.js";
   },
   checkStats(stepName, _, stats) {
     if (stepName === "0") {
@@ -27,8 +27,17 @@ module.exports = {
         "changing a global entry root must rebuild the chunk graph",
       );
       assert(
-        stats.includes("entry modules change detected"),
+        stats.includes("entry data change detected"),
         "the changed global entry root must invalidate the cached chunk graph",
+      );
+    } else if (stepName === "3") {
+      assert(
+        stats.includes("<t> rebuild chunk graph"),
+        "changing entry options must rebuild the chunk graph",
+      );
+      assert(
+        stats.includes("entry data change detected"),
+        "changed entry options must invalidate the cached chunk graph",
       );
     } else {
       throw new Error(`Unexpected watch step: ${stepName}`);

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/rspack.config.js
@@ -6,4 +6,9 @@ module.exports = {
   incremental: {
     buildChunkGraph: true,
   },
+  stats: {
+    preset: 'verbose',
+    logging: 'verbose',
+    loggingDebug: [/codeSplittingCache/, /incremental/],
+  },
 };

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.config.js
@@ -1,0 +1,26 @@
+function assert(condition, message) {
+  if (!condition) throw new Error(`Assertion failed: ${message}`);
+}
+
+module.exports = {
+  checkStats(stepName, _, stats) {
+    if (stepName === "0") {
+      assert(
+        stats.includes("<t> rebuild chunk graph"),
+        "cold build must build the chunk graph",
+      );
+    } else if (stepName === "1") {
+      assert(
+        !stats.includes("<t> rebuild chunk graph"),
+        "editing an existing leaf must reuse the chunk graph",
+      );
+      assert(
+        !stats.includes("new module detected"),
+        "an existing leaf must not be treated as a new module",
+      );
+    } else {
+      throw new Error(`Unexpected watch step: ${stepName}`);
+    }
+    return true;
+  },
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/pre-order-index/test.filter.js
@@ -1,1 +1,0 @@
-module.exports = () => "incremental.buildChunkGraph heuristic update is disabled";


### PR DESCRIPTION
## Summary

- Reuse a recovered chunk graph when an affected terminal module has no outgoing connections and already belongs to the cached graph.
- Preserve the conservative rebuild fallback for new leaves and changed connection topology.
- Add standalone watch regressions for terminal edits, duplicate entry roots, and pre-order indices.

The build-chunk-graph cache checks affected modules, and leaf-only edits previously fell through to a full graph rebuild because terminal modules have no outgoing entry in the recovered connection map. The new cached-chunk lookup only runs for that empty, missing-map case, avoiding repeated graph work without adding lookups to the common path.

## Related links

Split from #14840.

Closes #14768.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
