### PR TITLE
fix(napi): avoid runtime lock deadlock

### DIFF
--- a/crates/rspack_napi/src/runtime.rs
+++ b/crates/rspack_napi/src/runtime.rs
@@ -125,13 +125,18 @@ where
   with_runtime(|runtime| runtime.spawn(future))
 }
 
-fn with_runtime<R>(f: impl FnOnce(&tokio::runtime::Runtime) -> R) -> R {
+fn with_runtime<R>(f: impl FnOnce(&tokio::runtime::Handle) -> R) -> R {
   start_runtime();
-  let runtime = RUNTIME.read().expect("Read tokio runtime failed");
-  let runtime = runtime
+  // Runtime operations can re-enter through JavaScript callbacks, so release the lock before
+  // executing them instead of holding a read guard across block_on.
+  let handle = RUNTIME
+    .read()
+    .expect("Read tokio runtime failed")
     .as_ref()
-    .expect("Access tokio runtime failed after initialization");
-  f(runtime)
+    .expect("Access tokio runtime failed after initialization")
+    .handle()
+    .clone();
+  f(&handle)
 }
 
 fn start_runtime() {

--- a/tests/rspack-test/configCases/input-file-system/css-loader/index.js
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/index.js
@@ -1,0 +1,5 @@
+require("./style.css");
+
+it("should compile css with a custom input file system", () => {
+	expect(true).toBe(true);
+});

--- a/tests/rspack-test/configCases/input-file-system/css-loader/rspack.config.js
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/rspack.config.js
@@ -1,0 +1,28 @@
+const fs = require('node:fs');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'javascript/auto',
+        use: ['css-loader'],
+      },
+    ],
+  },
+  experiments: {
+    css: false,
+    useInputFileSystem: [/.*/],
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.inputFileSystem = {
+          readFile: fs.readFile,
+          stat: fs.stat,
+        };
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/input-file-system/css-loader/shared.css
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/shared.css
@@ -1,0 +1,3 @@
+.shared {
+	color: blue;
+}

--- a/tests/rspack-test/configCases/input-file-system/css-loader/style.css
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/style.css
@@ -1,0 +1,3 @@
+.class {
+	color: red;
+}

--- a/tests/rspack-test/configCases/input-file-system/css-loader/style.css
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/style.css
@@ -1,3 +1,5 @@
+@import "./shared.css";
+
 .class {
 	color: red;
 }

--- a/tests/rspack-test/configCases/input-file-system/css-loader/test.config.js
+++ b/tests/rspack-test/configCases/input-file-system/css-loader/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	timeout: 10000
+};


### PR DESCRIPTION
## Summary

Fix a process-global Tokio runtime deadlock that can leave a build permanently idle when `experiments.useInputFileSystem` delegates file-system operations to JavaScript and a loader such as `css-loader` or `sass-loader` performs asynchronous resolution.

The change clones a Tokio `Handle` while the runtime lock is held, releases the lock, and only then executes `block_on` or `spawn`. The public APIs, runtime ownership, and environment cleanup model remain unchanged.

## Problem and Trigger

The regression was introduced in Rspack 2.1.3 when binding code moved from napi-rs's Tokio runtime helpers to the process-global runtime in `rspack_napi`.

A concrete trigger is:

1. `experiments.useInputFileSystem` is enabled and `compiler.inputFileSystem` delegates `readFile`/`stat` to JavaScript.
2. Rust performs a synchronous file-system operation through `NodeFileSystem::read_sync`, `metadata_sync`, or `read_dir_sync`.
3. That operation enters `rspack_napi::runtime::block_on` and invokes the JavaScript file-system callback.
4. During loader processing, `css-loader`/`sass-loader` calls `loaderContext.getResolve()`; `JsResolver.resolve()` converts the asynchronous resolver future into a callback through `callbackify`.
5. `callbackify` calls `rspack_napi::runtime::spawn` while the outer `block_on` is still waiting.

The result is a build that makes no further progress and must be interrupted; no normal compilation error is produced.

## Previous Design and Root Cause

`RUNTIME` stores the shared Tokio `Runtime` behind `RwLock<Option<Runtime>>`. Every runtime operation called `start_runtime()`, acquired the `RUNTIME` read lock, and invoked the supplied closure while the read guard remained alive.

The outer file-system `block_on` therefore held the read lock for the complete lifetime of its future. Re-entry through `runtime::spawn` called `start_runtime()`, which always requested the same lock in write mode—even when the runtime was already initialized. The write lock could not be granted until the outer read guard was released, while the outer future could not finish until the re-entered resolver work was scheduled. This circular wait is the deadlock.

## Fix Design and Why It Works

`with_runtime` now initializes the runtime, acquires the read lock only long enough to clone `Runtime::handle()`, and drops the read guard before invoking the operation.

The cloned `Handle` targets the same multi-thread Tokio runtime, so `block_on` and `spawn` retain their existing scheduling behavior. Because no runtime lock is held while the future or JavaScript callback executes, a nested `spawn` can acquire the write lock in `start_runtime()`, observe the already initialized runtime, and continue. This removes the circular wait at its source rather than adding a timeout or bypassing resolver work.

## Correctness Risks

Overall correctness risk is low for normal operation, with the following boundaries:

- The change is internal to `rspack_napi`; public JavaScript/Rust APIs, configuration, result ordering, and error conversion are unchanged.
- `create_runtime()` always constructs a multi-thread runtime, for which `Handle::block_on` and `Runtime::block_on` drive the supplied future with equivalent runtime facilities. The current-thread-specific limitation of `Handle::block_on` does not apply here.
- Runtime ownership remains in `RUNTIME`, and shutdown is still triggered only when the last registered N-API environment is cleaned up. However, the runtime lock no longer serializes shutdown against the full duration of an in-flight operation. Correctness therefore relies on the existing `ACTIVE_ENVS` invariant that final environment cleanup does not overlap a valid binding call. Electron reload or teardown concurrent with an in-flight `block_on` is not directly covered by this PR.
- The committed config case now includes an `@import` handled by `css-loader`'s PostCSS import parser. This forces `loaderContext.getResolve()` while the custom `inputFileSystem` path is active and directly covers the reported re-entrant chain. Its 10-second timeout turns the pre-fix hang into a bounded test failure.

No material compatibility risk was identified from the inspected changes.

## Performance Regression Risks

Performance regression risk is low. Each `block_on`/`spawn` now clones and drops one internally reference-counted Tokio `Handle`, adding a constant amount of atomic reference-count work. The number of runtime lock acquisitions, tasks, resolver operations, and file-system calls is otherwise unchanged.

The read lock is now held for a much shorter interval, which reduces contention with nested runtime access and shutdown. CodSpeed initially reported a 0.68% aggregate regression, but its follow-up analysis attributed the flagged stage benchmarks to mimalloc sampling artifacts; `rspack_napi` is not in those benchmark binaries' dependency graph. There is no dedicated benchmark of this runtime-call path, so the assessment remains directional rather than directly measured.

The initial `Binary Size Limit` CI job is inconclusive: it stopped before making a valid comparison because binary-size data for base commit `7a96bdf0d1b98fb97df6a2df494cca38cd2656f2` had not yet been published. The job needs to be rerun; this failure is not evidence of a binary-size regression.

## Validation

- `cargo check -p rspack_napi`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/input-file-system/css-loader"`
- The issue reproduction with `@import` times out after 10 seconds on `@rspack/core@2.1.3` and completes in 540 ms with the locally built binding.

## Related links

Fixes #15064.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

<details>
<summary>Translation</summary>

## 概览

修复进程级 Tokio runtime 的死锁问题：当 `experiments.useInputFileSystem` 将文件系统操作委托给 JavaScript，且 `css-loader` 或 `sass-loader` 等 loader 执行异步解析时，构建可能永久停滞。

本次修改在持有 runtime 锁时克隆 Tokio `Handle`，随后释放锁，再执行 `block_on` 或 `spawn`。公开 API、runtime 所有权和环境清理模型均保持不变。

## 问题与触发条件

该回归由 Rspack 2.1.3 引入，当时 binding 代码从 napi-rs 的 Tokio runtime helper 迁移到了 `rspack_napi` 中的进程级共享 runtime。

具体触发链如下：

1. 开启 `experiments.useInputFileSystem`，并由 `compiler.inputFileSystem` 将 `readFile`/`stat` 委托给 JavaScript。
2. Rust 通过 `NodeFileSystem::read_sync`、`metadata_sync` 或 `read_dir_sync` 执行同步文件系统操作。
3. 该操作进入 `rspack_napi::runtime::block_on`，并调用 JavaScript 文件系统回调。
4. loader 处理期间，`css-loader`/`sass-loader` 调用 `loaderContext.getResolve()`；`JsResolver.resolve()` 通过 `callbackify` 将异步 resolver future 转为回调。
5. 外层 `block_on` 仍在等待时，`callbackify` 调用 `rspack_napi::runtime::spawn`。

最终构建不再继续推进，只能被手动中断，并且不会产生正常的编译错误。

## 原有设计与根因

`RUNTIME` 使用 `RwLock<Option<Runtime>>` 保存共享 Tokio `Runtime`。每个 runtime 操作都会调用 `start_runtime()`，获取 `RUNTIME` 读锁，并在读锁 guard 整个存活期间执行传入的闭包。

因此，外层文件系统 `block_on` 会在 future 的完整生命周期内持有读锁。通过 `runtime::spawn` 重入时会再次调用 `start_runtime()`；即使 runtime 已经初始化，它仍会请求同一把锁的写锁。写锁必须等待外层读锁释放，而外层 future 又必须等待重入的 resolver 工作成功调度后才能结束，形成循环等待并导致死锁。

## 修复设计及其原理

现在 `with_runtime` 会先初始化 runtime，只在获取并克隆 `Runtime::handle()` 时短暂持有读锁，并在执行实际操作之前释放读锁。

克隆的 `Handle` 仍指向同一个 multi-thread Tokio runtime，因此 `block_on` 和 `spawn` 保持原有调度语义。由于 future 或 JavaScript 回调执行期间不再持有 runtime 锁，嵌套的 `spawn` 可以在 `start_runtime()` 中获取写锁，确认 runtime 已经初始化并继续执行。该修改直接移除了循环等待，而不是通过超时或跳过 resolver 工作来规避问题。

## 正确性风险

正常运行路径上的整体正确性风险较低，但存在以下边界：

- 修改仅位于 `rspack_napi` 内部；公开 JavaScript/Rust API、配置、结果顺序和错误转换均未改变。
- `create_runtime()` 始终创建 multi-thread runtime，在该模式下，`Handle::block_on` 与 `Runtime::block_on` 使用等价的 runtime 能力驱动传入的 future；`Handle::block_on` 针对 current-thread runtime 的限制不适用于这里。
- runtime 所有权仍保留在 `RUNTIME` 中，并且仍然只在最后一个已注册的 N-API environment 清理时关闭。不过，runtime 锁不再覆盖进行中操作的完整生命周期，因此正确性依赖现有的 `ACTIVE_ENVS` 不变量：最终环境清理不会与合法的 binding 调用重叠。本 PR 未直接覆盖 Electron reload 或 teardown 与进行中的 `block_on` 并发发生的情况。
- 已提交的 config case 现在包含由 `css-loader` PostCSS import parser 处理的 `@import`。这会在自定义 `inputFileSystem` 路径活跃时强制调用 `loaderContext.getResolve()`，从而直接覆盖问题中的重入链；10 秒超时会将修复前的挂起转为有界的测试失败。

从已检查的修改中未发现实质性的兼容性风险。

## 性能回归风险

性能回归风险较低。每次 `block_on`/`spawn` 现在会克隆并释放一个内部引用计数的 Tokio `Handle`，增加常数级的原子引用计数工作。除此之外，runtime 锁获取次数、task 数量、resolver 操作和文件系统调用数量均未变化。

读锁的持有时间显著缩短，可以减少嵌套 runtime 访问和 shutdown 之间的锁竞争。CodSpeed 最初报告了 0.68% 的整体回归，但后续分析将被标记的 stage benchmark 归因于 mimalloc 采样波动；`rspack_napi` 不在这些 benchmark 二进制的依赖图中。目前没有针对该 runtime 调用路径的专门 benchmark，因此以上判断仍是方向性分析，而非直接实测结论。

首次 `Binary Size Limit` CI 任务的结果不具备判断意义：由于基准提交 `7a96bdf0d1b98fb97df6a2df494cca38cd2656f2` 的二进制大小数据尚未发布，任务在执行有效比较前即停止。该任务需要重新运行；当前失败并不能证明存在二进制大小回归。

## 验证

- `cargo check -p rspack_napi`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/input-file-system/css-loader"`
- 包含 `@import` 的 issue 复现项目在 `@rspack/core@2.1.3` 下运行 10 秒后超时，而使用本地构建的 binding 后在 540 ms 内完成。

## 相关链接

Fixes #15064.

</details>
