### PR TITLE
fix(lazy): match compiler prefixes exactly

### DIFF
--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -80,7 +80,9 @@ export const lazyCompilationMiddleware = (
 
     const keys = [...middlewareByCompiler.keys()];
     return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
-      const key = keys.find((key) => req.url?.startsWith(key));
+      const key = keys.find(
+        (key) => req.url === key || req.url?.startsWith(`${key}?`),
+      );
       if (!key) {
         return next?.();
       }

--- a/tests/rspack-test/multiCompilerCases/lazy-compilation.js
+++ b/tests/rspack-test/multiCompilerCases/lazy-compilation.js
@@ -1,9 +1,10 @@
 const { LazyCompilationTestPlugin } = require("@rspack/test-tools");
+const { lazyCompilationMiddleware } = require("@rspack/core");
 const path = require("path");
 const context = path.join(__dirname, "../fixtures");
 
-/** @type {import('@rspack/test-tools').TMultiCompilerCaseConfig} */
-module.exports = {
+/** @type {import('@rspack/test-tools').TMultiCompilerCaseConfig[]} */
+module.exports = [{
   description: "compiler has unique lazy compilation config",
   options() {
     return [
@@ -79,4 +80,95 @@ module.exports = {
       });
     });
   }
-};
+}, {
+  description: "should route colliding lazy compilation prefixes exactly",
+  options(testContext) {
+    return Array.from({ length: 11 }, (_, index) => {
+      const name = `compiler-${index}`;
+      return {
+        context,
+        mode: "development",
+        name,
+        target: "web",
+        devtool: false,
+        entry: "./esm/a.js",
+        lazyCompilation: { entries: true, imports: false },
+        output: {
+          path: testContext.getDist(name),
+          filename: "main.js",
+          chunkFilename: "[name].js"
+        }
+      };
+    });
+  },
+  async build(testContext, compiler) {
+    const builds = [];
+    const waiters = [];
+    const nextBuild = () =>
+      builds.length > 0
+        ? Promise.resolve(builds.shift())
+        : new Promise((resolve, reject) => {
+          const timeout = setTimeout(
+            () => reject(new Error("Timed out waiting for a lazy rebuild")),
+            10000
+          );
+          waiters.push(value => {
+            clearTimeout(timeout);
+            resolve(value);
+          });
+        });
+    const middleware = lazyCompilationMiddleware(compiler);
+
+    compiler.watch({}, (error, stats) => {
+      const value = {
+        error:
+          error ??
+          (stats?.hasErrors()
+            ? new Error(stats.toString({ all: false, errors: true }))
+            : undefined),
+        stats
+      };
+      (waiters.shift() ?? (build => builds.push(build)))(value);
+    });
+
+    try {
+      const initial = await nextBuild();
+      expect(initial.error).toBeUndefined();
+      const bundle = initial.stats.stats[10].compilation
+        .getAsset("main.js")
+        .source.source()
+        .toString();
+      const encoded = bundle.match(/var data = ("(?:[^"\\]|\\.)*")/)?.[1];
+      expect(encoded).toBeDefined();
+      const moduleId = JSON.parse(encoded);
+
+      await new Promise((resolve, reject) => {
+        middleware(
+          {
+            body: [moduleId],
+            method: "POST",
+            url: "/_rspack/lazy/trigger__10?source=test"
+          },
+          {
+            end: resolve,
+            write() {},
+            writeHead(status) {
+              expect(status).toBe(200);
+            }
+          },
+          reject
+        ).catch(reject);
+      });
+
+      const updated = await nextBuild();
+      expect(updated.error).toBeUndefined();
+      expect(updated.stats.stats.map(child => child.compilation.name)).toEqual([
+        "compiler-10"
+      ]);
+    } finally {
+      await new Promise((resolve, reject) =>
+        compiler.close(error => (error ? reject(error) : resolve()))
+      );
+    }
+  }
+}];

--- a/tests/rspack-test/multiCompilerCases/lazy-compilation.js
+++ b/tests/rspack-test/multiCompilerCases/lazy-compilation.js
@@ -83,8 +83,12 @@ module.exports = [{
 }, {
   description: "should route colliding lazy compilation prefixes exactly",
   options(testContext) {
-    return Array.from({ length: 11 }, (_, index) => {
-      const name = `compiler-${index}`;
+    const lazyCompilationPrefix = "/_rspack/lazy/trigger";
+    // Generated prefixes are `${lazyCompilationPrefix}__0` and `${lazyCompilationPrefix}__0__1`.
+    return [
+      { name: "compiler_1", prefix: lazyCompilationPrefix },
+      { name: "compiler_11", prefix: `${lazyCompilationPrefix}__0` }
+    ].map(({ name, prefix }) => {
       return {
         context,
         mode: "development",
@@ -92,7 +96,7 @@ module.exports = [{
         target: "web",
         devtool: false,
         entry: "./esm/a.js",
-        lazyCompilation: { entries: true, imports: false },
+        lazyCompilation: { entries: true, imports: false, prefix },
         output: {
           path: testContext.getDist(name),
           filename: "main.js",
@@ -134,7 +138,7 @@ module.exports = [{
     try {
       const initial = await nextBuild();
       expect(initial.error).toBeUndefined();
-      const bundle = initial.stats.stats[10].compilation
+      const bundle = initial.stats.stats[1].compilation
         .getAsset("main.js")
         .source.source()
         .toString();
@@ -147,7 +151,7 @@ module.exports = [{
           {
             body: [moduleId],
             method: "POST",
-            url: "/_rspack/lazy/trigger__10?source=test"
+            url: "/_rspack/lazy/trigger__0__1?source=test"
           },
           {
             end: resolve,
@@ -163,7 +167,7 @@ module.exports = [{
       const updated = await nextBuild();
       expect(updated.error).toBeUndefined();
       expect(updated.stats.stats.map(child => child.compilation.name)).toEqual([
-        "compiler-10"
+        "compiler_11"
       ]);
     } finally {
       await new Promise((resolve, reject) =>


### PR DESCRIPTION
## Summary

- require an exact lazy-compilation middleware prefix match, optionally followed by a query string
- prevent prefixes such as `trigger__1` from intercepting requests for `trigger__10`
- cover the colliding prefix case through the existing MultiCompiler case mechanism

The MultiCompiler middleware selected the first configured prefix for which `req.url.startsWith(prefix)` was true. Because compiler suffixes are decimal indices, a request for compiler 10 also matched compiler 1 and could be routed to the wrong child compiler. Matching either the complete prefix or the prefix followed by `?` preserves query strings without allowing one compiler prefix to consume another.

## Related links

- Split from #14844.

## Testing

- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "multiCompilerCases/lazy-compilation"`
- focused formatting and JavaScript lint checks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
