### PR TITLE
fix(split-chunks): process remaining module copies at lower priorities

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -6,7 +6,7 @@ use std::{
 use derive_more::Debug;
 use futures::future::BoxFuture;
 use rayon::prelude::*;
-use rspack_collections::IdentifierMap;
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{ChunkUkey, Compilation, Module, ModuleIdentifier, SourceType};
 use rspack_error::Result;
 use rspack_regex::RspackRegex;
@@ -233,3 +233,46 @@ pub struct FallbackCacheGroup {
 
 pub type ModuleSizes = IdentifierMap<FxHashMap<SourceType, f64>>;
 pub(crate) type ModuleChunks = Vec<FxHashSet<ChunkUkey>>;
+
+#[derive(Debug)]
+pub(crate) enum ModuleChunkMap {
+  Shared {
+    modules: IdentifierSet,
+    chunks: FxHashSet<ChunkUkey>,
+  },
+  ByModule(IdentifierMap<FxHashSet<ChunkUkey>>),
+}
+
+impl ModuleChunkMap {
+  pub fn get(&self, module: &ModuleIdentifier) -> Option<&FxHashSet<ChunkUkey>> {
+    match self {
+      Self::Shared { modules, chunks } => modules.contains(module).then_some(chunks),
+      Self::ByModule(module_chunks) => module_chunks.get(module),
+    }
+  }
+
+  pub fn insert_chunk(&mut self, module: ModuleIdentifier, chunk: ChunkUkey) {
+    if let Self::Shared { modules, chunks } = self {
+      let mut module_chunks = modules
+        .iter()
+        .map(|module| (*module, chunks.clone()))
+        .collect::<IdentifierMap<_>>();
+      module_chunks.entry(module).or_default().insert(chunk);
+      *self = Self::ByModule(module_chunks);
+      return;
+    }
+    let Self::ByModule(module_chunks) = self else {
+      unreachable!();
+    };
+    module_chunks.entry(module).or_default().insert(chunk);
+  }
+
+  pub fn retain_modules(&mut self, modules_to_keep: &IdentifierSet) {
+    match self {
+      Self::Shared { modules, .. } => modules.retain(|module| modules_to_keep.contains(module)),
+      Self::ByModule(module_chunks) => {
+        module_chunks.retain(|module, _| modules_to_keep.contains(module));
+      }
+    }
+  }
+}

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -108,11 +108,22 @@ impl fmt::Display for ModuleGroupKey {
 ///
 /// The original name of `ModuleGroup` is `ChunkInfoItem` borrowed from Webpack
 #[derive(Debug)]
+enum ModuleGroupChunks {
+  /// Anonymous groups are keyed by their exact chunk combination. `None` means the selected chunks
+  /// are still identical to `ModuleGroup::chunks`; a snapshot is created only if that union is
+  /// later mutated while choosing a reused destination.
+  Shared(Option<FxHashSet<ChunkUkey>>),
+  /// A named group can merge modules selected from different chunk combinations.
+  ByModule(IdentifierMap<FxHashSet<ChunkUkey>>),
+}
+
+#[derive(Debug)]
 pub(crate) struct ModuleGroup {
   pub modules: IdentifierSet,
-  /// The chunks selected for each module in this group.
+  /// The chunks selected for each module. Anonymous groups structurally share their exact chunk
+  /// combination instead of allocating one set per module.
   #[debug(skip)]
-  pub module_chunks: IdentifierMap<FxHashSet<ChunkUkey>>,
+  module_chunks: ModuleGroupChunks,
   /// the real index used for mapping the ModuleGroup to corresponding CacheGroup
   pub cache_group_index: u32,
   pub cache_group_reuse_existing_chunk: bool,
@@ -133,9 +144,14 @@ pub(crate) struct ModuleGroup {
 
 impl ModuleGroup {
   pub fn new(chunk_name: Option<String>, cache_group_index: u32, cache_group: &CacheGroup) -> Self {
+    let module_chunks = if chunk_name.is_some() {
+      ModuleGroupChunks::ByModule(Default::default())
+    } else {
+      ModuleGroupChunks::Shared(None)
+    };
     Self {
       modules: Default::default(),
-      module_chunks: Default::default(),
+      module_chunks,
       cache_group_index,
       cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
       sizes: Default::default(),
@@ -184,25 +200,72 @@ impl ModuleGroup {
     chunks: impl IntoIterator<Item = ChunkUkey>,
   ) {
     self.modules.insert(module);
-    let module_chunks = self.module_chunks.entry(module).or_default();
+    let ModuleGroupChunks::ByModule(module_chunks) = &mut self.module_chunks else {
+      unreachable!("add_module should only be used for named module groups");
+    };
+    let module_chunks = module_chunks.entry(module).or_default();
     for chunk in chunks {
       module_chunks.insert(chunk);
       self.chunks.insert(chunk);
     }
   }
 
+  pub fn add_module_with_shared_chunks(
+    &mut self,
+    module: ModuleIdentifier,
+    chunks: impl IntoIterator<Item = ChunkUkey>,
+  ) {
+    self.modules.insert(module);
+    let ModuleGroupChunks::Shared(shared_chunks) = &mut self.module_chunks else {
+      unreachable!("shared chunks should only be used for anonymous module groups");
+    };
+    if self.chunks.is_empty() {
+      debug_assert!(shared_chunks.is_none());
+      self.chunks.extend(chunks);
+    }
+  }
+
+  pub fn remove_group_chunk(&mut self, chunk: &ChunkUkey) {
+    if let ModuleGroupChunks::Shared(shared_chunks) = &mut self.module_chunks
+      && shared_chunks.is_none()
+    {
+      *shared_chunks = Some(self.chunks.clone());
+    }
+    self.chunks.remove(chunk);
+  }
+
+  pub fn get_module_chunks(&self, module: &ModuleIdentifier) -> Option<&FxHashSet<ChunkUkey>> {
+    if !self.modules.contains(module) {
+      return None;
+    }
+    match &self.module_chunks {
+      ModuleGroupChunks::Shared(Some(chunks)) => Some(chunks),
+      ModuleGroupChunks::Shared(None) => Some(&self.chunks),
+      ModuleGroupChunks::ByModule(module_chunks) => module_chunks.get(module),
+    }
+  }
+
+  pub fn uses_shared_module_chunks(&self) -> bool {
+    matches!(self.module_chunks, ModuleGroupChunks::Shared(_))
+  }
+
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
     if self.modules.remove(&module) {
-      self.module_chunks.remove(&module);
+      if let ModuleGroupChunks::ByModule(module_chunks) = &mut self.module_chunks {
+        module_chunks.remove(&module);
+      }
       self.removed.push(module);
     }
   }
 
   pub fn rebuild_chunks(&mut self) {
+    let ModuleGroupChunks::ByModule(module_chunks) = &self.module_chunks else {
+      return;
+    };
     self.chunks.clear();
     self
       .chunks
-      .extend(self.module_chunks.values().flatten().copied());
+      .extend(module_chunks.values().flatten().copied());
   }
 
   pub fn prepare_modules_for_sizes_and_compare(&mut self) {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -258,11 +258,26 @@ impl ModuleGroup {
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
-    if self.modules.remove(&module) {
-      if let ModuleGroupChunks::ByModule(module_chunks) = &mut self.module_chunks {
-        module_chunks.remove(&module);
+    self.remove_modules([module]);
+  }
+
+  pub fn remove_modules(&mut self, modules: impl IntoIterator<Item = ModuleIdentifier>) {
+    match &mut self.module_chunks {
+      ModuleGroupChunks::Shared(_) => {
+        for module in modules {
+          if self.modules.remove(&module) {
+            self.removed.push(module);
+          }
+        }
       }
-      self.removed.push(module);
+      ModuleGroupChunks::ByModule(module_chunks) => {
+        for module in modules {
+          if self.modules.remove(&module) {
+            module_chunks.remove(&module);
+            self.removed.push(module);
+          }
+        }
+      }
     }
   }
 

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -1,7 +1,7 @@
 use std::{cmp::Ordering, fmt};
 
 use derive_more::Debug;
-use rspack_collections::IdentifierSet;
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -110,6 +110,9 @@ impl fmt::Display for ModuleGroupKey {
 #[derive(Debug)]
 pub(crate) struct ModuleGroup {
   pub modules: IdentifierSet,
+  /// The chunks selected for each module in this group.
+  #[debug(skip)]
+  pub module_chunks: IdentifierMap<FxHashSet<ChunkUkey>>,
   /// the real index used for mapping the ModuleGroup to corresponding CacheGroup
   pub cache_group_index: u32,
   pub cache_group_reuse_existing_chunk: bool,
@@ -132,6 +135,7 @@ impl ModuleGroup {
   pub fn new(chunk_name: Option<String>, cache_group_index: u32, cache_group: &CacheGroup) -> Self {
     Self {
       modules: Default::default(),
+      module_chunks: Default::default(),
       cache_group_index,
       cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
       sizes: Default::default(),
@@ -174,14 +178,31 @@ impl ModuleGroup {
     }
   }
 
-  pub fn add_module(&mut self, module: ModuleIdentifier) {
+  pub fn add_module(
+    &mut self,
+    module: ModuleIdentifier,
+    chunks: impl IntoIterator<Item = ChunkUkey>,
+  ) {
     self.modules.insert(module);
+    let module_chunks = self.module_chunks.entry(module).or_default();
+    for chunk in chunks {
+      module_chunks.insert(chunk);
+      self.chunks.insert(chunk);
+    }
   }
 
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
     if self.modules.remove(&module) {
+      self.module_chunks.remove(&module);
       self.removed.push(module);
     }
+  }
+
+  pub fn rebuild_chunks(&mut self) {
+    self.chunks.clear();
+    self
+      .chunks
+      .extend(self.module_chunks.values().flatten().copied());
   }
 
   pub fn prepare_modules_for_sizes_and_compare(&mut self) {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -249,6 +249,14 @@ impl ModuleGroup {
     matches!(self.module_chunks, ModuleGroupChunks::Shared(_))
   }
 
+  pub fn shared_module_chunks(&self) -> Option<&FxHashSet<ChunkUkey>> {
+    match &self.module_chunks {
+      ModuleGroupChunks::Shared(Some(chunks)) => Some(chunks),
+      ModuleGroupChunks::Shared(None) => Some(&self.chunks),
+      ModuleGroupChunks::ByModule(_) => None,
+    }
+  }
+
   pub fn remove_module(&mut self, module: ModuleIdentifier) {
     if self.modules.remove(&module) {
       if let ModuleGroupChunks::ByModule(module_chunks) = &mut self.module_chunks {

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,11 +1,14 @@
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   Chunk, ChunkSplitData, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation,
 };
 use rustc_hash::FxHashSet;
 
-use crate::{SplitChunksPlugin, common::ModuleChunks, module_group::ModuleGroup};
+use crate::{
+  SplitChunksPlugin,
+  common::{ModuleChunkMap, ModuleChunks},
+  module_group::ModuleGroup,
+};
 
 fn put_split_chunk_reason(
   chunk_reason: &mut Option<String>,
@@ -199,52 +202,88 @@ impl SplitChunksPlugin {
     new_chunk: ChunkUkey,
     original_chunks: &FxHashSet<ChunkUkey>,
     compilation: &Compilation,
-  ) -> IdentifierMap<FxHashSet<ChunkUkey>> {
+  ) -> ModuleChunkMap {
     let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-    item
-      .modules
-      .iter()
-      .filter_map(|mid| {
-        let selected_chunks = item.module_chunks.get(mid)?;
-        if let Some(module) = compilation.module_by_identifier(mid)
-          && module
-            .chunk_condition(&new_chunk, compilation)
-            .is_some_and(|condition| !condition)
-        {
-          return None;
-        }
+    if item.uses_shared_module_chunks() {
+      debug_assert!(original_chunks.is_subset(&item.chunks));
+      let chunks = original_chunks.clone();
+      let modules = item
+        .modules
+        .iter()
+        .filter(|mid| {
+          compilation
+            .module_by_identifier(mid)
+            .and_then(|module| module.chunk_condition(&new_chunk, compilation))
+            != Some(false)
+        })
+        .copied()
+        .collect();
+      return ModuleChunkMap::Shared { modules, chunks };
+    }
 
-        let chunks = original_chunks
-          .iter()
-          .filter(|chunk| {
-            selected_chunks.contains(chunk) && chunk_graph.is_module_in_chunk(mid, **chunk)
-          })
-          .copied()
-          .collect::<FxHashSet<_>>();
-        (!chunks.is_empty()).then_some((*mid, chunks))
-      })
-      .collect()
+    ModuleChunkMap::ByModule(
+      item
+        .modules
+        .iter()
+        .filter_map(|mid| {
+          let selected_chunks = item.get_module_chunks(mid)?;
+          if let Some(module) = compilation.module_by_identifier(mid)
+            && module
+              .chunk_condition(&new_chunk, compilation)
+              .is_some_and(|condition| !condition)
+          {
+            return None;
+          }
+
+          let chunks = original_chunks
+            .iter()
+            .filter(|chunk| {
+              selected_chunks.contains(chunk) && chunk_graph.is_module_in_chunk(mid, **chunk)
+            })
+            .copied()
+            .collect::<FxHashSet<_>>();
+          (!chunks.is_empty()).then_some((*mid, chunks))
+        })
+        .collect(),
+    )
   }
 
   /// Moves `modules` into `new_chunk` and removes their selected source placements.
   // #[tracing::instrument(skip_all)]
   pub(crate) fn move_modules_to_new_chunk_and_remove_from_old_chunks(
     &self,
-    modules: &IdentifierSet,
-    placed_module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
+    placed_module_chunks: &ModuleChunkMap,
     new_chunk: ChunkUkey,
     compilation: &mut Compilation,
   ) {
-    let module_identifiers = modules.iter().copied().collect::<Vec<_>>();
-
     let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
-    for module in modules {
-      let Some(chunks) = placed_module_chunks.get(module) else {
-        continue;
-      };
+    let module_count = match placed_module_chunks {
+      ModuleChunkMap::Shared { modules, .. } => modules.len(),
+      ModuleChunkMap::ByModule(module_chunks) => module_chunks.len(),
+    };
+    let mut module_identifiers = Vec::with_capacity(module_count);
+    let mut move_module = |module: &ModuleIdentifier, chunks: &FxHashSet<ChunkUkey>| {
+      let mut has_source_placement = false;
       for chunk in chunks {
         if *chunk != new_chunk {
+          has_source_placement = true;
           chunk_graph.disconnect_chunk_and_module(chunk, *module);
+        }
+      }
+      if has_source_placement {
+        module_identifiers.push(*module);
+      }
+    };
+
+    match placed_module_chunks {
+      ModuleChunkMap::Shared { modules, chunks } => {
+        for module in modules {
+          move_module(module, chunks);
+        }
+      }
+      ModuleChunkMap::ByModule(module_chunks) => {
+        for (module, chunks) in module_chunks {
+          move_module(module, chunks);
         }
       }
     }

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -257,10 +257,24 @@ impl SplitChunksPlugin {
     compilation: &mut Compilation,
   ) {
     let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
-    let module_count = match placed_module_chunks {
-      ModuleChunkMap::Shared { modules, .. } => modules.len(),
-      ModuleChunkMap::ByModule(module_chunks) => module_chunks.len(),
+    if let ModuleChunkMap::Shared { modules, chunks } = placed_module_chunks {
+      let modules = modules.iter().copied().collect::<Vec<_>>();
+      let chunks = chunks
+        .iter()
+        .filter(|chunk| **chunk != new_chunk)
+        .copied()
+        .collect::<Vec<_>>();
+      if !chunks.is_empty() {
+        chunk_graph.disconnect_chunks_and_modules(&chunks, &modules);
+        chunk_graph.connect_chunk_and_modules(new_chunk, &modules);
+      }
+      return;
+    }
+
+    let ModuleChunkMap::ByModule(module_chunks) = placed_module_chunks else {
+      unreachable!();
     };
+    let module_count = module_chunks.len();
     let mut module_identifiers = Vec::with_capacity(module_count);
     let mut move_module = |module: &ModuleIdentifier, chunks: &FxHashSet<ChunkUkey>| {
       let mut has_source_placement = false;
@@ -275,17 +289,8 @@ impl SplitChunksPlugin {
       }
     };
 
-    match placed_module_chunks {
-      ModuleChunkMap::Shared { modules, chunks } => {
-        for module in modules {
-          move_module(module, chunks);
-        }
-      }
-      ModuleChunkMap::ByModule(module_chunks) => {
-        for (module, chunks) in module_chunks {
-          move_module(module, chunks);
-        }
-      }
+    for (module, chunks) in module_chunks {
+      move_module(module, chunks);
     }
 
     chunk_graph.connect_chunk_and_modules(new_chunk, &module_identifiers);

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -190,7 +190,7 @@ impl SplitChunksPlugin {
     }
   }
 
-  /// This de-duplicated each module fro other chunks, make sure there's only one copy of each module.
+  /// Moves eligible modules into `new_chunk` and returns the modules that were actually moved.
   // #[tracing::instrument(skip_all)]
   pub(crate) fn move_modules_to_new_chunk_and_remove_from_old_chunks(
     &self,
@@ -198,7 +198,7 @@ impl SplitChunksPlugin {
     new_chunk: ChunkUkey,
     original_chunks: &FxHashSet<ChunkUkey>,
     compilation: &mut Compilation,
-  ) {
+  ) -> Vec<ModuleIdentifier> {
     let modules = item
       .modules
       .iter()
@@ -226,6 +226,8 @@ impl SplitChunksPlugin {
       .build_chunk_graph_artifact
       .chunk_graph
       .connect_chunk_and_modules(new_chunk, &modules);
+
+    modules
   }
 
   /// Since the modules are moved into the `new_chunk`, we should

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -199,9 +199,15 @@ impl SplitChunksPlugin {
     original_chunks: &FxHashSet<ChunkUkey>,
     compilation: &mut Compilation,
   ) -> Vec<ModuleIdentifier> {
+    let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
     let modules = item
       .modules
       .iter()
+      .filter(|mid| {
+        original_chunks
+          .iter()
+          .any(|chunk| chunk_graph.is_module_in_chunk(mid, *chunk))
+      })
       .filter(|mid| {
         if let Some(module) = compilation.module_by_identifier(mid)
           && module

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use rspack_collections::IdentifierSet;
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
   Chunk, ChunkSplitData, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation,
 };
@@ -191,51 +191,65 @@ impl SplitChunksPlugin {
     }
   }
 
-  /// Moves eligible modules into `new_chunk` and returns the modules that were actually moved.
+  /// Returns the selected source chunks for modules that can move into `new_chunk`.
   // #[tracing::instrument(skip_all)]
-  pub(crate) fn move_modules_to_new_chunk_and_remove_from_old_chunks(
+  pub(crate) fn get_module_chunks_to_move(
     &self,
     item: &ModuleGroup,
     new_chunk: ChunkUkey,
     original_chunks: &FxHashSet<ChunkUkey>,
-    compilation: &mut Compilation,
-  ) -> IdentifierSet {
+    compilation: &Compilation,
+  ) -> IdentifierMap<FxHashSet<ChunkUkey>> {
     let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-    let modules = item
+    item
       .modules
       .iter()
-      .filter(|mid| {
-        original_chunks
-          .iter()
-          .any(|chunk| chunk_graph.is_module_in_chunk(mid, *chunk))
-      })
-      .filter(|mid| {
+      .filter_map(|mid| {
+        let selected_chunks = item.module_chunks.get(mid)?;
         if let Some(module) = compilation.module_by_identifier(mid)
           && module
             .chunk_condition(&new_chunk, compilation)
             .is_some_and(|condition| !condition)
         {
-          return false;
+          return None;
         }
-        true
-      })
-      .copied()
-      .collect::<IdentifierSet>();
 
-    let chunks = original_chunks.iter().copied().collect::<Vec<_>>();
+        let chunks = original_chunks
+          .iter()
+          .filter(|chunk| {
+            selected_chunks.contains(chunk) && chunk_graph.is_module_in_chunk(mid, **chunk)
+          })
+          .copied()
+          .collect::<FxHashSet<_>>();
+        (!chunks.is_empty()).then_some((*mid, chunks))
+      })
+      .collect()
+  }
+
+  /// Moves `modules` into `new_chunk` and removes their selected source placements.
+  // #[tracing::instrument(skip_all)]
+  pub(crate) fn move_modules_to_new_chunk_and_remove_from_old_chunks(
+    &self,
+    modules: &IdentifierSet,
+    placed_module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
+    new_chunk: ChunkUkey,
+    compilation: &mut Compilation,
+  ) {
     let module_identifiers = modules.iter().copied().collect::<Vec<_>>();
 
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .disconnect_chunks_and_modules(&chunks, &module_identifiers);
+    let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
+    for module in modules {
+      let Some(chunks) = placed_module_chunks.get(module) else {
+        continue;
+      };
+      for chunk in chunks {
+        if *chunk != new_chunk {
+          chunk_graph.disconnect_chunk_and_module(chunk, *module);
+        }
+      }
+    }
 
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .connect_chunk_and_modules(new_chunk, &module_identifiers);
-
-    modules
+    chunk_graph.connect_chunk_and_modules(new_chunk, &module_identifiers);
   }
 
   /// Since the modules are moved into the `new_chunk`, we should

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -1,4 +1,5 @@
 use rayon::prelude::*;
+use rspack_collections::IdentifierSet;
 use rspack_core::{
   Chunk, ChunkSplitData, ChunkUkey, Compilation, ModuleIdentifier, incremental::Mutation,
 };
@@ -198,7 +199,7 @@ impl SplitChunksPlugin {
     new_chunk: ChunkUkey,
     original_chunks: &FxHashSet<ChunkUkey>,
     compilation: &mut Compilation,
-  ) -> Vec<ModuleIdentifier> {
+  ) -> IdentifierSet {
     let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
     let modules = item
       .modules
@@ -219,19 +220,20 @@ impl SplitChunksPlugin {
         true
       })
       .copied()
-      .collect::<Vec<_>>();
+      .collect::<IdentifierSet>();
 
     let chunks = original_chunks.iter().copied().collect::<Vec<_>>();
+    let module_identifiers = modules.iter().copied().collect::<Vec<_>>();
 
     compilation
       .build_chunk_graph_artifact
       .chunk_graph
-      .disconnect_chunks_and_modules(&chunks, &modules);
+      .disconnect_chunks_and_modules(&chunks, &module_identifiers);
 
     compilation
       .build_chunk_graph_artifact
       .chunk_graph
-      .connect_chunk_and_modules(new_chunk, &modules);
+      .connect_chunk_and_modules(new_chunk, &module_identifiers);
 
     modules
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -1,6 +1,7 @@
 use rayon::prelude::*;
-use rspack_collections::IdentifierSet;
-use rspack_core::{ModuleIdentifier, SourceType};
+use rspack_collections::{IdentifierMap, IdentifierSet};
+use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
+use rustc_hash::FxHashSet;
 
 use super::ModuleGroupMap;
 use crate::{
@@ -109,6 +110,48 @@ impl SplitChunksPlugin {
         continue;
       }
       if size * (chunk_count as f64) < *min_reduction_size {
+        return false;
+      }
+    }
+
+    true
+  }
+
+  /// Calculate the actual reduction from module-source edges. A reused destination can be part of
+  /// `module_chunks`, but it keeps the module and therefore contributes no size reduction.
+  pub(crate) fn check_min_size_reduction_for_module_chunks(
+    module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
+    destination_chunk: ChunkUkey,
+    module_sizes: &ModuleSizes,
+    min_size_reduction: &SplitChunkSizes,
+  ) -> bool {
+    for (ty, min_reduction_size) in min_size_reduction.iter() {
+      if *min_reduction_size == 0.0f64 {
+        continue;
+      }
+
+      let mut has_non_zero_size = false;
+      let mut total_size_reduction = 0.0;
+      for (module, chunks) in module_chunks {
+        let Some(size) = module_sizes
+          .get(module)
+          .and_then(|module_sizes| module_sizes.get(ty))
+        else {
+          continue;
+        };
+        if *size == 0.0f64 {
+          continue;
+        }
+
+        has_non_zero_size = true;
+        let source_chunk_count = chunks
+          .iter()
+          .filter(|chunk| **chunk != destination_chunk)
+          .count();
+        total_size_reduction += size * source_chunk_count as f64;
+      }
+
+      if has_non_zero_size && total_size_reduction < *min_reduction_size {
         return false;
       }
     }

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -1,11 +1,13 @@
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, IdentifierSet};
+use rspack_collections::IdentifierSet;
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
 use rustc_hash::FxHashSet;
 
 use super::ModuleGroupMap;
 use crate::{
-  CacheGroup, SplitChunkSizes, SplitChunksPlugin, common::ModuleSizes, module_group::ModuleGroup,
+  CacheGroup, SplitChunkSizes, SplitChunksPlugin,
+  common::{ModuleChunkMap, ModuleSizes},
+  module_group::ModuleGroup,
 };
 
 pub trait ModulesContainer {
@@ -120,7 +122,7 @@ impl SplitChunksPlugin {
   /// Calculate the actual reduction from module-source edges. A reused destination can be part of
   /// `module_chunks`, but it keeps the module and therefore contributes no size reduction.
   pub(crate) fn check_min_size_reduction_for_module_chunks(
-    module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
+    module_chunks: &ModuleChunkMap,
     destination_chunk: ChunkUkey,
     module_sizes: &ModuleSizes,
     min_size_reduction: &SplitChunkSizes,
@@ -132,15 +134,15 @@ impl SplitChunksPlugin {
 
       let mut has_non_zero_size = false;
       let mut total_size_reduction = 0.0;
-      for (module, chunks) in module_chunks {
+      let mut add_module_reduction = |module: &ModuleIdentifier, chunks: &FxHashSet<ChunkUkey>| {
         let Some(size) = module_sizes
           .get(module)
           .and_then(|module_sizes| module_sizes.get(ty))
         else {
-          continue;
+          return;
         };
         if *size == 0.0f64 {
-          continue;
+          return;
         }
 
         has_non_zero_size = true;
@@ -149,6 +151,18 @@ impl SplitChunksPlugin {
           .filter(|chunk| **chunk != destination_chunk)
           .count();
         total_size_reduction += size * source_chunk_count as f64;
+      };
+      match module_chunks {
+        ModuleChunkMap::Shared { modules, chunks } => {
+          for module in modules {
+            add_module_reduction(module, chunks);
+          }
+        }
+        ModuleChunkMap::ByModule(module_chunks) => {
+          for (module, chunks) in module_chunks {
+            add_module_reduction(module, chunks);
+          }
+        }
       }
 
       if has_non_zero_size && total_size_reduction < *min_reduction_size {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -333,10 +333,11 @@ impl SplitChunksPlugin {
           continue;
         }
 
-        if !Self::check_min_size_reduction(
-          module_group.get_sizes(&module_sizes),
+        if !Self::check_min_size_reduction_for_module_chunks(
+          &placed_module_chunks,
+          new_chunk,
+          &module_sizes,
           &cache_group.min_size_reduction,
-          placement_chunks.len(),
         ) {
           tracing::trace!(
             "ModuleGroup({module_group_key}) is skipped after selecting its actual placements because it violates min_size_reduction {:#?}",

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use rayon::iter::{
   IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
-use rspack_collections::IdentifierMap;
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -228,27 +228,14 @@ impl SplitChunksPlugin {
           &mut is_reuse_existing_chunk_with_all_modules,
         );
 
-        let new_chunk_mut = compilation
-          .build_chunk_graph_artifact
-          .chunk_by_ukey
-          .expect_get_mut(&new_chunk);
         tracing::trace!(
           "{module_group_key}, get Chunk {:?} with is_reuse_existing_chunk: {is_reuse_existing_chunk:?} and {is_reuse_existing_chunk_with_all_modules:?}",
-          new_chunk_mut.chunk_reason()
+          compilation
+            .build_chunk_graph_artifact
+            .chunk_by_ukey
+            .expect_get(&new_chunk)
+            .chunk_reason()
         );
-
-        if let Some(chunk_reason) = new_chunk_mut.chunk_reason_mut() {
-          chunk_reason.push_str(&format!(" (cache group: {})", cache_group.key.as_str()));
-          if let Some(chunk_name) = &module_group.chunk_name {
-            chunk_reason.push_str(&format!(" (name: {chunk_name})"));
-          }
-        }
-
-        if let Some(filename) = &cache_group.filename {
-          new_chunk_mut.set_filename_template(Some(filename.clone()));
-        }
-
-        new_chunk_mut.add_id_name_hints(cache_group.id_hint.clone());
 
         if is_reuse_existing_chunk {
           // The chunk is not new but created in code splitting. We need remove `new_chunk` since we would remove
@@ -269,24 +256,112 @@ impl SplitChunksPlugin {
           self.ensure_max_request_fit(compilation, cache_group, &mut used_chunks);
         }
 
-        if used_chunks.len() != module_group.chunks.len() {
-          // There are some chunks removed by `ensure_max_request_fit`
-          let used_chunks_len = if is_reuse_existing_chunk {
-            used_chunks.len() + 1
-          } else {
-            used_chunks.len()
-          };
-
-          if used_chunks_len < cache_group.min_chunks as usize {
-            // `min_size` is not satisfied, ignore this invalid `ModuleGroup`
-            tracing::trace!(
-              "ModuleGroup({module_group_key}) is skipped. Reason: used_chunks_len({used_chunks_len:?}) < cache_group.min_chunks({:?})",
-              cache_group.min_chunks
-            );
-            continue;
-            // return;
+        // `ensure_max_request_fit` can remove all source chunks for only some modules in a named
+        // group. Track the exact original module-chunk edges that this split will consume instead
+        // of treating the remaining modules and chunks as a cross product.
+        let mut used_chunks = used_chunks.into_owned();
+        let mut placed_module_chunks =
+          self.get_module_chunks_to_move(&module_group, new_chunk, &used_chunks, compilation);
+        let mut modules_to_move = placed_module_chunks
+          .keys()
+          .copied()
+          .collect::<IdentifierSet>();
+        {
+          let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+          if is_reuse_existing_chunk {
+            // A module already in the reused destination does not need to move, but that original
+            // placement still belongs to the winning group and must be unavailable to competing
+            // groups at this and lower priorities.
+            for module in module_group
+              .modules
+              .iter()
+              .filter(|module| chunk_graph.is_module_in_chunk(module, new_chunk))
+            {
+              placed_module_chunks
+                .entry(*module)
+                .or_default()
+                .insert(new_chunk);
+            }
           }
         }
+
+        let modules_without_placement = module_group
+          .modules
+          .iter()
+          .filter(|module| {
+            placed_module_chunks
+              .get(module)
+              .is_none_or(|chunks| chunks.len() < cache_group.min_chunks as usize)
+          })
+          .copied()
+          .collect::<Vec<_>>();
+        for module in modules_without_placement {
+          module_group.remove_module(module);
+        }
+
+        // Max-request pruning and chunk conditions can change the module subset, so size checks
+        // performed before selecting `used_chunks` are no longer sufficient.
+        if min_size::remove_min_size_violating_modules(
+          &module_group_key,
+          &mut module_group,
+          cache_group,
+          &module_sizes,
+        ) {
+          tracing::trace!(
+            "ModuleGroup({module_group_key}) is skipped after selecting its actual placements because it violates min_size {:#?}",
+            cache_group.min_size,
+          );
+          continue;
+        }
+
+        placed_module_chunks.retain(|module, _| module_group.modules.contains(module));
+        modules_to_move.retain(|module| module_group.modules.contains(module));
+
+        let placement_chunks = placed_module_chunks
+          .values()
+          .flatten()
+          .copied()
+          .collect::<FxHashSet<_>>();
+        used_chunks.retain(|chunk| placement_chunks.contains(chunk));
+
+        if placement_chunks.len() < cache_group.min_chunks as usize {
+          tracing::trace!(
+            "ModuleGroup({module_group_key}) is skipped. Reason: placement_chunks.len()({:?}) < cache_group.min_chunks({:?})",
+            placement_chunks.len(),
+            cache_group.min_chunks
+          );
+          continue;
+        }
+
+        if !Self::check_min_size_reduction(
+          module_group.get_sizes(&module_sizes),
+          &cache_group.min_size_reduction,
+          placement_chunks.len(),
+        ) {
+          tracing::trace!(
+            "ModuleGroup({module_group_key}) is skipped after selecting its actual placements because it violates min_size_reduction {:#?}",
+            cache_group.min_size_reduction,
+          );
+          continue;
+        }
+
+        // Only mutate metadata on an existing destination after the winning group has passed all
+        // checks. A group skipped after max-request pruning must not leave cache-group metadata on
+        // a chunk it did not actually use.
+        let new_chunk_mut = compilation
+          .build_chunk_graph_artifact
+          .chunk_by_ukey
+          .expect_get_mut(&new_chunk);
+        if let Some(chunk_reason) = new_chunk_mut.chunk_reason_mut() {
+          chunk_reason.push_str(&format!(" (cache group: {})", cache_group.key.as_str()));
+          if let Some(chunk_name) = &module_group.chunk_name {
+            chunk_reason.push_str(&format!(" (name: {chunk_name})"));
+          }
+        }
+        if let Some(filename) = &cache_group.filename {
+          new_chunk_mut.set_filename_template(Some(filename.clone()));
+        }
+        new_chunk_mut.add_id_name_hints(cache_group.id_hint.clone());
 
         if !cache_group.max_initial_size.is_empty() || !cache_group.max_async_size.is_empty() {
           max_size_setting_map.insert(
@@ -300,45 +375,27 @@ impl SplitChunksPlugin {
           );
         }
 
-        let moved_modules = self.move_modules_to_new_chunk_and_remove_from_old_chunks(
-          &module_group,
+        self.move_modules_to_new_chunk_and_remove_from_old_chunks(
+          &modules_to_move,
+          &placed_module_chunks,
           new_chunk,
-          &used_chunks,
           compilation,
         );
 
         self.split_from_original_chunks(&module_group, &used_chunks, new_chunk, compilation);
 
         self.remove_all_modules_from_other_module_groups(
-          &moved_modules,
+          &placed_module_chunks,
           &mut module_group_map,
-          &used_chunks,
-          compilation,
           &module_sizes,
         );
 
         if index != priority_len - 1 {
-          // Only the chunks actually used by this split are unavailable to lower priorities.
-          // `ensure_max_request_fit` may have removed chunks from `module_group.chunks`.
-          for module in &moved_modules {
-            let removed_chunks = removed_module_chunks.entry(*module).or_default();
-            removed_chunks.extend(used_chunks.iter().copied());
-          }
-          if is_reuse_existing_chunk {
-            // Moving from the reused destination is unnecessary, so it is absent from both
-            // `used_chunks` and possibly `moved_modules`. Record every module already present in
-            // the destination to keep that original edge unavailable to lower priorities.
-            let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-            for module in module_group
-              .modules
-              .iter()
-              .filter(|module| chunk_graph.is_module_in_chunk(module, new_chunk))
-            {
-              removed_module_chunks
-                .entry(*module)
-                .or_default()
-                .insert(new_chunk);
-            }
+          for (module, chunks) in &placed_module_chunks {
+            removed_module_chunks
+              .entry(*module)
+              .or_default()
+              .extend(chunks.iter().copied());
           }
         }
       }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -7,7 +7,9 @@ mod module_group;
 use std::{borrow::Cow, cmp::Ordering, fmt::Debug};
 
 use itertools::Itertools;
-use rayon::iter::{IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator};
+use rayon::iter::{
+  IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
+};
 use rspack_collections::IdentifierMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
@@ -129,54 +131,76 @@ impl SplitChunksPlugin {
     let mut max_size_setting_map: FxHashMap<ChunkUkey, MaxSizeSetting> = Default::default();
     let mut removed_module_chunks: IdentifierMap<FxHashSet<ChunkUkey>> = IdentifierMap::default();
 
-    let mut combinator = module_group::Combinator::default();
-
-    let non_used_exports_min_chunks = self
-      .cache_groups
-      .iter()
-      .filter(|cache_group| !cache_group.used_exports)
-      .map(|cache_group| cache_group.min_chunks as usize)
-      .min();
-
-    if let Some(min_chunks) = non_used_exports_min_chunks {
-      combinator.prepare_group_by_chunks(
-        &all_modules,
-        &module_chunks,
-        &chunk_index_map,
-        min_chunks,
-      );
-    }
-
-    if self
-      .cache_groups
-      .iter()
-      .any(|cache_group| cache_group.used_exports)
-    {
-      combinator.prepare_group_by_used_exports(
-        &all_modules,
-        &compilation.exports_info_artifact,
-        &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-        &module_chunks,
-        &chunk_index_map,
-      );
-    }
-
     logger.time_end(start);
 
     let start = logger.time("process cache groups");
     let priority_len = priority_cache_groups.len();
     for (index, (_, cache_groups)) in priority_cache_groups.into_iter().enumerate() {
+      // A higher-priority cache group consumes module-chunk edges, not the whole module. Build the
+      // combinations for this priority from the original chunk sets minus the consumed edges so a
+      // lower-priority cache group can still group a newly formed residual chunk set. Do not read
+      // the current chunk graph here because it also contains chunks created by earlier splits.
+      let available_module_chunks = if removed_module_chunks.is_empty() {
+        Cow::Borrowed(&module_chunks)
+      } else {
+        Cow::Owned(
+          all_modules
+            .par_iter()
+            .enumerate()
+            .map(|(module_index, module)| {
+              let chunks = module_chunks
+                .get(module_index)
+                .expect("should have module chunks");
+              if let Some(removed_chunks) = removed_module_chunks.get(module) {
+                chunks.difference(removed_chunks).copied().collect()
+              } else {
+                chunks.clone()
+              }
+            })
+            .collect(),
+        )
+      };
+
+      let mut combinator = module_group::Combinator::default();
+      let non_used_exports_min_chunks = cache_groups
+        .iter()
+        .filter(|cache_group| !cache_group.cache_group.used_exports)
+        .map(|cache_group| cache_group.cache_group.min_chunks as usize)
+        .min();
+
+      if let Some(min_chunks) = non_used_exports_min_chunks {
+        combinator.prepare_group_by_chunks(
+          &all_modules,
+          available_module_chunks.as_ref(),
+          &chunk_index_map,
+          min_chunks,
+        );
+      }
+
+      if cache_groups
+        .iter()
+        .any(|cache_group| cache_group.cache_group.used_exports)
+      {
+        combinator.prepare_group_by_used_exports(
+          &all_modules,
+          &compilation.exports_info_artifact,
+          &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+          available_module_chunks.as_ref(),
+          &chunk_index_map,
+        );
+      }
+
       let mut module_group_map = self
         .prepare_module_group_map(
           &combinator,
           &all_modules,
           cache_groups,
-          &removed_module_chunks,
           compilation,
-          &module_chunks,
+          available_module_chunks.as_ref(),
           &chunk_index_map,
         )
         .await?;
+      rayon::spawn(move || drop(combinator));
       tracing::trace!("prepared module_group_map {:#?}", module_group_map);
 
       module_group_map
@@ -276,7 +300,7 @@ impl SplitChunksPlugin {
           );
         }
 
-        self.move_modules_to_new_chunk_and_remove_from_old_chunks(
+        let moved_modules = self.move_modules_to_new_chunk_and_remove_from_old_chunks(
           &module_group,
           new_chunk,
           &used_chunks,
@@ -294,11 +318,13 @@ impl SplitChunksPlugin {
         );
 
         if index != priority_len - 1 {
-          for module in module_group.modules.iter() {
+          // Only the chunks actually used by this split are unavailable to lower priorities.
+          // `ensure_max_request_fit` may have removed chunks from `module_group.chunks`.
+          for module in moved_modules {
             removed_module_chunks
-              .entry(*module)
+              .entry(module)
               .or_default()
-              .extend(module_group.chunks.iter().copied());
+              .extend(used_chunks.iter().copied());
           }
         }
       }
@@ -310,8 +336,6 @@ impl SplitChunksPlugin {
       .ensure_max_size_fit(compilation, &max_size_setting_map)
       .await?;
     logger.time_end(start);
-
-    rayon::spawn(move || drop(combinator));
 
     Ok(())
   }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -289,9 +289,17 @@ impl SplitChunksPlugin {
           .modules
           .iter()
           .filter(|module| {
-            placed_module_chunks
-              .get(module)
-              .is_none_or(|chunks| chunks.len() < cache_group.min_chunks as usize)
+            let Some(placed_chunks) = placed_module_chunks.get(module) else {
+              return true;
+            };
+            let Some(selected_chunks) = module_group.module_chunks.get(module) else {
+              return true;
+            };
+            placed_chunks
+              .iter()
+              .filter(|chunk| selected_chunks.contains(*chunk))
+              .count()
+              < cache_group.min_chunks as usize
           })
           .copied()
           .collect::<Vec<_>>();
@@ -317,17 +325,28 @@ impl SplitChunksPlugin {
         placed_module_chunks.retain(|module, _| module_group.modules.contains(module));
         modules_to_move.retain(|module| module_group.modules.contains(module));
 
-        let placement_chunks = placed_module_chunks
-          .values()
-          .flatten()
-          .copied()
+        // Keep a reused destination in `placed_module_chunks` for ownership cleanup, even when the
+        // cache group's chunk filter did not select it. Such an excluded destination must not count
+        // towards `minChunks` or the source chunks split into the destination.
+        let selected_placement_chunks = placed_module_chunks
+          .iter()
+          .flat_map(|(module, placed_chunks)| {
+            let selected_chunks = module_group
+              .module_chunks
+              .get(module)
+              .expect("should have selected module chunks");
+            placed_chunks
+              .iter()
+              .filter(|chunk| selected_chunks.contains(*chunk))
+              .copied()
+          })
           .collect::<FxHashSet<_>>();
-        used_chunks.retain(|chunk| placement_chunks.contains(chunk));
+        used_chunks.retain(|chunk| selected_placement_chunks.contains(chunk));
 
-        if placement_chunks.len() < cache_group.min_chunks as usize {
+        if selected_placement_chunks.len() < cache_group.min_chunks as usize {
           tracing::trace!(
-            "ModuleGroup({module_group_key}) is skipped. Reason: placement_chunks.len()({:?}) < cache_group.min_chunks({:?})",
-            placement_chunks.len(),
+            "ModuleGroup({module_group_key}) is skipped. Reason: selected_placement_chunks.len()({:?}) < cache_group.min_chunks({:?})",
+            selected_placement_chunks.len(),
             cache_group.min_chunks
           );
           continue;

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -278,24 +278,49 @@ impl SplitChunksPlugin {
           }
         }
 
-        let modules_without_placement = module_group
-          .modules
-          .iter()
-          .filter(|module| {
-            let Some(placed_chunks) = placed_module_chunks.get(module) else {
-              return true;
-            };
-            let Some(selected_chunks) = module_group.get_module_chunks(module) else {
-              return true;
-            };
-            placed_chunks
-              .iter()
-              .filter(|chunk| selected_chunks.contains(*chunk))
-              .count()
-              < cache_group.min_chunks as usize
-          })
-          .copied()
-          .collect::<Vec<_>>();
+        let modules_without_placement = match &placed_module_chunks {
+          ModuleChunkMap::Shared { modules, chunks }
+            if module_group.uses_shared_module_chunks() =>
+          {
+            debug_assert!(modules.is_subset(&module_group.modules));
+            debug_assert!(
+              chunks.is_subset(
+                module_group
+                  .shared_module_chunks()
+                  .expect("should have shared module chunks")
+              )
+            );
+            if chunks.len() < cache_group.min_chunks as usize {
+              module_group.modules.iter().copied().collect::<Vec<_>>()
+            } else if modules.len() == module_group.modules.len() {
+              Vec::new()
+            } else {
+              module_group
+                .modules
+                .difference(modules)
+                .copied()
+                .collect::<Vec<_>>()
+            }
+          }
+          _ => module_group
+            .modules
+            .iter()
+            .filter(|module| {
+              let Some(placed_chunks) = placed_module_chunks.get(module) else {
+                return true;
+              };
+              let Some(selected_chunks) = module_group.get_module_chunks(module) else {
+                return true;
+              };
+              placed_chunks
+                .iter()
+                .filter(|chunk| selected_chunks.contains(*chunk))
+                .count()
+                < cache_group.min_chunks as usize
+            })
+            .copied()
+            .collect::<Vec<_>>(),
+        };
         if !modules_without_placement.is_empty() {
           // End the borrow of `module_group.chunks` only on the slow path that mutates the group.
           // The common path can keep using the original set without cloning it.

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -310,7 +310,7 @@ impl SplitChunksPlugin {
         self.split_from_original_chunks(&module_group, &used_chunks, new_chunk, compilation);
 
         self.remove_all_modules_from_other_module_groups(
-          &module_group,
+          &moved_modules,
           &mut module_group_map,
           &used_chunks,
           compilation,
@@ -320,13 +320,24 @@ impl SplitChunksPlugin {
         if index != priority_len - 1 {
           // Only the chunks actually used by this split are unavailable to lower priorities.
           // `ensure_max_request_fit` may have removed chunks from `module_group.chunks`.
-          for module in moved_modules {
-            let removed_chunks = removed_module_chunks.entry(module).or_default();
+          for module in &moved_modules {
+            let removed_chunks = removed_module_chunks.entry(*module).or_default();
             removed_chunks.extend(used_chunks.iter().copied());
-            if is_reuse_existing_chunk {
-              // The reused destination was removed from `module_group.chunks`, but it is still a
-              // consumed original module-chunk edge and must not become a residual candidate.
-              removed_chunks.insert(new_chunk);
+          }
+          if is_reuse_existing_chunk {
+            // Moving from the reused destination is unnecessary, so it is absent from both
+            // `used_chunks` and possibly `moved_modules`. Record every module already present in
+            // the destination to keep that original edge unavailable to lower priorities.
+            let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
+            for module in module_group
+              .modules
+              .iter()
+              .filter(|module| chunk_graph.is_module_in_chunk(module, new_chunk))
+            {
+              removed_module_chunks
+                .entry(*module)
+                .or_default()
+                .insert(new_chunk);
             }
           }
         }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -321,10 +321,13 @@ impl SplitChunksPlugin {
           // Only the chunks actually used by this split are unavailable to lower priorities.
           // `ensure_max_request_fit` may have removed chunks from `module_group.chunks`.
           for module in moved_modules {
-            removed_module_chunks
-              .entry(module)
-              .or_default()
-              .extend(used_chunks.iter().copied());
+            let removed_chunks = removed_module_chunks.entry(module).or_default();
+            removed_chunks.extend(used_chunks.iter().copied());
+            if is_reuse_existing_chunk {
+              // The reused destination was removed from `module_group.chunks`, but it is still a
+              // consumed original module-chunk edge and must not become a residual candidate.
+              removed_chunks.insert(new_chunk);
+            }
           }
         }
       }

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -10,7 +10,7 @@ use itertools::Itertools;
 use rayon::iter::{
   IndexedParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator, ParallelIterator,
 };
-use rspack_collections::{IdentifierMap, IdentifierSet};
+use rspack_collections::IdentifierMap;
 use rspack_core::{ChunkUkey, Compilation, CompilationOptimizeChunks, Logger, Plugin};
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -20,7 +20,7 @@ use tracing::instrument;
 
 use crate::{
   CacheGroup, SplitChunkSizes,
-  common::FallbackCacheGroup,
+  common::{FallbackCacheGroup, ModuleChunkMap},
   get_module_sizes,
   module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey},
 };
@@ -240,7 +240,7 @@ impl SplitChunksPlugin {
         if is_reuse_existing_chunk {
           // The chunk is not new but created in code splitting. We need remove `new_chunk` since we would remove
           // modules in this `Chunk/ModuleGroup` from other chunks. Other chunks is stored in `ModuleGroup.chunks`.
-          module_group.chunks.remove(&new_chunk);
+          module_group.remove_group_chunk(&new_chunk);
         }
 
         // If the module group size exceeds enforceSizeThreshold, skip maxRequest constraints
@@ -259,13 +259,9 @@ impl SplitChunksPlugin {
         // `ensure_max_request_fit` can remove all source chunks for only some modules in a named
         // group. Track the exact original module-chunk edges that this split will consume instead
         // of treating the remaining modules and chunks as a cross product.
-        let mut used_chunks = used_chunks.into_owned();
+        let mut used_chunks = used_chunks;
         let mut placed_module_chunks =
           self.get_module_chunks_to_move(&module_group, new_chunk, &used_chunks, compilation);
-        let mut modules_to_move = placed_module_chunks
-          .keys()
-          .copied()
-          .collect::<IdentifierSet>();
         {
           let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
           if is_reuse_existing_chunk {
@@ -277,10 +273,7 @@ impl SplitChunksPlugin {
               .iter()
               .filter(|module| chunk_graph.is_module_in_chunk(module, new_chunk))
             {
-              placed_module_chunks
-                .entry(*module)
-                .or_default()
-                .insert(new_chunk);
+              placed_module_chunks.insert_chunk(*module, new_chunk);
             }
           }
         }
@@ -292,7 +285,7 @@ impl SplitChunksPlugin {
             let Some(placed_chunks) = placed_module_chunks.get(module) else {
               return true;
             };
-            let Some(selected_chunks) = module_group.module_chunks.get(module) else {
+            let Some(selected_chunks) = module_group.get_module_chunks(module) else {
               return true;
             };
             placed_chunks
@@ -303,45 +296,61 @@ impl SplitChunksPlugin {
           })
           .copied()
           .collect::<Vec<_>>();
-        for module in modules_without_placement {
-          module_group.remove_module(module);
-        }
+        if !modules_without_placement.is_empty() {
+          // End the borrow of `module_group.chunks` only on the slow path that mutates the group.
+          // The common path can keep using the original set without cloning it.
+          let used_chunks_owned = used_chunks.into_owned();
+          for module in modules_without_placement {
+            module_group.remove_module(module);
+          }
 
-        // Max-request pruning and chunk conditions can change the module subset, so size checks
-        // performed before selecting `used_chunks` are no longer sufficient.
-        if min_size::remove_min_size_violating_modules(
-          &module_group_key,
-          &mut module_group,
-          cache_group,
-          &module_sizes,
-        ) {
-          tracing::trace!(
-            "ModuleGroup({module_group_key}) is skipped after selecting its actual placements because it violates min_size {:#?}",
-            cache_group.min_size,
-          );
-          continue;
-        }
+          // Max-request pruning and chunk conditions can change the module subset, so size checks
+          // performed before selecting `used_chunks` are no longer sufficient.
+          if min_size::remove_min_size_violating_modules(
+            &module_group_key,
+            &mut module_group,
+            cache_group,
+            &module_sizes,
+          ) {
+            tracing::trace!(
+              "ModuleGroup({module_group_key}) is skipped after selecting its actual placements because it violates min_size {:#?}",
+              cache_group.min_size,
+            );
+            continue;
+          }
 
-        placed_module_chunks.retain(|module, _| module_group.modules.contains(module));
-        modules_to_move.retain(|module| module_group.modules.contains(module));
+          placed_module_chunks.retain_modules(&module_group.modules);
+          used_chunks = Cow::Owned(used_chunks_owned);
+        }
 
         // Keep a reused destination in `placed_module_chunks` for ownership cleanup, even when the
         // cache group's chunk filter did not select it. Such an excluded destination must not count
         // towards `minChunks` or the source chunks split into the destination.
-        let selected_placement_chunks = placed_module_chunks
-          .iter()
-          .flat_map(|(module, placed_chunks)| {
-            let selected_chunks = module_group
-              .module_chunks
-              .get(module)
-              .expect("should have selected module chunks");
-            placed_chunks
+        let selected_placement_chunks = match &placed_module_chunks {
+          ModuleChunkMap::Shared { chunks, .. } => Cow::Borrowed(chunks),
+          ModuleChunkMap::ByModule(module_chunks) => Cow::Owned(
+            module_chunks
               .iter()
-              .filter(|chunk| selected_chunks.contains(*chunk))
-              .copied()
-          })
-          .collect::<FxHashSet<_>>();
-        used_chunks.retain(|chunk| selected_placement_chunks.contains(chunk));
+              .flat_map(|(module, placed_chunks)| {
+                let selected_chunks = module_group
+                  .get_module_chunks(module)
+                  .expect("should have selected module chunks");
+                placed_chunks
+                  .iter()
+                  .filter(|chunk| selected_chunks.contains(*chunk))
+                  .copied()
+              })
+              .collect::<FxHashSet<_>>(),
+          ),
+        };
+        if used_chunks
+          .iter()
+          .any(|chunk| !selected_placement_chunks.contains(chunk))
+        {
+          used_chunks
+            .to_mut()
+            .retain(|chunk| selected_placement_chunks.contains(chunk));
+        }
 
         if selected_placement_chunks.len() < cache_group.min_chunks as usize {
           tracing::trace!(
@@ -396,7 +405,6 @@ impl SplitChunksPlugin {
         }
 
         self.move_modules_to_new_chunk_and_remove_from_old_chunks(
-          &modules_to_move,
           &placed_module_chunks,
           new_chunk,
           compilation,
@@ -411,11 +419,23 @@ impl SplitChunksPlugin {
         );
 
         if index != priority_len - 1 {
-          for (module, chunks) in &placed_module_chunks {
-            removed_module_chunks
-              .entry(*module)
-              .or_default()
-              .extend(chunks.iter().copied());
+          match &placed_module_chunks {
+            ModuleChunkMap::Shared { modules, chunks } => {
+              for module in modules {
+                removed_module_chunks
+                  .entry(*module)
+                  .or_default()
+                  .extend(chunks.iter().copied());
+              }
+            }
+            ModuleChunkMap::ByModule(module_chunks) => {
+              for (module, chunks) in module_chunks {
+                removed_module_chunks
+                  .entry(*module)
+                  .or_default()
+                  .extend(chunks.iter().copied());
+              }
+            }
           }
         }
       }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -6,7 +6,6 @@ use std::{
 
 use futures::future::join_all;
 use rayon::prelude::*;
-use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
   RuntimeKeyMap, UsageKey, get_runtime_key,
@@ -435,7 +434,6 @@ impl SplitChunksPlugin {
     combinator: &Combinator,
     all_modules: &[ModuleIdentifier],
     cache_groups: Vec<IndexedCacheGroup<'_>>,
-    removed_module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
     compilation: &Compilation,
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
@@ -444,8 +442,8 @@ impl SplitChunksPlugin {
     let module_group_map: FxDashMap<ModuleGroupKey, ModuleGroup> = FxDashMap::default();
     let module_group_results = rspack_parallel::scope::<_, Result<_>>(|token| {
       all_modules.iter().enumerate().for_each(|(module_index, mid)| {
-        let s = unsafe { token.used((&cache_groups, module_index, mid, &module_graph, compilation, &module_group_map, &combinator, module_chunks, removed_module_chunks, chunk_index_map)) };
-        s.spawn(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, removed_module_chunks, chunk_index_map)| async move {
+        let s = unsafe { token.used((&cache_groups, module_index, mid, &module_graph, compilation, &module_group_map, &combinator, module_chunks, chunk_index_map)) };
+        s.spawn(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, chunk_index_map)| async move {
           let belong_to_chunks = module_chunks
             .get(module_index)
             .expect("should have module chunks");
@@ -453,12 +451,6 @@ impl SplitChunksPlugin {
             return Ok(());
           }
 
-          let removed_chunks = removed_module_chunks.get(mid);
-          if let Some(removed_chunks) = removed_chunks
-            && belong_to_chunks.iter().all(|c| removed_chunks.contains(c))
-          {
-            return Ok(());
-          }
           let module = module_graph.module_by_identifier(mid).expect("should have module").as_ref();
           let mut used_exports_combs = None;
           let mut non_used_exports_combs = None;
@@ -540,14 +532,6 @@ impl SplitChunksPlugin {
               if matches!(&cache_group.chunk_filter, ChunkFilter::All)
                 && matches!(&cache_group.name, ChunkNameGetter::Disabled)
               {
-                if let Some(removed_chunks) = removed_chunks
-                  && chunk_combination
-                    .iter()
-                    .any(|c| removed_chunks.contains(c))
-                {
-                  continue;
-                }
-
                 let mut module_group = {
                   module_group_map
                     .entry(ModuleGroupKey::Anonymous {
@@ -605,11 +589,6 @@ impl SplitChunksPlugin {
                 continue;
               }
 
-              if let Some(removed_chunks) = removed_chunks
-                && selected_chunks.iter().any(|c| removed_chunks.contains(c))
-              {
-                continue;
-              }
               merge_matched_item_into_module_group_map(
                 MatchedItem {
                   module,

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -636,20 +636,48 @@ impl SplitChunksPlugin {
     let keys_of_invalid_group = module_group_map
       .par_iter_mut()
       .filter_map(|(key, other_module_group)| {
-        let duplicated_modules = other_module_group
-          .modules
-          .iter()
-          .filter(|module| {
-            let Some(placed_chunks) = placed_module_chunks.get(module) else {
-              return false;
-            };
-            let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
-              return false;
-            };
-            placed_chunks.intersection(other_chunks).next().is_some()
-          })
-          .copied()
-          .collect::<Vec<_>>();
+        let duplicated_modules = match (
+          placed_module_chunks,
+          other_module_group.shared_module_chunks(),
+        ) {
+          (
+            ModuleChunkMap::Shared {
+              modules,
+              chunks: placed_chunks,
+            },
+            Some(other_chunks),
+          ) => {
+            if placed_chunks.is_disjoint(other_chunks) {
+              return None;
+            }
+            if other_module_group.modules.len() > modules.len() {
+              modules
+                .intersection(&other_module_group.modules)
+                .copied()
+                .collect::<Vec<_>>()
+            } else {
+              other_module_group
+                .modules
+                .intersection(modules)
+                .copied()
+                .collect::<Vec<_>>()
+            }
+          }
+          _ => other_module_group
+            .modules
+            .iter()
+            .filter(|module| {
+              let Some(placed_chunks) = placed_module_chunks.get(module) else {
+                return false;
+              };
+              let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
+                return false;
+              };
+              placed_chunks.intersection(other_chunks).next().is_some()
+            })
+            .copied()
+            .collect::<Vec<_>>(),
+        };
 
         if duplicated_modules.is_empty() {
           return None;

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -647,9 +647,7 @@ impl SplitChunksPlugin {
             },
             Some(other_chunks),
           ) => {
-            if placed_chunks.is_disjoint(other_chunks) {
-              return None;
-            }
+            other_chunks.intersection(placed_chunks).next()?;
             if other_module_group.modules.len() > modules.len() {
               modules
                 .intersection(&other_module_group.modules)
@@ -683,9 +681,7 @@ impl SplitChunksPlugin {
           return None;
         }
 
-        for module in duplicated_modules {
-          other_module_group.remove_module(module);
-        }
+        other_module_group.remove_modules(duplicated_modules);
 
         if other_module_group.modules.is_empty() {
           tracing::trace!(

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -6,7 +6,7 @@ use std::{
 
 use futures::future::join_all;
 use rayon::prelude::*;
-use rspack_collections::IdentifierSet;
+use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
   RuntimeKeyMap, UsageKey, get_runtime_key,
@@ -541,10 +541,10 @@ impl SplitChunksPlugin {
                     })
                     .or_insert_with(|| ModuleGroup::new(None, *cache_group_index, cache_group))
                 };
-                module_group.add_module(module.identifier());
-                if module_group.chunks.is_empty() {
-                  module_group.chunks.extend(chunk_combination.iter().copied());
-                }
+                module_group.add_module(
+                  module.identifier(),
+                  chunk_combination.iter().copied(),
+                );
                 continue;
               }
 
@@ -629,36 +629,35 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(crate) fn remove_all_modules_from_other_module_groups(
     &self,
-    moved_modules: &IdentifierSet,
+    placed_module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
     module_group_map: &mut ModuleGroupMap,
-    used_chunks: &FxHashSet<ChunkUkey>,
-    compilation: &Compilation,
     module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
     let keys_of_invalid_group = module_group_map
       .par_iter_mut()
       .filter_map(|(key, other_module_group)| {
-        other_module_group
-          .chunks
-          .intersection(used_chunks)
-          .next()?;
+        let duplicated_modules = other_module_group
+          .modules
+          .iter()
+          .filter(|module| {
+            let Some(placed_chunks) = placed_module_chunks.get(module) else {
+              return false;
+            };
+            let Some(other_chunks) = other_module_group.module_chunks.get(module) else {
+              return false;
+            };
+            placed_chunks.intersection(other_chunks).next().is_some()
+          })
+          .copied()
+          .collect::<Vec<_>>();
 
-        let module_count = other_module_group.modules.len();
-
-        let duplicated_modules = if other_module_group.modules.len() > moved_modules.len() {
-          moved_modules.intersection(&other_module_group.modules).copied().collect::<Vec<_>>()
-        } else {
-          other_module_group.modules.intersection(moved_modules).copied().collect::<Vec<_>>()
-        };
+        if duplicated_modules.is_empty() {
+          return None;
+        }
 
         for module in duplicated_modules {
           other_module_group.remove_module(module);
-        }
-
-        if module_count == other_module_group.modules.len() {
-          // nothing is removed
-          return None;
         }
 
         if other_module_group.modules.is_empty() {
@@ -669,18 +668,23 @@ impl SplitChunksPlugin {
         }
 
         tracing::trace!("other_module_group: {other_module_group:#?}");
-        tracing::trace!("moved_modules: {moved_modules:#?}");
-
-        // Since there are modules removed, make sure the rest of chunks are all used.
-        other_module_group.chunks.retain(|c| {
-          compilation.build_chunk_graph_artifact.chunk_graph
-            .is_any_module_in_chunk(other_module_group.modules.iter(), *c)
-        });
+        tracing::trace!("placed_module_chunks: {placed_module_chunks:#?}");
 
         let cache_group = other_module_group.get_cache_group(&self.cache_groups);
 
         // Since we removed some modules and chunks from the `other_module_group`. There are chances
         // that the `min_chunks` and `min_size` validation is not satisfied anymore.
+
+        // Validate `min_size` again
+        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
+          tracing::trace!(
+            "{key} is deleted for violating min_size {:#?}",
+            cache_group.min_size,
+          );
+          return Some(key.clone());
+        }
+
+        other_module_group.rebuild_chunks();
 
         // Validate `min_chunks` again
         if other_module_group.chunks.len() < cache_group.min_chunks as usize {
@@ -688,15 +692,6 @@ impl SplitChunksPlugin {
             "{key} is deleted for each_module_group.chunks.len()({:?}) < cache_group.min_chunks({:?})",
             other_module_group.chunks.len(),
             cache_group.min_chunks
-          );
-          return Some(key.clone());
-        }
-
-        // Validate `min_size` again
-        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
-          tracing::trace!(
-            "{key} is deleted for violating min_size {:#?}",
-            cache_group.min_size,
           );
           return Some(key.clone());
         }
@@ -754,7 +749,6 @@ async fn merge_matched_item_into_module_group_map(
       f(ctx).await?
     }
   };
-  let is_anonymous = chunk_name.is_none();
   let key = if let Some(cache_group_name) = &chunk_name {
     ModuleGroupKey::Named {
       cache_group_index,
@@ -774,12 +768,7 @@ async fn merge_matched_item_into_module_group_map(
       .entry(key)
       .or_insert_with(|| ModuleGroup::new(chunk_name, cache_group_index, cache_group))
   };
-  let should_extend_chunks = !(is_anonymous && matches!(&selected_chunks, SelectedChunks::All(_)))
-    || module_group.chunks.is_empty();
-  module_group.add_module(module.identifier());
-  if should_extend_chunks {
-    module_group.chunks.extend(selected_chunks.iter().copied());
-  }
+  module_group.add_module(module.identifier(), selected_chunks.iter().copied());
 
   Ok(())
 }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -6,6 +6,7 @@ use std::{
 
 use futures::future::join_all;
 use rayon::prelude::*;
+use rspack_collections::IdentifierSet;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
   RuntimeKeyMap, UsageKey, get_runtime_key,
@@ -628,7 +629,7 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(crate) fn remove_all_modules_from_other_module_groups(
     &self,
-    current_module_group: &ModuleGroup,
+    moved_modules: &IdentifierSet,
     module_group_map: &mut ModuleGroupMap,
     used_chunks: &FxHashSet<ChunkUkey>,
     compilation: &Compilation,
@@ -645,10 +646,10 @@ impl SplitChunksPlugin {
 
         let module_count = other_module_group.modules.len();
 
-        let duplicated_modules = if other_module_group.modules.len() > current_module_group.modules.len() {
-          current_module_group.modules.intersection(&other_module_group.modules).copied().collect::<Vec<_>>()
+        let duplicated_modules = if other_module_group.modules.len() > moved_modules.len() {
+          moved_modules.intersection(&other_module_group.modules).copied().collect::<Vec<_>>()
         } else {
-          other_module_group.modules.intersection(&current_module_group.modules).copied().collect::<Vec<_>>()
+          other_module_group.modules.intersection(moved_modules).copied().collect::<Vec<_>>()
         };
 
         for module in duplicated_modules {
@@ -668,7 +669,7 @@ impl SplitChunksPlugin {
         }
 
         tracing::trace!("other_module_group: {other_module_group:#?}");
-        tracing::trace!("item.modules: {:#?}", current_module_group.modules);
+        tracing::trace!("moved_modules: {moved_modules:#?}");
 
         // Since there are modules removed, make sure the rest of chunks are all used.
         other_module_group.chunks.retain(|c| {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -6,7 +6,6 @@ use std::{
 
 use futures::future::join_all;
 use rayon::prelude::*;
-use rspack_collections::IdentifierMap;
 use rspack_core::{
   ChunkByUkey, ChunkUkey, Compilation, ExportsInfoArtifact, Module, ModuleIdentifier,
   RuntimeKeyMap, UsageKey, get_runtime_key,
@@ -19,7 +18,7 @@ use tracing::instrument;
 use super::ModuleGroupMap;
 use crate::{
   SplitChunksPlugin,
-  common::{ChunkFilter, ModuleChunks, ModuleSizes},
+  common::{ChunkFilter, ModuleChunkMap, ModuleChunks, ModuleSizes},
   min_size::remove_min_size_violating_modules,
   module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries},
   options::{
@@ -541,7 +540,7 @@ impl SplitChunksPlugin {
                     })
                     .or_insert_with(|| ModuleGroup::new(None, *cache_group_index, cache_group))
                 };
-                module_group.add_module(
+                module_group.add_module_with_shared_chunks(
                   module.identifier(),
                   chunk_combination.iter().copied(),
                 );
@@ -629,7 +628,7 @@ impl SplitChunksPlugin {
   // #[tracing::instrument(skip_all)]
   pub(crate) fn remove_all_modules_from_other_module_groups(
     &self,
-    placed_module_chunks: &IdentifierMap<FxHashSet<ChunkUkey>>,
+    placed_module_chunks: &ModuleChunkMap,
     module_group_map: &mut ModuleGroupMap,
     module_sizes: &ModuleSizes,
   ) {
@@ -644,7 +643,7 @@ impl SplitChunksPlugin {
             let Some(placed_chunks) = placed_module_chunks.get(module) else {
               return false;
             };
-            let Some(other_chunks) = other_module_group.module_chunks.get(module) else {
+            let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
               return false;
             };
             placed_chunks.intersection(other_chunks).next().is_some()
@@ -749,6 +748,7 @@ async fn merge_matched_item_into_module_group_map(
       f(ctx).await?
     }
   };
+  let is_named = chunk_name.is_some();
   let key = if let Some(cache_group_name) = &chunk_name {
     ModuleGroupKey::Named {
       cache_group_index,
@@ -768,7 +768,18 @@ async fn merge_matched_item_into_module_group_map(
       .entry(key)
       .or_insert_with(|| ModuleGroup::new(chunk_name, cache_group_index, cache_group))
   };
-  module_group.add_module(module.identifier(), selected_chunks.iter().copied());
+  if is_named {
+    module_group.add_module(module.identifier(), selected_chunks.iter().copied());
+  } else {
+    match selected_chunks {
+      SelectedChunks::All(chunks) => {
+        module_group.add_module_with_shared_chunks(module.identifier(), chunks.iter().copied());
+      }
+      SelectedChunks::Filtered(chunks) => {
+        module_group.add_module_with_shared_chunks(module.identifier(), chunks.iter().copied());
+      }
+    }
+  }
 
   Ok(())
 }

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/A.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/A.js
@@ -1,0 +1,4 @@
+import alpha from "./alpha";
+import prelude from "./prelude";
+
+export default `A:${alpha}:${prelude}`;

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/B.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/B.js
@@ -1,0 +1,3 @@
+import beta from "./beta";
+
+export default `B:${beta}`;

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/B.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/B.js
@@ -1,3 +1,4 @@
 import beta from "./beta";
+import gamma from "./gamma";
 
-export default `B:${beta}`;
+export default `B:${beta}:${gamma}`;

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/C.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/C.js
@@ -1,0 +1,3 @@
+import beta from "./beta";
+
+export default `C:${beta}`;

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/D.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/D.js
@@ -1,0 +1,3 @@
+import alpha from "./alpha";
+
+export default `D:${alpha}`;

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/alpha.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/alpha.js
@@ -1,0 +1,1 @@
+export default "alpha";

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/beta.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/beta.js
@@ -1,0 +1,1 @@
+export default "beta";

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/gamma.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/gamma.js
@@ -1,0 +1,1 @@
+export default "g";

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
@@ -2,6 +2,7 @@ it("should only move modules from chunks kept by max request limits", async () =
 	const modules = await Promise.all([
 		import(/* webpackChunkName: "A1" */ "./A"),
 		import(/* webpackChunkName: "A2" */ "./A?1"),
+		import(/* webpackChunkName: "D" */ "./D"),
 		import(/* webpackChunkName: "B1" */ "./B"),
 		import(/* webpackChunkName: "B2" */ "./B?1"),
 		import(/* webpackChunkName: "C" */ "./C")
@@ -10,6 +11,7 @@ it("should only move modules from chunks kept by max request limits", async () =
 	expect(modules.map(module => module.default)).toEqual([
 		"A:alpha:prelude",
 		"A:alpha:prelude",
+		"D:alpha",
 		"B:beta:g",
 		"B:beta:g",
 		"C:beta"

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
@@ -3,13 +3,15 @@ it("should only move modules from chunks kept by max request limits", async () =
 		import(/* webpackChunkName: "A1" */ "./A"),
 		import(/* webpackChunkName: "A2" */ "./A?1"),
 		import(/* webpackChunkName: "B1" */ "./B"),
-		import(/* webpackChunkName: "B2" */ "./B?1")
+		import(/* webpackChunkName: "B2" */ "./B?1"),
+		import(/* webpackChunkName: "C" */ "./C")
 	]);
 
 	expect(modules.map(module => module.default)).toEqual([
 		"A:alpha:prelude",
 		"A:alpha:prelude",
-		"B:beta",
-		"B:beta"
+		"B:beta:g",
+		"B:beta:g",
+		"C:beta"
 	]);
 });

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/index.js
@@ -1,0 +1,15 @@
+it("should only move modules from chunks kept by max request limits", async () => {
+	const modules = await Promise.all([
+		import(/* webpackChunkName: "A1" */ "./A"),
+		import(/* webpackChunkName: "A2" */ "./A?1"),
+		import(/* webpackChunkName: "B1" */ "./B"),
+		import(/* webpackChunkName: "B2" */ "./B?1")
+	]);
+
+	expect(modules.map(module => module.default)).toEqual([
+		"A:alpha:prelude",
+		"A:alpha:prelude",
+		"B:beta",
+		"B:beta"
+	]);
+});

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/prelude.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/prelude.js
@@ -1,0 +1,1 @@
+export default "prelude";

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
@@ -9,7 +9,7 @@ module.exports = {
       minSize: 0,
       maxAsyncRequests: Infinity,
       cacheGroups: {
-        // Raise A1/A2 to two requests so namedGroup keeps only B1/B2.
+        // Raise A1/A2 to two requests so namedGroup keeps only B1/B2/C.
         preSplit: {
           test: /[\\/]prelude\.js$/,
           chunks: 'all',
@@ -23,6 +23,14 @@ module.exports = {
           minChunks: 2,
           maxAsyncRequests: 2,
           name: 'shared_named',
+          priority: 100,
+        },
+        // Alpha is not moved by namedGroup and must remain in this same-priority candidate.
+        samePriority: {
+          test: /[\\/](alpha|gamma)\.js$/,
+          chunks: 'all',
+          minChunks: 2,
+          name: 'same_priority',
           priority: 100,
         },
         default: {
@@ -51,14 +59,20 @@ module.exports = {
             );
 
           const sharedNamed = compilation.namedChunks.get('shared_named');
+          const samePriority = compilation.namedChunks.get('same_priority');
           const alphaChunks = chunksContaining('alpha');
           const betaChunks = chunksContaining('beta');
+          const gammaChunks = chunksContaining('gamma');
 
           expect(compilation.namedChunks.get('pre_split')).toBeDefined();
           expect(sharedNamed).toBeDefined();
+          expect(samePriority).toBeDefined();
           expect(alphaChunks).toHaveLength(1);
-          expect(alphaChunks).not.toContain(sharedNamed);
-          expect(betaChunks).toEqual([sharedNamed]);
+          expect(alphaChunks).toContain(samePriority);
+          expect(betaChunks).toHaveLength(1);
+          expect(betaChunks).toContain(sharedNamed);
+          expect(gammaChunks).toHaveLength(1);
+          expect(gammaChunks).toContain(samePriority);
         });
       });
     },

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
@@ -1,80 +1,125 @@
 /** @typedef {import("@rspack/core").Compiler} Compiler */
 
-/** @type {import("@rspack/core").Configuration} */
-module.exports = {
-  mode: 'development',
-  target: 'web',
-  optimization: {
-    splitChunks: {
-      minSize: 0,
-      maxAsyncRequests: Infinity,
-      cacheGroups: {
-        // Raise A1/A2 to two requests so namedGroup keeps only B1/B2/C.
-        preSplit: {
-          test: /[\\/]prelude\.js$/,
-          chunks: 'all',
-          minChunks: 2,
-          name: 'pre_split',
-          priority: 200,
-        },
-        namedGroup: {
-          test: /[\\/](alpha|beta)\.js$/,
-          chunks: 'all',
-          minChunks: 2,
-          maxAsyncRequests: 2,
-          name: 'shared_named',
-          priority: 100,
-        },
-        // Alpha is not moved by namedGroup and must remain in this same-priority candidate.
-        samePriority: {
-          test: /[\\/](alpha|gamma)\.js$/,
-          chunks: 'all',
-          minChunks: 2,
-          name: 'same_priority',
-          priority: 100,
-        },
-        default: {
-          chunks: 'all',
-          minChunks: 2,
-        },
-        defaultVendors: false,
+/**
+ * @param {string} name
+ * @param {number} namedGroupMinSize
+ * @param {number} namedGroupMinSizeReduction
+ * @param {boolean} expectResidualSplit
+ * @returns {import("@rspack/core").Configuration}
+ */
+function createConfig(
+  name,
+  namedGroupMinSize,
+  namedGroupMinSizeReduction,
+  expectResidualSplit,
+) {
+  const cacheGroups = {
+    // Raise A1/A2 to two requests. D keeps one alpha source below minChunks in the residual-split
+    // variant, while the size-validation variants exclude D and keep only B1/B2/C.
+    preSplit: {
+      test: /[\\/]prelude\.js$/,
+      chunks: 'all',
+      minChunks: 2,
+      name: 'pre_split',
+      priority: 200,
+    },
+    namedGroup: {
+      test: /[\\/](alpha|beta)\.js$/,
+      chunks: expectResidualSplit ? 'all' : (chunk) => chunk.name !== 'D',
+      minChunks: 2,
+      minSize: namedGroupMinSize,
+      minSizeReduction: namedGroupMinSizeReduction,
+      maxAsyncRequests: 2,
+      name: 'shared_named',
+      priority: 100,
+    },
+    defaultVendors: false,
+  };
+
+  if (expectResidualSplit) {
+    // Alpha is not moved by namedGroup and must remain in this same-priority candidate.
+    cacheGroups.samePriority = {
+      test: /[\\/](alpha|gamma)\.js$/,
+      chunks: 'all',
+      minChunks: 2,
+      name: 'same_priority',
+      priority: 100,
+    };
+    cacheGroups.default = {
+      chunks: 'all',
+      minChunks: 2,
+    };
+  } else {
+    cacheGroups.default = false;
+  }
+
+  return {
+    name,
+    mode: 'development',
+    target: 'web',
+    output: {
+      filename: `${name}-[name].js`,
+      chunkFilename: `${name}-[name].js`,
+    },
+    optimization: {
+      splitChunks: {
+        minSize: 0,
+        maxAsyncRequests: Infinity,
+        cacheGroups,
       },
     },
-  },
-  plugins: [
-    /** @this {Compiler} */
-    function () {
-      this.hooks.compilation.tap('MaxRequestResidualModules', (compilation) => {
-        compilation.hooks.afterSeal.tap('MaxRequestResidualModules', () => {
-          const chunksContaining = (moduleName) =>
-            Array.from(compilation.chunks).filter((chunk) =>
-              Array.from(
-                compilation.chunkGraph.getChunkModulesIterable(chunk),
-              ).some((module) =>
-                module
-                  .identifier()
-                  .replaceAll('\\', '/')
-                  .endsWith(`/${moduleName}.js`),
-              ),
-            );
+    plugins: [
+      /** @this {Compiler} */
+      function () {
+        this.hooks.compilation.tap(name, (compilation) => {
+          compilation.hooks.afterSeal.tap(name, () => {
+            const chunksContaining = (moduleName) =>
+              Array.from(compilation.chunks).filter((chunk) =>
+                Array.from(
+                  compilation.chunkGraph.getChunkModulesIterable(chunk),
+                ).some((module) =>
+                  module
+                    .identifier()
+                    .replaceAll('\\', '/')
+                    .endsWith(`/${moduleName}.js`),
+                ),
+              );
 
-          const sharedNamed = compilation.namedChunks.get('shared_named');
-          const samePriority = compilation.namedChunks.get('same_priority');
-          const alphaChunks = chunksContaining('alpha');
-          const betaChunks = chunksContaining('beta');
-          const gammaChunks = chunksContaining('gamma');
+            const sharedNamed = compilation.namedChunks.get('shared_named');
+            const samePriority = compilation.namedChunks.get('same_priority');
+            const alphaChunks = chunksContaining('alpha');
+            const betaChunks = chunksContaining('beta');
+            const gammaChunks = chunksContaining('gamma');
 
-          expect(compilation.namedChunks.get('pre_split')).toBeDefined();
-          expect(sharedNamed).toBeDefined();
-          expect(samePriority).toBeDefined();
-          expect(alphaChunks).toHaveLength(1);
-          expect(alphaChunks).toContain(samePriority);
-          expect(betaChunks).toHaveLength(1);
-          expect(betaChunks).toContain(sharedNamed);
-          expect(gammaChunks).toHaveLength(1);
-          expect(gammaChunks).toContain(samePriority);
+            expect(compilation.namedChunks.get('pre_split')).toBeDefined();
+
+            if (expectResidualSplit) {
+              expect(sharedNamed).toBeDefined();
+              expect(samePriority).toBeDefined();
+              expect(alphaChunks).toHaveLength(1);
+              expect(alphaChunks).toContain(samePriority);
+              expect(betaChunks).toHaveLength(1);
+              expect(betaChunks).toContain(sharedNamed);
+              expect(gammaChunks).toHaveLength(1);
+              expect(gammaChunks).toContain(samePriority);
+            } else {
+              // Only beta remains after max-request pruning, and beta alone violates the configured
+              // size constraint.
+              expect(sharedNamed).toBeNull();
+              expect(alphaChunks).toHaveLength(3);
+              expect(betaChunks).toHaveLength(3);
+              expect(gammaChunks).toHaveLength(2);
+            }
+          });
         });
-      });
-    },
-  ],
-};
+      },
+    ],
+  };
+}
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+  createConfig('actual-moved-modules', 0, 0, true),
+  createConfig('revalidate-min-size', 30, 0, false),
+  createConfig('revalidate-min-size-reduction', 0, 100, false),
+];

--- a/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/max-request-residual-modules/rspack.config.js
@@ -1,0 +1,66 @@
+/** @typedef {import("@rspack/core").Compiler} Compiler */
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  optimization: {
+    splitChunks: {
+      minSize: 0,
+      maxAsyncRequests: Infinity,
+      cacheGroups: {
+        // Raise A1/A2 to two requests so namedGroup keeps only B1/B2.
+        preSplit: {
+          test: /[\\/]prelude\.js$/,
+          chunks: 'all',
+          minChunks: 2,
+          name: 'pre_split',
+          priority: 200,
+        },
+        namedGroup: {
+          test: /[\\/](alpha|beta)\.js$/,
+          chunks: 'all',
+          minChunks: 2,
+          maxAsyncRequests: 2,
+          name: 'shared_named',
+          priority: 100,
+        },
+        default: {
+          chunks: 'all',
+          minChunks: 2,
+        },
+        defaultVendors: false,
+      },
+    },
+  },
+  plugins: [
+    /** @this {Compiler} */
+    function () {
+      this.hooks.compilation.tap('MaxRequestResidualModules', (compilation) => {
+        compilation.hooks.afterSeal.tap('MaxRequestResidualModules', () => {
+          const chunksContaining = (moduleName) =>
+            Array.from(compilation.chunks).filter((chunk) =>
+              Array.from(
+                compilation.chunkGraph.getChunkModulesIterable(chunk),
+              ).some((module) =>
+                module
+                  .identifier()
+                  .replaceAll('\\', '/')
+                  .endsWith(`/${moduleName}.js`),
+              ),
+            );
+
+          const sharedNamed = compilation.namedChunks.get('shared_named');
+          const alphaChunks = chunksContaining('alpha');
+          const betaChunks = chunksContaining('beta');
+
+          expect(compilation.namedChunks.get('pre_split')).toBeDefined();
+          expect(sharedNamed).toBeDefined();
+          expect(alphaChunks).toHaveLength(1);
+          expect(alphaChunks).not.toContain(sharedNamed);
+          expect(betaChunks).toEqual([sharedNamed]);
+        });
+      });
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/Bar.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/Bar.js
@@ -1,0 +1,3 @@
+import util from "./util";
+
+export default `Bar:${util}`;

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/Foo.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/Foo.js
@@ -1,0 +1,4 @@
+import prelude from "./prelude";
+import util from "./util";
+
+export default `Foo:${util}:${prelude}`;

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/index.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/index.js
@@ -1,0 +1,13 @@
+it("should not count an excluded named destination towards minChunks", async () => {
+	const modules = await Promise.all([
+		import(/* webpackChunkName: "Target" */ "./util"),
+		import(/* webpackChunkName: "Foo" */ "./Foo"),
+		import(/* webpackChunkName: "Bar" */ "./Bar")
+	]);
+
+	expect(modules.map(module => module.default)).toEqual([
+		"util",
+		"Foo:util:prelude",
+		"Bar:util"
+	]);
+});

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/prelude.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/prelude.js
@@ -1,0 +1,1 @@
+export default "prelude";

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/rspack.config.js
@@ -1,0 +1,71 @@
+/** @typedef {import("@rspack/core").Compiler} Compiler */
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  optimization: {
+    splitChunks: {
+      minSize: 0,
+      maxAsyncRequests: Infinity,
+      cacheGroups: {
+        preSplit: {
+          test: /[\\/]prelude\.js$/,
+          chunks: 'all',
+          minChunks: 1,
+          name: 'pre_split',
+          priority: 200,
+        },
+        highPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: /^(Foo|Bar)$/,
+          maxAsyncRequests: 2,
+          minChunks: 2,
+          name: 'Target',
+          priority: 100,
+        },
+        lowerPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: 'all',
+          minChunks: 2,
+          name: 'lower_util',
+          priority: 0,
+        },
+        default: false,
+        defaultVendors: false,
+      },
+    },
+  },
+  plugins: [
+    /** @this {Compiler} */
+    function () {
+      this.hooks.compilation.tap(
+        'NamedTargetOutsideFilterResidual',
+        (compilation) => {
+          compilation.hooks.afterSeal.tap(
+            'NamedTargetOutsideFilterResidual',
+            () => {
+              const lowerPriorityChunk =
+                compilation.namedChunks.get('lower_util');
+              const utilChunks = Array.from(compilation.chunks).filter(
+                (chunk) =>
+                  Array.from(
+                    compilation.chunkGraph.getChunkModulesIterable(chunk),
+                  ).some((module) =>
+                    module
+                      .identifier()
+                      .replaceAll('\\', '/')
+                      .endsWith('/util.js'),
+                  ),
+              );
+
+              expect(lowerPriorityChunk).toBeDefined();
+              expect(utilChunks).toHaveLength(1);
+              expect(utilChunks).toContain(lowerPriorityChunk);
+            },
+          );
+        },
+      );
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/util.js
+++ b/tests/rspack-test/configCases/split-chunks/named-target-outside-filter-residual/util.js
@@ -1,0 +1,1 @@
+export default "util";

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Bar.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Bar.js
@@ -1,0 +1,3 @@
+import util from "./util";
+
+export default `Bar:${util}`;

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Extra.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Extra.js
@@ -1,0 +1,3 @@
+import helper from "./helper";
+
+export default `Extra:${helper}`;

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Foo.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Foo.js
@@ -1,0 +1,3 @@
+import util from "./util";
+
+export default `Foo:${util}`;

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Other.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/Other.js
@@ -1,0 +1,4 @@
+import util from "./util";
+import helper from "./helper";
+
+export default `Other:${util}:${helper}`;

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/helper.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/helper.js
@@ -1,0 +1,1 @@
+export default "helper";

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/index.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/index.js
@@ -1,0 +1,17 @@
+it("should split lower-priority residual chunks", async () => {
+  const modules = await Promise.all([
+    import(/* webpackChunkName: "Foo" */ "./Foo"),
+    import(/* webpackChunkName: "Bar" */ "./Bar"),
+    import(/* webpackChunkName: "Other" */ "./Other"),
+    import(/* webpackChunkName: "Other2" */ "./Other?1"),
+    import(/* webpackChunkName: "Extra" */ "./Extra"),
+  ]);
+
+  expect(modules.map((module) => module.default)).toEqual([
+    "Foo:util",
+    "Bar:util",
+    "Other:util:helper",
+    "Other:util:helper",
+    "Extra:helper",
+  ]);
+});

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/rspack.config.js
@@ -1,0 +1,108 @@
+/** @typedef {import("@rspack/core").Compiler} Compiler */
+
+const leafChunkNames = ['Foo', 'Bar', 'Other', 'Other2'];
+
+/**
+ * @param {string} name
+ * @param {RegExp} highPriorityChunks
+ * @param {number} expectedUtilChunkCount
+ * @param {string[]} expectedLeafChunksWithUtil
+ * @param {number} minSize
+ * @param {boolean} expectResidualModulesTogether
+ * @returns {import("@rspack/core").Configuration}
+ */
+function createConfig(
+  name,
+  highPriorityChunks,
+  expectedUtilChunkCount,
+  expectedLeafChunksWithUtil,
+  minSize = 0,
+  expectResidualModulesTogether = false,
+) {
+  return {
+    name,
+    mode: 'development',
+    target: 'web',
+    output: {
+      filename: `${name}-[name].js`,
+      chunkFilename: `${name}-[name].js`,
+    },
+    optimization: {
+      runtimeChunk: 'single',
+      splitChunks: {
+        minSize,
+        cacheGroups: {
+          shared_util: {
+            test: /[\\/]util\.js$/,
+            chunks: highPriorityChunks,
+            minSize: 0,
+            minChunks: 2,
+            name: 'shared_util',
+            priority: 100,
+          },
+          default: {
+            chunks: 'all',
+            minChunks: 2,
+          },
+        },
+      },
+    },
+    plugins: [
+      /** @this {Compiler} */
+      function () {
+        this.hooks.compilation.tap(name, (compilation) => {
+          compilation.hooks.afterSeal.tap(name, () => {
+            const utilChunks = [];
+            const helperChunks = [];
+
+            for (const chunk of compilation.chunks) {
+              const moduleIdentifiers = Array.from(
+                compilation.chunkGraph.getChunkModulesIterable(chunk),
+              ).map((module) => module.identifier().replaceAll('\\', '/'));
+              const containsUtil = moduleIdentifiers.some((identifier) =>
+                identifier.endsWith('/util.js'),
+              );
+              const containsHelper = moduleIdentifiers.some((identifier) =>
+                identifier.endsWith('/helper.js'),
+              );
+
+              if (containsUtil) {
+                utilChunks.push(chunk);
+              }
+              if (containsHelper) {
+                helperChunks.push(chunk);
+              }
+            }
+
+            const sharedUtilChunk = compilation.namedChunks.get('shared_util');
+            expect(sharedUtilChunk).toBeDefined();
+            expect(utilChunks).toContain(sharedUtilChunk);
+            expect(utilChunks).toHaveLength(expectedUtilChunkCount);
+            expect(
+              utilChunks
+                .map((chunk) => chunk.name)
+                .filter((chunkName) => leafChunkNames.includes(chunkName))
+                .sort(),
+            ).toEqual([...expectedLeafChunksWithUtil].sort());
+
+            if (expectResidualModulesTogether) {
+              const residualUtilChunk = utilChunks.find(
+                (chunk) => chunk !== sharedUtilChunk,
+              );
+              expect(residualUtilChunk).toBeDefined();
+              expect(helperChunks).toContain(residualUtilChunk);
+            }
+          });
+        });
+      },
+    ],
+  };
+}
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+  createConfig('partial-residual', /^(Foo|Bar)$/, 2, []),
+  createConfig('residual-below-min-chunks', /^(Foo|Bar|Other)$/, 2, ['Other2']),
+  createConfig('no-residual', /^(Foo|Bar|Other|Other2)$/, 1, []),
+  createConfig('regroup-residual', /^(Foo|Bar)$/, 2, [], 30, true),
+];

--- a/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/util.js
+++ b/tests/rspack-test/configCases/split-chunks/priority-residual-chunks/util.js
@@ -1,0 +1,1 @@
+export default "util";

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/Foo.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/Foo.js
@@ -1,0 +1,4 @@
+import prelude from "./prelude";
+import util from "./util";
+
+export default `Foo:${util}:${prelude}`;

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/index.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/index.js
@@ -1,0 +1,11 @@
+it("should preserve a reused destination when all other sources are pruned", async () => {
+	const modules = await Promise.all([
+		import(/* webpackChunkName: "Foo" */ "./Foo"),
+		import(/* webpackChunkName: "ReusableUtil" */ "./util")
+	]);
+
+	expect(modules.map(module => module.default)).toEqual([
+		"Foo:util:prelude",
+		"util"
+	]);
+});

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/prelude.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/prelude.js
@@ -1,0 +1,1 @@
+export default "prelude";

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
@@ -1,87 +1,104 @@
 /** @typedef {import("@rspack/core").Compiler} Compiler */
 
-/** @type {import("@rspack/core").Configuration} */
-module.exports = {
-  mode: 'development',
-  target: 'web',
-  optimization: {
-    splitChunks: {
-      minSize: 0,
-      maxAsyncRequests: Infinity,
-      cacheGroups: {
-        preSplit: {
-          test: /[\\/]prelude\.js$/,
-          chunks: 'all',
-          minChunks: 1,
-          name: 'pre_split',
-          priority: 200,
+/**
+ * @param {string} name
+ * @param {number} minSizeReduction
+ * @param {boolean} expectSamePriority
+ * @returns {import("@rspack/core").Configuration}
+ */
+function createConfig(name, minSizeReduction, expectSamePriority) {
+  return {
+    name,
+    mode: 'development',
+    target: 'web',
+    output: {
+      filename: `${name}-[name].js`,
+      chunkFilename: `${name}-[name].js`,
+    },
+    optimization: {
+      splitChunks: {
+        minSize: 0,
+        maxAsyncRequests: Infinity,
+        cacheGroups: {
+          preSplit: {
+            test: /[\\/]prelude\.js$/,
+            chunks: 'all',
+            minChunks: 1,
+            name: 'pre_split',
+            priority: 200,
+          },
+          // Foo is at its request limit after preSplit, leaving only the reused destination.
+          highPriority: {
+            test: /[\\/]util\.js$/,
+            chunks: 'all',
+            maxAsyncRequests: 2,
+            minChunks: 1,
+            minSizeReduction,
+            priority: 100,
+            reuseExistingChunk: true,
+          },
+          // With no size-reduction requirement, the reused destination is claimed by highPriority
+          // and this candidate must not move util back out at the same priority. With a positive
+          // requirement, highPriority reduces no source chunk and this candidate must remain valid.
+          samePriority: {
+            test: /[\\/]util\.js$/,
+            chunks: 'all',
+            minChunks: 1,
+            name: 'same_priority',
+            priority: 100,
+          },
+          lowerPriority: {
+            test: /[\\/]util\.js$/,
+            chunks: 'all',
+            minChunks: 1,
+            name: 'lower_util',
+            priority: 0,
+          },
+          default: false,
+          defaultVendors: false,
         },
-        // Foo is at its request limit after preSplit, leaving only the reused destination.
-        highPriority: {
-          test: /[\\/]util\.js$/,
-          chunks: 'all',
-          maxAsyncRequests: 2,
-          minChunks: 1,
-          priority: 100,
-          reuseExistingChunk: true,
-        },
-        // The reused destination is also claimed by highPriority, so this candidate must not move
-        // util back out at the same priority.
-        samePriority: {
-          test: /[\\/]util\.js$/,
-          chunks: 'all',
-          minChunks: 1,
-          name: 'same_priority',
-          priority: 100,
-        },
-        lowerPriority: {
-          test: /[\\/]util\.js$/,
-          chunks: 'all',
-          minChunks: 1,
-          name: 'lower_util',
-          priority: 0,
-        },
-        default: false,
-        defaultVendors: false,
       },
     },
-  },
-  plugins: [
-    /** @this {Compiler} */
-    function () {
-      this.hooks.compilation.tap(
-        'ReuseExistingChunkMaxRequestResidual',
-        (compilation) => {
-          compilation.hooks.afterSeal.tap(
-            'ReuseExistingChunkMaxRequestResidual',
-            () => {
-              const reusableChunk = compilation.namedChunks.get('ReusableUtil');
-              const lowerPriorityChunk =
-                compilation.namedChunks.get('lower_util');
-              const samePriorityChunk =
-                compilation.namedChunks.get('same_priority');
-              const utilChunks = Array.from(compilation.chunks).filter(
-                (chunk) =>
-                  Array.from(
-                    compilation.chunkGraph.getChunkModulesIterable(chunk),
-                  ).some((module) =>
-                    module
-                      .identifier()
-                      .replaceAll('\\', '/')
-                      .endsWith('/util.js'),
-                  ),
-              );
+    plugins: [
+      /** @this {Compiler} */
+      function () {
+        this.hooks.compilation.tap(name, (compilation) => {
+          compilation.hooks.afterSeal.tap(name, () => {
+            const reusableChunk = compilation.namedChunks.get('ReusableUtil');
+            const lowerPriorityChunk =
+              compilation.namedChunks.get('lower_util');
+            const samePriorityChunk =
+              compilation.namedChunks.get('same_priority');
+            const utilChunks = Array.from(compilation.chunks).filter((chunk) =>
+              Array.from(
+                compilation.chunkGraph.getChunkModulesIterable(chunk),
+              ).some((module) =>
+                module.identifier().replaceAll('\\', '/').endsWith('/util.js'),
+              ),
+            );
 
-              expect(reusableChunk).toBeDefined();
+            expect(reusableChunk).toBeDefined();
+            if (expectSamePriority) {
+              expect(samePriorityChunk).toBeDefined();
+              expect(lowerPriorityChunk).toBeNull();
+              expect(utilChunks).toHaveLength(1);
+              expect(utilChunks).toContain(samePriorityChunk);
+            } else {
               expect(samePriorityChunk).toBeNull();
               expect(lowerPriorityChunk).toBeDefined();
               expect(utilChunks).toHaveLength(2);
               expect(utilChunks).toContain(reusableChunk);
               expect(utilChunks).toContain(lowerPriorityChunk);
-            },
-          );
-        },
-      );
-    },
-  ],
-};
+            }
+          });
+        });
+      },
+    ],
+  };
+}
+
+/** @type {import("@rspack/core").Configuration[]} */
+module.exports = [
+  createConfig('preserve-reused-destination', 0, false),
+  createConfig('revalidate-min-size-reduction', 1, true),
+];

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
@@ -1,0 +1,75 @@
+/** @typedef {import("@rspack/core").Compiler} Compiler */
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  optimization: {
+    splitChunks: {
+      minSize: 0,
+      maxAsyncRequests: Infinity,
+      cacheGroups: {
+        preSplit: {
+          test: /[\\/]prelude\.js$/,
+          chunks: 'all',
+          minChunks: 1,
+          name: 'pre_split',
+          priority: 200,
+        },
+        // Foo is at its request limit after preSplit, leaving only the reused destination.
+        highPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: 'all',
+          maxAsyncRequests: 2,
+          minChunks: 1,
+          priority: 100,
+          reuseExistingChunk: true,
+        },
+        lowerPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: 'all',
+          minChunks: 1,
+          name: 'lower_util',
+          priority: 0,
+        },
+        default: false,
+        defaultVendors: false,
+      },
+    },
+  },
+  plugins: [
+    /** @this {Compiler} */
+    function () {
+      this.hooks.compilation.tap(
+        'ReuseExistingChunkMaxRequestResidual',
+        (compilation) => {
+          compilation.hooks.afterSeal.tap(
+            'ReuseExistingChunkMaxRequestResidual',
+            () => {
+              const reusableChunk = compilation.namedChunks.get('ReusableUtil');
+              const lowerPriorityChunk =
+                compilation.namedChunks.get('lower_util');
+              const utilChunks = Array.from(compilation.chunks).filter(
+                (chunk) =>
+                  Array.from(
+                    compilation.chunkGraph.getChunkModulesIterable(chunk),
+                  ).some((module) =>
+                    module
+                      .identifier()
+                      .replaceAll('\\', '/')
+                      .endsWith('/util.js'),
+                  ),
+              );
+
+              expect(reusableChunk).toBeDefined();
+              expect(lowerPriorityChunk).toBeDefined();
+              expect(utilChunks).toHaveLength(2);
+              expect(utilChunks).toContain(reusableChunk);
+              expect(utilChunks).toContain(lowerPriorityChunk);
+            },
+          );
+        },
+      );
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/rspack.config.js
@@ -25,6 +25,15 @@ module.exports = {
           priority: 100,
           reuseExistingChunk: true,
         },
+        // The reused destination is also claimed by highPriority, so this candidate must not move
+        // util back out at the same priority.
+        samePriority: {
+          test: /[\\/]util\.js$/,
+          chunks: 'all',
+          minChunks: 1,
+          name: 'same_priority',
+          priority: 100,
+        },
         lowerPriority: {
           test: /[\\/]util\.js$/,
           chunks: 'all',
@@ -49,6 +58,8 @@ module.exports = {
               const reusableChunk = compilation.namedChunks.get('ReusableUtil');
               const lowerPriorityChunk =
                 compilation.namedChunks.get('lower_util');
+              const samePriorityChunk =
+                compilation.namedChunks.get('same_priority');
               const utilChunks = Array.from(compilation.chunks).filter(
                 (chunk) =>
                   Array.from(
@@ -62,6 +73,7 @@ module.exports = {
               );
 
               expect(reusableChunk).toBeDefined();
+              expect(samePriorityChunk).toBeNull();
               expect(lowerPriorityChunk).toBeDefined();
               expect(utilChunks).toHaveLength(2);
               expect(utilChunks).toContain(reusableChunk);

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/util.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-max-request-residual/util.js
@@ -1,0 +1,1 @@
+export default "util";

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/Bar.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/Bar.js
@@ -1,0 +1,3 @@
+import util from "./util";
+
+export default `Bar:${util}`;

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/Foo.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/Foo.js
@@ -1,0 +1,3 @@
+import util from "./util";
+
+export default `Foo:${util}`;

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/index.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/index.js
@@ -1,0 +1,13 @@
+it("should preserve a reused destination at lower priorities", async () => {
+  const modules = await Promise.all([
+    import(/* webpackChunkName: "Foo" */ "./Foo"),
+    import(/* webpackChunkName: "Bar" */ "./Bar"),
+    import(/* webpackChunkName: "ReusableUtil" */ "./util"),
+  ]);
+
+  expect(modules.map((module) => module.default)).toEqual([
+    "Foo:util",
+    "Bar:util",
+    "util",
+  ]);
+});

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/rspack.config.js
@@ -47,7 +47,8 @@ module.exports = {
 
             expect(reusableChunk).toBeDefined();
             expect(lowerPriorityChunk).toBeNull();
-            expect(utilChunks).toEqual([reusableChunk]);
+            expect(utilChunks).toHaveLength(1);
+            expect(utilChunks).toContain(reusableChunk);
           });
         },
       );

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/rspack.config.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/rspack.config.js
@@ -1,0 +1,56 @@
+/** @typedef {import("@rspack/core").Compiler} Compiler */
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'web',
+  optimization: {
+    splitChunks: {
+      minSize: 0,
+      cacheGroups: {
+        highPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: /^(Foo|Bar|ReusableUtil)$/,
+          minChunks: 2,
+          priority: 100,
+          reuseExistingChunk: true,
+        },
+        lowerPriority: {
+          test: /[\\/]util\.js$/,
+          chunks: 'all',
+          minChunks: 1,
+          name: 'lower_util',
+          priority: 0,
+        },
+        default: false,
+        defaultVendors: false,
+      },
+    },
+  },
+  plugins: [
+    /** @this {Compiler} */
+    function () {
+      this.hooks.compilation.tap(
+        'ReuseExistingChunkResidual',
+        (compilation) => {
+          compilation.hooks.afterSeal.tap('ReuseExistingChunkResidual', () => {
+            const reusableChunk = compilation.namedChunks.get('ReusableUtil');
+            const lowerPriorityChunk =
+              compilation.namedChunks.get('lower_util');
+            const utilChunks = Array.from(compilation.chunks).filter((chunk) =>
+              Array.from(
+                compilation.chunkGraph.getChunkModulesIterable(chunk),
+              ).some((module) =>
+                module.identifier().replaceAll('\\', '/').endsWith('/util.js'),
+              ),
+            );
+
+            expect(reusableChunk).toBeDefined();
+            expect(lowerPriorityChunk).toBeNull();
+            expect(utilChunks).toEqual([reusableChunk]);
+          });
+        },
+      );
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/util.js
+++ b/tests/rspack-test/configCases/split-chunks/reuse-existing-chunk-residual/util.js
@@ -1,0 +1,1 @@
+export default "util";


### PR DESCRIPTION
## Summary
Previously, `prepare_module_group_map` discarded a lower-priority candidate when any selected chunk overlapped `removed_module_chunks`. A higher-priority cache group that selected only part of a module's chunks could therefore suppress an otherwise valid residual candidate. For example, extracting `util.js` from `Foo` and `Bar` prevented `default` from extracting the remaining `Other` and `Other2` copies.

Lower-priority cache groups now rebuild their candidates from the remaining original module-chunk edges and revalidate their constraints. This preserves cache-group priority for overlapping edges while allowing disjoint residual edges to be processed.

When max-request filtering removes every source chunk containing one module from a named module group, that module is no longer connected to the named destination. Same-priority cleanup also uses the actual moved-module set, so an untouched module remains eligible in another candidate.

A reused original destination is recorded independently from source movement. Even when max-request filtering removes every other source and `moved_modules` is empty, lower priorities cannot move the module back out of the reused chunk.
