### PR TITLE
fix(watcher): preserve recursive context watches

### DIFF
--- a/crates/rspack_watcher/src/analyzer/directories.rs
+++ b/crates/rspack_watcher/src/analyzer/directories.rs
@@ -1,15 +1,15 @@
 #![allow(unused)]
 use rspack_paths::ArcPath;
-use rspack_util::fx_hash::FxHashSet as HashSet;
+use rspack_util::fx_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use super::{Analyzer, WatchPattern};
 use crate::paths::PathAccessor;
 
 /// `WatcherDirectoriesAnalyzer` analyzes the path register and determines
 ///
-/// which directories should be watched individually (non-recursively).
-/// This is typically used on platforms where recursive watching is not
-/// available or not desired, so each directory is watched separately.
+/// which directories should be watched individually. File parents stay
+/// non-recursive, while registered context directories must be recursive so
+/// changes in pre-existing child directories are observable.
 #[derive(Default)]
 pub struct WatcherDirectoriesAnalyzer;
 
@@ -25,25 +25,47 @@ impl Analyzer for WatcherDirectoriesAnalyzer {
 const DIRECTORY_WATCH_DEPTH: u32 = 2;
 
 impl WatcherDirectoriesAnalyzer {
-  /// Finds all directories that should be watched individually (non-recursively).
+  /// Finds all directories that should be watched individually, keeping the
+  /// strongest required mode when a file parent and context share a path.
   fn find_watch_directories<'a>(&self, path_accessor: PathAccessor<'a>) -> HashSet<WatchPattern> {
-    let mut patterns = HashSet::default();
-    let all = path_accessor.all();
-    for path in all {
+    let mut modes = HashMap::default();
+    let directories = path_accessor.directories().0;
+
+    for path in path_accessor.all() {
       if let Some((dir, deep)) = self.find_exists_path(path) {
-        // Insert the parent directory of the file
-        patterns.insert(WatchPattern {
-          path: dir,
-          mode: if deep >= DIRECTORY_WATCH_DEPTH {
-            notify::RecursiveMode::Recursive
-          } else {
-            notify::RecursiveMode::NonRecursive
-          },
-        });
+        let recursive = deep >= DIRECTORY_WATCH_DEPTH || directories.contains(&dir);
+        modes
+          .entry(dir)
+          .and_modify(|current| *current |= recursive)
+          .or_insert(recursive);
       }
     }
 
-    patterns
+    // A recursive root already covers its descendants. Re-registering a child
+    // non-recursively duplicates inotify work and can downgrade that child's mode.
+    let recursive_roots: HashSet<ArcPath> = modes
+      .iter()
+      .filter_map(|(path, recursive)| recursive.then_some(path.clone()))
+      .collect();
+
+    modes
+      .into_iter()
+      .filter(|(path, _)| {
+        path
+          .as_ref()
+          .ancestors()
+          .skip(1)
+          .all(|parent| !recursive_roots.contains(&ArcPath::from(parent)))
+      })
+      .map(|(path, recursive)| WatchPattern {
+        path,
+        mode: if recursive {
+          notify::RecursiveMode::Recursive
+        } else {
+          notify::RecursiveMode::NonRecursive
+        },
+      })
+      .collect()
   }
 
   /// Finds the deepest existing directory path and its depth.
@@ -101,7 +123,7 @@ mod tests {
     }));
     assert!(watch_patterns.contains(&WatchPattern {
       path: ArcPath::from(current_dir.join("src")),
-      mode: notify::RecursiveMode::NonRecursive
+      mode: notify::RecursiveMode::Recursive
     }));
   }
 
@@ -134,11 +156,7 @@ mod tests {
     let analyzer = WatcherDirectoriesAnalyzer::default();
     let watch_patterns = analyzer.analyze(path_manager.access());
 
-    assert_eq!(watch_patterns.len(), 3);
-    assert!(watch_patterns.contains(&WatchPattern {
-      path: dir_0.clone(),
-      mode: notify::RecursiveMode::NonRecursive,
-    }));
+    assert_eq!(watch_patterns.len(), 2);
     assert!(watch_patterns.contains(&WatchPattern {
       path: dir_0,
       mode: notify::RecursiveMode::Recursive,

--- a/crates/rspack_watcher/src/disk_watcher.rs
+++ b/crates/rspack_watcher/src/disk_watcher.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 
 use notify::{Event, EventKind, RecommendedWatcher, Watcher, event::ModifyKind};
 use rspack_paths::ArcPath;
@@ -85,17 +85,20 @@ impl DiskWatcher {
   ) -> rspack_error::Result<()> {
     let new_patterns: HashSet<WatchPattern> = patterns.collect();
 
-    let new_paths = new_patterns.iter().map(|p| &p.path).collect::<HashSet<_>>();
-
-    // Collect stale paths that are no longer needed, then unwatch and remove them.
-    let stale_paths: HashSet<ArcPath> = self
+    // A changed recursive mode must be unwatched before it is registered again.
+    let stale_patterns: Vec<(ArcPath, bool)> = self
       .watch_patterns
       .iter()
-      .filter(|p| !new_paths.contains(&p.path))
-      .map(|p| p.path.clone())
+      .filter(|p| !new_patterns.contains(*p))
+      .map(|p| {
+        (
+          p.path.clone(),
+          matches!(p.mode, notify::RecursiveMode::Recursive),
+        )
+      })
       .collect();
 
-    for path in &stale_paths {
+    for (path, _) in &stale_patterns {
       if let Some(watcher) = &mut self.inner
         && let Err(e) = watcher.unwatch(path)
         && !matches!(e.kind, notify::ErrorKind::WatchNotFound)
@@ -104,9 +107,24 @@ impl DiskWatcher {
       }
     }
 
-    self
-      .watch_patterns
-      .retain(|p| !stale_paths.contains(&p.path));
+    // notify's inotify backend removes every descendant watch when a recursive
+    // parent is unwatched, so retained children must also be registered again.
+    let stale_paths: HashSet<&Path> = stale_patterns
+      .iter()
+      .map(|(path, _)| path.as_ref())
+      .collect();
+    let stale_recursive_paths: HashSet<&Path> = stale_patterns
+      .iter()
+      .filter_map(|(path, recursive)| recursive.then_some(path.as_ref()))
+      .collect();
+    self.watch_patterns.retain(|p| {
+      !stale_paths.contains(p.path.as_ref())
+        && !p
+          .path
+          .as_ref()
+          .ancestors()
+          .any(|path| stale_recursive_paths.contains(path))
+    });
 
     for pattern in new_patterns {
       if self.watch_patterns.contains(&pattern) {

--- a/crates/rspack_watcher/tests/watcher.rs
+++ b/crates/rspack_watcher/tests/watcher.rs
@@ -173,3 +173,36 @@ fn should_emit_remove_when_a_watched_file_is_deleted() {
     },
   );
 }
+
+#[test]
+fn should_watch_a_file_created_in_an_existing_context_child() {
+  let mut helper = h!(FsWatcherOptions {
+    aggregate_timeout: Some(100),
+    ..Default::default()
+  });
+  std::fs::create_dir_all(helper.join("assets/empty-child")).unwrap();
+
+  let rx = watch!(dirs @ helper, "assets");
+
+  helper.tick(|| {
+    helper.file("assets/empty-child/created.txt");
+  });
+
+  let context_change_events = c!();
+  helper.collect_events(
+    rx,
+    |_, _| {},
+    |changes, abort| {
+      changes.assert_changed(helper.join("assets"));
+      assert!(
+        !changes
+          .changed_files
+          .contains(helper.join("assets/empty-child/created.txt").as_str())
+      );
+      add!(context_change_events);
+      *abort = true;
+    },
+  );
+
+  assert!(load!(context_change_events) > 0);
+}


### PR DESCRIPTION
### PR Overview

This bug fix keeps the native watcher aligned with the current dependency set when context coverage or watch modes change across rebuilds. It was extracted from #14844 and is independent of #15019. The change is internal to `rspack_watcher`; it does not change public JavaScript/Rust APIs, configuration, or documented behavior.

### Problem and Trigger

On platforms that use `WatcherDirectoriesAnalyzer`, including Linux, an existing context directory was previously watched non-recursively because its mode was derived only from the number of missing path segments. A write such as `assets/empty-child/created.txt`, where `empty-child` already existed when watching started, could therefore be missed.

Two transition cases could also desynchronize Rspack's bookkeeping from the OS watcher: changing the same path between `NonRecursive` and `Recursive` was ignored by path-only diffing, and removing a recursive inotify parent also removed its descendant OS watches even when Rspack still considered a retained child registered.

### Previous Design and Root Cause

`WatcherDirectoriesAnalyzer` emitted an independent `WatchPattern` for every dependency. Because recursive mode is part of `WatchPattern` identity, one path could be represented with different modes, and child patterns already covered by a recursive ancestor were retained.

`DiskWatcher::watch` determined stale registrations from paths only and removed only those exact paths from `watch_patterns`. A mode change could leave the previous registration active, while recursively unwatching a parent could silently invalidate descendant OS watches without removing the corresponding retained entries from Rspack's internal set.

### Fix Design

- Aggregate requirements by path and keep the strongest required mode: registered contexts use `Recursive`, while ordinary file parents remain `NonRecursive`.
- Remove child patterns already covered by a recursive ancestor.
- Diff complete `WatchPattern` values so a mode change unwatches the old registration before adding the new one.
- When a stale recursive root is removed, evict its descendants from internal bookkeeping using component-aware `Path::ancestors`; retained descendants are then registered again, while similarly prefixed sibling paths remain independent.
- Reuse the existing watcher integration entry to verify that creating a file below a pre-existing context child reports the registered context, rather than the unregistered child file, as changed.

### Correctness Risks

No material correctness defect was identified from the inspected changes. The fix directly realigns analyzer output, internal registration state, and OS watcher state, and it does not cross a public compatibility boundary. The end-to-end test covers the original recursive-context trigger through `FsWatcher`, and the remote watcher matrix is green on Linux, macOS, and Windows. Mode replacement and retained-descendant re-registration do not have dedicated isolated regression cases, so those paths were assessed from their state transitions and `notify`'s inotify unwatch semantics.

### Performance Regression Risks

No material performance regression is expected. The analyzer adds an `FxHashMap` and ancestor checks, while `DiskWatcher::watch` creates temporary collections proportional to stale registrations. This work runs when watch registrations are refreshed, not for each filesystem event, and pruning descendants covered by recursive roots can reduce redundant native watches. No dedicated performance benchmark was added for this split.

<details>
<summary>Translation</summary>

**本评论仅用于辅助代码审查，不构成直接的代码审查建议。**

### PR 概览

这是一个 bug fix，用于在跨重建过程中 context 覆盖范围或 watch mode 发生变化时，确保 native watcher 始终与当前 dependency set 保持一致。该改动从 #14844 中拆出，并且不依赖 #15019。改动仅限于 `rspack_watcher` 内部，不会改变公开的 JavaScript/Rust API、配置或文档约定。

### 问题与触发条件

在使用 `WatcherDirectoriesAnalyzer` 的平台（包括 Linux）上，旧实现仅根据缺失路径段的数量决定 watch mode，因此一个已经存在的 context directory 会被注册为非递归监听。如果 `empty-child` 在监听开始前就已存在，那么写入 `assets/empty-child/created.txt` 之类的操作可能无法被观察到。

另外两个切换场景也可能让 Rspack 的内部记录与 OS watcher 状态失去同步：同一路径在 `NonRecursive` 与 `Recursive` 之间切换时，基于 path 的差异计算会忽略 mode 变化；移除一个递归 inotify parent 时，底层还会移除 descendant OS watches，即使 Rspack 仍认为某个 retained child 已经注册。

### 旧设计与根因

`WatcherDirectoriesAnalyzer` 为每个 dependency 独立生成 `WatchPattern`。由于 recursive mode 是 `WatchPattern` identity 的一部分，同一个 path 可能以不同 mode 同时出现，而且已经被 recursive ancestor 覆盖的 child pattern 仍会保留。

`DiskWatcher::watch` 只根据 path 判断 stale registration，并且只从 `watch_patterns` 中删除这些完全相同的 path。因此 mode 变化可能让旧 registration 继续存在；递归取消 parent 的监听时，也可能在没有清除 Rspack retained entry 的情况下，使 descendant OS watch 静默失效。

### 修复设计

- 按 path 汇总监听需求并保留最强的 mode：注册的 context 使用 `Recursive`，普通 file parent 保持 `NonRecursive`。
- 删除已经被 recursive ancestor 覆盖的 child pattern。
- 比较完整的 `WatchPattern`，使 mode 变化时先取消旧 registration，再添加新 registration。
- 移除 stale recursive root 时，通过具备 path component 语义的 `Path::ancestors` 清除内部 descendant 记录；retained descendant 随后会重新注册，而名称前缀相似的 sibling path 不受影响。
- 复用现有 watcher integration entry，验证在预先存在的 context child 下创建文件时，被报告为 changed 的是已注册的 context，而不是未注册的 child file。

### 正确性风险

从已检查的改动中没有发现实质性正确性缺陷。该修复直接重新对齐 analyzer output、内部 registration state 与 OS watcher state，并且不涉及公开兼容性边界。端到端测试通过 `FsWatcher` 覆盖了原始 recursive-context 触发场景，远端 watcher matrix 在 Linux、macOS 和 Windows 上均已通过。mode replacement 与 retained-descendant re-registration 没有独立的专用回归 case，因此对这两条路径的判断主要来自状态转换分析以及 `notify` 的 inotify unwatch 语义。

### 性能回归风险

预计不会产生实质性性能回归。analyzer 新增了一个 `FxHashMap` 和 ancestor 检查，`DiskWatcher::watch` 会创建与 stale registration 数量成比例的临时集合。这些工作只发生在刷新 watch registration 时，而不是每次 filesystem event 到来时；同时，删除已被 recursive root 覆盖的 descendant 可以减少冗余的 native watch。本次拆分没有新增专用性能 benchmark。

</details>
