### PR TITLE
chore(deps): replace create-rstack with create-toolkit

### DIFF
--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -24,7 +24,7 @@
     "dev": "rs lib -w"
   },
   "dependencies": {
-    "create-rstack": "catalog:"
+    "@rstackjs/create-toolkit": "catalog:"
   },
   "devDependencies": {
     "rstack": "catalog:",

--- a/packages/create-rspack/src/index.ts
+++ b/packages/create-rspack/src/index.ts
@@ -8,7 +8,7 @@ import {
   type ESLintTemplateName,
   type RslintTemplateName,
   select,
-} from 'create-rstack';
+} from '@rstackjs/create-toolkit';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ catalogs:
     '@rstack-dev/doc-ui':
       specifier: 1.14.7
       version: 1.14.7
+    '@rstackjs/create-toolkit':
+      specifier: 2.1.4
+      version: 2.1.4
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -196,9 +199,6 @@ catalogs:
     core-js:
       specifier: 3.49.0
       version: 3.49.0
-    create-rstack:
-      specifier: 2.1.3
-      version: 2.1.3
     cross-env:
       specifier: ^10.1.0
       version: 10.1.0
@@ -690,9 +690,9 @@ importers:
 
   packages/create-rspack:
     dependencies:
-      create-rstack:
+      '@rstackjs/create-toolkit':
         specifier: 'catalog:'
-        version: 2.1.3
+        version: 2.1.4
     devDependencies:
       rstack:
         specifier: 'catalog:'
@@ -3350,6 +3350,10 @@ packages:
       '@rspress/core':
         optional: true
 
+  '@rstackjs/create-toolkit@2.1.4':
+    resolution: {integrity: sha512-kwPhfMdgWN7z/Op5UKMszhmZy7+hzqXeiQPli4uycYYTLxCVUGLlEW3etoGoZlrM2t5zLqXZQAgL60PTUR/ocw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@rstackjs/load-config@0.1.2':
     resolution: {integrity: sha512-6hChPVosmh2rzEt1M1CvGpsaE/+gGlt51ci5pbyd4Bd1FXyH+Owlg99ECvdcWtD7zdDwDM3jGkQL05xn9oWSIA==}
     peerDependencies:
@@ -4468,10 +4472,6 @@ packages:
 
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
-
-  create-rstack@2.1.3:
-    resolution: {integrity: sha512-3n8JzuzbMYger7fnhIb8DDYs7b4lnNgLJm6kKve+qCKeqpCsTZaiZBQ3cYy7/FjWNtccbJ4XhfA/WNvzETD3vw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
 
   cross-env@10.1.0:
     resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
@@ -9696,6 +9696,8 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.1)(@rspack/core@2.1.8)(core-js@3.49.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
+  '@rstackjs/create-toolkit@2.1.4': {}
+
   '@rstackjs/load-config@0.1.2(jiti@2.7.0)':
     optionalDependencies:
       jiti: 2.7.0
@@ -10787,8 +10789,6 @@ snapshots:
       sha.js: 2.4.12
 
   create-require@1.1.1: {}
-
-  create-rstack@2.1.3: {}
 
   cross-env@10.1.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -205,8 +205,7 @@ minimumReleaseAgeExclude:
   - 'rstack'
   - '@swc/*'
   - 'heading-case'
-  - '@rstackjs/create-toolkit'
-  - '@rstackjs/load-config'
+  - '@rstackjs/*'
 
 patchedDependencies:
   webpack-sources@3.5.1: patches/webpack-sources@3.5.1.patch

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ catalog:
   '@rspress/plugin-rss': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
   '@rstack-dev/doc-ui': '1.14.7'
+  '@rstackjs/create-toolkit': '2.1.4'
   '@rstackjs/load-config': '^0.1.2'
   '@shikijs/transformers': '^4.3.1'
   '@swc/helpers': '0.5.23'
@@ -83,7 +84,6 @@ catalog:
   'concat-stream': '^2.0.0'
   'connect-next': '^4.0.3'
   'core-js': '3.49.0'
-  'create-rstack': '2.1.3'
   'cross-env': '^10.1.0'
   'cspell': '^10.0.1'
   'cspell-ban-words': '0.0.4'
@@ -205,6 +205,7 @@ minimumReleaseAgeExclude:
   - 'rstack'
   - '@swc/*'
   - 'heading-case'
+  - '@rstackjs/create-toolkit'
   - '@rstackjs/load-config'
 
 patchedDependencies:


### PR DESCRIPTION
## Summary

- Replace `create-rstack` with its renamed package, `@rstackjs/create-toolkit` v2.1.4.
- Update `create-rspack` imports and workspace dependencies without changing scaffolding behavior.

## Related links

- https://github.com/rstackjs/create-toolkit/releases/tag/v2.1.4

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).