### PR TITLE
docs: correct loader context callback and clearDependencies

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -170,15 +170,16 @@ export interface LoaderContext<OptionsType = {}> {
    */
   async(): LoaderContextCallback;
   /**
-   * A function that can be called synchronously or asynchronously in order to return multiple
-   * results. The expected arguments are:
+   * A function that can be called synchronously or asynchronously to return multiple results.
+   * The expected arguments are:
    *
-   * 1. The first parameter must be `Error` or `null`, which marks the current module as a
-   * compilation failure.
-   * 2. The second argument is a `string` or `Buffer`, which indicates the contents of the file
-   * after the module has been processed by the loader.
-   * 3. The third parameter is a source map that can be processed by the loader.
-   * 4. The fourth parameter is ignored by Rspack and can be anything (e.g. some metadata).
+   * 1. The first parameter is an `Error` when the loader fails, or `null` or `undefined` when it
+   * succeeds.
+   * 2. The second parameter is the transformed content as a `string` or `Buffer`. It can be
+   * omitted when reporting an error.
+   * 3. The third parameter is an optional source map as a `string` or `RawSourceMap`.
+   * 4. The fourth parameter is optional additional data. Rspack passes it as the third argument
+   * to the next loader in the chain.
    */
   callback: LoaderContextCallback;
   /**
@@ -326,7 +327,10 @@ export interface LoaderContext<OptionsType = {}> {
    */
   addMissingDependency(missing: string): void;
   /**
-   * Removes all dependencies of the loader result.
+   * Clears all file, context, and missing dependencies collected by the loader chain. Build
+   * dependencies are not cleared. This also resets `cacheable` to `true`, overriding any earlier
+   * call to `this.cacheable(false)`. Only use this method when the current loader will register
+   * every dependency required by the final result.
    */
   clearDependencies(): void;
   /**

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -131,28 +131,31 @@ export default function loader(source) {
 - **Type:**
 
 ```ts
+interface AdditionalData {
+  [index: string]: any;
+}
+
 function callback(
-  err: Error | null,
-  content: string | Buffer,
-  sourceMap?: Rspack.RawSourceMap,
-  meta?: any,
+  err?: Error | null,
+  content?: string | Buffer,
+  sourceMap?: string | Rspack.RawSourceMap,
+  additionalData?: AdditionalData,
 ): void;
 ```
 
-A function that can be called synchronously or asynchronously in order to return multiple results. The expected arguments are:
+Call `this.callback()` to return a loader's results, either synchronously or asynchronously. Its arguments are:
 
-1. The first parameter must be `Error` or `null`, which marks the current module as a compilation failure.
-2. The second argument is a `string` or `Buffer`, which indicates the contents of the file after the module has been processed by the loader.
-3. The third parameter is a source map that can be processed by the loader.
-4. The fourth parameter is ignored by Rspack and can be anything (e.g. some metadata).
+1. `err`: An `Error` when the loader fails, or `null` or `undefined` when it succeeds.
+2. `content`: The transformed module content as a `string` or `Buffer`. It can be omitted when reporting an error.
+3. `sourceMap`: An optional source map as a `string` or `Rspack.RawSourceMap`.
+4. `additionalData`: Optional additional data. Rspack passes it as the third argument to the next loader in the chain.
 
 > See [Sync loader](/api/loader-api/writing-loaders#sync-loader) for more details.
 
 :::warning
 In case this function is called, you should return `undefined` to avoid ambiguous loader results.
 
-The value passed to `this.callback` will be passed to the next loader in the chain.
-The `sourceMap` and `meta` parameters are optional. If they are not passed, the next loader will not receive them.
+The `content`, `sourceMap`, and `additionalData` values are passed to the next loader in the chain.
 :::
 
 ## this.clearDependencies()
@@ -163,7 +166,9 @@ The `sourceMap` and `meta` parameters are optional. If they are not passed, the 
 function clearDependencies(): void;
 ```
 
-Removes all dependencies of the loader result.
+Clears all [file dependencies](#thisadddependency), [context dependencies](#thisaddcontextdependency), and [missing dependencies](#thisaddmissingdependency) collected by the loader chain. [Build dependencies](#thisaddbuilddependency) are not cleared. This also resets [`cacheable`](#thiscacheable) to `true`, overriding any earlier call to `this.cacheable(false)`.
+
+Only use this method when the current loader will register every dependency required by the final result.
 
 ## this.context
 

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -129,25 +129,31 @@ export default function loader(source) {
 - **类型：**
 
 ```ts
+interface AdditionalData {
+  [index: string]: any;
+}
+
 function callback(
-  err: Error | null,
-  content: string | Buffer,
-  sourceMap?: Rspack.RawSourceMap,
-  meta?: any,
+  err?: Error | null,
+  content?: string | Buffer,
+  sourceMap?: string | Rspack.RawSourceMap,
+  additionalData?: AdditionalData,
 ): void;
 ```
 
-将 Loader 处理后的结果告诉 Rspack。
+调用 `this.callback()` 返回 loader 的处理结果，同步或异步 loader 均可使用。各参数的含义如下：
 
-第一个参数必须是 `Error` 或者 `null`，会标记当前模块为编译失败，第二个参数是一个 `string` 或者 `Buffer`，表示模块被该 Loader 处理后的文件内容，第三个参数是一个可以该 Loader 处理后的 source map，第四个参数会被 Rspack 忽略，可以是任何东西（例如一些元数据）。
+1. `err`：loader 执行失败时传入 `Error`；执行成功时传入 `null` 或 `undefined`。
+2. `content`：转换后的模块内容，可以是 `string` 或 `Buffer`。只报告错误时可以省略。
+3. `sourceMap`：可选的 source map，可以是 `string` 或 `Rspack.RawSourceMap`。
+4. `additionalData`：可选的附加数据。Rspack 会将它作为第三个参数传给 loader 链中的下一个 loader。
 
 > 查看 [同步 loader](/api/loader-api/writing-loaders#同步-loader) 了解如何使用。
 
 :::warning
 当这个函数被调用时，你应该返回 `undefined` 以避免 loader 结果的歧义。
 
-传递给 `this.callback` 的值会传递给下一个 loader。
-`sourceMap` 和 `meta` 参数是可选的，如果没有传递，那么下一个 loader 将不会收到它们。
+`content`、`sourceMap` 和 `additionalData` 会传递给 loader 链中的下一个 loader。
 :::
 
 ## this.clearDependencies()
@@ -158,7 +164,9 @@ function callback(
 function clearDependencies(): void;
 ```
 
-移除 loader 结果的所有依赖。
+清除 loader 链中已收集的所有[文件依赖](#thisadddependency)、[上下文依赖](#thisaddcontextdependency)和[缺失依赖](#thisaddmissingdependency)，但不会清除 [build dependencies](#thisaddbuilddependency)。它还会将 [`cacheable`](#thiscacheable) 重置为 `true`，因此此前任何 loader 调用 `this.cacheable(false)` 产生的设置都会失效。
+
+只有在当前 loader 会为最终结果重新注册全部所需依赖时，才应调用此方法。
 
 ## this.context
 


### PR DESCRIPTION
## Summary

This PR corrects the loader context documentation and JSDoc to match the loader runner behavior. It documents callback additional data forwarding and accurate parameter types, and clarifies which dependency sets `clearDependencies()` resets, including its cacheability impact.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).