### PR TITLE
fix: preserve ignored URL when import.meta.url is disabled

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -97,6 +97,7 @@ pub fn get_url_request(
 
 pub struct URLPlugin {
   pub mode: Option<JavascriptParserUrl>,
+  pub import_meta_url_enabled: bool,
 }
 
 #[rspack_macros::implemented_javascript_parser_hooks]
@@ -121,7 +122,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
     let magic_comment_options = try_extract_magic_comment(parser, expr.span, arg.span());
     match magic_comment_options.get_ignore_value() {
       Some(MagicCommentValue::Bool(true)) => {
-        if args.len() != 2 {
+        if args.len() != 2 || !self.import_meta_url_enabled {
           return None;
         }
         let arg2 = args.get(1)?;

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -3,9 +3,9 @@
 use concat_string::concat_string;
 use rspack_core::{
   ChunkInitFragments, ChunkUkey, CodeGenerationDataFilename, Compilation, CompilationParams,
-  CompilerCompilation, DependencyId, JavascriptParserUrl, Module, ModuleType,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, PathData, Plugin, PublicPath,
-  RuntimeCodeTemplate, RuntimeGlobals, RuntimeSpec, SourceType, URLStaticMode,
+  CompilerCompilation, DependencyId, ImportMetaKnownProperties, JavascriptParserUrl, Module,
+  ModuleType, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, PathData, Plugin,
+  PublicPath, RuntimeCodeTemplate, RuntimeGlobals, RuntimeSpec, SourceType, URLStaticMode,
   get_js_chunk_filename_template, get_undo_path,
   rspack_sources::{BoxSource, ReplaceSource, SourceExt},
 };
@@ -184,6 +184,9 @@ async fn normal_module_factory_parser(
     if !matches!(options.url, Some(JavascriptParserUrl::Disable)) {
       parser.add_parser_plugin(Box::new(crate::parser_plugin::URLPlugin {
         mode: options.url,
+        import_meta_url_enabled: options
+          .import_meta()
+          .is_known_property_enabled(ImportMetaKnownProperties::URL),
       }));
     }
   }

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/disabled-fields.js
@@ -14,6 +14,7 @@ export default {
 	filename: import.meta.filename,
 	globType: typeof import.meta.glob,
 	hotType: typeof import.meta.webpackHot,
+	ignoredUrl: new URL(/* rspackIgnore: true */ "external", import.meta.url),
 	main: import.meta.main,
 	sourceDirname,
 	sourceFilename,

--- a/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
+++ b/tests/rspack-test/configCases/module/import-meta-parser-options/index.js
@@ -19,11 +19,15 @@ it("should preserve disabled import.meta fields for runtime evaluation", () => {
 	expect(disabledFields.contextType).toBe("undefined");
 	expect(disabledFields.globType).toBe("undefined");
 	expect(disabledFields.hotType).toBe("undefined");
+	expect(disabledFields.ignoredUrl.pathname.endsWith("external")).toBe(true);
 	expect(disabledFields.destructuredUrl).toBe(disabledFields.url);
 	expect(disabledFields.destructuredWebpack).toBeUndefined();
 
 	const source = fs.readFileSync(__filename, "utf-8");
 	const importMeta = ["import", "meta"].join(".");
+	expect(source).toContain(
+		`new URL(/* rspackIgnore: true */ "external", ${importMeta}.url)`
+	);
 	expect(source).toContain(`${importMeta}.url`);
 	expect(source).toContain(`${importMeta}.webpackContext`);
 	expect(source).toContain(`${importMeta}.glob`);


### PR DESCRIPTION
## Summary

Fix ignored `new URL(..., import.meta.url)` expressions when `module.parser.javascript.importMeta.url` is disabled.

The URL parser previously added a `RuntimeGlobals::BASE_URI` presentational dependency whenever `webpackIgnore: true` or `rspackIgnore: true` was present, without checking whether `import.meta.url` handling was enabled. For example:

```js
new URL(/* rspackIgnore: true */ "external", import.meta.url)
```

was incorrectly emitted as:

```js
new URL(/* rspackIgnore: true */ "external", __rspack_context.b)
```

The URL plugin now receives the resolved `importMeta.url` state and leaves the expression untouched when that field is disabled. A regression assertion was added to the existing `module/import-meta-parser-options` case to verify both runtime behavior and the emitted source.

## Related links

N/A.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test -t "configCases/module/import-meta-parser-options"`
- `pnpm run test -t "configCases/parsing/url-ignore"`
- `cargo fmt --all --check`
- Commit hooks: Rust/JavaScript formatting and JavaScript lint

## Checklist

- [x] Tests updated.
- [x] Documentation not required.

---
_by OpenAI Codex_