### PR TITLE
docs: document loaderContext.addBuildDependency

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -333,6 +333,10 @@ export interface LoaderContext<OptionsType = {}> {
   getDependencies(): string[];
   getContextDependencies(): string[];
   getMissingDependencies(): string[];
+  /**
+   * Add a file as a build dependency of the loader result.
+   * Build dependencies invalidate the persistent cache when they change.
+   */
   addBuildDependency(file: string): void;
   /**
    * Compile and execute a module at the build time.

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -11,6 +11,33 @@ import WebpackLicense from '@components/WebpackLicense';
 
 The loader context represents the properties that are available inside of a loader assigned to the `this` property.
 
+## this.addBuildDependency()
+
+- **Type:**
+
+```ts
+function addBuildDependency(file: string): void;
+```
+
+Add a file as a build dependency of the loader result. Build dependencies are used to invalidate the persistent cache when they change.
+
+Use this for files that affect a loader's behavior or transformation result, such as a loader configuration file.
+
+```js title="loader.js"
+const path = require('node:path');
+
+module.exports = function loader(source) {
+  this.addBuildDependency(
+    path.resolve(this.rootContext, 'custom-loader.config.js'),
+  );
+  return source;
+};
+```
+
+:::tip
+`this.addBuildDependency()` does not make the file a watch dependency. If changes to the file should trigger a rebuild in watch mode, also call [this.addDependency()](#thisadddependency).
+:::
+
 ## this.addContextDependency()
 
 - **Type:**

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -11,6 +11,33 @@ import WebpackLicense from '@components/WebpackLicense';
 
 Loader 上下文表示 loader 内部可用的属性，这些属性在 loader 中通过 `this` 属性进行访问。
 
+## this.addBuildDependency()
+
+- **类型：**
+
+```ts
+function addBuildDependency(file: string): void;
+```
+
+添加一个文件作为 loader 结果的构建依赖。当构建依赖发生变化时，Rspack 会使持久化缓存失效。
+
+它适用于会影响 loader 行为或转换结果的文件，例如 loader 的配置文件。
+
+```js title="loader.js"
+const path = require('node:path');
+
+module.exports = function loader(source) {
+  this.addBuildDependency(
+    path.resolve(this.rootContext, 'custom-loader.config.js'),
+  );
+  return source;
+};
+```
+
+:::tip
+`this.addBuildDependency()` 不会将文件添加为 watch 依赖。如果文件变化时还应在 watch 模式下触发重新构建，请同时调用 [this.addDependency()](#thisadddependency)。
+:::
+
 ## this.addContextDependency()
 
 - **类型：**


### PR DESCRIPTION
## Summary

Document `loaderContext.addBuildDependency` in English and Chinese, including its persistent cache behavior and relationship to watch dependencies. Add matching JSDoc to `LoaderContext` so the API behavior is available in editor tooltips.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).