### PR TITLE
docs: migrate loaderContext examples to ESM

### DIFF
--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -23,15 +23,15 @@ Add a file as a build dependency of the loader result. Build dependencies are us
 
 Use this for files that affect a loader's behavior or transformation result, such as a loader configuration file.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addBuildDependency(
     path.resolve(this.rootContext, 'custom-loader.config.js'),
   );
   return source;
-};
+}
 ```
 
 :::tip
@@ -50,13 +50,13 @@ Add the directory as a dependency for the loader results so that any changes to 
 
 For example, adding `src/static` as a dependency. When the files in the `src/static` directory change, it will trigger a rebuild.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addContextDependency(path.resolve(this.rootContext, 'src/static'));
   return source;
-};
+}
 ```
 
 ## this.addDependency()
@@ -69,13 +69,13 @@ function addDependency(file: string): void;
 
 Add a file as a dependency on the loader results so that any changes to them can be listened to. For example, `sass-loader`, `less-loader` use this trick to recompile when the imported style files change.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addDependency(path.resolve(this.rootContext, 'src/styles/foo.scss'));
   return source;
-};
+}
 ```
 
 ## this.addMissingDependency()
@@ -88,15 +88,15 @@ function addMissingDependency(file: string): void;
 
 Add a currently non-existent file as a dependency of the loader result, so that its creation and any changes can be listened. For example, when a new file is created at that path, it will trigger a rebuild.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addMissingDependency(
     path.resolve(this.rootContext, 'src/dynamic-file.json'),
   );
   return source;
-};
+}
 ```
 
 ## this.async()
@@ -119,11 +119,11 @@ A function that sets the cacheable flag.
 
 By default, the processing results of the loader are marked as cacheable. Calling this method and passing `false` turns off the loader's ability to cache processing results.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   this.cacheable(false);
   return source;
-};
+}
 ```
 
 ## this.callback()
@@ -173,11 +173,11 @@ The directory path of the currently processed module, which changes with the loc
 
 For example, if the loader is processing `/project/src/components/Button.js`, then the value of `this.context` would be `/project/src/components`.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.context); // '/project/src/components'
   return source;
-};
+}
 ```
 
 If the module being processed is not from the file system, such as a virtual module, then the value of `this.context` is `null`.
@@ -196,11 +196,11 @@ The index in the loaders array of the current loader.
 
 During the pitch phase, you can modify the array to adjust the loader chain. Use [this.loaderIndex](#thisloaderindex) to locate the current loader.
 
-```js title="loader.js"
-module.exports.pitch = function () {
+```js title="loader.mjs"
+export function pitch() {
   const currentLoader = this.loaders[this.loaderIndex];
   console.log(currentLoader.request);
-};
+}
 ```
 
 ## this.data
@@ -291,9 +291,9 @@ Unlike `throw` and `this.callback(err)` in the loader, it does not mark the curr
 
 When only `message` and `severity` are provided, only the basic module error information will be printed.
 
-```js title="loader.js"
+```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
-module.exports = function () {
+export default function () {
   this.experiments.emitDiagnostic({
     message: '`React` is not defined',
     severity: 'error',
@@ -303,24 +303,24 @@ module.exports = function () {
     severity: 'warning',
   });
   return '';
-};
+}
 ```
 
 This will print:
 
 ```
-ERROR in (./loader.js!)
+ERROR in (./loader.mjs!)
   × ModuleError: `React` is not defined
 
-WARNING in (./loader.js!)
+WARNING in (./loader.mjs!)
   ⚠ ModuleWarning: `React` is not defined
 ```
 
 - Printing code snippet:
 
-```js title="loader.js"
+```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
-module.exports = function () {
+export default function () {
   this.experiments.emitDiagnostic({
     message: '`React` is not defined',
     severity: 'error',
@@ -333,7 +333,7 @@ module.exports = function () {
     file: './some-file.js',
   });
   return '';
-};
+}
 ```
 
 This will print:
@@ -367,18 +367,18 @@ Emit a new file. This method allows you to create new files during the loader ex
 
 - Basic example:
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   // Emit a new file that will be output as `foo.js` in the output directory
   this.emitFile('foo.js', 'console.log("Hello, world!");');
   return source;
-};
+}
 ```
 
 - Example with asset info:
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   this.emitFile(
     'foo.js',
     'console.log("Hello, world!");',
@@ -389,7 +389,7 @@ module.exports = function loader(source) {
   );
 
   return source;
-};
+}
 ```
 
 ## this.fs
@@ -417,7 +417,7 @@ export default {
       {
         test: /\.txt$/,
         use: {
-          loader: './my-loader.js',
+          loader: './my-loader.mjs',
           options: {
             foo: 'bar',
           },
@@ -428,14 +428,14 @@ export default {
 };
 ```
 
-In `my-loader.js` get the options passed in:
+In `my-loader.mjs` get the options passed in:
 
-```js title="my-loader.js"
-module.exports = function myLoader(source) {
+```js title="my-loader.mjs"
+export default function myLoader(source) {
   const options = this.getOptions();
   console.log(options); // { foo: 'bar' }
   return source;
-};
+}
 ```
 
 :::tip
@@ -485,11 +485,11 @@ Create a resolver like `this.resolve`.
 
 Whether HMR is enabled.
 
-```js title="loader.js"
-module.exports = function (source) {
+```js title="loader.mjs"
+export default function (source) {
   console.log(this.hot); // true if HMR is enabled
   return source;
-};
+}
 ```
 
 ## this.importModule()
@@ -529,10 +529,10 @@ Compile and execute a module at the build time. This is an alternative lightweig
 
 `importModule` will return a Promise if no callback is provided.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = async function loader(source) {
+export default async function loader(source) {
   const modulePath = path.resolve(this.rootContext, 'some-module.ts');
   const moduleExports = await this.importModule(modulePath, {
     // optional options
@@ -540,15 +540,15 @@ module.exports = async function loader(source) {
 
   const result = someProcessing(source, moduleExports);
   return result;
-};
+}
 ```
 
 Or you can pass a callback to it.
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   const callback = this.async();
   const modulePath = path.resolve(this.rootContext, 'some-module.ts');
 
@@ -565,7 +565,7 @@ module.exports = function loader(source) {
       callback(null, result);
     },
   );
-};
+}
 ```
 
 ## this.query
@@ -588,13 +588,13 @@ Unlike [this.getOptions()](#thisgetoptions), the query-string form is not parsed
 For example, consider the following loader chain:
 
 ```text
-/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
 ```
 
-When Rspack runs `loader1.js`, `this.remainingRequest` is:
+When Rspack runs `loader1.mjs`, `this.remainingRequest` is:
 
 ```text
-/path/to/loader2.js!/path/to/resource.js
+/path/to/loader2.mjs!/path/to/resource.js
 ```
 
 You can use it to create an inline request without invoking the current loader again. See [Inline matchResource](/api/loader-api/inline-match-resource) for an example.
@@ -605,7 +605,7 @@ You can use it to create an inline request without invoking the current loader a
 
 The module specifier string after being resolved.
 
-For example, if a `resource.js` is processed by `loader1.js` and `loader2.js`, the value of `this.request` will be `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`.
+For example, if a `resource.js` is processed by `loader1.mjs` and `loader2.mjs`, the value of `this.request` will be `/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js`.
 
 ## this.resolve()
 
@@ -633,11 +633,11 @@ The value of [`mode`](/config/mode) is read when Rspack is run.
 
 The possible values are: `'production'`, `'development'`, `'none'`
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.mode); // 'production' or other values
   return source;
-};
+}
 ```
 
 ## this.target
@@ -646,11 +646,11 @@ module.exports = function loader(source) {
 
 The current compilation target. Passed from [`target`](/config/target) configuration options.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.target); // 'web' or other values
   return source;
-};
+}
 ```
 
 ## this.utils
@@ -671,8 +671,8 @@ Access to the following utilities.
 - `contextify`: Return a new request string avoiding absolute paths when possible.
 - `createHash`: Return a new Hash object from provided hash function.
 
-```js title="loader.js"
-module.exports = function (content) {
+```js title="loader.mjs"
+export default function (content) {
   this.utils.contextify(
     this.context,
     this.utils.absolutify(this.context, './index.js'),
@@ -687,7 +687,7 @@ module.exports = function (content) {
   mainHash.digest('hex');
 
   return content;
-};
+}
 ```
 
 ## this.resource
@@ -696,11 +696,11 @@ module.exports = function (content) {
 
 The path string of the current module. For example `'/abc/resource.js?query#hash'`.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resource); // '/abc/resource.js?query#hash'
   return source;
-};
+}
 ```
 
 ## this.resourcePath
@@ -709,11 +709,11 @@ module.exports = function loader(source) {
 
 The path string of the current module, excluding the query and fragment parameters. For example `'/abc/resource.js?query#hash'` in `'/abc/resource.js'`.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourcePath); // '/abc/resource.js'
   return source;
-};
+}
 ```
 
 ## this.resourceQuery
@@ -722,11 +722,11 @@ module.exports = function loader(source) {
 
 The query parameter for the path string of the current module. For example `'?query'` in `'/abc/resource.js?query#hash'`.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourceQuery); // '?query'
   return source;
-};
+}
 ```
 
 ## this.resourceFragment
@@ -735,11 +735,11 @@ module.exports = function loader(source) {
 
 The fragment parameter of the current module's path string. For example `'#hash'` in `'/abc/resource.js?query#hash'`.
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourceFragment); // '#hash'
   return source;
-};
+}
 ```
 
 ## this.rootContext
@@ -748,11 +748,11 @@ module.exports = function loader(source) {
 
 The base path configured in Rspack config via [context](/config/context).
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.rootContext); // /path/to/project
   return source;
-};
+}
 ```
 
 ## this.sourceMap

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -23,15 +23,15 @@ function addBuildDependency(file: string): void;
 
 它适用于会影响 loader 行为或转换结果的文件，例如 loader 的配置文件。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addBuildDependency(
     path.resolve(this.rootContext, 'custom-loader.config.js'),
   );
   return source;
-};
+}
 ```
 
 :::tip
@@ -50,13 +50,13 @@ function addContextDependency(directory: string): void;
 
 例如，添加 `src/static` 目录作为依赖，当目录中的文件发生变化时，会触发重新构建。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addContextDependency(path.resolve(this.rootContext, 'src/static'));
   return source;
-};
+}
 ```
 
 ## this.addDependency()
@@ -69,13 +69,13 @@ function addDependency(file: string): void;
 
 添加一个文件作为 loader 结果的依赖，使它们的任何变化可以被监听到。例如，`sass-loader`、`less-loader` 就使用了这个技巧，当导入的样式文件发生变化时就会重新编译。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addDependency(path.resolve(this.rootContext, 'src/styles/foo.scss'));
   return source;
-};
+}
 ```
 
 ## this.addMissingDependency()
@@ -88,15 +88,15 @@ function addMissingDependency(file: string): void;
 
 添加一个当前不存在的文件作为 loader 结果的依赖，使它们的创建和任何变化可以被监听到。例如，当该路径下新建了文件时，会触发重新构建。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   this.addMissingDependency(
     path.resolve(this.rootContext, 'src/dynamic-file.json'),
   );
   return source;
-};
+}
 ```
 
 ## this.async()
@@ -117,11 +117,11 @@ function cacheable(flag: boolean = true): void;
 
 默认情况下，loader 的处理结果会被标记为可缓存。调用这个方法然后传入 `false`，可以关闭 loader 处理结果的缓存能力。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   this.cacheable(false);
   return source;
-};
+}
 ```
 
 ## this.callback()
@@ -168,11 +168,11 @@ function clearDependencies(): void;
 
 例如，如果 loader 处理的是 `/project/src/components/Button.js`，那么 `this.context` 的值就是 `/project/src/components`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.context); // '/project/src/components'
   return source;
-};
+}
 ```
 
 如果被处理的是模块不是来自文件系统，例如虚拟模块，那么 `this.context` 的值为 `null`。
@@ -191,11 +191,11 @@ module.exports = function loader(source) {
 
 在 pitch 阶段可以修改这个数组，以调整 loader 链。可通过 [this.loaderIndex](#thisloaderindex) 定位当前 loader。
 
-```js title="loader.js"
-module.exports.pitch = function () {
+```js title="loader.mjs"
+export function pitch() {
   const currentLoader = this.loaders[this.loaderIndex];
   console.log(currentLoader.request);
-};
+}
 ```
 
 ## this.data
@@ -282,9 +282,9 @@ function emitDiagnostic(diagnostic: Diagnostic): void;
 
 当仅使用 `message` 和 `severity` 时，仅会打印基础的模块错误信息。
 
-```js title="loader.js"
+```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
-module.exports = function () {
+export default function () {
   this.experiments.emitDiagnostic({
     message: '`React` is not defined',
     severity: 'error',
@@ -294,24 +294,24 @@ module.exports = function () {
     severity: 'warning',
   });
   return '';
-};
+}
 ```
 
 将会打印：
 
 ```
-ERROR in (./loader.js!)
+ERROR in (./loader.mjs!)
   × ModuleError: `React` is not defined
 
-WARNING in (./loader.js!)
+WARNING in (./loader.mjs!)
   ⚠ ModuleWarning: `React` is not defined
 ```
 
 - 打印代码片段：
 
-```js title="loader.js"
+```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
-module.exports = function () {
+export default function () {
   this.experiments.emitDiagnostic({
     message: '`React` is not defined',
     severity: 'error',
@@ -324,7 +324,7 @@ module.exports = function () {
     file: './some-file.js',
   });
   return '';
-};
+}
 ```
 
 将会打印：
@@ -358,18 +358,18 @@ function emitFile(
 
 - 基础示例：
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   // 输出一个新文件，该文件将在产物目录中输出为 `foo.js`
   this.emitFile('foo.js', 'console.log("Hello, world!");');
   return source;
-};
+}
 ```
 
 - 带有 asset info 的示例：
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   this.emitFile(
     'foo.js',
     'console.log("Hello, world!");',
@@ -380,7 +380,7 @@ module.exports = function loader(source) {
   );
 
   return source;
-};
+}
 ```
 
 ## this.fs
@@ -408,7 +408,7 @@ export default {
       {
         test: /\.txt$/,
         use: {
-          loader: './my-loader.js',
+          loader: './my-loader.mjs',
           options: {
             foo: 'bar',
           },
@@ -419,14 +419,14 @@ export default {
 };
 ```
 
-在 `my-loader.js` 中获取传入的选项：
+在 `my-loader.mjs` 中获取传入的选项：
 
-```js title="my-loader.js"
-module.exports = function myLoader(source) {
+```js title="my-loader.mjs"
+export default function myLoader(source) {
   const options = this.getOptions();
   console.log(options); // { foo: 'bar' }
   return source;
-};
+}
 ```
 
 :::tip
@@ -476,11 +476,11 @@ function getResolve(options: ResolveOptions): resolve;
 
 是否启用了 HMR。
 
-```js title="loader.js"
-module.exports = function (source) {
+```js title="loader.mjs"
+export default function (source) {
   console.log(this.hot); // true if HMR is enabled
   return source;
-};
+}
 ```
 
 ## this.importModule()
@@ -520,10 +520,10 @@ function importModule<T = any>(
 
 在没有提供回调函数时，`importModule` 会返回一个 Promise。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = async function loader(source) {
+export default async function loader(source) {
   const modulePath = path.resolve(this.rootContext, 'some-module.ts');
   const moduleExports = await this.importModule(modulePath, {
     // 可选参数
@@ -531,15 +531,15 @@ module.exports = async function loader(source) {
 
   const result = someProcessing(source, moduleExports);
   return result;
-};
+}
 ```
 
 或者你可以传递一个回调函数给它。
 
-```js title="loader.js"
-const path = require('node:path');
+```js title="loader.mjs"
+import path from 'node:path';
 
-module.exports = function loader(source) {
+export default function loader(source) {
   const callback = this.async();
   const modulePath = path.resolve(this.rootContext, 'some-module.ts');
 
@@ -556,7 +556,7 @@ module.exports = function loader(source) {
       callback(null, result);
     },
   );
-};
+}
 ```
 
 ## this.query
@@ -579,13 +579,13 @@ module.exports = function loader(source) {
 例如，假设 loader 链为：
 
 ```text
-/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
 ```
 
-执行到 `loader1.js` 时，`this.remainingRequest` 为：
+执行到 `loader1.mjs` 时，`this.remainingRequest` 为：
 
 ```text
-/path/to/loader2.js!/path/to/resource.js
+/path/to/loader2.mjs!/path/to/resource.js
 ```
 
 它通常用于构造内联请求，避免再次执行当前 loader。可以参考 [Inline matchResource](/api/loader-api/inline-match-resource) 中的示例。
@@ -596,7 +596,7 @@ module.exports = function loader(source) {
 
 解析后的 module specifier 字符串。
 
-例如，如果 `resource.js` 被 `loader1.js` 和 `loader2.js` 处理，那么 `this.request` 的值为 `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`。
+例如，如果 `resource.js` 被 `loader1.mjs` 和 `loader2.mjs` 处理，那么 `this.request` 的值为 `/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js`。
 
 ## this.resolve()
 
@@ -622,11 +622,11 @@ function resolve(
 
 当 Rspack 运行时读取 [mode](/config/mode) 的值，可能的值为：`'production'`、`'development'`、`'none'`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.mode); // 'production' or other values
   return source;
-};
+}
 ```
 
 ## this.target
@@ -635,11 +635,11 @@ module.exports = function loader(source) {
 
 当前编译的目标。对应 [`target`](/config/target) 配置项的值。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.target); // 'web' or other values
   return source;
-};
+}
 ```
 
 ## this.utils
@@ -660,8 +660,8 @@ type Utils = {
 - `contextify`: 返回一个新的 request 字符串，尽可能避免使用绝对路径。
 - `createHash`: 基于提供的哈希函数返回一个新的 Hash 对象。
 
-```js title="loader.js"
-module.exports = function (content) {
+```js title="loader.mjs"
+export default function (content) {
   this.utils.contextify(
     this.context,
     this.utils.absolutify(this.context, './index.js'),
@@ -676,7 +676,7 @@ module.exports = function (content) {
   mainHash.digest('hex');
 
   return content;
-};
+}
 ```
 
 ## this.resource
@@ -685,11 +685,11 @@ module.exports = function (content) {
 
 当前模块的路径字符串。比如 `'/abc/resource.js?query#hash'`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resource); // '/abc/resource.js?query#hash'
   return source;
-};
+}
 ```
 
 ## this.resourcePath
@@ -698,11 +698,11 @@ module.exports = function loader(source) {
 
 当前模块的路径字符串，不包括 query 和 fragment 参数。比如 `'/abc/resource.js?query#hash'` 中的 `'/abc/resource.js'`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourcePath); // '/abc/resource.js'
   return source;
-};
+}
 ```
 
 ## this.resourceQuery
@@ -711,11 +711,11 @@ module.exports = function loader(source) {
 
 当前模块的路径字符串的 query 参数。比如 `'/abc/resource.js?query#hash'` 中的 `'?query'`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourceQuery); // '?query'
   return source;
-};
+}
 ```
 
 ## this.resourceFragment
@@ -724,11 +724,11 @@ module.exports = function loader(source) {
 
 当前模块的路径字符串的 fragment 参数。比如 `'/abc/resource.js?query#hash'` 中的 `'#hash'`。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.resourceFragment); // '#hash'
   return source;
-};
+}
 ```
 
 ## this.rootContext
@@ -737,11 +737,11 @@ module.exports = function loader(source) {
 
 Rspack config 中通过 [context](/config/context) 配置的基础路径。
 
-```js title="loader.js"
-module.exports = function loader(source) {
+```js title="loader.mjs"
+export default function loader(source) {
   console.log(this.rootContext); // /path/to/project
   return source;
-};
+}
 ```
 
 ## this.sourceMap


### PR DESCRIPTION
## Summary

The loader context API reference still uses CommonJS for its loader examples, while Rspack supports ESM loaders and the surrounding documentation increasingly favors ESM. This PR migrates all English and Chinese loader context examples to ESM, including `.mjs` file names, default and pitch exports, Node.js imports, and related request strings.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).