### PR TITLE
perf: cache compilation assets proxy

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -243,6 +243,7 @@ export class Compilation {
   #errors?: RspackError[];
   #warnings?: RspackError[];
   #chunks?: ReadonlySet<Chunk>;
+  #assetsProxy?: Assets;
 
   hooks: Readonly<{
     processAssets: liteTapable.AsyncSeriesHook<Assets>;
@@ -479,7 +480,10 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
    * Get a map of all assets.
    */
   get assets(): Record<string, Source> {
-    return this.#createCachedAssets();
+    if (!this.#assetsProxy) {
+      this.#assetsProxy = this.#createAssetsProxy();
+    }
+    return this.#assetsProxy;
   }
 
   /**
@@ -560,7 +564,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
     return this.#inner.codeGenerationResults;
   }
 
-  #createCachedAssets() {
+  #createAssetsProxy() {
     return new Proxy(
       {},
       {

--- a/tests/rspack-test/compilerCases/assets.js
+++ b/tests/rspack-test/compilerCases/assets.js
@@ -26,6 +26,22 @@ module.exports = [{
 		};
 	}
 }, {
+	description: "should cache the assets proxy per compilation",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./d",
+			plugins: [{
+				apply(compiler) {
+					compiler.hooks.compilation.tap("Plugin", compilation => {
+						const map = compilation.assets;
+						expect(compilation.assets).toBe(map);
+					});
+				}
+			}]
+		};
+	}
+}, {
 	description: "should have error if the asset to be emitted is exist",
 	error: true,
 	options(context) {


### PR DESCRIPTION
## Summary

Every `compilation.assets` access currently creates a new `Proxy` and handler closures, including repeated accesses from plugins and asset hooks.

This PR lazily reuses one Proxy per `Compilation`, avoiding repeated construction while its traps continue to read live asset state.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).