### PR TITLE
fix: track lazy compilation activation lifecycle

### DIFF
--- a/packages/rspack/hot/lazy-compilation-node.js
+++ b/packages/rspack/hot/lazy-compilation-node.js
@@ -2,81 +2,6 @@ import { createRequire } from 'node:module';
 
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
 var require = createRequire(import.meta.url);
-var compiling = new Set();
-var errorHandlers = new Set();
-
-/** @type {import("http").ClientRequest | undefined} */
-var pendingRequest;
-/** @type {boolean} */
-var hasPendingUpdate = false;
-
-function sendRequest() {
-  if (compiling.size === 0) {
-    hasPendingUpdate = false;
-    return;
-  }
-
-  var modules = Array.from(compiling);
-  var data = modules.join('\n');
-
-  var httpModule = urlBase.startsWith('https')
-    ? require('https')
-    : require('http');
-
-  var request = httpModule.request(
-    urlBase,
-    {
-      method: 'POST',
-      agent: false,
-      headers: {
-        'Content-Type': 'text/plain',
-      },
-    },
-    function (res) {
-      pendingRequest = undefined;
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        var error = new Error(
-          'Problem communicating active modules to the server: HTTP ' +
-            res.statusCode,
-        );
-        errorHandlers.forEach(function (onError) {
-          onError(error);
-        });
-      }
-      // Consume response data to free up memory
-      res.resume();
-      if (hasPendingUpdate) {
-        hasPendingUpdate = false;
-        sendRequest();
-      }
-    },
-  );
-
-  pendingRequest = request;
-
-  request.on('error', function (err) {
-    pendingRequest = undefined;
-    var error = new Error(
-      'Problem communicating active modules to the server: ' + err.message,
-    );
-    errorHandlers.forEach(function (onError) {
-      onError(error);
-    });
-  });
-
-  request.write(data);
-  request.end();
-}
-
-function sendActiveRequest() {
-  hasPendingUpdate = true;
-
-  // If no request is pending, start one
-  if (!pendingRequest) {
-    hasPendingUpdate = false;
-    sendRequest();
-  }
-}
 
 /**
  * @param {{ data: string, onError: (err: Error) => void, active: boolean, module: module }} options options
@@ -87,23 +12,64 @@ export const activate = function (options) {
   var onError = options.onError;
   var active = options.active;
   var module = options.module;
+  /** @type {import("http").IncomingMessage | undefined} */
+  var response;
+  var disposed = false;
 
-  errorHandlers.add(onError);
-
-  if (!compiling.has(data)) {
-    compiling.add(data);
-    sendActiveRequest();
+  function errorHandler(err) {
+    if (disposed) {
+      return;
+    }
+    err.message =
+      'Problem communicating active modules to the server: ' + err.message;
+    onError(err);
   }
 
-  if (!active && !module.hot) {
-    console.log(
-      'Hot Module Replacement is not enabled. Waiting for process restart...',
-    );
-  }
+  var httpModule = urlBase.startsWith('https')
+    ? require('https')
+    : require('http');
+  var request = httpModule.request(
+    urlBase,
+    {
+      method: 'POST',
+      agent: false,
+      headers: {
+        Accept: 'text/event-stream',
+        'Content-Type': 'text/plain',
+      },
+    },
+    function (res) {
+      response = res;
+      response.on('error', errorHandler);
+      response.resume();
+
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        onError(
+          new Error(
+            'Problem communicating active modules to the server: HTTP ' +
+              res.statusCode,
+          ),
+        );
+      }
+
+      if (!active && !module.hot) {
+        console.log(
+          'Hot Module Replacement is not enabled. Waiting for process restart...',
+        );
+      }
+    },
+  );
+
+  request.on('error', errorHandler);
+  request.write(data);
+  request.end();
 
   return function () {
-    errorHandlers.delete(onError);
-    compiling.delete(data);
-    sendActiveRequest();
+    disposed = true;
+    if (response) {
+      response.destroy();
+    } else {
+      request.destroy();
+    }
   };
 };

--- a/packages/rspack/hot/lazy-compilation-node.js
+++ b/packages/rspack/hot/lazy-compilation-node.js
@@ -28,15 +28,18 @@ export const activate = function (options) {
   var httpModule = urlBase.startsWith('https')
     ? require('https')
     : require('http');
+  var headers = {
+    'Content-Type': 'text/plain',
+  };
+  if (module.hot) {
+    headers.Accept = 'text/event-stream';
+  }
   var request = httpModule.request(
     urlBase,
     {
       method: 'POST',
       agent: false,
-      headers: {
-        Accept: 'text/event-stream',
-        'Content-Type': 'text/plain',
-      },
+      headers: headers,
     },
     function (res) {
       response = res;

--- a/packages/rspack/hot/lazy-compilation-web.js
+++ b/packages/rspack/hot/lazy-compilation-web.js
@@ -5,68 +5,85 @@ if (typeof XMLHttpRequest === 'undefined') {
 }
 
 var urlBase = decodeURIComponent(__resourceQuery.slice(1));
-var compiling = new Set();
+var activeKeys = new Map();
 var errorHandlers = new Set();
 
 /** @type {XMLHttpRequest | undefined} */
-var pendingXhr;
-/** @type {boolean} */
-var hasPendingUpdate = false;
+var activeXhr;
+/** @type {ReturnType<typeof setTimeout> | undefined} */
+var reconnectTimer;
+
+var reportError = function reportError(message) {
+  var error = new Error(message);
+  errorHandlers.forEach(function (onError) {
+    onError(error);
+  });
+};
 
 var sendRequest = function sendRequest() {
-  if (compiling.size === 0) {
-    hasPendingUpdate = false;
+  if (activeKeys.size === 0) {
     return;
   }
 
-  var modules = Array.from(compiling);
+  var modules = Array.from(activeKeys.keys());
   var data = modules.join('\n');
 
   var xhr = new XMLHttpRequest();
-  pendingXhr = xhr;
+  activeXhr = xhr;
   xhr.open('POST', urlBase, true);
   // text/plain Content-Type is simple request header
   xhr.setRequestHeader('Content-Type', 'text/plain');
+  xhr.setRequestHeader('Accept', 'text/event-stream');
 
-  xhr.onreadystatechange = function () {
-    if (xhr.readyState === 4) {
-      pendingXhr = undefined;
-      if (xhr.status < 200 || xhr.status >= 300) {
-        var error = new Error(
-          'Problem communicating active modules to the server: HTTP ' +
-            xhr.status,
-        );
-        errorHandlers.forEach(function (onError) {
-          onError(error);
-        });
-      }
-      if (hasPendingUpdate) {
-        hasPendingUpdate = false;
+  xhr.onloadend = function () {
+    if (activeXhr !== xhr) {
+      return;
+    }
+
+    activeXhr = undefined;
+    if (xhr.status < 200 || xhr.status >= 300) {
+      reportError(
+        xhr.status
+          ? 'Problem communicating active modules to the server: HTTP ' +
+              xhr.status
+          : 'Problem communicating active modules to the server',
+      );
+    }
+
+    reconnectTimer = setTimeout(function () {
+      reconnectTimer = undefined;
+      if (!activeXhr && activeKeys.size) {
         sendRequest();
       }
-    }
+    }, 1000);
   };
 
-  xhr.onerror = function () {
-    pendingXhr = undefined;
-    var error = new Error('Problem communicating active modules to the server');
-    errorHandlers.forEach(function (onError) {
-      onError(error);
-    });
-  };
-
-  xhr.send(data);
+  try {
+    xhr.send(data);
+  } catch (error) {
+    activeXhr = undefined;
+    reportError(
+      error instanceof Error
+        ? 'Problem communicating active modules to the server: ' + error.message
+        : 'Problem communicating active modules to the server',
+    );
+  }
 };
 
-function sendActiveRequest() {
-  hasPendingUpdate = true;
-
-  // If no request is pending, start one
-  if (!pendingXhr) {
-    hasPendingUpdate = false;
+var updateRequest = function updateRequest() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = undefined;
+  }
+  if (activeXhr) {
+    var xhr = activeXhr;
+    activeXhr = undefined;
+    xhr.abort();
+  }
+  if (activeKeys.size) {
     sendRequest();
   }
-}
+};
 
 /**
  * @param {{ data: string, onError: (err: Error) => void, active: boolean, module: module }} options options
@@ -78,9 +95,10 @@ export const activate = function (options) {
   var active = options.active;
   errorHandlers.add(onError);
 
-  if (!compiling.has(data)) {
-    compiling.add(data);
-    sendActiveRequest();
+  var value = activeKeys.get(data) || 0;
+  activeKeys.set(data, value + 1);
+  if (value === 0) {
+    updateRequest();
   }
 
   if (!active && !import.meta.webpackHot) {
@@ -91,7 +109,16 @@ export const activate = function (options) {
 
   return function () {
     errorHandlers.delete(onError);
-    compiling.delete(data);
-    sendActiveRequest();
+    // HMR recreates the proxy immediately after disposing it. Delay the
+    // decrement so that transition does not flap the server-side connection.
+    setTimeout(function () {
+      var value = activeKeys.get(data);
+      if (value === 1) {
+        activeKeys.delete(data);
+        updateRequest();
+      } else if (value !== undefined) {
+        activeKeys.set(data, value - 1);
+      }
+    }, 1000);
   };
 };

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -71,19 +71,19 @@ export const lazyCompilationMiddleware = (
       const prefix = options.prefix || LAZY_COMPILATION_PREFIX;
       options.prefix = `${prefix}__${i++}`;
       const activeModules = new Map<string, number>();
-      const pendingModules = new Set<string>();
+      const legacyModules = new Map<string, NodeJS.Timeout>();
 
       middlewareByCompiler.set(
         options.prefix,
         lazyCompilationMiddlewareInternal(
           c,
           activeModules,
-          pendingModules,
+          legacyModules,
           options.prefix,
         ),
       );
 
-      applyPlugin(c, options, activeModules, pendingModules);
+      applyPlugin(c, options, activeModules, legacyModules);
     }
 
     const keys = [...middlewareByCompiler.keys()];
@@ -104,19 +104,19 @@ export const lazyCompilationMiddleware = (
   }
 
   const activeModules = new Map<string, number>();
-  const pendingModules = new Set<string>();
+  const legacyModules = new Map<string, NodeJS.Timeout>();
 
   const options = {
     ...compiler.options.lazyCompilation,
   };
 
-  applyPlugin(compiler, options, activeModules, pendingModules);
+  applyPlugin(compiler, options, activeModules, legacyModules);
 
   const lazyCompilationPrefix = options.prefix || LAZY_COMPILATION_PREFIX;
   return lazyCompilationMiddlewareInternal(
     compiler,
     activeModules,
-    pendingModules,
+    legacyModules,
     lazyCompilationPrefix,
   );
 };
@@ -125,15 +125,14 @@ function applyPlugin(
   compiler: Compiler,
   options: LazyCompilationOptions,
   activeModules: Map<string, number>,
-  pendingModules: Set<string>,
+  legacyModules: Map<string, NodeJS.Timeout>,
 ) {
   const plugin = new BuiltinLazyCompilationPlugin(
     () => {
       const modules = new Set(activeModules.keys());
-      for (const key of pendingModules) {
+      for (const key of legacyModules.keys()) {
         modules.add(key);
       }
-      pendingModules.clear();
       return modules;
     },
     options.entries ?? true,
@@ -241,7 +240,7 @@ function readModuleIdsFromBody(
 const lazyCompilationMiddlewareInternal = (
   compiler: Compiler,
   activeModules: Map<string, number>,
-  pendingModules: Set<string>,
+  legacyModules: Map<string, NodeJS.Timeout>,
   lazyCompilationPrefix: string,
 ): DevServerMiddlewareHandler => {
   const logger = compiler.getInfrastructureLogger('LazyCompilation');
@@ -260,7 +259,7 @@ const lazyCompilationMiddlewareInternal = (
     }
     activeResponses.clear();
     activeModules.clear();
-    pendingModules.clear();
+    legacyModules.clear();
   });
 
   return async (
@@ -293,8 +292,28 @@ const lazyCompilationMiddlewareInternal = (
     if (!req.headers.accept?.includes('text/event-stream')) {
       let moduleActivated = false;
       for (const key of keys) {
-        const activated = activeModules.has(key) || pendingModules.has(key);
-        pendingModules.add(key);
+        const previousTimer = legacyModules.get(key);
+        const activated = activeModules.has(key) || previousTimer !== undefined;
+        if (previousTimer) {
+          clearTimeout(previousTimer);
+          idleTimers.delete(previousTimer);
+        }
+
+        const timer = setTimeout(() => {
+          idleTimers.delete(timer);
+          if (legacyModules.get(key) === timer) {
+            legacyModules.delete(key);
+            if (!activeModules.has(key)) {
+              logger.log(
+                `${key} is no longer in use. Next compilation will skip this module.`,
+              );
+            }
+          }
+        }, LAZY_COMPILATION_IDLE_TIMEOUT);
+        timer.unref?.();
+        idleTimers.add(timer);
+        legacyModules.set(key, timer);
+
         if (!activated) {
           logger.log(`${key} is now in use and will be compiled.`);
           moduleActivated = true;
@@ -323,7 +342,7 @@ const lazyCompilationMiddlewareInternal = (
           const oldValue = activeModules.get(key) || 0;
           if (oldValue <= 1) {
             activeModules.delete(key);
-            if (oldValue === 1) {
+            if (oldValue === 1 && !legacyModules.has(key)) {
               logger.log(
                 `${key} is no longer in use. Next compilation will skip this module.`,
               );
@@ -354,7 +373,7 @@ const lazyCompilationMiddlewareInternal = (
     for (const key of keys) {
       const oldValue = activeModules.get(key) || 0;
       activeModules.set(key, oldValue + 1);
-      if (oldValue === 0) {
+      if (oldValue === 0 && !legacyModules.has(key)) {
         logger.log(`${key} is now in use and will be compiled.`);
         moduleActivated = true;
       }

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -10,6 +10,8 @@ const require = createRequire(import.meta.url);
 
 export const LAZY_COMPILATION_PREFIX = '/_rspack/lazy/trigger';
 
+const LAZY_COMPILATION_IDLE_TIMEOUT = 120_000;
+
 const getDefaultClient = (compiler: Compiler): string =>
   require.resolve(
     `../hot/lazy-compilation-${
@@ -68,14 +70,20 @@ export const lazyCompilationMiddleware = (
 
       const prefix = options.prefix || LAZY_COMPILATION_PREFIX;
       options.prefix = `${prefix}__${i++}`;
-      const activeModules = new Set<string>();
+      const activeModules = new Map<string, number>();
+      const pendingModules = new Set<string>();
 
       middlewareByCompiler.set(
         options.prefix,
-        lazyCompilationMiddlewareInternal(c, activeModules, options.prefix),
+        lazyCompilationMiddlewareInternal(
+          c,
+          activeModules,
+          pendingModules,
+          options.prefix,
+        ),
       );
 
-      applyPlugin(c, options, activeModules);
+      applyPlugin(c, options, activeModules, pendingModules);
     }
 
     const keys = [...middlewareByCompiler.keys()];
@@ -95,18 +103,20 @@ export const lazyCompilationMiddleware = (
     return noop;
   }
 
-  const activeModules: Set<string> = new Set();
+  const activeModules = new Map<string, number>();
+  const pendingModules = new Set<string>();
 
   const options = {
     ...compiler.options.lazyCompilation,
   };
 
-  applyPlugin(compiler, options, activeModules);
+  applyPlugin(compiler, options, activeModules, pendingModules);
 
   const lazyCompilationPrefix = options.prefix || LAZY_COMPILATION_PREFIX;
   return lazyCompilationMiddlewareInternal(
     compiler,
     activeModules,
+    pendingModules,
     lazyCompilationPrefix,
   );
 };
@@ -114,13 +124,17 @@ export const lazyCompilationMiddleware = (
 function applyPlugin(
   compiler: Compiler,
   options: LazyCompilationOptions,
-  activeModules: Set<string>,
+  activeModules: Map<string, number>,
+  pendingModules: Set<string>,
 ) {
   const plugin = new BuiltinLazyCompilationPlugin(
     () => {
-      const res = new Set(activeModules);
-      activeModules.clear();
-      return res;
+      const modules = new Set(activeModules.keys());
+      for (const key of pendingModules) {
+        modules.add(key);
+      }
+      pendingModules.clear();
+      return modules;
     },
     options.entries ?? true,
     options.imports ?? true,
@@ -225,11 +239,29 @@ function readModuleIdsFromBody(
 }
 
 const lazyCompilationMiddlewareInternal = (
-  compiler: Compiler | MultiCompiler,
-  activeModules: Set<string>,
+  compiler: Compiler,
+  activeModules: Map<string, number>,
+  pendingModules: Set<string>,
   lazyCompilationPrefix: string,
 ): DevServerMiddlewareHandler => {
   const logger = compiler.getInfrastructureLogger('LazyCompilation');
+  const idleTimers = new Set<NodeJS.Timeout>();
+  const activeResponses = new Set<ServerResponse>();
+  let isClosing = false;
+
+  compiler.hooks.shutdown.tap('LazyCompilationMiddleware', () => {
+    isClosing = true;
+    for (const timer of idleTimers) {
+      clearTimeout(timer);
+    }
+    idleTimers.clear();
+    for (const response of activeResponses) {
+      response.destroy();
+    }
+    activeResponses.clear();
+    activeModules.clear();
+    pendingModules.clear();
+  });
 
   return async (
     req: IncomingMessage,
@@ -250,22 +282,86 @@ const lazyCompilationMiddlewareInternal = (
       return;
     }
 
-    const moduleActivated = [];
-    for (const key of modules) {
-      const activated = activeModules.has(key);
-      activeModules.add(key);
-      if (!activated) {
+    if (isClosing) {
+      res.writeHead(503);
+      res.end('Compiler is shutting down');
+      return;
+    }
+
+    const keys = new Set(modules);
+
+    if (!req.headers.accept?.includes('text/event-stream')) {
+      let moduleActivated = false;
+      for (const key of keys) {
+        const activated = activeModules.has(key) || pendingModules.has(key);
+        pendingModules.add(key);
+        if (!activated) {
+          logger.log(`${key} is now in use and will be compiled.`);
+          moduleActivated = true;
+        }
+      }
+
+      if (moduleActivated && compiler.watching) {
+        compiler.watching.invalidate();
+      }
+
+      res.writeHead(200);
+      res.end('\n');
+      return;
+    }
+
+    req.socket.on('close', () => {
+      if (isClosing) {
+        return;
+      }
+
+      // Keep recently disconnected clients active long enough to reconnect
+      // without turning an HMR update into another lazy activation rebuild.
+      const timer = setTimeout(() => {
+        idleTimers.delete(timer);
+        for (const key of keys) {
+          const oldValue = activeModules.get(key) || 0;
+          if (oldValue <= 1) {
+            activeModules.delete(key);
+            if (oldValue === 1) {
+              logger.log(
+                `${key} is no longer in use. Next compilation will skip this module.`,
+              );
+            }
+          } else {
+            activeModules.set(key, oldValue - 1);
+          }
+        }
+      }, LAZY_COMPILATION_IDLE_TIMEOUT);
+      timer.unref?.();
+      idleTimers.add(timer);
+    });
+
+    req.socket.setNoDelay?.(true);
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': '*',
+      'Access-Control-Allow-Headers': '*',
+    });
+    activeResponses.add(res);
+    res.on('close', () => {
+      activeResponses.delete(res);
+    });
+    res.write('\n');
+
+    let moduleActivated = false;
+    for (const key of keys) {
+      const oldValue = activeModules.get(key) || 0;
+      activeModules.set(key, oldValue + 1);
+      if (oldValue === 0) {
         logger.log(`${key} is now in use and will be compiled.`);
-        moduleActivated.push(key);
+        moduleActivated = true;
       }
     }
 
-    if (moduleActivated.length && compiler.watching) {
+    if (moduleActivated && compiler.watching) {
       compiler.watching.invalidate();
     }
-
-    res.writeHead(200);
-    res.write('\n');
-    res.end();
   };
 };

--- a/tests/e2e/cases/lazy-compilation/cross-origin/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/cross-origin/index.test.ts
@@ -139,13 +139,19 @@ test('should work with cross-origin lazy compilation using simple POST request',
   const { lazyCompilationPort } = crossOriginSetup;
 
   // Set up request interception to verify the request format
-  const requests: { method: string; contentType: string; body: string }[] = [];
+  const requests: {
+    method: string;
+    accept: string;
+    contentType: string;
+    body: string;
+  }[] = [];
 
   page.on('request', (request) => {
     const url = request.url();
     if (url.includes(`${lazyCompilationPort}`)) {
       requests.push({
         method: request.method(),
+        accept: request.headers().accept || '',
         contentType: request.headers()['content-type'] || '',
         body: request.postData() || '',
       });
@@ -168,6 +174,7 @@ test('should work with cross-origin lazy compilation using simple POST request',
   // Verify the request was a simple POST request with text/plain content type
   const lazyRequest = requests.find((r) => r.method === 'POST');
   expect(lazyRequest).toBeDefined();
+  expect(lazyRequest!.accept).toBe('text/event-stream');
   expect(lazyRequest!.contentType).toBe('text/plain');
   // The body should be newline-separated module IDs, not JSON
   expect(lazyRequest!.body).not.toMatch(/^\[/); // Not a JSON array

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/index.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@/fixtures';
+
+test('should not rebuild when an active module is reported again', async ({
+  page,
+  rspack,
+}) => {
+  const requests: Array<{ body: string; url: string }> = [];
+  page.on('request', (request) => {
+    if (
+      request.method() === 'POST' &&
+      request.url().includes('/_rspack/lazy/trigger')
+    ) {
+      requests.push({
+        body: request.postData() || '',
+        url: request.url(),
+      });
+    }
+  });
+
+  await page.getByRole('button', { name: 'load lazy module' }).click();
+  await expect(page.locator('body')).toHaveText('lazy module loaded');
+  expect(requests).toHaveLength(1);
+
+  const buildCount = rspack.compiler.__buildCount;
+  const request = requests[0];
+  await page.evaluate(async ({ body, url }) => {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+      body,
+    });
+    await response.text();
+  }, request);
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  expect(rspack.compiler.__buildCount).toBe(buildCount);
+});

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/index.test.ts
@@ -34,4 +34,34 @@ test('should not rebuild when an active module is reported again', async ({
 
   await new Promise((resolve) => setTimeout(resolve, 1000));
   expect(rspack.compiler.__buildCount).toBe(buildCount);
+
+  const legacyModule = `legacy-module-${Date.now()}`;
+  await page.evaluate(
+    async ({ url, legacyModule }) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: legacyModule,
+      });
+      await response.text();
+    },
+    { url: request.url, legacyModule },
+  );
+
+  await expect.poll(() => rspack.compiler.__buildCount).toBe(buildCount + 1);
+
+  await page.evaluate(
+    async ({ url, legacyModule }) => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body: legacyModule,
+      });
+      await response.text();
+    },
+    { url: request.url, legacyModule },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+  expect(rspack.compiler.__buildCount).toBe(buildCount + 1);
 });

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/rspack.config.js
@@ -1,0 +1,52 @@
+const { rspack } = require('@rspack/core');
+const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  entry: './src/index.jsx',
+  mode: 'development',
+  devtool: false,
+  stats: 'errors-warnings',
+  resolve: {
+    extensions: ['...', '.jsx'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx$/,
+        loader: 'builtin:swc-loader',
+        options: {
+          detectSyntax: 'auto',
+          jsc: {
+            transform: {
+              react: {
+                runtime: 'automatic',
+                development: true,
+                refresh: true,
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+  lazyCompilation: {
+    entries: false,
+    imports: true,
+  },
+  devServer: {
+    hot: true,
+  },
+  plugins: [
+    new rspack.HtmlRspackPlugin({ template: './src/index.html' }),
+    new ReactRefreshRspackPlugin(),
+    {
+      apply(compiler) {
+        compiler.__buildCount = 0;
+        compiler.hooks.done.tap('BuildCountPlugin', () => {
+          compiler.__buildCount++;
+        });
+      },
+    },
+  ],
+};

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/Lazy.jsx
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/Lazy.jsx
@@ -1,0 +1,3 @@
+export default function Lazy() {
+  return 'lazy module loaded';
+}

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/index.html
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/index.html
@@ -1,0 +1,1 @@
+<div id="root"></div>

--- a/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/index.jsx
+++ b/tests/e2e/cases/lazy-compilation/hmr-rebuild-loop/src/index.jsx
@@ -1,0 +1,20 @@
+import React, { Suspense, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const Lazy = React.lazy(() => import('./Lazy.jsx'));
+
+function App() {
+  const [showLazy, setShowLazy] = useState(false);
+
+  return showLazy ? (
+    <Suspense fallback="loading">
+      <Lazy />
+    </Suspense>
+  ) : (
+    <button type="button" onClick={() => setShowLazy(true)}>
+      load lazy module
+    </button>
+  );
+}
+
+createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
## Summary

Fix the LazyCompilation + HMR rebuild loop by tracking the lifetime of active lazy modules instead of clearing all activation state at every compilation or retaining every historically activated module forever.

The implementation ports webpack's reference-counted connection model and delayed idle deactivation while preserving Rspack's POST-body transport for large module identifier sets.

## Problem and Trigger

The loop is triggered when all of the following are true:

1. `lazyCompilation.imports` and HMR are enabled.
2. A dynamic import activates a lazy proxy and causes the expected rebuild.
3. HMR disposes and re-evaluates the proxy, causing the client to report the same module again.

The middleware previously used one `Set` both as the current active-module snapshot and as request deduplication state. `BuiltinLazyCompilationPlugin` copied and cleared that set at the start of every compilation. The web client also removed the module from its local set as soon as the proxy was disposed.

After the activation rebuild, the same identifier could therefore be absent on both sides. Its next report looked like a first activation and called `compiler.watching.invalidate()` again, producing another HMR update and repeating the cycle without any source-file change.

## Why the Previous Fix Was Incomplete

Keeping every identifier in a permanent `Set` makes repeated reports idempotent, but it loses the lazy-module lifecycle:

- idle modules never become lazy again;
- retained state grows monotonically for the compiler lifetime;
- every compilation snapshots historical activations rather than currently used modules.

This PR instead keeps only live references plus a bounded idle grace period.

## Fix Design

### Client lifecycle

- The web client stores `activeKeys` as `Map<module, referenceCount>`.
- Multiple users of the same proxy update the connection only on the `0 -> 1` and `1 -> 0` transitions.
- Disposal decrements the client count after one second. An HMR dispose/recreate within that interval keeps the same connection alive and does not flap the module inactive.
- The web client keeps one long-lived XHR containing all active module identifiers in the POST body and reconnects if the response ends unexpectedly.
- With HMR, the Node client keeps a long-lived POST request for each active proxy and closes it from the proxy's dispose callback. Without HMR it uses a finite POST so the socket cannot keep the process alive while it waits for a restart.

### Server lifecycle

- The middleware stores `Map<module, referenceCount>` instead of a permanent set.
- Opening a long-lived request increments every reported module. Only a `0 -> 1` transition invalidates the watcher.
- Closing a request schedules its decrements after 120 seconds, matching webpack's idle grace period. Entries are deleted when their count reaches zero, so inactive module identifiers are not retained indefinitely.
- `CompilerMake` receives a snapshot of the current map keys without clearing live connection state.
- Compiler shutdown cancels idle timers, closes active responses, and clears the lifecycle state.
- Each child of a `MultiCompiler` owns an independent map, timers, and responses.

### Why POST is retained

webpack encodes active keys in an EventSource URL. Rspack previously moved identifiers into a POST body because large lazy-module sets can exceed browser or server URL limits. This PR therefore uses an SSE-like long-lived response over POST rather than restoring the URL-based transport.

The built-in clients opt into the long-lived protocol with `Accept: text/event-stream`, which is a CORS-safelisted request header. A custom client that does not send that header keeps the existing finite POST behavior: its response ends normally, while its identifiers remain deduplicated across compilations for a refreshable 120-second idle window. This avoids breaking existing `lazyCompilation.client` implementations without retaining their identifiers indefinitely.

Reference: [webpack lazy compilation backend](https://github.com/webpack/webpack/blob/5b9ba026da6fd9b36a35125d2302ab84f8b1af54/lib/hmr/lazyCompilationBackend.js) and [webpack web client](https://github.com/webpack/webpack/blob/5b9ba026da6fd9b36a35125d2302ab84f8b1af54/hot/lazy-compilation-web.js).

## Why This Fixes the Loop

The first connection for a module still performs the required `0 -> 1` transition and invalidates the watcher. That connection remains represented in the server map across compilations. HMR's transient proxy disposal is absorbed by the web client's one-second reference-count delay, so re-evaluation does not create a new activation. Even if another client or connection reports the same module, the server count is already non-zero and does not invalidate again.

Once all clients disconnect and the 120-second grace period expires, the count reaches zero and the map entry is deleted. A later import can then perform a legitimate new lazy activation.

## Correctness Risks

- Deactivation is intentionally delayed by 120 seconds. A module may remain active during this grace period, but it is eventually removed instead of being retained for the compiler lifetime.
- Replacing a connection temporarily increments references before the disconnected connection's delayed decrement runs. The count can therefore be higher than the number of current connections during the grace period, but the relevant active/inactive invariant remains correct and every closed connection has a matching scheduled decrement.
- Browser clients aggregate active modules into one connection; Node clients use one connection per proxy, following webpack's Node-client shape. Both paths depend on connection-close delivery for eventual cleanup.
- Legacy custom clients keep their finite POST behavior. Because they provide no connection lifetime, their identifiers use a refreshable 120-second TTL rather than precise connection-based deactivation; clients can opt into `Accept: text/event-stream` for the full lifecycle model.
- No public configuration, emitted asset, or Rust API changes are introduced.

## Performance Regression Risks

- The fix removes the unbounded rebuild loop, which is the dominant performance improvement in the reported scenario.
- Server memory is `O(A + D + L)`, where `A` is the set of currently active modules, `D` is recently disconnected connection state, and `L` is finite-protocol identifiers retained during their refreshable 120-second TTL. Expired or zero-count entries are deleted, so state no longer grows with every historical activation.
- The web target uses one additional long-lived HTTP connection per runtime, regardless of the number of active modules. The Node target can use one connection per active lazy proxy, consistent with webpack's Node client.
- Updating the web client's active-key set recreates its connection and copies the current keys into a POST body, so update work is `O(A)`. This replaces the existing `O(A)` finite POST snapshot and does not reintroduce URL-length limits.
- Idle timers are unreferenced and are cancelled on compiler shutdown. Frequent connection churn can temporarily retain timers and key sets for up to 120 seconds.
- No Rust hot path or production compilation path is changed; the behavior is limited to development-time lazy compilation.

## Related links

Closes #15062.

## Validation

- `pnpm run build:js`
- `pnpm --dir tests/e2e test cases/lazy-compilation` (24 passed)
- `pnpm --dir tests/rspack-test exec rs test --project hottest -t lazy-compilation` (8 passed, 129 filtered/skipped)
- Targeted Rslint, formatting, and `git diff --check`

The regression uses React Refresh and `React.lazy`, verifies that the first activation completes, and asserts that re-reporting it does not cause another build. It also reports a finite-protocol-only identifier, waits for the resulting compilation to finish, reports it again, and verifies that cross-compilation deduplication prevents another rebuild. The cross-origin case verifies that the built-in client negotiates the long-lived POST protocol without a preflight-only content type.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

<details>
<summary>Translation</summary>

## 概述

通过跟踪 active lazy module 的真实生命周期，修复 LazyCompilation 与 HMR 组合使用时的重复构建循环。该实现不会在每次编译时清空全部激活状态，也不会永久保留所有曾经激活过的模块。

实现移植了 webpack 的连接引用计数与延迟 idle deactivation，同时继续使用 Rspack 的 POST body 传输，避免大量 module identifier 导致 URL 超长。

## 问题与触发条件

以下条件同时满足时会触发循环：

1. 启用了 `lazyCompilation.imports` 和 HMR。
2. 动态导入激活 lazy proxy，并触发一次符合预期的重新构建。
3. HMR dispose 并重新执行 proxy，客户端再次上报相同模块。

middleware 原先用同一个 `Set` 同时表示当前 active module 快照和请求去重状态。`BuiltinLazyCompilationPlugin` 在每次编译开始时复制并清空该集合；web client 又会在 proxy dispose 时立即删除本地记录。

因此，activation rebuild 完成后，同一 identifier 可能同时不存在于两侧。后续上报会被误判为首次激活，再次调用 `compiler.watching.invalidate()`，产生新的 HMR update，并在没有源文件变化的情况下重复循环。

## 为什么永久 Set 方案不完整

永久保留 identifier 虽然能让重复上报幂等，但会破坏 lazy module 的生命周期：

- idle module 永远不能重新变回 lazy；
- retained state 在 compiler 生命周期内单调增长；
- 每次编译都会处理历史激活记录，而不只是当前仍在使用的模块。

本 PR 只保留 live reference 和有界的 idle grace period。

## 修复设计

### 客户端生命周期

- web client 使用 `Map<module, referenceCount>` 保存 `activeKeys`。
- 同一 proxy 的多个使用者只在 `0 -> 1` 和 `1 -> 0` 时更新连接。
- dispose 后延迟一秒再递减。HMR 在此期间完成 dispose/recreate 时会继续复用连接，不会让模块在 active/inactive 之间抖动。
- web client 使用一个长连接 XHR，通过 POST body 上报全部 active identifier；连接意外结束时会重连。
- 启用 HMR 时，Node client 为每个 active proxy 保持一个长连接 POST，并在 proxy dispose 时关闭；未启用 HMR 时使用短 POST，避免进程等待重启时被 socket 阻止退出。

### 服务端生命周期

- middleware 使用 `Map<module, referenceCount>`，不再使用永久集合。
- 长连接建立时递增上报模块的引用计数，只有 `0 -> 1` 才会使 watcher 失效。
- 连接关闭 120 秒后执行递减，与 webpack 的 idle grace period 一致。计数归零时删除 entry，因此不会无限保留 inactive identifier。
- `CompilerMake` 获取当前 map key 的快照，但不会清空仍然存活的连接状态。
- compiler shutdown 会取消 idle timer、关闭 active response 并清空生命周期状态。
- `MultiCompiler` 的每个子 compiler 独立持有 map、timer 和 response。

### 为什么继续使用 POST

webpack 把 active key 编码在 EventSource URL 中。Rspack 之前改为 POST body，是因为大量 lazy module 会超过浏览器或服务器的 URL 长度限制。因此本 PR 使用“POST + SSE-like 长响应”，不会退回 URL 传输。

内置客户端通过 CORS safelisted 的 `Accept: text/event-stream` header 协商长连接协议。没有该 header 的 custom client 继续使用原有短 POST：response 会正常结束，同时 identifier 会在可刷新的 120 秒 idle window 内跨编译去重。这样既不会破坏现有 `lazyCompilation.client` 实现，也不会永久保留 identifier。

参考：[webpack lazy compilation backend](https://github.com/webpack/webpack/blob/5b9ba026da6fd9b36a35125d2302ab84f8b1af54/lib/hmr/lazyCompilationBackend.js) 和 [webpack web client](https://github.com/webpack/webpack/blob/5b9ba026da6fd9b36a35125d2302ab84f8b1af54/hot/lazy-compilation-web.js)。

## 为什么能够修复循环

模块的第一条连接仍然执行必要的 `0 -> 1` 并使 watcher 失效；该连接会跨编译保留在服务端 map 中。HMR 的瞬时 proxy dispose 会被 web client 的一秒引用计数延迟吸收，因此重新执行不会产生新的 activation。即使另一个客户端或连接再次上报相同模块，服务端计数已经非零，也不会再次 invalidate。

当所有客户端断开且 120 秒 grace period 到期后，计数会归零并删除 map entry。之后再次 import 时可以执行一次合法的新 lazy activation。

## 正确性风险

- Deactivation 会有意延迟 120 秒。模块在 grace period 内仍保持 active，但最终会被删除，不会保留到 compiler 结束。
- 替换连接时，新连接会先增加引用，旧连接在延迟期结束后再减少引用，因此 grace period 内计数可能高于当前连接数；但 active/inactive 不变量保持正确，每条关闭的连接都有对应的递减。
- 浏览器把 active module 聚合到一个连接；Node target 与 webpack Node client 一样，为每个 proxy 使用一个连接。两条路径都依赖 connection close 完成最终清理。
- 旧 custom client 保持短 POST 行为。由于它不提供连接生命周期，identifier 使用可刷新的 120 秒 TTL，而不是精确的 connection-based deactivation；显式使用 `Accept: text/event-stream` 可以获得完整生命周期模型。
- 不改变公共配置、输出资源或 Rust API。

## 性能回归风险

- 修复消除了报告场景中的无界 rebuild loop，这是主要性能收益。
- 服务端内存为 `O(A + D + L)`：`A` 是当前 active module，`D` 是最近断开的连接状态，`L` 是可刷新 120 秒 TTL 内保留的短协议 identifier。过期或计数归零后会删除 entry，不再随历史激活次数单调增长。
- web target 每个 runtime 使用一个额外长 HTTP 连接，与 active module 数量无关；Node target 最多为每个 active lazy proxy 使用一个连接，与 webpack Node client 一致。
- web client 更新 active key 时会重建连接，并把当前 key 复制到 POST body，工作量为 `O(A)`；这与现有有限 POST 快照相同，同时不会重新引入 URL 长度限制。
- idle timer 使用 `unref`，并在 compiler shutdown 时取消。频繁连接切换会在最长 120 秒内临时保留 timer 和 key set。
- 不修改 Rust hot path 或生产编译路径，仅影响开发期 lazy compilation。

## 相关链接

Closes #15062。

## 验证

- `pnpm run build:js`
- `pnpm --dir tests/e2e test cases/lazy-compilation`（24 项通过）
- `pnpm --dir tests/rspack-test exec rs test --project hottest -t lazy-compilation`（8 项通过，129 项过滤/跳过）
- 定向 Rslint、格式检查和 `git diff --check`

回归用例使用 React Refresh 与 `React.lazy`，验证首次激活能够完成，并断言重复上报不会产生额外构建。它还会通过短协议上报一个独立 identifier，等待对应 compilation 完成后再次上报，验证跨编译去重不会产生第二次 rebuild。跨域用例会验证内置客户端能够协商长连接 POST，且保持 simple content type。

## 检查清单

- [x] 已更新测试（或无需更新）。
- [x] 已更新文档（或无需更新）。

</details>
