### PR TITLE
docs: document loaderContext.loaders and remainingRequest

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -207,6 +207,10 @@ export interface LoaderContext<OptionsType = {}> {
    * The index in the loaders array of the current loader.
    */
   loaderIndex: number;
+  /**
+   * A request string consisting of the loaders that follow the current loader
+   * in the chain and the current resource, joined with `!`.
+   */
   remainingRequest: string;
   currentRequest: string;
   previousRequest: string;
@@ -217,22 +221,10 @@ export interface LoaderContext<OptionsType = {}> {
    */
   request: string;
   /**
-   * An array of all the loaders. It is writable in the pitch phase.
-   * loaders = [{request: string, path: string, query: string, module: function}]
-   *
-   * In the example:
-   * [
-   *   { request: "/abc/loader1.js?xyz",
-   *     path: "/abc/loader1.js",
-   *     query: "?xyz",
-   *     module: [Function]
-   *   },
-   *   { request: "/abc/node_modules/loader2/index.js",
-   *     path: "/abc/node_modules/loader2/index.js",
-   *     query: "",
-   *     module: [Function]
-   *   }
-   * ]
+   * An array containing all loaders applied to the current module. Each item
+   * provides information such as the resolved request, path, query, and
+   * options. The array can be modified during the pitch phase to adjust the
+   * loader chain.
    */
   loaders: LoaderObject[];
   /**

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -188,6 +188,21 @@ If the module being processed is not from the file system, such as a virtual mod
 
 The index in the loaders array of the current loader.
 
+## this.loaders
+
+- **Type:** `LoaderObject[]`
+
+`this.loaders` contains all loaders applied to the current module. Each item provides information such as the resolved `request`, `path`, `query`, and `options`.
+
+During the pitch phase, you can modify the array to adjust the loader chain. Use [this.loaderIndex](#thisloaderindex) to locate the current loader.
+
+```js title="loader.js"
+module.exports.pitch = function () {
+  const currentLoader = this.loaders[this.loaderIndex];
+  console.log(currentLoader.request);
+};
+```
+
 ## this.data
 
 - **Type:** `unknown`
@@ -563,6 +578,26 @@ The value depends on the loader configuration:
 - If the current loader has no options, but was invoked with a query string, this will be a string starting with `?`.
 
 Unlike [this.getOptions()](#thisgetoptions), the query-string form is not parsed. For example, `loader: './my-loader?s=foo+bar'` gives `this.query === '?s=foo+bar'`.
+
+## this.remainingRequest
+
+- **Type:** `string`
+
+`this.remainingRequest` consists of the loaders that follow the current loader in the chain and the current resource, joined with `!`.
+
+For example, consider the following loader chain:
+
+```text
+/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js
+```
+
+When Rspack runs `loader1.js`, `this.remainingRequest` is:
+
+```text
+/path/to/loader2.js!/path/to/resource.js
+```
+
+You can use it to create an inline request without invoking the current loader again. See [Inline matchResource](/api/loader-api/inline-match-resource) for an example.
 
 ## this.request
 

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -183,6 +183,21 @@ module.exports = function loader(source) {
 
 当前 loader 在 loaders 数组中的索引。
 
+## this.loaders
+
+- **类型：** `LoaderObject[]`
+
+`this.loaders` 包含应用于当前模块的所有 loader。每一项都提供解析后的 `request`、`path`、`query` 和 `options` 等信息。
+
+在 pitch 阶段可以修改这个数组，以调整 loader 链。可通过 [this.loaderIndex](#thisloaderindex) 定位当前 loader。
+
+```js title="loader.js"
+module.exports.pitch = function () {
+  const currentLoader = this.loaders[this.loaderIndex];
+  console.log(currentLoader.request);
+};
+```
+
 ## this.data
 
 - **类型：** `unknown`
@@ -554,6 +569,26 @@ module.exports = function loader(source) {
 - 如果当前 loader 没有选项，但是通过查询字符串调用，这将是一个以 `?` 开头的字符串。
 
 与 [this.getOptions()](#thisgetoptions) 不同，查询字符串形式在这里不会被解析。例如，`loader: './my-loader?s=foo+bar'` 时，`this.query === '?s=foo+bar'`。
+
+## this.remainingRequest
+
+- **类型：** `string`
+
+`this.remainingRequest` 由 loader 链中位于当前 loader 之后的所有 loader 和当前资源组成，各部分使用 `!` 连接。
+
+例如，假设 loader 链为：
+
+```text
+/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js
+```
+
+执行到 `loader1.js` 时，`this.remainingRequest` 为：
+
+```text
+/path/to/loader2.js!/path/to/resource.js
+```
+
+它通常用于构造内联请求，避免再次执行当前 loader。可以参考 [Inline matchResource](/api/loader-api/inline-match-resource) 中的示例。
 
 ## this.request
 


### PR DESCRIPTION
## Summary

Loader authors currently lack reference documentation for inspecting the loader chain and reusing the remaining request. This PR documents `this.loaders` and `this.remainingRequest` in English and Chinese, adds examples, and aligns their `LoaderContext` JSDoc with the current runtime behavior.

The `this.loaders` JSDoc now describes the current loader object fields instead of the outdated `module` field example.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).