### PR TITLE
fix: keep compilation dependency iterators disjoint

### DIFF
--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -525,7 +525,7 @@ impl Compilation {
       .build_module_graph_artifact
       .context_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.context_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .context_dependencies
@@ -554,7 +554,7 @@ impl Compilation {
       .build_module_graph_artifact
       .missing_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.missing_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .missing_dependencies
@@ -583,7 +583,7 @@ impl Compilation {
       .build_module_graph_artifact
       .build_dependencies
       .added_files()
-      .chain(&self.file_dependencies);
+      .chain(&self.build_dependencies);
     let updated_files = self
       .build_module_graph_artifact
       .build_dependencies


### PR DESCRIPTION
## Summary

- keep compilation-level context, missing, and build dependencies in their corresponding `added` iterators
- prevent compilation-level file dependencies from leaking into the other dependency categories

The context, missing, and build iterator implementations incorrectly chained `self.file_dependencies` when reporting compilation-level additions. As a result, consumers could receive file dependencies under unrelated categories while omitting the actual compilation-level dependency for that category.

## Related links

- Split from #14844.

## Testing

- dev binding build (`node scripts/build.js` from `crates/node_binding`)
- `cargo fmt --all --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
