### PR TITLE
perf: optimize ESM library module concatenation

### DIFF
--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -1,11 +1,13 @@
 use std::future::Future;
 
 use async_trait::async_trait;
+use rspack_sources::SourceExt;
 
 use super::*;
 use crate::{
-  CacheValue, Etag, ModuleCodeGenerationContext, MultiItemCache, compilation::pass::PassExt,
-  get_runtime_key, logger::Logger,
+  CacheValue, ConcatenationCodeGenerationSource, Etag, ModuleCodeGenerationContext, MultiItemCache,
+  PendingConcatenationScopeInfo, SourceType, compilation::pass::PassExt, get_runtime_key,
+  logger::Logger,
 };
 
 const CODE_GENERATION_CACHE_NAME: &str = "Compilation/codeGeneration";
@@ -212,6 +214,38 @@ pub(crate) async fn code_generation_modules(
             };
             let mut codegen_result_builder =
               module.code_generation(&mut code_generation_context).await?;
+            let concatenation_source = code_generation_context.concatenation_source.take();
+            drop(code_generation_context);
+
+            if let Some(source) = concatenation_source {
+              let pending_scope_info = module
+                .build_info()
+                .pending_concatenation_scope_info
+                .as_deref()
+                .ok_or_else(|| {
+                  rspack_error::error!(
+                    "module {} entered faster module concatenation without pending concatenation scope info",
+                    module.identifier()
+                  )
+                })?;
+              let source_kind_matches = matches!(
+                (pending_scope_info, source.as_ref()),
+                (
+                  PendingConcatenationScopeInfo::Analyzed(_),
+                  ConcatenationCodeGenerationSource::Analyzed(_)
+                ) | (
+                  PendingConcatenationScopeInfo::Generated,
+                  ConcatenationCodeGenerationSource::Generated(_)
+                )
+              );
+              if !source_kind_matches {
+                return Err(rspack_error::error!(
+                  "module {} returned a concatenation source that does not match its pending scope info",
+                  module.identifier()
+                ));
+              }
+              codegen_result_builder.add(SourceType::JavaScript, (*source).into_source().boxed());
+            }
 
             if let Some(scope) = concatenation_scope.as_mut()
               && scope.is_codegen_data_collection_enabled()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -71,6 +71,7 @@ mod faster;
 
 pub(crate) use faster::populate_info_from_pending;
 use faster::render_concatenated_module_source;
+pub use faster::render_concatenation_source;
 
 pub const CONCATENATION_PLACEHOLDER_PREFIX: &str = "__rspack_";
 pub(crate) const GENERATED_TOP_LEVEL_SYMBOL_PREFIX: &str = "__rspack_generated_top_level_symbol_";
@@ -310,15 +311,20 @@ pub type ConcatenatedImportMap =
 
 /// A codegen-created top-level binding whose final name is assigned after all
 /// modules in the concatenation are known.
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct GeneratedTopLevelSymbol {
+  #[cacheable(with=AsPreset)]
   pub preferred_name: Atom,
+  #[cacheable(with=AsPreset)]
   pub placeholder: Atom,
   pub target: GeneratedTopLevelSymbolTarget,
   /// Make-time binding resolved from `original_range` for a rebound symbol.
+  #[cacheable(with=AsOption<AsPreset>)]
   pub resolved_binding: Option<Atom>,
 }
 
+#[cacheable]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GeneratedTopLevelSymbolTarget {
   /// A new binding created during code generation.
@@ -330,8 +336,10 @@ pub enum GeneratedTopLevelSymbolTarget {
 
 /// Scope identifier supplied by dependency templates because it cannot be
 /// reconstructed from the make-time scope information alone.
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct AddedScopeIdent {
+  #[cacheable(with=AsPreset)]
   pub symbol: Atom,
   pub range: DependencyRange,
   pub shorthand: bool,
@@ -340,6 +348,7 @@ pub struct AddedScopeIdent {
 
 /// Dependency-template correction applied to an identifier collected during
 /// make, after codegen replacements have changed its syntax.
+#[cacheable]
 #[derive(Debug, Clone, Copy)]
 pub enum OriginalScopeIdentUpdate {
   Remove(DependencyRange),
@@ -348,15 +357,18 @@ pub enum OriginalScopeIdentUpdate {
 
 /// Incremental data needed to rebuild concatenation scope information without
 /// reparsing the generated module source.
+#[cacheable]
 #[derive(Debug, Clone, Default)]
 pub struct FasterModuleConcatenationInfo {
   /// Corrections to make-time identifiers caused by dependency replacements.
   pub original_scope_ident_updates: SmallVec<[OriginalScopeIdentUpdate; 4]>,
   /// Scope identifiers supplied by dependency templates in addition to the
   /// make-time collection.
+  #[cacheable(with=AsVec)]
   pub added_scope_idents: Vec<AddedScopeIdent>,
   /// Names introduced or referenced by generated code that must be reserved
   /// during global deconfliction.
+  #[cacheable(with=AsVec<AsPreset>)]
   pub added_used_names: Vec<Atom>,
 }
 

--- a/crates/rspack_core/src/concatenated_module/faster.rs
+++ b/crates/rspack_core/src/concatenated_module/faster.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::{
   ConcatenatedModuleIdent, ConcatenationScope, ConcatenationScopeIdentKind, DependencyRange,
-  PendingConcatenationScopeInfo, RenderedInitFragments,
+  ModuleIdentifier, PendingConcatenationScopeInfo, RenderedInitFragments,
 };
 
 type SeenIdent = (Atom, SyntaxContext, DependencyRange, bool, bool);
@@ -447,17 +447,18 @@ fn apply_placeholder_replacements_to_source(
   source
 }
 
-pub(super) fn render_concatenated_module_source(
-  info: &mut ConcatenatedModuleInfo,
+fn render_concatenation_source_inner(
+  source: ReplaceSource,
+  fragments: Option<RenderedInitFragments>,
   module_reference_replacements: &[(String, String)],
-  rendered_init_fragments_hasher: Option<&mut RspackHasher>,
+  generated_symbols: &[GeneratedTopLevelSymbol],
+  internal_names: &rustc_hash::FxHashMap<Atom, Atom>,
+  rendered_init_fragments_hasher: Option<(ModuleIdentifier, &mut RspackHasher)>,
 ) -> BoxSource {
-  let source = info.source.take().expect("should have source");
-  let fragments = info.rendered_init_fragments.take();
   let replacements = PlaceholderReplacements {
     module_references: module_reference_replacements,
-    generated_symbols: &info.generated_top_level_symbols,
-    internal_names: &info.internal_names,
+    generated_symbols,
+    internal_names,
   };
   if fragments.is_none() && replacements.is_empty() {
     return source.boxed();
@@ -471,8 +472,8 @@ pub(super) fn render_concatenated_module_source(
     let mut end = fragments.end;
     apply_placeholder_replacements(&mut start, &replacements);
     apply_placeholder_replacements(&mut end, &replacements);
-    if let Some(hasher) = rendered_init_fragments_hasher {
-      info.module.hash(hasher);
+    if let Some((module, hasher)) = rendered_init_fragments_hasher {
+      module.hash(hasher);
       RenderedInitFragments::hash_parts(&start, &end, hasher);
     }
     ConcatSource::new([
@@ -484,4 +485,42 @@ pub(super) fn render_concatenated_module_source(
   } else {
     rendered_source
   }
+}
+
+/// Renders a faster-concatenation source after its final binding names are
+/// known. Only generated replacement contents and init fragments may contain
+/// concatenation placeholders; the original source is intentionally not
+/// scanned or rewritten.
+pub fn render_concatenation_source(
+  source: ReplaceSource,
+  fragments: Option<RenderedInitFragments>,
+  module_reference_replacements: &[(String, String)],
+  generated_symbols: &[GeneratedTopLevelSymbol],
+  internal_names: &rustc_hash::FxHashMap<Atom, Atom>,
+) -> BoxSource {
+  render_concatenation_source_inner(
+    source,
+    fragments,
+    module_reference_replacements,
+    generated_symbols,
+    internal_names,
+    None,
+  )
+}
+
+pub(super) fn render_concatenated_module_source(
+  info: &mut ConcatenatedModuleInfo,
+  module_reference_replacements: &[(String, String)],
+  rendered_init_fragments_hasher: Option<&mut RspackHasher>,
+) -> BoxSource {
+  let source = info.source.take().expect("should have source");
+  let fragments = info.rendered_init_fragments.take();
+  render_concatenation_source_inner(
+    source,
+    fragments,
+    module_reference_replacements,
+    &info.generated_top_level_symbols,
+    &info.internal_names,
+    rendered_init_fragments_hasher.map(|hasher| (info.module, hasher)),
+  )
 }

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -282,7 +282,7 @@ impl<'a> TemplateReplaceSource<'a> {
     name: Option<String>,
   ) {
     if let Some(scope) = self.concatenation_scope.as_deref_mut() {
-      scope.record_non_shorthand_source_edit(original_range, &content);
+      scope.record_non_shorthand_source_edit(original_range);
     }
     self.source.insert(start, content, name);
   }

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -12,12 +12,12 @@ use swc_core::atoms::Atom;
 use swc_experimental_ecma_ast::{is_valid_continue, is_valid_start};
 
 use crate::{
-  DependencyRange, ModuleIdentifier,
+  DependencyRange, ModuleIdentifier, PendingConcatenationScopeInfo,
   concatenated_module::{
     ConcatenatedImportMap, ConcatenatedModuleInfo, FasterModuleConcatenationInfo,
-    GENERATED_TOP_LEVEL_SYMBOL_PREFIX, GeneratedTopLevelSymbolTarget,
+    GENERATED_TOP_LEVEL_SYMBOL_PREFIX, GeneratedTopLevelSymbol, GeneratedTopLevelSymbolTarget,
     MODULE_REFERENCE_PLACEHOLDER_PREFIX, MODULE_REFERENCE_PREFIX, MODULE_REFERENCE_SUFFIX,
-    ModuleInfo, OriginalScopeIdentUpdate,
+    ModuleInfo, OriginalScopeIdentUpdate, populate_info_from_pending,
   },
 };
 
@@ -211,6 +211,12 @@ pub struct CodeGenerationDataConcatenationScopeOutput {
   import_map: ConcatenatedImportMap,
   #[cacheable(with=AsMap<AsCacheable, AsMap<AsCacheable, AsCacheable>>)]
   refs: IdentifierIndexMap<FxIndexMap<String, ModuleReferenceOptions>>,
+  #[cacheable(with=AsOption<AsCacheable>)]
+  faster_module_concatenation_info: Option<FasterModuleConcatenationInfo>,
+  #[cacheable(with=AsVec)]
+  generated_top_level_symbols: Vec<GeneratedTopLevelSymbol>,
+  #[cacheable(with=AsMap<AsCacheable, AsCacheable>)]
+  module_references: FxIndexMap<String, ConcatenatedModuleReference>,
 }
 
 impl CodeGenerationDataConcatenationScopeOutput {
@@ -223,13 +229,38 @@ impl CodeGenerationDataConcatenationScopeOutput {
       .raw_export_map
       .clone_from(&self.raw_export_map);
     current_module.import_map.clone_from(&self.import_map);
+    current_module
+      .generated_top_level_symbols
+      .clone_from(&self.generated_top_level_symbols);
+    current_module
+      .module_references
+      .clone_from(&self.module_references);
   }
 
   pub fn refs(&self) -> &IdentifierIndexMap<FxIndexMap<String, ModuleReferenceOptions>> {
     &self.refs
   }
+
+  pub fn is_faster_module_concatenation(&self) -> bool {
+    self.faster_module_concatenation_info.is_some()
+  }
+
+  pub fn apply_scope_info(
+    &self,
+    pending: &PendingConcatenationScopeInfo,
+    original_source: &str,
+    current_module: &mut ConcatenatedModuleInfo,
+  ) {
+    self.apply_to(current_module);
+    let mut faster_info = self
+      .faster_module_concatenation_info
+      .clone()
+      .expect("should have faster module concatenation info");
+    populate_info_from_pending(pending, original_source, current_module, &mut faster_info);
+  }
 }
 
+#[cacheable]
 #[derive(Debug, Clone)]
 pub struct ConcatenatedModuleReference {
   pub module: ModuleIdentifier,
@@ -284,6 +315,14 @@ impl ConcatenationScope {
       raw_export_map: self.current_module.raw_export_map.take(),
       import_map: self.current_module.import_map.take(),
       refs: std::mem::take(&mut self.refs),
+      faster_module_concatenation_info: self
+        .faster_module_concatenation_info
+        .take()
+        .map(|info| *info),
+      generated_top_level_symbols: std::mem::take(
+        &mut self.current_module.generated_top_level_symbols,
+      ),
+      module_references: std::mem::take(&mut self.current_module.module_references),
     }
   }
 
@@ -394,7 +433,7 @@ impl ConcatenationScope {
   }
 
   pub fn set_original_range_non_shorthand(&mut self, range: DependencyRange) {
-    self.record_non_shorthand_source_edit(range, "");
+    self.record_non_shorthand_source_edit(range);
   }
 
   #[inline]
@@ -419,20 +458,13 @@ impl ConcatenationScope {
   }
 
   #[inline]
-  pub(crate) fn record_non_shorthand_source_edit(
-    &mut self,
-    range: DependencyRange,
-    generated_code: &str,
-  ) {
+  pub(crate) fn record_non_shorthand_source_edit(&mut self, range: DependencyRange) {
     let Some(info) = self.faster_module_concatenation_info.as_deref_mut() else {
       return;
     };
     info
       .original_scope_ident_updates
       .push(OriginalScopeIdentUpdate::NonShorthand(range));
-    if !generated_code.is_empty() {
-      add_used_names_from_generated_code(info, generated_code);
-    }
   }
 
   pub fn add_scope_ident(&mut self, symbol: Atom, range: DependencyRange) {

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -329,6 +329,11 @@ pub struct ChunkLinkContext {
   pub refs: FxHashMap<String, Ref>,
 
   /**
+  module-local references emitted as structured concatenation placeholders
+  */
+  pub module_reference_refs: IdentifierMap<FxHashMap<String, Ref>>,
+
+  /**
   all used symbols in current chunk
   */
   pub used_names: FxHashSet<Atom>,
@@ -355,6 +360,7 @@ impl ChunkLinkContext {
       hashbang: None,
       directives: Default::default(),
       refs: Default::default(),
+      module_reference_refs: Default::default(),
       used_names: Default::default(),
       exported_symbols: Default::default(),
       raw_import_stmts: Default::default(),

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1,4 +1,5 @@
 use std::{
+  borrow::Cow,
   collections::{self},
   hash::BuildHasher,
   sync::{Arc, LazyLock},
@@ -11,13 +12,15 @@ use rspack_core::{
   ChunkUkey, CodeGenerationDataChunkInitFragments, CodeGenerationDataConcatenationScopeOutput,
   CodeGenerationDataPreservedAssetImport, CodeGenerationPublicPathAutoReplace, Compilation,
   ConcatenatedModuleIdent, ConditionalInitFragment, DependencyType, ExportInfo, ExportMode,
-  ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
-  RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeTemplateRenderMode, RuntimeVariable,
-  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
-  all_runtime_module_variables, collect_ident, escape_name_atom_ref, find_new_name, find_target,
-  get_cached_readable_identifier, get_module_directives, get_module_hashbang, property_access,
-  property_name, reserved_names::RESERVED_NAMES_ATOM_SET, rspack_sources::ReplaceSource,
+  ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult,
+  GeneratedTopLevelSymbolTarget, ImportSpec, InitFragmentKey, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
+  PendingConcatenationScopeInfo, RenderedInitFragments, RuntimeGlobals, RuntimeGlobalsRenderMode,
+  RuntimeTemplateRenderMode, RuntimeVariable, SideEffectsStateArtifact, SourceType, URLStaticMode,
+  UsageState, UsedName, UsedNameItem, all_runtime_module_variables, collect_ident,
+  escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
+  get_module_directives, get_module_hashbang, property_access, property_name,
+  reserved_names::RESERVED_NAMES_ATOM_SET, rspack_sources::ReplaceSource,
   split_readable_identifier, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Error, Result};
@@ -79,6 +82,12 @@ enum ExternalImportBinding {
   Default,
   Named(Atom),
   Namespace,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum ReferenceTarget {
+  Legacy(String),
+  Module(ModuleIdentifier, String),
 }
 
 impl EsmLibraryPlugin {
@@ -639,9 +648,16 @@ impl EsmLibraryPlugin {
         match info {
           ModuleInfo::Concatenated(info) => {
             for (id, _) in info.binding_to_ref.iter() {
+              let name = info
+                .generated_top_level_symbols
+                .iter()
+                .find(|symbol| {
+                  symbol.target == GeneratedTopLevelSymbolTarget::New && symbol.placeholder == id.0
+                })
+                .map_or(&id.0, |symbol| &symbol.preferred_name);
               escaped_names
-                .entry(id.0.clone())
-                .or_insert_with(|| escape_name_atom_ref(&id.0));
+                .entry(name.clone())
+                .or_insert_with(|| escape_name_atom_ref(name));
             }
 
             if let Some(import_map) = &info.import_map {
@@ -1308,27 +1324,35 @@ var {} = {{}};
           }
         }
 
-        for (atom, ctxt) in concate_info.binding_to_ref.keys() {
+        for (id, ctxt) in concate_info.binding_to_ref.keys() {
           // only need to handle top level scope
           if ctxt != &concate_info.module_ctxt {
             continue;
           }
 
-          if all_used_names.contains(atom) {
-            let new_name = find_new_name(
+          let name = concate_info
+            .generated_top_level_symbols
+            .iter()
+            .find(|symbol| {
+              symbol.target == GeneratedTopLevelSymbolTarget::New && symbol.placeholder == *id
+            })
+            .map_or(id, |symbol| &symbol.preferred_name);
+          let final_name = if all_used_names.contains(name) {
+            find_new_name(
               escaped_names
-                .get(atom)
+                .get(name)
                 .expect("should have escaped name")
                 .as_ref(),
               &all_used_names,
               &escaped_identifiers[&readable_identifier],
-            );
-
-            all_used_names.insert(new_name.clone());
-            internal_names.insert(atom.clone(), new_name);
+            )
           } else {
-            all_used_names.insert(atom.clone());
-            internal_names.insert(atom.clone(), atom.clone());
+            name.clone()
+          };
+          all_used_names.insert(final_name.clone());
+          internal_names.insert(id.clone(), final_name.clone());
+          if id != name && name == &*rspack_core::DEFAULT_EXPORT_ATOM {
+            internal_names.insert(name.clone(), final_name);
           }
         }
 
@@ -1611,98 +1635,153 @@ var {} = {{}};
                   runtime_template,
                 )
                 .await?;
-              concatenation_scope_output.apply_to(&mut concate_info);
-
-              let jsx = module
-                .as_ref()
-                .as_normal_module()
-                .and_then(|normal_module| normal_module.get_parser_options())
-                .and_then(|options| {
-                  options
-                    .get_javascript()
-                    .and_then(|js_options| js_options.jsx)
-                })
-                .unwrap_or(false);
-              let source_str = render_source
-                .source
-                .source()
-                .into_string_lossy()
-                .into_owned();
-              let allocator = Allocator::new();
-              let lexer = swc_experimental_ecma_parser::Lexer::new(
-                &allocator,
-                Syntax::Es(EsSyntax {
-                  jsx,
-                  ..Default::default()
-                }),
-                EsVersion::EsNext,
-                StringSource::new(&source_str),
-                None,
-              );
-              let mut parser = Parser::new_from(&allocator, lexer);
-              let module = match parser.parse_module() {
-                Ok(module) => module,
-                Err(err) => {
-                  return Err(Error::from_string(
-                    Some(source_str.clone()),
-                    err.span().real_lo() as usize,
-                    err.span().real_hi() as usize,
-                    "JavaScript parse error:\n".to_string(),
-                    err.kind().msg().to_string(),
-                  ));
-                }
-              };
-              let program = Program::Module(allocator.boxed(module));
-              let semantic = resolver(&program);
-              let ids = collect_ident(&allocator, &program);
-
-              concate_info.module_ctxt =
-                SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
-              concate_info.global_ctxt =
-                SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
-
-              let top_level_scope_id = semantic.top_level_scope_id();
-              let mut all_used_names = FxHashSet::default();
-              all_used_names.reserve(ids.len());
-              concate_info.idents.reserve(ids.len());
-              concate_info.global_scope_ident.reserve(ids.len());
-              let mut binding_to_ref: FxIndexMap<
-                (Atom, SyntaxContext),
-                Vec<ConcatenatedModuleIdent>,
-              > = Default::default();
-              binding_to_ref.reserve(ids.len());
-
-              for ident in ids {
-                let scope = semantic.node_scope(&ident.id);
-                let is_global = SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
-                let legacy = if is_global {
-                  let leg = ident.to_legacy(&semantic);
-                  concate_info.global_scope_ident.push(leg.clone());
-                  all_used_names.insert(leg.id.sym.clone());
-                  Some(leg)
+              let faster_module_concatenation =
+                concatenation_scope_output.is_faster_module_concatenation();
+              if faster_module_concatenation {
+                let pending_scope_info = module
+                  .build_info()
+                  .pending_concatenation_scope_info
+                  .as_deref()
+                  .ok_or_else(|| {
+                    rspack_error::error!(
+                      "module {id} entered faster ESM library concatenation without pending concatenation scope info"
+                    )
+                  })?;
+                let original_source = if matches!(
+                  pending_scope_info,
+                  PendingConcatenationScopeInfo::Analyzed(_)
+                ) {
+                  module
+                    .source()
+                    .ok_or_else(|| {
+                      rspack_error::error!(
+                        "module {id} has analyzed ESM library concatenation scope info without a make-time source"
+                      )
+                    })?
+                    .source()
+                    .into_string_lossy()
                 } else {
-                  None
+                  Cow::Borrowed("")
                 };
-                if ident.is_class_expr_with_ident {
-                  all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                  continue;
-                }
-                if scope != top_level_scope_id {
-                  all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                }
-                let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
-                concate_info.idents.push(legacy.clone());
-                binding_to_ref
-                  .entry((legacy.id.sym.clone(), legacy.id.ctxt))
-                  .or_default()
-                  .push(legacy);
-              }
+                concatenation_scope_output.apply_scope_info(
+                  pending_scope_info,
+                  &original_source,
+                  &mut concate_info,
+                );
+                concate_info.rendered_init_fragments = codegen_res
+                  .data()
+                  .get::<RenderedInitFragments>()
+                  .cloned()
+                  .filter(|fragments| !fragments.is_empty());
+              } else {
+                concatenation_scope_output.apply_to(&mut concate_info);
+                let jsx = module
+                  .as_ref()
+                  .as_normal_module()
+                  .and_then(|normal_module| normal_module.get_parser_options())
+                  .and_then(|options| {
+                    options
+                      .get_javascript()
+                      .and_then(|js_options| js_options.jsx)
+                  })
+                  .unwrap_or(false);
+                let source_str = render_source
+                  .source
+                  .source()
+                  .into_string_lossy()
+                  .into_owned();
+                let allocator = Allocator::new();
+                let lexer = swc_experimental_ecma_parser::Lexer::new(
+                  &allocator,
+                  Syntax::Es(EsSyntax {
+                    jsx,
+                    ..Default::default()
+                  }),
+                  EsVersion::EsNext,
+                  StringSource::new(&source_str),
+                  None,
+                );
+                let mut parser = Parser::new_from(&allocator, lexer);
+                let parsed_module = match parser.parse_module() {
+                  Ok(module) => module,
+                  Err(err) => {
+                    return Err(Error::from_string(
+                      Some(source_str.clone()),
+                      err.span().real_lo() as usize,
+                      err.span().real_hi() as usize,
+                      "JavaScript parse error:\n".to_string(),
+                      err.kind().msg().to_string(),
+                    ));
+                  }
+                };
+                let program = Program::Module(allocator.boxed(parsed_module));
+                let semantic = resolver(&program);
+                let ids = collect_ident(&allocator, &program);
 
-              concate_info.all_used_names = all_used_names;
-              concate_info.binding_to_ref = binding_to_ref;
+                concate_info.module_ctxt =
+                  SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
+                concate_info.global_ctxt =
+                  SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
+
+                let top_level_scope_id = semantic.top_level_scope_id();
+                let mut all_used_names = FxHashSet::default();
+                all_used_names.reserve(ids.len());
+                concate_info.idents.reserve(ids.len());
+                concate_info.global_scope_ident.reserve(ids.len());
+                let mut binding_to_ref: FxIndexMap<
+                  (Atom, SyntaxContext),
+                  Vec<ConcatenatedModuleIdent>,
+                > = Default::default();
+                binding_to_ref.reserve(ids.len());
+
+                for ident in ids {
+                  let scope = semantic.node_scope(&ident.id);
+                  let is_global =
+                    SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
+                  let legacy = if is_global {
+                    let legacy = ident.to_legacy(&semantic);
+                    concate_info.global_scope_ident.push(legacy.clone());
+                    all_used_names.insert(legacy.id.sym.clone());
+                    Some(legacy)
+                  } else {
+                    None
+                  };
+                  if ident.is_class_expr_with_ident {
+                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                    continue;
+                  }
+                  if scope != top_level_scope_id {
+                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                  }
+                  let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
+                  concate_info.idents.push(legacy.clone());
+                  binding_to_ref
+                    .entry((legacy.id.sym.clone(), legacy.id.ctxt))
+                    .or_default()
+                    .push(legacy);
+                }
+
+                concate_info.all_used_names = all_used_names;
+                concate_info.binding_to_ref = binding_to_ref;
+              }
               concate_info.has_ast = true;
-              concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-              concate_info.internal_source = Some(render_source.source.clone());
+              if faster_module_concatenation {
+                let source = render_source
+                  .source
+                  .as_any()
+                  .downcast_ref::<ReplaceSource>()
+                  .cloned()
+                  .ok_or_else(|| {
+                    rspack_error::error!(
+                      "module {id} lost its editable ESM library concatenation source while rendering module content"
+                    )
+                  })?;
+                concate_info.internal_source = Some(source.inner().clone());
+                concate_info.source = Some(source);
+              } else {
+                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
+                concate_info.internal_source = Some(render_source.source.clone());
+              }
               concate_info.runtime_requirements = runtime_requirements;
               concate_info.chunk_init_fragments = codegen_res
                 .data()
@@ -2900,7 +2979,17 @@ var {} = {{}};
         for (ref_module, all_refs) in concatenation_scope_output.refs() {
           // import all atoms from ref_module
           for (ref_string, options) in all_refs.iter() {
-            if refs.contains_key(ref_string) {
+            let reference_target = if concatenation_scope_output.is_faster_module_concatenation() {
+              ReferenceTarget::Module(*m, ref_string.clone())
+            } else {
+              ReferenceTarget::Legacy(
+                ref_string
+                  .strip_suffix("._")
+                  .expect("should have suffix: '._'")
+                  .to_string(),
+              )
+            };
+            if refs.contains_key(&reference_target) {
               continue;
             }
 
@@ -2924,13 +3013,7 @@ var {} = {{}};
               continue;
             };
 
-            refs.insert(
-              ref_string
-                .strip_suffix("._")
-                .expect("should have prefix: '._'")
-                .to_string(),
-              binding,
-            );
+            refs.insert(reference_target, binding);
           }
         }
       }
@@ -2939,8 +3022,8 @@ var {} = {{}};
       // if symbol is from outside, we should deconflict them,
       // because we've only deconflicted local symbols before
       let mut ref_by_symbol =
-        FxIndexMap::<(Atom, ModuleIdentifier), Vec<(String, SymbolRef)>>::default();
-      let mut inline_refs = FxHashMap::<String, Ref>::default();
+        FxIndexMap::<(Atom, ModuleIdentifier), Vec<(ReferenceTarget, SymbolRef)>>::default();
+      let mut inline_refs = FxHashMap::<ReferenceTarget, Ref>::default();
 
       refs
         .into_iter()
@@ -3025,8 +3108,25 @@ var {} = {{}};
         }
       }
 
+      let mut legacy_refs = FxHashMap::default();
+      let mut module_reference_refs: IdentifierMap<FxHashMap<String, Ref>> = Default::default();
+      for (target, binding) in refs {
+        match target {
+          ReferenceTarget::Legacy(reference) => {
+            legacy_refs.insert(reference, binding);
+          }
+          ReferenceTarget::Module(module, reference) => {
+            module_reference_refs
+              .entry(module)
+              .or_default()
+              .insert(reference, binding);
+          }
+        }
+      }
+
       chunk_link.needed_namespace_objects = needed_namespace_objects.clone();
-      chunk_link.refs = refs;
+      chunk_link.refs = legacy_refs;
+      chunk_link.module_reference_refs = module_reference_refs;
 
       // ensure imports external module
       for m in &chunk_link.decl_modules {
@@ -3079,6 +3179,12 @@ var {} = {{}};
       let all_chunk_used_symbols = chunk_link
         .refs
         .values()
+        .chain(
+          chunk_link
+            .module_reference_refs
+            .values()
+            .flat_map(|refs| refs.values()),
+        )
         .filter_map(|symbol_ref| {
           if let Ref::Symbol(symbol_ref) = symbol_ref {
             Some(&symbol_ref.symbol)
@@ -3440,6 +3546,28 @@ var {} = {{}};
         if let Some(ref export_id) = export_id
           && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
         {
+          if let Some(reference) = info.module_references.get(direct_export) {
+            let referenced_info_id = reference.module;
+            let mut referenced_export_name = reference.options.ids.clone();
+            referenced_export_name.extend(export_name.iter().skip(1).cloned());
+            return Self::get_binding(
+              from,
+              mg,
+              mg_cache,
+              exports_info_artifact,
+              &referenced_info_id,
+              referenced_export_name,
+              module_to_info_map,
+              needed_namespace_objects,
+              reference.options.call,
+              !reference.options.direct_import,
+              module.build_meta().strict_esm_module(),
+              reference.options.asi_safe,
+              already_visited,
+              required,
+              all_used_names,
+            );
+          }
           if let Some(used_name) = used_name {
             match used_name {
               UsedName::Normal(used_name) => {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -15,12 +15,13 @@ use rspack_core::{
   CompilationAfterCodeGeneration, CompilationConcatenationScope, CompilationFinishModules,
   CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeDependencies,
   CompilationParams, CompilationProcessAssets, CompilationRuntimeRequirementInTree,
-  CompilerCompilation, ConcatenatedModuleInfo, ConcatenationScope, DependencyType,
-  ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult, JavascriptParserUrl, Logger,
-  ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType,
+  CompilerCompilation, ConcatenatedModuleInfo, ConcatenationScope, ConcatenationScopeInfoMode,
+  DependencyType, ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult, JavascriptParserUrl,
+  Logger, ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType,
   NormalModuleFactoryAfterFactorize, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
-  Plugin, REQUIRE_SCOPE_GLOBALS, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, get_target, is_esm_dep_like,
+  PendingConcatenationScopeInfo, Plugin, REQUIRE_SCOPE_GLOBALS, RuntimeCodeTemplate,
+  RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact, SideEffectsStateArtifact, get_target,
+  is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -342,7 +343,7 @@ async fn finish_modules(
 #[plugin_hook(CompilationConcatenationScope for EsmLibraryPlugin)]
 async fn concatenation_scope(
   &self,
-  _compilation: &Compilation,
+  compilation: &Compilation,
   module: ModuleIdentifier,
 ) -> Result<Option<ConcatenationScope>> {
   let modules_map = self.concatenated_modules_map_for_codegen.borrow();
@@ -359,6 +360,32 @@ async fn concatenation_scope(
     current_module.as_ref().clone(),
   );
   scope.enable_codegen_data_collection();
+  let can_use_faster_module_concatenation = compilation
+    .get_module_graph()
+    .module_by_identifier(&module)
+    .is_some_and(|module| {
+      matches!(
+        (
+          module.concatenation_scope_info_mode(),
+          module
+            .build_info()
+            .pending_concatenation_scope_info
+            .as_deref()
+        ),
+        (
+          ConcatenationScopeInfoMode::AnalyzeAtMake,
+          Some(PendingConcatenationScopeInfo::Analyzed(_))
+        ) | (
+          ConcatenationScopeInfoMode::GenerateAtCodegen,
+          Some(PendingConcatenationScopeInfo::Generated)
+        )
+      )
+    });
+  if compilation.options.experiments.faster_module_concatenation
+    && can_use_faster_module_concatenation
+  {
+    scope.enable_faster_module_concatenation();
+  }
   Ok(Some(scope))
 }
 

--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -7,7 +7,8 @@ use rspack_core::{
   AssetInfo, Chunk, ChunkGraph, ChunkGroup, ChunkRenderContext, ChunkUkey,
   CodeGenerationDataPreservedAssetImport, Compilation, ConcatenatedModuleInfo, InitFragment,
   ModuleIdentifier, PathData, PathInfo, RuntimeCodeTemplate, RuntimeGlobals, RuntimeVariable,
-  SourceType, export_name, get_js_chunk_filename_template, get_undo_path, render_init_fragments,
+  SourceType, export_name, get_js_chunk_filename_template, get_undo_path,
+  render_concatenation_source, render_init_fragments,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
 };
 use rspack_error::Result;
@@ -774,7 +775,7 @@ var {} = {{}};
   pub fn render_module(
     info: &ConcatenatedModuleInfo,
     chunk_link: &ChunkLinkContext,
-  ) -> Result<ReplaceSource> {
+  ) -> Result<BoxSource> {
     let Some(mut source) = info.source.clone() else {
       return Err(rspack_error::Error::error(format!(
         "module: {} has no source",
@@ -813,6 +814,9 @@ var {} = {{}};
       }
 
       if let Some(internal_name) = info.get_internal_name(&ident.id.sym) {
+        if !ident.shorthand && internal_name == &ident.id.sym {
+          continue;
+        }
         let name = if ident.shorthand {
           format!("{}: {}", &ident.id.sym, &internal_name)
         } else {
@@ -822,7 +826,25 @@ var {} = {{}};
       }
     }
 
-    Ok(source)
+    let mut module_reference_replacements = Vec::with_capacity(info.module_references.len());
+    let module_reference_refs = chunk_link.module_reference_refs.get(&info.module);
+    for placeholder in info.module_references.keys() {
+      if let Some(binding_ref) = module_reference_refs.and_then(|refs| refs.get(placeholder)) {
+        let final_name = match binding_ref {
+          Ref::Symbol(symbol_ref) => symbol_ref.render(),
+          Ref::Inline(inline) => inline.clone(),
+        };
+        module_reference_replacements.push((placeholder.clone(), final_name));
+      }
+    }
+
+    Ok(render_concatenation_source(
+      source,
+      info.rendered_init_fragments.clone(),
+      &module_reference_replacements,
+      &info.generated_top_level_symbols,
+      &info.internal_names,
+    ))
   }
 
   pub fn render_external_required(

--- a/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/index.js
@@ -1,0 +1,1 @@
+export { value } from './mock-loader.js!./value';

--- a/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/mock-loader.js
+++ b/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/mock-loader.js
@@ -1,0 +1,7 @@
+let generated = false;
+
+module.exports = function () {
+  const value = generated ? 'second' : 'first';
+  generated = true;
+  return `export const value = ${JSON.stringify(value)};`;
+};

--- a/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/rspack.config.js
@@ -1,0 +1,44 @@
+let firstAsset;
+
+class CheckAssetPlugin {
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap('CheckAssetPlugin', (compilation) => {
+      compilation.hooks.afterProcessAssets.tap('CheckAssetPlugin', (assets) => {
+        const asset = Object.keys(assets).find(
+          (name) => name.startsWith('main.') && name.endsWith('.mjs'),
+        );
+        if (!asset) {
+          throw new Error('JavaScript asset not found');
+        }
+        if (firstAsset === undefined) {
+          firstAsset = asset;
+        } else {
+          expect(asset).not.toBe(firstAsset);
+        }
+      });
+    });
+  }
+}
+
+const createConfig = () => ({
+  mode: 'production',
+  target: 'async-node',
+  entry: './index.js',
+  experiments: {
+    fasterModuleConcatenation: true,
+  },
+  output: {
+    filename: '[name].[contenthash].mjs',
+    module: true,
+    library: {
+      type: 'modern-module',
+    },
+  },
+  optimization: {
+    minimize: false,
+    runtimeChunk: false,
+  },
+  plugins: [new CheckAssetPlugin()],
+});
+
+module.exports = [createConfig(), createConfig()];

--- a/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/test.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  findBundle: () => [],
+};

--- a/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/value.js
+++ b/tests/rspack-test/configCases/concatenate-modules/esm-library-codegen-hash/value.js
@@ -1,0 +1,1 @@
+throw new Error('This source should be replaced by mock-loader');

--- a/tests/rspack-test/esmOutputCases/new-url/url-only-asset/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/new-url/url-only-asset/rspack.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  experiments: {
+    fasterModuleConcatenation: true,
+  },
   module: {
     parser: {
       javascript: {

--- a/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/preserve-modules/namespace-object-bare-import/rspack.config.js
@@ -3,6 +3,9 @@ const path = require('path');
 /** @type {import('@rspack/core').Configuration} */
 module.exports = {
   entry: './src/index.js',
+  experiments: {
+    fasterModuleConcatenation: true,
+  },
   output: {
     library: {
       type: 'modern-module',

--- a/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/runtime/modern-module-sri/rspack.config.js
@@ -2,6 +2,9 @@ const rspack = require('@rspack/core');
 
 module.exports = {
   target: 'web',
+  experiments: {
+    fasterModuleConcatenation: true,
+  },
   output: {
     crossOriginLoading: 'anonymous',
   },


### PR DESCRIPTION
## Summary

- Reuse the concatenation scope information collected during make and updated by dependency templates when linking ESM library output.
- Apply recorded identifier updates and generated top-level symbols before the final ESM link, avoiding the additional concatenated-module parse.
- Preserve the legacy ESM library linking path when faster module concatenation is disabled.

This PR is stacked on #14852 and should be reviewed and merged after it.

Checks run:

- `cargo check -p rspack_plugin_esm_library`
- `pnpm run build:binding:dev`
- `pnpm run test -t "esmOutputCases/deconflict"`
- `pnpm run test -t "esmOutputCases/worker/new-url-relative"`

## Related links

- Base PR: #14852

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
