### PR TITLE
docs: document loader dependency getters

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -322,8 +322,17 @@ export interface LoaderContext<OptionsType = {}> {
    * Removes all dependencies of the loader result.
    */
   clearDependencies(): void;
+  /**
+   * Get a copy of all files the loader currently watches as dependencies.
+   */
   getDependencies(): string[];
+  /**
+   * Get a copy of all directories the loader currently watches as context dependencies.
+   */
   getContextDependencies(): string[];
+  /**
+   * Get a copy of all paths to files that the loader is watching but that do not exist yet.
+   */
   getMissingDependencies(): string[];
   /**
    * Add a file as a build dependency of the loader result.

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -398,6 +398,65 @@ export default function loader(source) {
 
 Access to the `compilation` object's `inputFileSystem` property.
 
+## this.getContextDependencies()
+
+- **Type:**
+
+```ts
+function getContextDependencies(): string[];
+```
+
+Returns all directories the loader currently watches as context dependencies, including directories added with [this.addContextDependency()](#thisaddcontextdependency).
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const contextDependencies = this.getContextDependencies();
+  console.log(contextDependencies);
+
+  return source;
+}
+```
+
+## this.getDependencies()
+
+- **Type:**
+
+```ts
+function getDependencies(): string[];
+```
+
+Returns all files the loader currently watches as dependencies, including files added with [this.addDependency()](#thisadddependency) or [this.dependency()](#thisdependency).
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const dependencies = this.getDependencies();
+  console.log(dependencies);
+
+  return source;
+}
+```
+
+## this.getMissingDependencies()
+
+- **Type:**
+
+```ts
+function getMissingDependencies(): string[];
+```
+
+Returns all paths to files that the loader is watching but that do not exist yet, including paths added with [this.addMissingDependency()](#thisaddmissingdependency). Creating one of these files may trigger a rebuild.
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const missingDependencies = this.getMissingDependencies();
+  console.log(missingDependencies);
+
+  return source;
+}
+```
+
+Each method returns a new array. Modifying the returned array does not change the dependencies registered by the loader. To remove dependencies from these three lists, use [this.clearDependencies()](#thiscleardependencies).
+
 ## this.getOptions()
 
 - **Type:**

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -389,6 +389,65 @@ export default function loader(source) {
 
 访问 `compilation` 对象的 `inputFileSystem` 属性。
 
+## this.getContextDependencies()
+
+- **类型：**
+
+```ts
+function getContextDependencies(): string[];
+```
+
+返回 loader 当前作为上下文依赖监听的所有目录，其中包括通过 [this.addContextDependency()](#thisaddcontextdependency) 添加的目录。
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const contextDependencies = this.getContextDependencies();
+  console.log(contextDependencies);
+
+  return source;
+}
+```
+
+## this.getDependencies()
+
+- **类型：**
+
+```ts
+function getDependencies(): string[];
+```
+
+返回 loader 当前作为依赖监听的所有文件，其中包括通过 [this.addDependency()](#thisadddependency) 或 [this.dependency()](#thisdependency) 添加的文件。
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const dependencies = this.getDependencies();
+  console.log(dependencies);
+
+  return source;
+}
+```
+
+## this.getMissingDependencies()
+
+- **类型：**
+
+```ts
+function getMissingDependencies(): string[];
+```
+
+返回 loader 当前监听的所有尚不存在的文件路径，其中包括通过 [this.addMissingDependency()](#thisaddmissingdependency) 添加的路径。当这些文件被创建时，可能会触发重新构建。
+
+```js title="loader.mjs"
+export default function loader(source) {
+  const missingDependencies = this.getMissingDependencies();
+  console.log(missingDependencies);
+
+  return source;
+}
+```
+
+这三个方法都会返回一个新数组。修改返回的数组不会影响 loader 已注册的依赖。如需清空这三类依赖列表，请使用 [this.clearDependencies()](#thiscleardependencies)。
+
 ## this.getOptions()
 
 - **类型：**


### PR DESCRIPTION
## Summary

Document the loader context dependency getter APIs in English and Chinese, with a separate ESM example for each method. Add matching JSDoc to the public `LoaderContext` type and clarify how missing dependencies can trigger rebuilds.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).