### PR TITLE
docs: document loader context environment

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -12,6 +12,7 @@ import type Hash from '../util/hash';
 import { parseResource } from '../util/identifier';
 import type { RspackOptionsNormalized } from './normalization';
 import type {
+  Environment,
   Mode,
   PublicPath,
   Resolve,
@@ -236,6 +237,12 @@ export interface LoaderContext<OptionsType = {}> {
    * The current compilation target. Passed from `target` configuration options.
    */
   target?: Target;
+  /**
+   * Describes the capabilities supported by the target environment. This is the effective value
+   * of `output.environment`: Rspack infers the capabilities from `target`, then applies the
+   * explicit settings from `output.environment`.
+   */
+  environment: Environment;
   /**
    * Whether HMR is enabled.
    */

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -712,6 +712,24 @@ export default function loader(source) {
 }
 ```
 
+## this.environment
+
+- **Type:** `Environment`
+
+Describes the capabilities supported by the target environment. This is the effective value of [`output.environment`](/config/output#outputenvironment): Rspack infers the capabilities from [`target`](/config/target), then applies the explicit settings from `output.environment`.
+
+A loader can use this information to choose syntax supported by the output environment.
+
+```js title="loader.mjs"
+export default function loader(source) {
+  if (this.environment.optionalChaining) {
+    console.log('Optional chaining is supported');
+  }
+
+  return source;
+}
+```
+
 ## this.utils
 
 - **Type:**

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -701,6 +701,24 @@ export default function loader(source) {
 }
 ```
 
+## this.environment
+
+- **类型：** `Environment`
+
+描述目标运行环境支持的能力。该值是最终生效的 [`output.environment`](/config/output#outputenvironment)：Rspack 会根据 [`target`](/config/target) 自动判断目标环境支持的能力，再应用 `output.environment` 中的显式配置。
+
+loader 可以根据这些信息选择输出环境支持的语法。
+
+```js title="loader.mjs"
+export default function loader(source) {
+  if (this.environment.optionalChaining) {
+    console.log('Optional chaining is supported');
+  }
+
+  return source;
+}
+```
+
 ## this.utils
 
 - **类型：**


### PR DESCRIPTION
## Summary

Loader authors can already read target environment capabilities through `this.environment`, but the property was missing from the public `LoaderContext` type and API docs. This PR adds the `Environment` type and matching JSDoc, plus synchronized English and Chinese docs with ESM examples explaining inferred and explicit environment settings.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).