### PR TITLE
fix: handle optional chains in member hook traversal

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -10,8 +10,8 @@ use swc_experimental_ecma_ast::{
   GetterProp, Ident, IdentName, IfStmt, JSXAttr, JSXAttrOrSpread, JSXAttrValue, JSXElement,
   JSXElementChild, JSXElementName, JSXExpr, JSXExprContainer, JSXFragment, JSXMemberExpr,
   JSXNamespacedName, JSXObject, KeyValueProp, LabeledStmt, MemberExpr, MemberProp, MetaPropExpr,
-  ModuleDecl, ModuleItem, NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall, OptChainExpr,
-  Param, Pat, Prop, PropName, PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp,
+  ModuleDecl, ModuleItem, NewExpr, ObjectLit, ObjectPat, ObjectPatProp, OptCall, OptChainBase,
+  OptChainExpr, Param, Pat, Prop, PropName, PropOrSpread, RestPat, ReturnStmt, SeqExpr, SetterProp,
   SimpleAssignTarget, Stmt, SwitchCase, SwitchStmt, TaggedTpl, ThisExpr, ThrowStmt, Tpl, TryStmt,
   UnaryExpr, UnaryOp, UpdateExpr, VarDeclOrExpr, WhileStmt, WithStmt, YieldExpr,
 };
@@ -1194,6 +1194,7 @@ impl JavascriptParser<'_> {
           self.walk_member_expression_with_expression_name(
             expr,
             &expr_info.name,
+            &expr_info.members,
             Some(|this: &mut Self| {
               drive.unhandled_expression_member_chain(this, &expr_info.root_info, expr)
             }),
@@ -1253,23 +1254,37 @@ impl JavascriptParser<'_> {
     &mut self,
     expr: &MemberExpr,
     name: &str,
+    members: &[Atom],
     on_unhandled: Option<F>,
   ) where
     F: FnOnce(&mut Self) -> Option<bool>,
   {
     let drive = self.plugin_drive.clone();
-    if let Some(member) = expr.obj.as_member()
-      && let Some(len) = member_prop_len(&expr.prop)
+    let member = match &expr.obj {
+      Expr::Member(member) => Some(&**member),
+      Expr::OptChain(chain) => match &chain.base {
+        OptChainBase::Member(member) => Some(&**member),
+        OptChainBase::Call(_) => None,
+      },
+      _ => None,
+    };
+    if let Some(member) = member
+      && let Some(property) = members.last()
     {
       let origin = name.len();
-      let name = &name[0..origin - 1 - len];
+      let name = &name[0..origin - 1 - property.len()];
       if name
         .call_hooks_name(self, |this, for_name| drive.member(this, member, for_name))
         .unwrap_or_default()
       {
         return;
       }
-      self.walk_member_expression_with_expression_name(member, name, on_unhandled);
+      self.walk_member_expression_with_expression_name(
+        member,
+        name,
+        &members[..members.len() - 1],
+        on_unhandled,
+      );
     } else if on_unhandled.is_none() {
       self.walk_expression(&expr.obj);
     } else if let Some(on_unhandled) = on_unhandled
@@ -2137,13 +2152,5 @@ impl JavascriptParser<'_> {
         };
       }
     });
-  }
-}
-
-fn member_prop_len(member_prop: &MemberProp) -> Option<usize> {
-  match member_prop {
-    MemberProp::Ident(ident) => Some(ident.sym.len()),
-    MemberProp::PrivateName(name) => Some(name.name.len() + 1),
-    MemberProp::Computed(_) => None,
   }
 }

--- a/tests/rspack-test/configCases/parsing/import-meta-webpack-hot-member-chain/index.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-webpack-hot-member-chain/index.js
@@ -1,0 +1,5 @@
+it("should parse nested and computed import.meta.webpackHot member chains", () => {
+	expect(import.meta.webpackHot.data?.components?.Counter).toBeUndefined();
+	expect(import.meta.webpackHot["data"]).toBeUndefined();
+	expect(import.meta["webpackHot"].data).toBeUndefined();
+});

--- a/tests/rspack-test/configCases/parsing/import-meta-webpack-hot-member-chain/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-webpack-hot-member-chain/rspack.config.js
@@ -1,0 +1,9 @@
+const { HotModuleReplacementPlugin } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  target: 'web',
+  plugins: [new HotModuleReplacementPlugin()],
+};


### PR DESCRIPTION
## Summary

- Traverse member expressions wrapped in optional chains when resolving parser hooks.
- Reuse extracted static member names so computed properties behave like dot access.
- Add regression coverage for nested and computed `import.meta.webpackHot` chains.

Rspack previously treated `import.meta.webpackHot.data?.components` as an unsupported `import.meta` chain and emitted `undefined.data...`. This fixes the parser traversal generically instead of special-casing HMR or Octane.

## Related links

- Exposed by https://github.com/octanejs/octane/issues/485
- Octane workaround: https://github.com/octanejs/octane/pull/562
- Follow-up to https://github.com/web-infra-dev/rspack/issues/5596

## Validation

- `pnpm run build:binding:dev`
- New config case, including runtime-mode config
- Existing optional-chaining and `import.meta.webpackHot` config cases
- Relevant HMR update, recovery, and optional-chaining cases
- `cargo fmt --all --check`
- `cargo check -p rspack_plugin_javascript --all-targets --locked`
- JS formatting and pre-commit lint checks

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (not required; internal parser fix).

## Provenance

- [x] An agent produced this diff (`agent-authored`).
