### PR TITLE
fix: support loader context APIs in parallel loaders

### DIFF
--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -719,6 +719,7 @@ export async function runLoaders(
         ? loaderContext._module
         : undefined;
     const workerLoaderContext = {
+      version: loaderContext.version,
       hot: loaderContext.hot,
       context: loaderContext.context,
       resourcePath: loaderContext.resourcePath,
@@ -824,10 +825,14 @@ export async function runLoaders(
           }
           case RequestType.Resolve: {
             return new Promise((resolve, reject) => {
-              loaderContext.resolve(args[0], args[1], (err, result) => {
-                if (err) reject(err);
-                else resolve(result);
-              });
+              loaderContext.resolve(
+                args[0],
+                args[1],
+                (err, result, resolveRequest) => {
+                  if (err) reject(err);
+                  else resolve([result, resolveRequest]);
+                },
+              );
             });
           }
           case RequestType.GetResolve: {
@@ -835,16 +840,16 @@ export async function runLoaders(
               loaderContext.getResolve(args[0])(
                 args[1],
                 args[2],
-                (err, result) => {
+                (err, result, resolveRequest) => {
                   if (err) reject(err);
-                  else resolve(result);
+                  else resolve([result, resolveRequest]);
                 },
               );
             });
           }
           case RequestType.GetLogger: {
             const [type, name, arg] = args;
-            (loaderContext.getLogger(name) as any)[type](...arg);
+            (loaderContext.getLogger(name) as any)[type](...(arg ?? []));
             break;
           }
           case RequestType.EmitError: {

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -849,7 +849,7 @@ export async function runLoaders(
           }
           case RequestType.GetLogger: {
             const [type, name, arg] = args;
-            (loaderContext.getLogger(name) as any)[type](...(arg ?? []));
+            (loaderContext.getLogger(name) as any)[type](...arg);
             break;
           }
           case RequestType.EmitError: {

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -81,6 +81,11 @@ async function loaderImpl(
       sendRequest(RequestType.AddContextDependency, context),
     );
   };
+  loaderContext.addMissingDependency = function addMissingDependency(missing) {
+    pendingDependencyRequest.push(
+      sendRequest(RequestType.AddMissingDependency, missing),
+    );
+  };
   loaderContext.addBuildDependency = function addBuildDependency(file) {
     pendingDependencyRequest.push(
       sendRequest(RequestType.AddBuildDependency, file),
@@ -103,8 +108,8 @@ async function loaderImpl(
   };
   loaderContext.resolve = function resolve(context, request, callback) {
     sendRequest(RequestType.Resolve, context, request).then(
-      (result) => {
-        callback(null, result);
+      ([result, resolveRequest]) => {
+        callback(null, result, resolveRequest);
       },
       (err) => {
         callback(err);
@@ -116,7 +121,7 @@ async function loaderImpl(
       if (!callback) {
         return new Promise((resolve, reject) => {
           sendRequest(RequestType.GetResolve, options, context, request).then(
-            (result) => {
+            ([result]) => {
               resolve(result);
             },
             (err) => {
@@ -126,8 +131,8 @@ async function loaderImpl(
         });
       }
       sendRequest(RequestType.GetResolve, options, context, request).then(
-        (result) => {
-          callback(null, result);
+        ([result, resolveRequest]) => {
+          callback(null, result, resolveRequest);
         },
         (err) => {
           callback(err);
@@ -161,7 +166,7 @@ async function loaderImpl(
         sendRequest(RequestType.GetLogger, 'trace', name, ['Trace']);
       },
       clear() {
-        sendRequest(RequestType.GetLogger, 'clear', name);
+        sendRequest(RequestType.GetLogger, 'clear', name, []);
       },
       status(...args) {
         sendRequest(RequestType.GetLogger, 'status', name, args);

--- a/tests/rspack-test/configCases/loader-parallel/loader-context/dependency.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-context/dependency.js
@@ -1,0 +1,1 @@
+export default 'dependency';

--- a/tests/rspack-test/configCases/loader-parallel/loader-context/index.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-context/index.js
@@ -1,0 +1,8 @@
+it('should expose loader context APIs in parallel loaders', () => {
+  expect(require('./resource')).toEqual({
+    version: 2,
+    logger: true,
+    resolve: true,
+    getResolve: true,
+  });
+});

--- a/tests/rspack-test/configCases/loader-parallel/loader-context/loader.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-context/loader.js
@@ -1,0 +1,41 @@
+/** @type {import('@rspack/core').LoaderDefinition} */
+module.exports = function () {
+  const callback = this.async();
+  const logger = this.getLogger('parallel-loader');
+  const getResolve = this.getResolve();
+
+  logger.clear();
+  logger.info('loader context APIs are available');
+
+  this.resolve(
+    this.context,
+    './dependency.js',
+    (resolveError, _resolveResult, resolveRequest) => {
+      if (resolveError) {
+        callback(resolveError);
+        return;
+      }
+
+      getResolve(
+        this.context,
+        './dependency.js',
+        (getResolveError, _getResolveResult, getResolveRequest) => {
+          if (getResolveError) {
+            callback(getResolveError);
+            return;
+          }
+
+          callback(
+            null,
+            `module.exports = ${JSON.stringify({
+              version: this.version,
+              logger: typeof logger.clear === 'function',
+              resolve: resolveRequest?.path.endsWith('dependency.js'),
+              getResolve: getResolveRequest?.path.endsWith('dependency.js'),
+            })}`,
+          );
+        },
+      );
+    },
+  );
+};

--- a/tests/rspack-test/configCases/loader-parallel/loader-context/resource.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-context/resource.js
@@ -1,0 +1,1 @@
+export default 'resource';

--- a/tests/rspack-test/configCases/loader-parallel/loader-context/rspack.config.js
+++ b/tests/rspack-test/configCases/loader-parallel/loader-context/rspack.config.js
@@ -1,0 +1,17 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /resource\.js$/,
+        use: [
+          {
+            loader: './loader.js',
+            parallel: true,
+            options: {},
+          },
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Parallel loaders exposed an incomplete loader context because several values and callback payloads were not forwarded between the worker and main thread. This PR forwards `version`, `addMissingDependency()`, and resolver request metadata, and fixes zero-argument logger calls such as `clear()`. An integration case verifies these APIs under parallel execution.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).