### PR TITLE
docs(release): group release targets by Node.js support tier

### DIFF
--- a/website/docs/en/contribute/development/releasing.md
+++ b/website/docs/en/contribute/development/releasing.md
@@ -14,21 +14,38 @@ The latest stable release follows the Semantic Versioning specification (x.y.z).
 
 The [full release workflow](https://github.com/web-infra-dev/rspack/actions/workflows/release.yml?query=is%3Asuccess) is triggered manually by Rspack maintainers on Tuesday with the complete release notes.
 
-During the release, the following binary artifacts for the target platforms are built:
+During the release, the binary artifacts below are built, grouped by the support tier that the [Node.js platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list) gives to the platform they run on:
+
+**Tier 1**
 
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
-- riscv64gc-unknown-linux-gnu
+- x86_64-pc-windows-msvc
+- aarch64-apple-darwin
+
+**Tier 2**
+
 - powerpc64le-unknown-linux-gnu
 - s390x-unknown-linux-gnu
+- aarch64-pc-windows-msvc
+- x86_64-apple-darwin
+
+**Experimental**
+
 - x86_64-unknown-linux-musl
+- riscv64gc-unknown-linux-gnu
+
+**Others**
+
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl
 - i686-pc-windows-msvc
-- x86_64-pc-windows-msvc
-- aarch64-pc-windows-msvc
-- x86_64-apple-darwin
-- aarch64-apple-darwin
+
+:::warning Platforms below Tier 1
+
+For these platforms Rspack only guarantees that the binding is built successfully. CI verifies the build only and never runs the test suite on them, so a green CI run is not a guarantee that Rspack behaves correctly there.
+
+:::
 
 ### Release steps
 

--- a/website/docs/zh/contribute/development/releasing.md
+++ b/website/docs/zh/contribute/development/releasing.md
@@ -14,21 +14,38 @@ Latest 是最新的稳定版本，遵循 Semantic Versioning 语义化版本号�
 
 [全量发布工作流](https://github.com/web-infra-dev/rspack/actions/workflows/release.yml?query=is%3Asuccess) 会在每周二由 Rspack 维护者手动触发，并带有完整的 release notes。
 
-在发布过程中，会构建以下目标平台的二进制产物：
+在发布过程中，会构建以下二进制产物，并按照 [Node.js 平台列表](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list) 中对应运行平台的支持等级分组：
+
+**Tier 1**
 
 - x86_64-unknown-linux-gnu
 - aarch64-unknown-linux-gnu
-- riscv64gc-unknown-linux-gnu
+- x86_64-pc-windows-msvc
+- aarch64-apple-darwin
+
+**Tier 2**
+
 - powerpc64le-unknown-linux-gnu
 - s390x-unknown-linux-gnu
+- aarch64-pc-windows-msvc
+- x86_64-apple-darwin
+
+**Experimental**
+
 - x86_64-unknown-linux-musl
+- riscv64gc-unknown-linux-gnu
+
+**其他**
+
 - aarch64-unknown-linux-musl
 - riscv64gc-unknown-linux-musl
 - i686-pc-windows-msvc
-- x86_64-pc-windows-msvc
-- aarch64-pc-windows-msvc
-- x86_64-apple-darwin
-- aarch64-apple-darwin
+
+:::warning 低于 Tier 1 的平台
+
+对于这些平台，Rspack 只保证 binding 能够构建成功。CI 中只校验构建，不会在这些 target 上运行测试套件，因此 CI 通过并不能保证 Rspack 在这些平台上的行为正确。
+
+:::
 
 ### 发布步骤
 


### PR DESCRIPTION
## Why

The release target list in `releasing.md` was a flat list, which gave no hint that the targets are supported very unevenly. Two of them (`powerpc64le-unknown-linux-gnu`, `s390x-unknown-linux-gnu`, added in #14962) are Node.js Tier 2 platforms and, like riscv64 and the musl/32-bit Windows targets, are only build-verified in CI — no test suite ever runs on them.

This groups the list by the support tier from the [Node.js platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list) and states explicitly what Rspack guarantees for everything below Tier 1: the binding builds, nothing more.

Before:

```
- x86_64-unknown-linux-gnu
- aarch64-unknown-linux-gnu
- riscv64gc-unknown-linux-gnu
- powerpc64le-unknown-linux-gnu
...
```

After:

```
**Tier 1**
- x86_64-unknown-linux-gnu
...
**Tier 2**
- powerpc64le-unknown-linux-gnu
...
**Experimental**
...
**Others**
...
```

Docs only, both `en` and `zh`. The set of targets is unchanged and still matches the release matrix in `reusable-release-npm.yml`.
