### PR TITLE
fix: avoid retaining flattened diagnostic sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,6 +4016,7 @@ dependencies = [
  "rspack_collections",
  "rspack_location",
  "rspack_paths",
+ "rspack_sources",
  "serde_json",
  "termcolor",
  "textwrap",

--- a/crates/rspack_binding_api/src/diagnostic.rs
+++ b/crates/rspack_binding_api/src/diagnostic.rs
@@ -1,5 +1,8 @@
 use napi::bindgen_prelude::*;
-use rspack_core::DependencyLocation;
+use rspack_core::{
+  DependencyLocation,
+  rspack_sources::{RawStringSource, SourceExt},
+};
 use rspack_error::{Diagnostic, Error as RspackError, Label, Severity};
 use rspack_util::location::byte_line_column_to_offset;
 
@@ -87,7 +90,7 @@ pub fn format_diagnostic(diagnostic: JsDiagnostic) -> Result<External<Diagnostic
     }]);
   }
 
-  error.src = source_code.map(Into::into);
+  error.src = source_code.map(|source| RawStringSource::from(source).boxed());
 
   let mut diagnostic = Diagnostic::from(error);
   diagnostic.file = file.map(Into::into);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/factorize.rs
@@ -95,7 +95,7 @@ impl Task<TaskContext> for FactorizeTask {
         if let Some(s) = self.original_module_source {
           let has_source_code = e.src.is_some();
           if !has_source_code {
-            e.src = Some(s.source().into_string_lossy().into_owned().into());
+            e.src = Some(s);
           }
         }
         // Bail out if `options.bail` set to `true`,

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -3,8 +3,7 @@ use rspack_error::Result;
 
 use super::*;
 use crate::{
-  DependencyDiagnosticsContext, OptimizationBailoutItem, SideEffectsStateArtifact, cache::Cache,
-  logger::Logger, pass::PassExt,
+  OptimizationBailoutItem, SideEffectsStateArtifact, cache::Cache, logger::Logger, pass::PassExt,
 };
 
 pub struct FinishModulesPhasePass;
@@ -206,19 +205,13 @@ fn collect_dependencies_diagnostics(
       let mgm = module_graph
         .module_graph_module_by_identifier(module_identifier)
         .expect("should have mgm");
-      let diagnostics_context = DependencyDiagnosticsContext::default();
       let diagnostics = mgm
         .all_dependencies()
         .iter()
         .filter_map(|dependency_id| {
           let dependency = module_graph.dependency_by_id(dependency_id);
           dependency
-            .get_diagnostics_with_context(
-              module_graph,
-              module_graph_cache,
-              exports_info_artifact,
-              &diagnostics_context,
-            )
+            .get_diagnostics(module_graph, module_graph_cache, exports_info_artifact)
             .map(|diagnostics| {
               diagnostics.into_iter().map(|mut diagnostic| {
                 diagnostic.module_identifier = Some(*module_identifier);

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -1,8 +1,4 @@
-use std::{
-  any::Any,
-  fmt::Debug,
-  sync::{Arc, OnceLock},
-};
+use std::{any::Any, fmt::Debug};
 
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::cacheable_dyn;
@@ -17,9 +13,8 @@ use super::{
 };
 use crate::{
   AsContextDependency, ConnectionState, Context, ExportsInfoArtifact, ForwardId, ImportAttributes,
-  ImportPhase, JavascriptParserUrl, LazyUntil, Module, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleLayer, ReferencedExport, RuntimeSpec, SideEffectsStateArtifact,
-  create_exports_object_referenced,
+  ImportPhase, JavascriptParserUrl, LazyUntil, ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer,
+  ReferencedExport, RuntimeSpec, SideEffectsStateArtifact, create_exports_object_referenced,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -27,27 +22,6 @@ pub enum AffectType {
   True,
   False,
   Transitive,
-}
-
-/// Module-scoped state shared while collecting diagnostics from its dependencies.
-#[derive(Debug, Default)]
-pub struct DependencyDiagnosticsContext {
-  module_source: OnceLock<Option<Arc<str>>>,
-}
-
-impl DependencyDiagnosticsContext {
-  fn get_or_init_module_source(&self, init: impl FnOnce() -> Option<Arc<str>>) -> Option<Arc<str>> {
-    self.module_source.get_or_init(init).clone()
-  }
-
-  /// Lazily materialize the module source once and share it across its diagnostics.
-  pub fn module_source(&self, module: &dyn Module) -> Option<Arc<str>> {
-    self.get_or_init_module_source(|| {
-      module
-        .source()
-        .map(|source| source.source().into_string_lossy().into())
-    })
-  }
 }
 
 #[cacheable_dyn]
@@ -142,16 +116,6 @@ pub trait Dependency:
     _exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
     None
-  }
-
-  fn get_diagnostics_with_context(
-    &self,
-    module_graph: &ModuleGraph,
-    module_graph_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
-    _context: &DependencyDiagnosticsContext,
-  ) -> Option<Vec<Diagnostic>> {
-    self.get_diagnostics(module_graph, module_graph_cache, exports_info_artifact)
   }
 
   fn get_referenced_exports(

--- a/crates/rspack_error/Cargo.toml
+++ b/crates/rspack_error/Cargo.toml
@@ -15,6 +15,7 @@ rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_location    = { workspace = true }
 rspack_paths       = { workspace = true }
+rspack_sources     = { workspace = true }
 serde_json         = { workspace = true }
 termcolor          = { workspace = true }
 textwrap           = { workspace = true }

--- a/crates/rspack_error/src/convert.rs
+++ b/crates/rspack_error/src/convert.rs
@@ -1,4 +1,5 @@
 use miette::SourceOffset;
+use rspack_sources::{RawStringSource, SourceExt};
 
 use crate::{
   Result,
@@ -33,7 +34,7 @@ impl<T> SerdeResultToRspackResultExt<T> for std::result::Result<T, serde_json::E
         offset: offset.offset(),
         len: 0,
       }]);
-      error.src = Some(content.into());
+      error.src = Some(RawStringSource::from(content).boxed());
       error
     })
   }

--- a/crates/rspack_error/src/displayer/renderer/mod.rs
+++ b/crates/rspack_error/src/displayer/renderer/mod.rs
@@ -1,9 +1,106 @@
 mod graphical;
 
-use miette::GraphicalTheme;
+use std::{borrow::Cow, fmt};
+
+use miette::{
+  Diagnostic as MietteDiagnostic, GraphicalTheme, LabeledSpan, MietteError, SourceCode, SourceSpan,
+  SpanContents,
+};
 
 use self::graphical::GraphicalReportHandler;
 use crate::{Result, error::Error};
+
+struct RenderSource<'a>(Cow<'a, str>);
+
+impl SourceCode for RenderSource<'_> {
+  fn read_span<'a>(
+    &'a self,
+    span: &SourceSpan,
+    context_lines_before: usize,
+    context_lines_after: usize,
+  ) -> std::result::Result<Box<dyn SpanContents<'a> + 'a>, MietteError> {
+    self
+      .0
+      .read_span(span, context_lines_before, context_lines_after)
+  }
+}
+
+// `miette::Diagnostic::source_code` can only borrow source data stored by the diagnostic. This
+// wrapper owns a flattened source for exactly one render, allowing composite sources to provide
+// snippets without caching a second full source copy on `Error`.
+struct RenderDiagnostic<'a> {
+  error: &'a Error,
+  source: Option<RenderSource<'a>>,
+  source_error: Option<Box<RenderDiagnostic<'a>>>,
+}
+
+impl<'a> RenderDiagnostic<'a> {
+  fn new(error: &'a Error) -> Self {
+    Self {
+      error,
+      source: error
+        .src
+        .as_ref()
+        .map(|source| RenderSource(source.source().into_string_lossy())),
+      source_error: error.source_error.as_deref().map(Self::new).map(Box::new),
+    }
+  }
+}
+
+impl fmt::Debug for RenderDiagnostic<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Debug::fmt(self.error, f)
+  }
+}
+
+impl fmt::Display for RenderDiagnostic<'_> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fmt::Display::fmt(self.error, f)
+  }
+}
+
+impl std::error::Error for RenderDiagnostic<'_> {
+  fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+    std::error::Error::source(self.error)
+  }
+}
+
+impl MietteDiagnostic for RenderDiagnostic<'_> {
+  fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+    MietteDiagnostic::code(self.error)
+  }
+
+  fn severity(&self) -> Option<miette::Severity> {
+    MietteDiagnostic::severity(self.error)
+  }
+
+  fn help(&self) -> Option<Box<dyn fmt::Display + '_>> {
+    MietteDiagnostic::help(self.error)
+  }
+
+  fn url(&self) -> Option<Box<dyn fmt::Display + '_>> {
+    MietteDiagnostic::url(self.error)
+  }
+
+  fn source_code(&self) -> Option<&dyn SourceCode> {
+    self.source.as_ref().map(|source| source as &dyn SourceCode)
+  }
+
+  fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+    MietteDiagnostic::labels(self.error)
+  }
+
+  fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn MietteDiagnostic> + '_>> {
+    MietteDiagnostic::related(self.error)
+  }
+
+  fn diagnostic_source(&self) -> Option<&dyn MietteDiagnostic> {
+    self
+      .source_error
+      .as_deref()
+      .map(|error| error as &dyn MietteDiagnostic)
+  }
+}
 
 pub struct Renderer(GraphicalReportHandler);
 
@@ -24,7 +121,8 @@ impl Renderer {
 
   pub fn render(&self, error: &Error) -> Result<String> {
     let mut buf = String::new();
-    self.0.render_report(&mut buf, error)?;
+    let diagnostic = RenderDiagnostic::new(error);
+    self.0.render_report(&mut buf, &diagnostic)?;
     Ok(buf)
   }
 }

--- a/crates/rspack_error/src/error.rs
+++ b/crates/rspack_error/src/error.rs
@@ -1,7 +1,11 @@
-use std::{fmt::Display, sync::Arc};
+use std::fmt::Display;
 
 use miette::{Diagnostic as MietteDiagnostic, LabeledSpan};
-use rspack_cacheable::cacheable;
+use rspack_cacheable::{
+  cacheable,
+  with::{AsOption, AsPreset},
+};
+use rspack_sources::{BoxSource, RawStringSource, SourceExt};
 
 /// Error severity. Defaults to [`Severity::Error`].
 #[cacheable]
@@ -35,7 +39,8 @@ pub struct ErrorData {
   /// Message.
   pub message: String,
   /// Source code.
-  pub src: Option<Arc<str>>,
+  #[cacheable(with=AsOption<AsPreset>)]
+  pub src: Option<BoxSource>,
   /// Labels displayed in source code.
   ///
   /// The source code block will be displayed only if both source code and labels exist.
@@ -106,11 +111,17 @@ impl Error {
     title: String,
     message: String,
   ) -> Self {
-    Self::from_shared_source(src.map(Into::into), start, end, title, message)
+    Self::from_source(
+      src.map(|source| RawStringSource::from(source).boxed()),
+      start,
+      end,
+      title,
+      message,
+    )
   }
 
-  pub fn from_shared_source(
-    src: Option<Arc<str>>,
+  pub fn from_source(
+    src: Option<BoxSource>,
     start: usize,
     end: usize,
     title: String,
@@ -194,7 +205,11 @@ impl MietteDiagnostic for Error {
   }
 
   fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-    self.src.as_ref().map(|s| s as &dyn miette::SourceCode)
+    // A composite `BoxSource` has no stable flattened string to borrow here. Caching one on the
+    // error would retain a second full copy of the module source. Rspack's `Renderer` supplies a
+    // render-scoped `SourceCode` adapter instead, so its normal CLI and stats output keep snippets
+    // without extending the flattened source's lifetime.
+    None
   }
 
   fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
@@ -249,6 +264,7 @@ impl From<anyhow::Error> for Error {
 #[cfg(test)]
 mod test {
   use owo_colors::with_override;
+  use rspack_sources::{RawStringSource, SourceExt};
 
   use super::{Error, ErrorData, Label};
   use crate::{Renderer, Severity};
@@ -259,7 +275,9 @@ mod test {
     let sub_err = Error(Box::new(ErrorData {
       severity: Severity::Warning,
       message: "An unexpected keyword.".into(),
-      src: Some("const a = { const };\nconst b = { var };".into()),
+      src: Some(
+        RawStringSource::from("const a = { const };\nconst b = { var };".to_string()).boxed(),
+      ),
       labels: Some(vec![
         Label {
           name: Some("keyword 1".into()),
@@ -282,7 +300,7 @@ mod test {
     let mid_err = Error(Box::new(ErrorData {
       severity: Severity::Error,
       message: "Can not parse current module.".into(),
-      src: Some("const a = { const };".into()),
+      src: Some(RawStringSource::from("const a = { const };".to_string()).boxed()),
       labels: Some(vec![Label {
         name: Some("parse failed".into()),
         offset: 0,

--- a/crates/rspack_javascript_compiler/src/compiler/parse.rs
+++ b/crates/rspack_javascript_compiler/src/compiler/parse.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use rspack_error::BatchErrors;
+use rspack_sources::{RawStringSource, SourceExt};
 use swc_core::{
   base::config::IsModule,
   common::{
@@ -61,7 +62,7 @@ impl JavaScriptCompiler {
           .with_context(ast::Context::new(self.cm, Some(self.globals)))
       })
       .map_err(|errs| {
-        let source: Arc<str> = Arc::from(fm.src.as_ref());
+        let source = RawStringSource::from(fm.src.to_string()).boxed();
         BatchErrors(
           errs
             .dedup_ecma_errors()
@@ -89,7 +90,7 @@ impl JavaScriptCompiler {
         )
       })
       .map_err(|errs| {
-        let source: Arc<str> = source.into();
+        let source = RawStringSource::from(source).boxed();
         BatchErrors(
           errs
             .dedup_ecma_errors()
@@ -113,7 +114,7 @@ impl JavaScriptCompiler {
     parse_with_lexer(lexer, is_module, false)
       .map(|(program, _)| program)
       .map_err(|errs| {
-        let source: Arc<str> = Arc::from(fm.src.as_ref());
+        let source = RawStringSource::from(fm.src.to_string()).boxed();
         BatchErrors(
           errs
             .dedup_ecma_errors()

--- a/crates/rspack_javascript_compiler/src/error.rs
+++ b/crates/rspack_javascript_compiler/src/error.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use rspack_error::{BatchErrors, Error, Label, Severity, error};
+use rspack_sources::{BoxSource, RawStringSource, SourceExt};
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap, FxHashSet as HashSet};
 use swc_core::common::{
@@ -52,9 +53,9 @@ pub trait DedupEcmaErrors {
 
 pub fn ecma_parse_error_deduped_to_rspack_error(
   EcmaError(message, span): EcmaError,
-  source: Arc<str>,
+  source: BoxSource,
 ) -> Error {
-  Error::from_shared_source(
+  Error::from_source(
     Some(source),
     span.real_lo() as usize,
     span.real_hi() as usize,
@@ -95,7 +96,7 @@ pub(crate) fn swc_diagnostics_to_rspack_error(
 fn swc_diagnostic_to_rspack_error(
   diagnostic: &SwcDiagnostic,
   source_map: &SourceMap,
-  source_cache: &mut FxHashMap<u32, Arc<str>>,
+  source_cache: &mut FxHashMap<u32, BoxSource>,
 ) -> Error {
   let mut message = diagnostic.message();
   let code = diagnostic.code.as_ref().map(|code| match code {
@@ -142,7 +143,7 @@ fn swc_diagnostic_to_rspack_error(
     error.src = Some(
       source_cache
         .entry(source_file.start_pos.0)
-        .or_insert_with(|| Arc::from(source_file.src.as_ref()))
+        .or_insert_with(|| RawStringSource::from(source_file.src.to_string()).boxed())
         .clone(),
     );
     if !labels.is_empty() {
@@ -168,7 +169,7 @@ fn swc_diagnostic_to_rspack_error(
 struct RspackErrorEmitter {
   tx: mpsc::Sender<Error>,
   source_map: Arc<SourceMap>,
-  source_cache: FxHashMap<u32, Arc<str>>,
+  source_cache: FxHashMap<u32, BoxSource>,
   title: String,
 }
 
@@ -182,11 +183,13 @@ impl Emitter for RspackErrorEmitter {
       let source = self
         .source_cache
         .entry(source_file_and_byte_pos.sf.start_pos.0)
-        .or_insert_with(|| Arc::from(source_file_and_byte_pos.sf.src.as_ref()))
+        .or_insert_with(|| {
+          RawStringSource::from(source_file_and_byte_pos.sf.src.to_string()).boxed()
+        })
         .clone();
       self
         .tx
-        .send(Error::from_shared_source(
+        .send(Error::from_source(
           Some(source),
           source_file_and_byte_pos.pos.0 as usize,
           source_file_and_byte_pos.pos.0 as usize,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -9,11 +9,10 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, ChunkGraph, ConditionalInitFragment, ConnectionState, Dependency,
   DependencyCategory, DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
-  DependencyDiagnosticsContext, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, DetermineExportAssignmentsKey,
-  ESMExportBinding, ESMExportInitFragment, ExportMode, ExportModeDynamicReexport,
-  ExportModeEmptyStar, ExportModeFakeNamespaceObject, ExportModeNormalReexport,
-  ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
+  DependencyId, DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType,
+  DependencyType, DetermineExportAssignmentsKey, ESMExportBinding, ESMExportInitFragment,
+  ExportMode, ExportModeDynamicReexport, ExportModeEmptyStar, ExportModeFakeNamespaceObject,
+  ExportModeNormalReexport, ExportModeReexportDynamicDefault, ExportModeReexportNamedDefault,
   ExportModeReexportNamespaceObject, ExportModeReexportUndefined, ExportModeUnused,
   ExportNameOrSpec, ExportPresenceMode, ExportProvided, ExportSpec, ExportsInfoArtifact,
   ExportsInfoData, ExportsOfExportsSpec, ExportsSpec, ExportsType, FactorizeInfo, ForwardId,
@@ -1040,7 +1039,6 @@ impl ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
     should_error: bool,
-    diagnostics_context: &DependencyDiagnosticsContext,
   ) -> Option<Vec<Diagnostic>> {
     let create_error = |message: String| {
       let (severity, title) = if should_error {
@@ -1053,9 +1051,9 @@ impl ESMExportImportedSpecifierDependency {
         .expect("should have parent module for dependency");
       let mut error = if let Some(span) = self.range()
         && let Some(parent_module) = module_graph.module_by_identifier(parent_module_identifier)
-        && let Some(source) = diagnostics_context.module_source(parent_module.as_ref())
+        && let Some(source) = parent_module.source().cloned()
       {
-        Error::from_shared_source(
+        Error::from_source(
           Some(source),
           span.start as usize,
           span.end as usize,
@@ -1425,21 +1423,6 @@ impl Dependency for ESMExportImportedSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
-    self.get_diagnostics_with_context(
-      module_graph,
-      module_graph_cache,
-      exports_info_artifact,
-      &DependencyDiagnosticsContext::default(),
-    )
-  }
-
-  fn get_diagnostics_with_context(
-    &self,
-    module_graph: &ModuleGraph,
-    module_graph_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
-    diagnostics_context: &DependencyDiagnosticsContext,
-  ) -> Option<Vec<Diagnostic>> {
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
     let ids = self.get_ids(module_graph);
@@ -1459,7 +1442,6 @@ impl Dependency for ESMExportImportedSpecifierDependency {
           name,
           true,
           should_error,
-          diagnostics_context,
         )
       {
         diagnostics.push(error);
@@ -1470,7 +1452,6 @@ impl Dependency for ESMExportImportedSpecifierDependency {
         module_graph_cache,
         exports_info_artifact,
         should_error,
-        diagnostics_context,
       ) {
         diagnostics.extend(errors);
       }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_dependency.rs
@@ -3,12 +3,11 @@ use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, AwaitDependenciesInitFragment, BuildMetaDefaultObject, ChunkGraph,
   ConditionalInitFragment, ConnectionState, Dependency, DependencyCategory,
-  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn,
-  DependencyDiagnosticsContext, DependencyId, DependencyLocation, DependencyRange,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportProvided, ExportsInfoArtifact,
-  ExportsType, FactorizeInfo, ForwardId, ImportAttributes, ImportPhase, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, LazyUntil, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ProvidedExports, ReferencedExport,
+  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ExportProvided, ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes,
+  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LazyUntil, ModuleDependency,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ProvidedExports, ReferencedExport,
   ResourceIdentifier, RuntimeCondition, RuntimeSpec, SideEffectsStateArtifact, SourceType,
   TemplateContext, TemplateReplaceSource, TypeReexportPresenceMode, filter_runtime,
 };
@@ -283,7 +282,6 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
   name: &Atom,
   is_reexport: bool,
   should_error: bool,
-  diagnostics_context: &DependencyDiagnosticsContext,
 ) -> Option<Diagnostic> {
   let imported_module = module_graph.get_module_by_dependency_id(module_dependency.id())?;
   if imported_module.first_error().is_some() {
@@ -315,9 +313,9 @@ pub fn esm_import_dependency_get_linking_error<T: ModuleDependency>(
       (Severity::Warning, "ESModulesLinkingWarning")
     };
     let mut error = if let Some(span) = module_dependency.range()
-      && let Some(source) = diagnostics_context.module_source(parent_module.as_ref())
+      && let Some(source) = parent_module.source().cloned()
     {
-      Error::from_shared_source(
+      Error::from_source(
         Some(source),
         span.start as usize,
         span.end as usize,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_import_specifier_dependency.rs
@@ -5,14 +5,13 @@ use rspack_cacheable::{
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
-  DependencyCondition, DependencyConditionFn, DependencyDiagnosticsContext, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportPresenceMode, ExportProvided, ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId,
-  ImportAttributes, ImportPhase, JavascriptParserOptions, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport,
-  ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
-  TemplateReplaceSource, UsedByExports, UsedName, create_exports_object_referenced,
-  property_access, to_normal_comment,
+  DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportPresenceMode, ExportProvided,
+  ExportsInfoArtifact, ExportsType, FactorizeInfo, ForwardId, ImportAttributes, ImportPhase,
+  JavascriptParserOptions, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ModuleReferenceOptions, ReferencedExport, ResourceIdentifier, RuntimeSpec,
+  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedByExports, UsedName,
+  create_exports_object_referenced, property_access, to_normal_comment,
 };
 use rspack_error::Diagnostic;
 use rspack_hash::{RspackHash, RspackHasher};
@@ -240,21 +239,6 @@ impl Dependency for ESMImportSpecifierDependency {
     module_graph_cache: &ModuleGraphCacheArtifact,
     exports_info_artifact: &ExportsInfoArtifact,
   ) -> Option<Vec<Diagnostic>> {
-    self.get_diagnostics_with_context(
-      module_graph,
-      module_graph_cache,
-      exports_info_artifact,
-      &DependencyDiagnosticsContext::default(),
-    )
-  }
-
-  fn get_diagnostics_with_context(
-    &self,
-    module_graph: &ModuleGraph,
-    module_graph_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
-    diagnostics_context: &DependencyDiagnosticsContext,
-  ) -> Option<Vec<Diagnostic>> {
     let module = module_graph.get_parent_module(&self.id)?;
     let module = module_graph.module_by_identifier(module)?;
     let should_error = self
@@ -276,7 +260,6 @@ impl Dependency for ESMImportSpecifierDependency {
       &self.name,
       false,
       should_error,
-      diagnostics_context,
     ) {
       return Some(vec![diagnostic]);
     }

--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, sync::LazyLock};
 
 use regex::Regex;
-use rspack_core::DependencyRange;
+use rspack_core::{DependencyRange, rspack_sources::BoxSource};
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_regex::RspackRegex;
 use rspack_util::SpanExt;
@@ -13,7 +13,7 @@ use swc_experimental_ecma_ast::{
 use swc_experimental_ecma_parser::{EsSyntax, Syntax, parse_file_as_expr};
 use swc_experimental_ecma_transforms_base::remove_paren::remove_paren;
 
-use crate::visitors::{JavascriptParser, create_traceable_error};
+use crate::visitors::{JavascriptParser, create_traceable_error_from_source};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum RspackComment {
@@ -92,18 +92,18 @@ impl RspackCommentMap {
   }
 
   fn push_conflict_warning(
-    source: &str,
+    source: &BoxSource,
     ignored_comment_name: impl fmt::Display,
     preferred_comment_name: impl fmt::Display,
     item: &MagicCommentItem,
     warning_diagnostics: &mut Vec<Diagnostic>,
   ) {
-    let mut error: Error = create_traceable_error(
+    let mut error: Error = create_traceable_error_from_source(
       "Magic comments conflict".into(),
       format!(
         "`{ignored_comment_name}` is ignored because `{preferred_comment_name}` is also specified. Prefer `{preferred_comment_name}`."
       ),
-      source.to_owned(),
+      source.clone(),
       item.span,
     );
     error.severity = Severity::Warning;
@@ -113,7 +113,7 @@ impl RspackCommentMap {
 
   fn insert_with_conflict_warning(
     &mut self,
-    source: &str,
+    source: &BoxSource,
     rspack_comment: RspackComment,
     item: MagicCommentItem,
     warning_diagnostics: &mut Vec<Diagnostic>,
@@ -250,17 +250,17 @@ impl RspackCommentMap {
 }
 
 fn push_magic_comment_parse_warning(
-  source: &str,
+  source: &BoxSource,
   comment_name: impl fmt::Display,
   comment_type: &str,
   received: &str,
   warning_diagnostics: &mut Vec<Diagnostic>,
   span: DependencyRange,
 ) {
-  let mut error: Error = create_traceable_error(
+  let mut error: Error = create_traceable_error_from_source(
     "Magic comments parse failed".into(),
     format!("`{comment_name}` expected {comment_type}, but received: {received}."),
-    source.to_owned(),
+    source.clone(),
     span,
   );
   error.severity = Severity::Warning;
@@ -279,7 +279,7 @@ pub fn try_extract_magic_comment(
   if let Some(comments) = parser.ast.comments.leading.get(&span.start) {
     analyze_comments(
       allocator,
-      parser.source,
+      &parser.diagnostic_source,
       comments,
       error_span,
       &mut warning_diagnostics,
@@ -289,7 +289,7 @@ pub fn try_extract_magic_comment(
   if let Some(comments) = parser.ast.comments.trailing.get(&span.end) {
     analyze_comments(
       allocator,
-      parser.source,
+      &parser.diagnostic_source,
       comments,
       error_span,
       &mut warning_diagnostics,
@@ -561,7 +561,7 @@ fn parse_magic_comment_name(name: &str) -> Option<(RspackComment, MagicCommentPr
 
 fn analyze_comments(
   allocator: &Allocator,
-  source: &str,
+  diagnostic_source: &BoxSource,
   comments: &[Comment],
   error_span: Span,
   warning_diagnostics: &mut Vec<Diagnostic>,
@@ -605,7 +605,7 @@ fn analyze_comments(
           .unwrap_or(error_span.into());
       let push_parse_warning = |comment_type| {
         push_magic_comment_parse_warning(
-          source,
+          diagnostic_source,
           item_name,
           comment_type,
           received,
@@ -716,13 +716,19 @@ fn analyze_comments(
         value,
         span: item_span,
       };
-      result.insert_with_conflict_warning(source, rspack_comment, item, warning_diagnostics);
+      result.insert_with_conflict_warning(
+        diagnostic_source,
+        rspack_comment,
+        item,
+        warning_diagnostics,
+      );
     }
   }
 }
 
 #[cfg(test)]
 mod tests_extract_magic_comment_object {
+  use rspack_core::rspack_sources::{RawStringSource, SourceExt};
   use swc_experimental_ecma_ast::DUMMY_SP;
 
   use super::*;
@@ -751,9 +757,10 @@ mod tests_extract_magic_comment_object {
     let mut result = RspackCommentMap::new();
     let mut warning_diagnostics = Vec::new();
     let allocator = Allocator::new();
+    let diagnostic_source = RawStringSource::from("").boxed();
     analyze_comments(
       &allocator,
-      "",
+      &diagnostic_source,
       &[Comment {
         kind: CommentKind::Block,
         span: DUMMY_SP,

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -55,11 +55,10 @@ static LEGACY_REQUIRE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
 fn append_experimental_parse_errors(
   diagnostics: &mut Vec<Diagnostic>,
-  source: &str,
+  source: &BoxSource,
   errors: impl IntoIterator<Item = swc_experimental_ecma_parser::error::Error>,
 ) {
   let mut visited = HashSet::new();
-  let source: Arc<str> = source.into();
   diagnostics.extend(errors.into_iter().filter_map(|err| {
     let span = err.span();
     let message = err.kind().msg().to_string();
@@ -67,7 +66,7 @@ fn append_experimental_parse_errors(
       return None;
     }
     Some(
-      Error::from_shared_source(
+      Error::from_source(
         Some(source.clone()),
         span.start.saturating_sub(1) as usize,
         span.end.saturating_sub(1) as usize,
@@ -85,25 +84,26 @@ mod tests {
 
   #[test]
   fn parse_errors_share_source_code() {
-    let source = "'\\101';'\\102';";
+    let source_text = "'\\101';'\\102';";
+    let source = rspack_core::rspack_sources::RawStringSource::from(source_text).boxed();
     let allocator = Allocator::new();
     let lexer = Lexer::new(
       &allocator,
       Syntax::Es(EsSyntax::default()),
       EsVersion::EsNext,
-      StringSource::new(source),
+      StringSource::new(source_text),
       None,
     );
     let mut parser = Parser::new_from(&allocator, lexer);
     parser.parse_module().expect("should recover parse errors");
 
     let mut diagnostics = Vec::new();
-    append_experimental_parse_errors(&mut diagnostics, source, parser.take_errors());
+    append_experimental_parse_errors(&mut diagnostics, &source, parser.take_errors());
 
     assert_eq!(diagnostics.len(), 2);
     let first_source = diagnostics[0].src.as_ref().expect("should have source");
     let second_source = diagnostics[1].src.as_ref().expect("should have source");
-    assert_eq!(first_source.as_ptr(), second_source.as_ptr());
+    assert!(Arc::ptr_eq(first_source, second_source));
   }
 }
 
@@ -326,7 +326,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       Err(e) => {
         let mut errors = parser.take_errors();
         errors.push(e);
-        append_experimental_parse_errors(&mut diagnostics, &source_string, errors);
+        append_experimental_parse_errors(&mut diagnostics, &source, errors);
         return default_with_diagnostics(source, diagnostics);
       }
     };
@@ -335,7 +335,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     let tokens = parser.input_mut().iter.take();
     drop(parser);
     if !parse_errors.is_empty() {
-      append_experimental_parse_errors(&mut diagnostics, &source_string, parse_errors);
+      append_experimental_parse_errors(&mut diagnostics, &source, parse_errors);
       return default_with_diagnostics(source, diagnostics);
     }
 
@@ -362,6 +362,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       mut side_effects_item,
     } = match scan_dependencies(
       &source_string,
+      source.clone(),
       &parsed_ast,
       resource_data,
       compiler_options,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -23,7 +23,8 @@ use crate::{
   parser_plugin::require_ensure_dependencies_block_parse_plugin::GetFunctionExpression,
   utils::eval::BasicEvaluatedExpression,
   visitors::{
-    JavascriptParser, Statement, context_reg_exp, create_context_dependency, create_traceable_error,
+    JavascriptParser, Statement, context_reg_exp, create_context_dependency,
+    create_traceable_error_from_source,
   },
 };
 
@@ -330,10 +331,10 @@ impl AMDRequireDependenciesBlockParserPlugin {
           call_expr.span.into(),
         ));
         parser.add_presentational_dependency(dep);
-        let mut error: Error = create_traceable_error(
+        let mut error: Error = create_traceable_error_from_source(
           "UnsupportedFeatureWarning".into(),
           "Cannot statically analyse 'require(…, …)'".into(),
-          parser.source.to_string(),
+          parser.diagnostic_source.clone(),
           call_expr.span.into(),
         );
         error.severity = Severity::Warning;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -2,7 +2,7 @@ use concat_string::concat_string;
 use rspack_core::{
   ConstDependency, ImportMetaKnownProperties, ModuleArgument, RuntimeGlobals,
   RuntimeGlobalsRenderMode, RuntimeRequirementsDependency,
-  RuntimeRequirementsDependencyWriteOperation, property_access,
+  RuntimeRequirementsDependencyWriteOperation, property_access, rspack_sources::BoxSource,
   runtime_mode::RuntimeMode as ExperimentRuntimeMode,
 };
 use rspack_error::{Error, Severity};
@@ -18,22 +18,24 @@ use crate::{
   },
   parser_plugin::JavascriptParserPlugin,
   utils::eval::{self, BasicEvaluatedExpression},
-  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error, expr_name},
+  visitors::{
+    JavascriptParser, Statement, VariableDeclaration, create_traceable_error_from_source, expr_name,
+  },
 };
 
 fn expression_not_supported(
-  source: &str,
+  source: BoxSource,
   name: &str,
   is_call: bool,
   expr_span: Span,
 ) -> (Error, Box<ConstDependency>) {
-  let mut error = create_traceable_error(
+  let mut error = create_traceable_error_from_source(
     "Unsupported feature".into(),
     format!(
       "{name}{} is not supported by Rspack.",
       if is_call { "()" } else { "" }
     ),
-    source.to_owned(),
+    source,
     expr_span.into(),
   );
   error.severity = Severity::Warning;
@@ -706,8 +708,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
       || for_name == "require.main.require"
       || for_name == "module.parent.require"
     {
-      let (warning, dep) =
-        expression_not_supported(parser.source, for_name, false, member_expr.span());
+      let (warning, dep) = expression_not_supported(
+        parser.diagnostic_source.clone(),
+        for_name,
+        false,
+        member_expr.span(),
+      );
       parser.add_warning(warning.into());
       parser.add_presentational_dependency(dep);
       return Some(true);
@@ -956,7 +962,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
       || for_name == "require.main.require"
       || for_name == "module.parent.require"
     {
-      let (warning, dep) = expression_not_supported(parser.source, for_name, true, call_expr.span);
+      let (warning, dep) = expression_not_supported(
+        parser.diagnostic_source.clone(),
+        for_name,
+        true,
+        call_expr.span,
+      );
       parser.add_warning(warning.into());
       parser.add_presentational_dependency(dep);
       return Some(true);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -35,7 +35,8 @@ use crate::{
   visitors::{
     CallHooksName, ExportedVariableInfo, JavascriptParser, StatementPath, TagInfoData,
     VariableDeclaration, VariableDeclarationKind, VariableInfo, VariableInfoFlags, context_reg_exp,
-    create_context_dependency, create_traceable_error, expr_name, get_non_optional_part,
+    create_context_dependency, create_traceable_error_from_source, expr_name,
+    get_non_optional_part,
   },
 };
 
@@ -976,10 +977,10 @@ fn wrap_created_require_with_side_effects(parser: &mut JavascriptParser, span: S
 #[cold]
 #[inline(never)]
 fn add_create_require_warning(parser: &mut JavascriptParser, message: &str, span: Span) {
-  let mut error = create_traceable_error(
+  let mut error = create_traceable_error_from_source(
     "Unsupported feature".into(),
     message.to_string(),
-    parser.source.to_string(),
+    parser.diagnostic_source.clone(),
     span.into(),
   );
   error.severity = Severity::Warning;
@@ -1905,11 +1906,11 @@ impl CommonJsImportsParserPlugin {
     if let Some(true) = parser.javascript_options.unknown_context_critical
       && !is_renaming_require
     {
-      let mut error = create_traceable_error(
+      let mut error = create_traceable_error_from_source(
         "Critical dependency".into(),
         "require function is used in a way in which dependencies cannot be statically extracted"
           .to_string(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         span.into(),
       );
       error.severity = Severity::Warning;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -8,16 +8,16 @@ use super::JavascriptParserPlugin;
 use crate::{
   dependency::ESMCompatibilityDependency,
   utils::eval::BasicEvaluatedExpression,
-  visitors::{JavascriptParser, create_traceable_error},
+  visitors::{JavascriptParser, create_traceable_error_from_source},
 };
 
 impl JavascriptParser<'_> {
   fn throw_top_level_await_error(&mut self, msg: String, span: Span) {
     self.add_error(
-      create_traceable_error(
+      create_traceable_error_from_source(
         "JavaScript parse error".into(),
         msg,
-        self.source.to_string(),
+        self.diagnostic_source.clone(),
         span.into(),
       )
       .into(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -23,7 +23,7 @@ use crate::{
   utils::object_properties::get_attributes,
   visitors::{
     ExportDefaultDeclaration, ExportDefaultExpression, ExportImport, ExportLocal, JavascriptParser,
-    create_traceable_error,
+    create_traceable_error_from_source,
   },
 };
 
@@ -134,10 +134,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       .insert(export_name.clone())
     {
       parser.add_error(
-        create_traceable_error(
+        create_traceable_error_from_source(
           "JavaScript parse error".into(),
           format!("Duplicate export of '{export_name}'"),
-          parser.source.to_string(),
+          parser.diagnostic_source.clone(),
           export_name_span.into(),
         )
         .into(),
@@ -228,10 +228,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
         .insert(export_name.clone())
       {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "JavaScript parse error".into(),
             format!("Duplicate export of '{export_name}'"),
-            parser.source.to_string(),
+            parser.diagnostic_source.clone(),
             export_name_span.expect("should exist").into(),
           )
           .into(),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -34,7 +34,7 @@ use crate::{
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
-    RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
+    RootName, context_reg_exp, create_context_dependency, expr_name,
     get_non_optional_member_chain_from_expr, member_property_to_atom,
   },
 };
@@ -416,7 +416,7 @@ impl ImportMetaPlugin {
       .evaluated_source_range
       .unwrap_or_else(|| DependencyRange::from(span));
     let mut error = Error::warning(message);
-    error.src = Some(parser.source.to_string().into());
+    error.src = Some(parser.diagnostic_source.clone());
     error.labels = Some(vec![Label {
       name: None,
       offset: range.start as usize,
@@ -747,11 +747,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       } else {
         // import.meta
         // warn when access import.meta directly
-        let mut error: Error = create_traceable_error(
+        let range = DependencyRange::from(span);
+        let mut error = Error::from_source(
+          Some(parser.diagnostic_source.clone()),
+          range.start as usize,
+          range.end as usize,
           "Critical dependency".into(),
           "Accessing import.meta directly is unsupported (only property access or destructuring is supported)".into(),
-          parser.source.to_string(),
-          span.into()
         );
         error.severity = Severity::Warning;
         parser.add_warning(error.into());

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -22,7 +22,7 @@ use crate::{
   visitors::{
     ContextModuleScanResult, JavascriptParser, PatRef, Statement, TagInfoData, TopLevelScope,
     VariableDeclaration, VariableDeclarationKind, context_reg_exp, create_context_dependency,
-    create_traceable_error, get_non_optional_part, parse_order_string,
+    create_traceable_error_from_source, get_non_optional_part, parse_order_string,
   },
 };
 
@@ -358,10 +358,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
       || referenced_fulfilled_ns_obj.is_some()
       || referenced_in_members.is_some();
     if is_statical && has_exports_magic_comment {
-      let mut error: Error = create_traceable_error(
+      let mut error: Error = create_traceable_error_from_source(
         "Useless magic comments".into(),
         "You don't need `webpackExports` if the usage of dynamic import is statically analyse-able. You can safely remove the `webpackExports` magic comment.".into(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         import_call_span.into(),
       );
       error.severity = Severity::Warning;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/context_dependency_helper.rs
@@ -5,7 +5,7 @@ use rspack_core::parse_resource;
 use rspack_error::{Diagnostic, Severity};
 use rspack_util::{json_stringify_str, quote_meta};
 
-use super::create_traceable_error;
+use super::create_traceable_error_from_source;
 use crate::utils::eval::{BasicEvaluatedExpression, TemplateStringKind};
 
 // Webpack will walk only the dynamic parts of evaluated expression in this function
@@ -98,10 +98,10 @@ pub fn create_context_dependency(
     }
 
     if let Some(true) = parser.javascript_options.wrapped_context_critical {
-      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error(
+      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error_from_source(
         "Critical dependency".into(),
         "a part of the request of a dependency is an expression".to_string(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         param.range().into(),
       ));
       warn.severity = Severity::Warning;
@@ -170,10 +170,10 @@ pub fn create_context_dependency(
     }
 
     if let Some(true) = parser.javascript_options.wrapped_context_critical {
-      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error(
+      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error_from_source(
         "Critical dependency".into(),
         "a part of the request of a dependency is an expression".to_string(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         param.range().into(),
       ));
       warn.severity = Severity::Warning;
@@ -199,10 +199,10 @@ pub fn create_context_dependency(
     }
   } else {
     if let Some(true) = parser.javascript_options.expr_context_critical {
-      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error(
+      let mut warn: Diagnostic = Diagnostic::from(create_traceable_error_from_source(
         "Critical dependency".into(),
         "the request of a dependency is an expression".to_string(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         param.range().into(),
       ));
       warn.severity = Severity::Warning;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/mod.rs
@@ -6,6 +6,7 @@ use rspack_core::{
   ArcComputed, AsyncDependenciesBlock, BoxDependency, BoxDependencyTemplate, BuildInfo, BuildMeta,
   CompilerOptions, FactoryMeta, ImportMeta, ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta,
   ParserOptions, ResolvedModuleOptions, ResourceData, SideEffectsBailoutItemWithSpan,
+  rspack_sources::BoxSource,
 };
 use rspack_error::Diagnostic;
 use rustc_hash::FxHashSet;
@@ -45,6 +46,7 @@ pub struct ParsedJavaScriptAst<'ast> {
 #[allow(clippy::too_many_arguments)]
 pub fn scan_dependencies(
   source: &str,
+  diagnostic_source: BoxSource,
   ast: &ParsedJavaScriptAst<'_>,
   resource_data: &ResourceData,
   compiler_options: &CompilerOptions,
@@ -63,6 +65,7 @@ pub fn scan_dependencies(
 ) -> Result<ScanDependenciesResult, Vec<Diagnostic>> {
   let mut parser = JavascriptParser::new(
     source,
+    diagnostic_source,
     ast,
     compiler_options,
     module_parser_options

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -25,7 +25,7 @@ use rspack_core::{
   CompilerOptions, DependencyId, DependencyLocation, DependencyRange, FactoryMeta, ImportMeta,
   ImportMetaKnownProperties, JavascriptParserCommonjsExportsOption, JavascriptParserOptions,
   ModuleIdentifier, ModuleLayer, ModuleType, ParseMeta, ResolvedModuleOptions, ResourceData,
-  SideEffectsBailoutItemWithSpan,
+  SideEffectsBailoutItemWithSpan, rspack_sources::BoxSource,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_util::fx_hash::FxIndexSet;
@@ -418,6 +418,7 @@ pub struct JavascriptParser<'parser> {
   blocks: Vec<Box<AsyncDependenciesBlock>>,
   // ===== inputs =======
   pub(crate) source: &'parser str,
+  pub(crate) diagnostic_source: BoxSource,
   pub ast: &'parser ParsedJavaScriptAst<'parser>,
   pub parse_meta: ParseMeta,
   pub factory_meta: Option<&'parser FactoryMeta>,
@@ -467,6 +468,7 @@ impl<'parser> JavascriptParser<'parser> {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     source: &'parser str,
+    diagnostic_source: BoxSource,
     ast: &'parser ParsedJavaScriptAst<'parser>,
     compiler_options: &'parser CompilerOptions,
     javascript_options: &'parser JavascriptParserOptions,
@@ -604,6 +606,7 @@ impl<'parser> JavascriptParser<'parser> {
       ast,
       javascript_options,
       source,
+      diagnostic_source,
       errors,
       warning_diagnostics,
       dependencies,
@@ -814,6 +817,10 @@ impl<'parser> JavascriptParser<'parser> {
 
   pub fn source(&self) -> &str {
     self.source
+  }
+
+  pub fn diagnostic_source(&self) -> &BoxSource {
+    &self.diagnostic_source
   }
 
   pub fn is_top_level_scope(&self) -> bool {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use rspack_core::DependencyRange;
+use rspack_core::{DependencyRange, rspack_sources::BoxSource};
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_regex::RspackRegex;
 use swc_atoms::Atom;
@@ -65,13 +65,13 @@ pub fn static_string_from_expr(expr: &Expr) -> Option<String> {
     })
 }
 
-pub fn create_traceable_error(
+pub fn create_traceable_error_from_source(
   title: String,
   message: String,
-  source: String,
+  source: BoxSource,
   span: DependencyRange,
 ) -> Error {
-  Error::from_string(
+  Error::from_source(
     Some(source),
     span.start as usize,
     span.end as usize,
@@ -105,10 +105,10 @@ pub fn clean_regexp_in_context_module(
 ) -> Option<RspackRegex> {
   if regexp.sticky() || regexp.global() {
     if let Some(error_span) = error_span {
-      let mut error = create_traceable_error(
+      let mut error = create_traceable_error_from_source(
         "Critical dependency".into(),
         "Contexts can't use RegExps with the 'g' or 'y' flags".to_string(),
-        parser.source.to_string(),
+        parser.diagnostic_source.clone(),
         error_span,
       );
       error.severity = Severity::Warning;

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -10,7 +10,9 @@ use rspack_plugin_javascript::{
     self,
     eval::{self},
   },
-  visitors::{JavascriptParser, Statement, VariableDeclaration, create_traceable_error, expr_name},
+  visitors::{
+    JavascriptParser, Statement, VariableDeclaration, create_traceable_error_from_source, expr_name,
+  },
 };
 use rspack_util::{SpanExt, atom::Atom, json_stringify_str, swc::get_swc_comments};
 use swc_experimental_ecma_ast::{
@@ -209,10 +211,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.requireActual` function expects 1 argument".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),
@@ -268,10 +270,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.importActual` function expects 1 argument".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),
@@ -459,10 +461,10 @@ impl RstestParserPlugin {
           parser.add_dependency(Box::new(module_dep));
         } else {
           parser.add_error(
-            create_traceable_error(
+            create_traceable_error_from_source(
               "Invalid function call".into(),
               "`rs.mock` function expects a string literal as the first argument".into(),
-              parser.source().to_string(),
+              parser.diagnostic_source().clone(),
               call_expr.span.into(),
             )
             .into(),
@@ -471,10 +473,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.mock` function expects 1 or 2 arguments".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),
@@ -517,10 +519,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.hoisted` function expects 1 argument".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),
@@ -545,10 +547,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.resetModules` function expects 0 arguments".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),
@@ -636,10 +638,10 @@ impl RstestParserPlugin {
       }
       _ => {
         parser.add_error(
-          create_traceable_error(
+          create_traceable_error_from_source(
             "Invalid function call".into(),
             "`rs.importMock` or `rs.requireMock` function expects 1 argument".into(),
-            parser.source().to_string(),
+            parser.diagnostic_source().clone(),
             call_expr.span.into(),
           )
           .into(),


### PR DESCRIPTION
## Summary

Store diagnostic sources as `BoxSource` so parser and linking diagnostics reuse module sources instead of retaining flattened `Arc<str>` copies. Composite sources are flattened only for the duration of rendering.

## Memory results

Peak footprint, median of three runs with an approximately 60 MB module source:

| Warnings | Compile | Compile + `toJson` |
| ---: | ---: | ---: |
| 0 | 308.8 MB | 310.6 MB |
| 30 | 303.1 MB | 310.1 MB |
| 600 | 328.0 MB | 336.0 MB |

Before this change, 30 warnings retained an additional 55.1 MB. After the change, 30 warnings show no stable increase; 600 warnings add 19.3 MB during compile and 25.4 MB with `toJson`.

Doubling the source to approximately 120 MB leaves the 600-warning `toJson` increase nearly unchanged at 24.3 MB, indicating that the remaining growth comes from diagnostic metadata and rendered output rather than retained source copies.

This addresses source ownership only; the long single-line diagnostic rendering in #14961 remains.

Related: #14961