### PR TITLE
fix(ci): drop TARGET_CC=clang for ppc64le/s390x cross builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,29 @@ jobs:
       profile: 'ci'
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
+  # TEMP: verify the clang-15 step on a GitHub-hosted runner too
+  build-ppc64-hosted:
+    name: Build ppc64 hosted
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: powerpc64le-unknown-linux-gnu
+      profile: 'ci'
+      runner: '"ubuntu-22.04"'
+      binding_postfix: '-hosted'
+
+  build-s390x-hosted:
+    name: Build s390x hosted
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: s390x-unknown-linux-gnu
+      profile: 'ci'
+      runner: '"ubuntu-22.04"'
+      binding_postfix: '-hosted'
+
   # TODO: Enable this job after Rspack portable cache is implemented.
   check-cache:
     name: Check Cache Portable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,26 @@ jobs:
       profile: 'ci'
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
+  build-ppc64:
+    name: Build ppc64
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: powerpc64le-unknown-linux-gnu
+      profile: 'ci'
+      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+
+  build-s390x:
+    name: Build s390x
+    needs: [check-changed]
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
+    uses: ./.github/workflows/reusable-build-build.yml
+    with:
+      target: s390x-unknown-linux-gnu
+      profile: 'ci'
+      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+
   # TODO: Enable this job after Rspack portable cache is implemented.
   check-cache:
     name: Check Cache Portable
@@ -187,6 +207,8 @@ jobs:
         test-mac,
         build-wasm,
         build-riscv64,
+        build-ppc64,
+        build-s390x,
         test-wasm,
         check-changed,
         size-limit,
@@ -200,13 +222,13 @@ jobs:
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name == 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,skipped' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,success,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
           && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,skipped,skipped' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,skipped,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,29 +165,6 @@ jobs:
       profile: 'ci'
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
-  # TEMP: verify the clang-15 step on a GitHub-hosted runner too
-  build-ppc64-hosted:
-    name: Build ppc64 hosted
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: powerpc64le-unknown-linux-gnu
-      profile: 'ci'
-      runner: '"ubuntu-22.04"'
-      binding_postfix: '-hosted'
-
-  build-s390x-hosted:
-    name: Build s390x hosted
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: s390x-unknown-linux-gnu
-      profile: 'ci'
-      runner: '"ubuntu-22.04"'
-      binding_postfix: '-hosted'
-
   # TODO: Enable this job after Rspack portable cache is implemented.
   check-cache:
     name: Check Cache Portable

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -50,6 +50,10 @@ jobs:
             runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
           - target: riscv64gc-unknown-linux-musl
             runner: "'ubuntu-latest'"
+          - target: powerpc64le-unknown-linux-gnu
+            runner: "'ubuntu-latest'"
+          - target: s390x-unknown-linux-gnu
+            runner: "'ubuntu-latest'"
           - target: i686-pc-windows-msvc
             runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -52,6 +52,10 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-build-all.yml
+++ b/.github/workflows/reusable-build-all.yml
@@ -37,6 +37,10 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -86,6 +86,17 @@ jobs:
         with:
           tool: cargo-zigbuild
 
+      - name: TEMP diagnose host compilers
+        if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu' }}
+        continue-on-error: true
+        run: |
+          which -a clang clang-14 clang-15 clang-16 clang-17 clang-18 gcc zig || true
+          clang --version || true
+          clang -print-targets || true
+          ls -d /usr/lib/llvm-* 2>/dev/null || true
+          sudo apt-get update -qq || true
+          apt-cache policy clang clang-14 clang-15 llvm || true
+
       # setup rust target for native runner
       - name: Setup Rust Target
         run: rustup target add ${{ inputs.target }}
@@ -158,6 +169,16 @@ jobs:
       - name: Build s390x-unknown-linux-gnu
         if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
         run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+
+      - name: TEMP diagnose napi cross toolchain
+        if: ${{ always() && (inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu') }}
+        continue-on-error: true
+        run: |
+          find "$HOME/.napi-rs" -maxdepth 4 -type d -name bin 2>/dev/null
+          for cc in $(find "$HOME/.napi-rs" -type f -name '*-gcc' 2>/dev/null); do
+            echo "== $cc"
+            "$cc" --version | head -1
+          done
 
       # Windows
       - name: Build i686-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -86,14 +86,11 @@ jobs:
         with:
           tool: cargo-zigbuild
 
-      # The `clang` on PATH may come from the Android NDK, whose LLVM lacks the
-      # PowerPC and SystemZ backends.
-      - name: Install clang for ppc64/s390x cross build
+      - name: Install clang with PowerPC and SystemZ backends
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-15
-          /usr/bin/clang-15 -print-targets
 
       # setup rust target for native runner
       - name: Setup Rust Target

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -86,16 +86,14 @@ jobs:
         with:
           tool: cargo-zigbuild
 
-      - name: TEMP diagnose host compilers
+      # The `clang` on PATH may come from the Android NDK, whose LLVM lacks the
+      # PowerPC and SystemZ backends.
+      - name: Install clang for ppc64/s390x cross build
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu' }}
-        continue-on-error: true
         run: |
-          which -a clang clang-14 clang-15 clang-16 clang-17 clang-18 gcc zig || true
-          clang --version || true
-          clang -print-targets || true
-          ls -d /usr/lib/llvm-* 2>/dev/null || true
-          sudo apt-get update -qq || true
-          apt-cache policy clang clang-14 clang-15 llvm || true
+          sudo apt-get update
+          sudo apt-get install -y clang-15
+          /usr/bin/clang-15 -print-targets
 
       # setup rust target for native runner
       - name: Setup Rust Target
@@ -165,20 +163,14 @@ jobs:
       - name: Build powerpc64le-unknown-linux-gnu
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
         run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+        env:
+          TARGET_CC: /usr/bin/clang-15
 
       - name: Build s390x-unknown-linux-gnu
         if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
         run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
-
-      - name: TEMP diagnose napi cross toolchain
-        if: ${{ always() && (inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu') }}
-        continue-on-error: true
-        run: |
-          find "$HOME/.napi-rs" -maxdepth 4 -type d -name bin 2>/dev/null
-          for cc in $(find "$HOME/.napi-rs" -type f -name '*-gcc' 2>/dev/null); do
-            echo "== $cc"
-            "$cc" --version | head -1
-          done
+        env:
+          TARGET_CC: /usr/bin/clang-15
 
       # Windows
       - name: Build i686-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -151,6 +151,18 @@ jobs:
         env:
           TARGET_CC: clang
 
+      - name: Build powerpc64le-unknown-linux-gnu
+        if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
+        run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+        env:
+          TARGET_CC: clang
+
+      - name: Build s390x-unknown-linux-gnu
+        if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
+        run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
+        env:
+          TARGET_CC: clang
+
       # Windows
       - name: Build i686-pc-windows-msvc
         if: ${{ inputs.target == 'i686-pc-windows-msvc' }}

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -88,9 +88,7 @@ jobs:
 
       - name: Install clang with PowerPC and SystemZ backends
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' || inputs.target == 's390x-unknown-linux-gnu' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-15
+        run: command -v clang-15 || { sudo apt-get update && sudo apt-get install -y clang-15; }
 
       # setup rust target for native runner
       - name: Setup Rust Target
@@ -161,13 +159,13 @@ jobs:
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
         run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
         env:
-          TARGET_CC: /usr/bin/clang-15
+          TARGET_CC: clang-15
 
       - name: Build s390x-unknown-linux-gnu
         if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
         run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
         env:
-          TARGET_CC: /usr/bin/clang-15
+          TARGET_CC: clang-15
 
       # Windows
       - name: Build i686-pc-windows-msvc

--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -154,14 +154,10 @@ jobs:
       - name: Build powerpc64le-unknown-linux-gnu
         if: ${{ inputs.target == 'powerpc64le-unknown-linux-gnu' }}
         run: RUST_TARGET=powerpc64le-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
-        env:
-          TARGET_CC: clang
 
       - name: Build s390x-unknown-linux-gnu
         if: ${{ inputs.target == 's390x-unknown-linux-gnu' }}
         run: RUST_TARGET=s390x-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:${{ inputs.profile }}
-        env:
-          TARGET_CC: clang
 
       # Windows
       - name: Build i686-pc-windows-msvc

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -97,6 +97,8 @@ jobs:
         node: ${{ fromJSON(
           inputs.target == 'wasm32-wasip1-threads'&& '[24]'
           || inputs.target == 'riscv64gc-unknown-linux-gnu' && '[22]'
+          || inputs.target == 'powerpc64le-unknown-linux-gnu' && '[22]'
+          || inputs.target == 's390x-unknown-linux-gnu' && '[22]'
           || contains(inputs.target, 'linux') && '[22, 24]'
           || '[22]') }}
     name: Test Node ${{ matrix.node }}

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -58,6 +58,12 @@ jobs:
           - target: riscv64gc-unknown-linux-musl
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
             test-runner: '"ubuntu-22.04"'
+          - target: powerpc64le-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            test-runner: '"ubuntu-22.04"'
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            test-runner: '"ubuntu-22.04"'
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
             test-runner: '"windows-latest"'

--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ npm/**/*.node
 !npm/linux-arm64-musl
 !npm/linux-riscv64-gnu
 !npm/linux-riscv64-musl
+!npm/linux-ppc64-gnu
+!npm/linux-s390x-gnu
 !npm/linux-x64-gnu/
 !npm/linux-x64-musl
 !npm/wasm32-wasi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,9 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json-escape-simd"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a18a0eb3c0a783620d2ae8cdda9590aae18b1608964ee9c7c43162562786424"
+checksum = "c22a2041e3874a055a4eb03ea2395aaccdefa84ce75b31d542d72a741c3c6ad3"
 
 [[package]]
 name = "json-strip-comments"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ insta               = { version = "1.42.0", default-features = false }
 itertools           = { version = "0.14.0", default-features = false, features = ["use_std"] }
 itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
-json-escape-simd    = { version = "3.1.0", default-features = false }
+json-escape-simd    = { version = "3.1.1", default-features = false }
 lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
 md4                 = { version = "0.10.2", default-features = false }
 memchr              = { version = "2.8.2", default-features = false }

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -57,7 +57,9 @@
       "aarch64-unknown-linux-musl",
       "aarch64-pc-windows-msvc",
       "riscv64gc-unknown-linux-gnu",
-      "riscv64gc-unknown-linux-musl"
+      "riscv64gc-unknown-linux-musl",
+      "powerpc64le-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,
@@ -76,6 +78,8 @@
     "@rspack/binding-linux-arm64-musl": "workspace:*",
     "@rspack/binding-linux-riscv64-gnu": "workspace:*",
     "@rspack/binding-linux-riscv64-musl": "workspace:*",
+    "@rspack/binding-linux-ppc64-gnu": "workspace:*",
+    "@rspack/binding-linux-s390x-gnu": "workspace:*",
     "@rspack/binding-linux-x64-gnu": "workspace:*",
     "@rspack/binding-linux-x64-musl": "workspace:*",
     "@rspack/binding-wasm32-wasi": "workspace:*",

--- a/crates/rspack_binding_builder_testing/package.json
+++ b/crates/rspack_binding_builder_testing/package.json
@@ -45,7 +45,9 @@
       "aarch64-unknown-linux-musl",
       "aarch64-pc-windows-msvc",
       "riscv64gc-unknown-linux-gnu",
-      "riscv64gc-unknown-linux-musl"
+      "riscv64gc-unknown-linux-musl",
+      "powerpc64le-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu"
     ],
     "wasm": {
       "initialMemory": 16384,

--- a/npm/linux-ppc64-gnu/package.json
+++ b/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rspack/binding-linux-ppc64-gnu",
+  "version": "2.1.5",
+  "license": "MIT",
+  "description": "Node binding for rspack",
+  "main": "rspack.linux-ppc64-gnu.node",
+  "homepage": "https://rspack.rs",
+  "bugs": "https://github.com/web-infra-dev/rspack/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "os": [
+      "linux"
+    ],
+    "cpu": [
+      "ppc64"
+    ],
+    "libc": [
+      "glibc"
+    ]
+  },
+  "files": [
+    "rspack.linux-ppc64-gnu.node"
+  ]
+}

--- a/npm/linux-s390x-gnu/package.json
+++ b/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@rspack/binding-linux-s390x-gnu",
+  "version": "2.1.5",
+  "license": "MIT",
+  "description": "Node binding for rspack",
+  "main": "rspack.linux-s390x-gnu.node",
+  "homepage": "https://rspack.rs",
+  "bugs": "https://github.com/web-infra-dev/rspack/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rspack",
+    "directory": "packages/rspack"
+  },
+  "publishConfig": {
+    "access": "public",
+    "os": [
+      "linux"
+    ],
+    "cpu": [
+      "s390x"
+    ],
+    "libc": [
+      "glibc"
+    ]
+  },
+  "files": [
+    "rspack.linux-s390x-gnu.node"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,12 +544,18 @@ importers:
       '@rspack/binding-linux-arm64-musl':
         specifier: workspace:*
         version: link:../../npm/linux-arm64-musl
+      '@rspack/binding-linux-ppc64-gnu':
+        specifier: workspace:*
+        version: link:../../npm/linux-ppc64-gnu
       '@rspack/binding-linux-riscv64-gnu':
         specifier: workspace:*
         version: link:../../npm/linux-riscv64-gnu
       '@rspack/binding-linux-riscv64-musl':
         specifier: workspace:*
         version: link:../../npm/linux-riscv64-musl
+      '@rspack/binding-linux-s390x-gnu':
+        specifier: workspace:*
+        version: link:../../npm/linux-s390x-gnu
       '@rspack/binding-linux-x64-gnu':
         specifier: workspace:*
         version: link:../../npm/linux-x64-gnu
@@ -659,9 +665,13 @@ importers:
 
   npm/linux-arm64-musl: {}
 
+  npm/linux-ppc64-gnu: {}
+
   npm/linux-riscv64-gnu: {}
 
   npm/linux-riscv64-musl: {}
+
+  npm/linux-s390x-gnu: {}
 
   npm/linux-x64-gnu: {}
 

--- a/scripts/build-npm.cjs
+++ b/scripts/build-npm.cjs
@@ -12,6 +12,8 @@ const CpuToNodeArch = {
   i686: 'ia32',
   armv7: 'arm',
   riscv64gc: 'riscv64',
+  powerpc64le: 'ppc64',
+  s390x: 's390x',
 };
 
 const SysToNodePlatform = {

--- a/website/docs/en/contribute/development/releasing.md
+++ b/website/docs/en/contribute/development/releasing.md
@@ -19,6 +19,8 @@ During the release, the following binary artifacts for the target platforms are 
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
 - riscv64gc-unknown-linux-gnu
+- powerpc64le-unknown-linux-gnu
+- s390x-unknown-linux-gnu
 - x86_64-unknown-linux-musl
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -46,6 +46,8 @@ Currently supported platforms:
 - `linux-arm64-musl`
 - `linux-riscv64-gnu`
 - `linux-riscv64-musl`
+- `linux-ppc64-gnu`
+- `linux-s390x-gnu`
 - `linux-x64-gnu`
 - `linux-x64-musl`
 - `win32-arm64-msvc`

--- a/website/docs/zh/contribute/development/releasing.md
+++ b/website/docs/zh/contribute/development/releasing.md
@@ -19,6 +19,8 @@ Latest 是最新的稳定版本，遵循 Semantic Versioning 语义化版本号�
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
 - riscv64gc-unknown-linux-gnu
+- powerpc64le-unknown-linux-gnu
+- s390x-unknown-linux-gnu
 - x86_64-unknown-linux-musl
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -46,6 +46,8 @@ Rspack 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) �
 - `linux-arm64-musl`
 - `linux-riscv64-gnu`
 - `linux-riscv64-musl`
+- `linux-ppc64-gnu`
+- `linux-s390x-gnu`
 - `linux-x64-gnu`
 - `linux-x64-musl`
 - `win32-arm64-msvc`

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -152,6 +152,8 @@ perfetto
 Peschke
 pftrace
 pmmmwh
+powerpc64le
+ppc64
 proxied
 proxying
 px2rem
@@ -180,6 +182,7 @@ ruleoneof
 ruleparserdataurlcondition
 Rust
 rustup
+s390x
 samply
 samsung
 sanyuan


### PR DESCRIPTION
Verification draft on top of #14962. Not for merge — the fix is the workflow change on top of #14962's commits.

## Why

#14962's ppc64le/s390x builds fail on the self-hosted Linux runners:

```
psm:             clang -cc1as: error: unknown target triple 's390x-unknown-linux-gnu'
libmimalloc-sys: error: unable to create target: 'No available targets are compatible with triple "s390x-unknown-linux-gnu"'
```

The `clang` on PATH there is the Android NDK one, whose LLVM has no PowerPC/SystemZ backend:

```
$ which clang
/home/runner/Android/SDK/ndk/21.1.6352462/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
$ clang --version
Android (6317467 based on r365631c1) clang version 9.0.8 (based on LLVM 9.0.8svn)
```

x86_64/aarch64 share the same `TARGET_CC: clang` and are fine because that clang does have their backends. #14962's own CI was green only because it comes from a fork: `vars.LINUX_SELF_HOSTED_RUNNER_LABELS` is empty in that context, so its jobs fell back to GitHub-hosted `ubuntu-22.04`, where `clang` is the system clang-14 with all backends. Once merged, `Build ppc64` / `Build s390x` on main run on self-hosted and break — https://github.com/web-infra-dev/rspack/actions/runs/30985725683.

Dropping `TARGET_CC` altogether does not work either: `--use-napi-cross` then falls back to the cross toolchain's own gcc, which is old enough to reject `-fdiagnostics-color=always` and `-Wdate-time` (GCC < 4.9). That gcc is meant to supply the sysroot, binutils and linker, not to compile.

So make these two jobs use clang-15, which has both backends, and keep the napi cross sysroot and its glibc 2.17 baseline. The install is a no-op on GitHub-hosted runners, which already ship clang-15.

## Verified

Both targets green on both runner types (temporary extra jobs pinned to `ubuntu-22.04` were used for the hosted side and have been removed again):

| target | runner | `command -v clang-15` | result |
| --- | --- | --- | --- |
| powerpc64le | self-hosted | miss, apt installs 15.0.7 | pass 6m09s |
| s390x | self-hosted | miss, apt installs 15.0.7 | pass 6m44s |
| powerpc64le | ubuntu-22.04 | hit `/usr/bin/clang-15` | pass 17m02s |
| s390x | ubuntu-22.04 | hit `/usr/bin/clang-15` | pass 16m24s |
