### PR TITLE
fix: align loader context docs and types with implementation

### DIFF
--- a/packages/rspack/src/RspackError.ts
+++ b/packages/rspack/src/RspackError.ts
@@ -4,7 +4,7 @@ export type { RspackError } from '@rspack/binding';
 export type RspackSeverity = binding.JsRspackSeverity;
 
 export class NonErrorEmittedError extends Error {
-  constructor(error: unknown) {
+  constructor(error: Error) {
     super();
     this.name = 'NonErrorEmittedError';
     this.message = `(Emitted value instead of an instance of Error) ${error}`;

--- a/packages/rspack/src/RspackError.ts
+++ b/packages/rspack/src/RspackError.ts
@@ -4,7 +4,7 @@ export type { RspackError } from '@rspack/binding';
 export type RspackSeverity = binding.JsRspackSeverity;
 
 export class NonErrorEmittedError extends Error {
-  constructor(error: Error) {
+  constructor(error: unknown) {
     super();
     this.name = 'NonErrorEmittedError';
     this.message = `(Emitted value instead of an instance of Error) ${error}`;

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -292,16 +292,15 @@ export interface LoaderContext<OptionsType = {}> {
    */
   getLogger(name?: string): Logger;
   /**
-   * Emit an error. Strings are wrapped in an `Error` object. Unlike `throw` and
-   * `this.callback(err)` in the loader, it does not mark the current module as a compilation
-   * failure. It adds an error to Rspack's Compilation and displays it on the command line at the
-   * end of this compilation.
+   * Emit an error. Unlike `throw` and `this.callback(err)` in the loader, it does not mark the
+   * current module as a compilation failure. It adds an error to Rspack's Compilation and displays
+   * it on the command line at the end of this compilation.
    */
-  emitError(error: Error | string): void;
+  emitError(error: Error): void;
   /**
-   * Emit a warning. Strings are wrapped in an `Error` object.
+   * Emit a warning.
    */
-  emitWarning(warning: Error | string): void;
+  emitWarning(warning: Error): void;
   /**
    * Emit a new file. This method allows you to create new files during the loader execution.
    */

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -120,6 +120,10 @@ export interface Diagnostic {
 }
 
 export interface LoaderExperiments {
+  /**
+   * Emit an error or warning diagnostic without marking the current module as a compilation
+   * failure.
+   */
   emitDiagnostic(diagnostic: Diagnostic): void;
 }
 
@@ -152,7 +156,7 @@ export interface LoaderContext<OptionsType = {}> {
   resource: string;
   /**
    * The path string of the current module, excluding the query and fragment parameters.
-   * @example `'/abc/resource.js?query#hash'` in `'/abc/resource.js'`.
+   * @example `'/abc/resource.js'` in `'/abc/resource.js?query#hash'`.
    */
   resourcePath: string;
   /**
@@ -183,10 +187,10 @@ export interface LoaderContext<OptionsType = {}> {
    */
   callback: LoaderContextCallback;
   /**
-   * A function that sets the cacheable flag.
-   * By default, the processing results of the loader are marked as cacheable.
-   * Calling this method and passing `false` turns off the loader's ability to
-   * cache processing results.
+   * By default, the final build result produced for the current module by the entire loader chain
+   * is cacheable. Passing `false` marks that result as non-cacheable. Calls from subsequent loaders
+   * with `true` or no argument do not make it cacheable again; only `this.clearDependencies()`
+   * resets this state.
    */
   cacheable(cacheable?: boolean): void;
   /**
@@ -203,6 +207,7 @@ export interface LoaderContext<OptionsType = {}> {
    * location of each processed module.
    * For example, if the loader is processing `/project/src/components/Button.js`,
    * then the value of `this.context` would be `/project/src/components`.
+   * The value is `null` when the current module has no resource path.
    */
   context: string | null;
   /**
@@ -214,12 +219,20 @@ export interface LoaderContext<OptionsType = {}> {
    * in the chain and the current resource, joined with `!`.
    */
   remainingRequest: string;
+  /**
+   * A request string consisting of the current loader, the loaders that follow it, and the current
+   * resource, joined with `!`.
+   */
   currentRequest: string;
+  /**
+   * A request string consisting of the loaders that precede the current loader, joined with `!`.
+   * It does not include the current resource.
+   */
   previousRequest: string;
   /**
-   * The module specifier string after being resolved.
-   * For example, if a `resource.js` is processed by `loader1.js` and `loader2.js`, the value of
-   * `this.request` will be `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`.
+   * The complete request string, consisting of all loaders and the current resource joined with
+   * `!`. For example, if a `resource.js` is processed by `loader1.js` and `loader2.js`, the value
+   * is `/path/to/loader1.js!/path/to/loader2.js!/path/to/resource.js`.
    */
   request: string;
   /**
@@ -230,18 +243,18 @@ export interface LoaderContext<OptionsType = {}> {
    */
   loaders: LoaderObject[];
   /**
-   * The value of `mode` is read when Rspack is run.
-   * The possible values are: `'production'`, `'development'`, `'none'`
+   * The value of the `mode` configuration. It is `undefined` when `mode` is not configured, even
+   * though Rspack applies production-oriented defaults in that case.
    */
   mode?: Mode;
   /**
-   * The current compilation target. Passed from `target` configuration options.
+   * A loader-facing target derived from the `target` configuration.
    */
   target?: Target;
   /**
-   * Describes the capabilities supported by the target environment. This is the effective value
-   * of `output.environment`: Rspack infers the capabilities from `target`, then applies the
-   * explicit settings from `output.environment`.
+   * Describes the capabilities supported by the target environment. By default, this is the
+   * effective value of `output.environment`: Rspack infers capabilities from `target`, then
+   * applies the explicit settings from `output.environment`.
    */
   environment: Environment;
   /**
@@ -251,7 +264,7 @@ export interface LoaderContext<OptionsType = {}> {
   /**
    * Get the options passed in by the loader's user.
    * @param schema To provide the best performance, Rspack does not perform the schema
-   * validation. If your loader requires schema validation, please call scheme-utils or
+   * validation. If your loader requires schema validation, please call schema-utils or
    * zod on your own.
    */
   getOptions(schema?: any): OptionsType;
@@ -260,42 +273,35 @@ export interface LoaderContext<OptionsType = {}> {
    * @param context The absolute path to a directory. This directory is used as the starting
    * location for resolving.
    * @param request The module specifier to be resolved.
-   * @param callback A callback function that gives the resolved path.
+   * @param callback Receives an error, the resolved path or `false`, and optional resolution
+   * details.
    */
-  resolve(
-    context: string,
-    request: string,
-    callback: (
-      arg0: null | Error,
-      arg1?: string | false,
-      arg2?: ResolveRequest,
-    ) => void,
-  ): void;
+  resolve(context: string, request: string, callback: ResolveCallback): void;
   /**
-   * Create a resolver like `this.resolve`.
+   * Create a resolver like `this.resolve`. When the returned resolver is called without a
+   * callback, it returns a Promise.
+   * @param options Optional options used to customize the resolver.
    */
   getResolve(
-    options: Resolve,
-  ):
-    | ((context: string, request: string, callback: ResolveCallback) => void)
-    | ((
-        context: string,
-        request: string,
-      ) => Promise<string | false | undefined>);
+    options?: Resolve,
+  ): ((context: string, request: string, callback: ResolveCallback) => void) &
+    ((context: string, request: string) => Promise<string | false | undefined>);
   /**
    * Get the logger of this compilation, through which messages can be logged.
+   * @param name An optional name for the logger.
    */
-  getLogger(name: string): Logger;
+  getLogger(name?: string): Logger;
   /**
-   * Emit an error. Unlike `throw` and `this.callback(err)` in the loader, it does not
-   * mark the current module as a compilation failure, it just adds an error to Rspack's
-   * Compilation and displays it on the command line at the end of this compilation.
+   * Emit an error. Strings are wrapped in an `Error` object. Unlike `throw` and
+   * `this.callback(err)` in the loader, it does not mark the current module as a compilation
+   * failure. It adds an error to Rspack's Compilation and displays it on the command line at the
+   * end of this compilation.
    */
-  emitError(error: Error): void;
+  emitError(error: Error | string): void;
   /**
-   * Emit a warning.
+   * Emit a warning. Strings are wrapped in an `Error` object.
    */
-  emitWarning(warning: Error): void;
+  emitWarning(warning: Error | string): void;
   /**
    * Emit a new file. This method allows you to create new files during the loader execution.
    */

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -31,6 +31,7 @@ import {
   isUseSimpleSourceMap,
   isUseSourceMap,
   type LoaderContext,
+  type ResolveCallback,
 } from '../config/adapterRuleUse';
 import { NormalModule } from '../NormalModule';
 import type { ResolveContext } from '../Resolver';
@@ -511,7 +512,21 @@ export async function runLoaders(
   loaderContext.getResolve = function getResolve(options) {
     const resolver = getResolver();
     const child = options ? resolver.withOptions(options) : resolver;
-    return (context, request, callback) => {
+
+    function resolveWithOptions(
+      context: string,
+      request: string,
+      callback: ResolveCallback,
+    ): void;
+    function resolveWithOptions(
+      context: string,
+      request: string,
+    ): Promise<string | false | undefined>;
+    function resolveWithOptions(
+      context: string,
+      request: string,
+      callback?: ResolveCallback,
+    ) {
       if (callback) {
         child.resolve({}, context, request, getResolveContext(), callback);
         return;
@@ -529,7 +544,9 @@ export async function runLoaders(
           },
         );
       });
-    };
+    }
+
+    return resolveWithOptions;
   };
   loaderContext.getLogger = function getLogger(name) {
     return compiler._lastCompilation!.getLogger(

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -554,6 +554,8 @@ export async function runLoaders(
     );
   };
   loaderContext.rootContext = compiler.context;
+  // The public API intentionally accepts only Error instances. Keep these runtime checks for
+  // untyped JavaScript loaders that pass strings or other non-Error values.
   loaderContext.emitError = function emitError(e) {
     if (!(e instanceof Error)) {
       e = new NonErrorEmittedError(e);

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -5,6 +5,8 @@ import { type MessagePort, receiveMessageOnPort } from 'node:worker_threads';
 
 import { JsLoaderState, type NormalModule } from '@rspack/binding';
 import type { LoaderContext } from '../config';
+import type { ResolveCallback } from '../config/adapterRuleUse';
+import type { ResolveRequest } from '../Resolver';
 import * as swc from '../swc';
 import { cleverMerge } from '../util/cleverMerge';
 import { createHash } from '../util/createHash';
@@ -117,10 +119,28 @@ async function loaderImpl(
     );
   };
   loaderContext.getResolve = function getResolve(options) {
-    return (context, request, callback) => {
+    function resolveWithOptions(
+      context: string,
+      request: string,
+      callback: ResolveCallback,
+    ): void;
+    function resolveWithOptions(
+      context: string,
+      request: string,
+    ): Promise<string | false | undefined>;
+    function resolveWithOptions(
+      context: string,
+      request: string,
+      callback?: ResolveCallback,
+    ) {
       if (!callback) {
-        return new Promise((resolve, reject) => {
-          sendRequest(RequestType.GetResolve, options, context, request).then(
+        return new Promise<string | false | undefined>((resolve, reject) => {
+          sendRequest<[string | false | undefined, ResolveRequest | undefined]>(
+            RequestType.GetResolve,
+            options,
+            context,
+            request,
+          ).then(
             ([result]) => {
               resolve(result);
             },
@@ -138,7 +158,9 @@ async function loaderImpl(
           callback(err);
         },
       );
-    };
+    }
+
+    return resolveWithOptions;
   };
   loaderContext.getLogger = function getLogger(name) {
     return {

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -115,9 +115,9 @@ Tells Rspack that this loader will be called asynchronously. Returns [this.callb
 function cacheable(flag: boolean = true): void;
 ```
 
-A function that sets the cacheable flag.
+By default, the final build result produced for the current module by the entire loader chain is cacheable. Calling `this.cacheable(false)` marks that result as non-cacheable.
 
-By default, the processing results of the loader are marked as cacheable. Calling this method and passing `false` turns off the loader's ability to cache processing results.
+Once a loader has called `this.cacheable(false)`, subsequent loaders cannot make the result cacheable again by calling `this.cacheable(true)` or `this.cacheable()`. Only [`this.clearDependencies()`](#thiscleardependencies) resets this state.
 
 ```js title="loader.mjs"
 export default function loader(source) {
@@ -185,7 +185,7 @@ export default function loader(source) {
 }
 ```
 
-If the module being processed is not from the file system, such as a virtual module, then the value of `this.context` is `null`.
+If the current module has no resource path, the value of `this.context` is `null`.
 
 ## this.loaderIndex
 
@@ -229,10 +229,10 @@ Alias of [this.addDependency()](#thisadddependency).
 - **Type:**
 
 ```ts
-function emitError(error: Error): void;
+function emitError(error: Error | string): void;
 ```
 
-Emit an error.
+Emit an error. If a string is passed, Rspack wraps it in an `Error` object.
 
 ::: info
 Unlike `throw` and `this.callback(err)` in the loader, it does not mark the current module as a compilation failure, it just adds an error to Rspack's Compilation and displays it on the command line at the end of this compilation.
@@ -243,10 +243,10 @@ Unlike `throw` and `this.callback(err)` in the loader, it does not mark the curr
 - **Type:**
 
 ```ts
-function emitWarning(warning: Error): void;
+function emitWarning(warning: Error | string): void;
 ```
 
-Emit a warning.
+Emit a warning. If a string is passed, Rspack wraps it in an `Error` object.
 
 ## this.experiments.emitDiagnostic()
 
@@ -286,15 +286,15 @@ interface Diagnostic {
 function emitDiagnostic(diagnostic: Diagnostic): void;
 ```
 
-Formats and emits a diagnostic message (error or warning log). Supports the display of module paths, source code snippets and line/column numbers.
+Formats and emits an error or warning diagnostic. Supports the display of module paths, source code snippets, and line/column numbers.
 
 ::: info
-Unlike `throw` and `this.callback(err)` in the loader, it does not mark the current module as a compilation failure, it just adds an error to Rspack's Compilation and displays it on the command line at the end of this compilation.
+Unlike `throw` and `this.callback(err)` in a loader, it does not mark the current module as a compilation failure. It adds an error or warning to Rspack's Compilation according to `severity`, then displays it on the command line at the end of the compilation.
 :::
 
 - Basic example:
 
-When only `message` and `severity` are provided, only the basic module error information will be printed.
+When only `message` and `severity` are provided, only the basic diagnostic information will be printed.
 
 ```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
@@ -538,10 +538,37 @@ To provide the best performance, Rspack does not perform the schema validation. 
 - **Type:**
 
 ```ts
-function getResolve(options: ResolveOptions): resolve;
+type ResolveFunction = {
+  (
+    context: string,
+    request: string,
+    callback: (
+      err: Error | null,
+      result?: string | false,
+      resolveRequest?: ResolveRequest,
+    ) => void,
+  ): void;
+  (context: string, request: string): Promise<string | false | undefined>;
+};
+
+function getResolve(options?: ResolveOptions): ResolveFunction;
 ```
 
-Create a resolver like `this.resolve`.
+Creates a resolver like [`this.resolve()`](#thisresolve). Pass `options` to customize the resolver. If no options are provided, it uses the normal resolver without additional options.
+
+The returned resolver supports both callback and Promise forms. When no callback is passed, it returns a Promise.
+
+```js title="loader.mjs"
+export default async function loader(source) {
+  const resolve = this.getResolve({
+    extensions: ['.js', '.json'],
+  });
+  const result = await resolve(this.context, './dependency');
+
+  console.log(result);
+  return source;
+}
+```
 
 ## this.hot
 
@@ -663,11 +690,47 @@ When Rspack runs `loader1.mjs`, `this.remainingRequest` is:
 
 You can use it to create an inline request without invoking the current loader again. See [Inline matchResource](/api/loader-api/inline-match-resource) for an example.
 
+## this.currentRequest
+
+- **Type:** `string`
+
+`this.currentRequest` consists of the current loader, the loaders that follow it in the chain, and the current resource, joined with `!`.
+
+For example, consider the following loader chain:
+
+```text
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
+```
+
+When Rspack runs `loader2.mjs`, `this.currentRequest` is:
+
+```text
+/path/to/loader2.mjs!/path/to/resource.js
+```
+
+## this.previousRequest
+
+- **Type:** `string`
+
+`this.previousRequest` consists of the loaders that precede the current loader, joined with `!`. It does not include the current resource.
+
+For example, consider the following loader chain:
+
+```text
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
+```
+
+When Rspack runs `loader2.mjs`, `this.previousRequest` is:
+
+```text
+/path/to/loader1.mjs
+```
+
 ## this.request
 
 - **Type:** `string`
 
-The module specifier string after being resolved.
+The complete request string, consisting of all loaders and the current resource joined with `!`.
 
 For example, if a `resource.js` is processed by `loader1.mjs` and `loader2.mjs`, the value of `this.request` will be `/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js`.
 
@@ -679,7 +742,11 @@ For example, if a `resource.js` is processed by `loader1.mjs` and `loader2.mjs`,
 function resolve(
   context: string,
   request: string,
-  callback: (err: Error | null, result: string) => void,
+  callback: (
+    err: Error | null,
+    result?: string | false,
+    resolveRequest?: ResolveRequest,
+  ) => void,
 ): void;
 ```
 
@@ -687,28 +754,28 @@ Resolve a module specifier.
 
 - `context` must be the absolute path to a directory. This directory is used as the starting location for resolving.
 - `request` is the module specifier to be resolved.
-- `callback` is a callback function that gives the resolved path.
+- `callback` receives the error, the resolved path (or `false` when the request is ignored), and optional resolution details.
 
 ## this.mode
 
-- **Type:** `Mode`
+- **Type:** `Mode | undefined`
 
-The value of [`mode`](/config/mode) is read when Rspack is run.
+The value of the [`mode`](/config/mode) configuration.
 
-The possible values are: `'production'`, `'development'`, `'none'`
+The possible values are `'production'`, `'development'`, `'none'`, and `undefined`. If `mode` is not configured, `this.mode` is `undefined`, even though Rspack applies production-oriented defaults.
 
 ```js title="loader.mjs"
 export default function loader(source) {
-  console.log(this.mode); // 'production' or other values
+  console.log(this.mode); // 'production', 'development', 'none', or undefined
   return source;
 }
 ```
 
 ## this.target
 
-- **Type:** `Target`
+- **Type:** `Target | undefined`
 
-The current compilation target. Passed from [`target`](/config/target) configuration options.
+By default, this is a simplified target value derived from the [`target`](/config/target) configuration. When possible, Rspack maps the target's capabilities to a value such as `'web'`, `'node'`, `'nwjs'`, or `'electron-main'`. Therefore, `this.target` is not necessarily identical to the original `target` configuration.
 
 ```js title="loader.mjs"
 export default function loader(source) {
@@ -721,7 +788,7 @@ export default function loader(source) {
 
 - **Type:** `Environment`
 
-Describes the capabilities supported by the target environment. This is the effective value of [`output.environment`](/config/output#outputenvironment): Rspack infers the capabilities from [`target`](/config/target), then applies the explicit settings from `output.environment`.
+Describes the capabilities supported by the target environment. By default, this is the effective value of [`output.environment`](/config/output#outputenvironment): Rspack infers the capabilities from [`target`](/config/target), then applies the explicit settings from `output.environment`.
 
 A loader can use this information to choose syntax supported by the output environment.
 
@@ -789,7 +856,7 @@ export default function loader(source) {
 
 - **Type:** `string`
 
-The path string of the current module, excluding the query and fragment parameters. For example `'/abc/resource.js?query#hash'` in `'/abc/resource.js'`.
+The path string of the current module, excluding the query and fragment parameters. For example, the value is `'/abc/resource.js'` for `'/abc/resource.js?query#hash'`.
 
 ```js title="loader.mjs"
 export default function loader(source) {

--- a/website/docs/en/api/loader-api/context.mdx
+++ b/website/docs/en/api/loader-api/context.mdx
@@ -229,10 +229,10 @@ Alias of [this.addDependency()](#thisadddependency).
 - **Type:**
 
 ```ts
-function emitError(error: Error | string): void;
+function emitError(error: Error): void;
 ```
 
-Emit an error. If a string is passed, Rspack wraps it in an `Error` object.
+Emit an error.
 
 ::: info
 Unlike `throw` and `this.callback(err)` in the loader, it does not mark the current module as a compilation failure, it just adds an error to Rspack's Compilation and displays it on the command line at the end of this compilation.
@@ -243,10 +243,10 @@ Unlike `throw` and `this.callback(err)` in the loader, it does not mark the curr
 - **Type:**
 
 ```ts
-function emitWarning(warning: Error | string): void;
+function emitWarning(warning: Error): void;
 ```
 
-Emit a warning. If a string is passed, Rspack wraps it in an `Error` object.
+Emit a warning.
 
 ## this.experiments.emitDiagnostic()
 

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -229,10 +229,10 @@ function dependency(file: string): void;
 - **类型：**
 
 ```ts
-function emitError(error: Error | string): void;
+function emitError(error: Error): void;
 ```
 
-发出一个错误。如果传入字符串，Rspack 会将它包装为 `Error` 对象。
+发出一个错误。
 
 与在 loader 中 `throw` 和 `this.callback(err)` 不同，它不会将当前模块标记为编译失败，只会向 Rspack 的 Compilation 添加一个错误，并在本次编译结束后显示在命令行中。
 
@@ -241,10 +241,10 @@ function emitError(error: Error | string): void;
 - **类型：**
 
 ```ts
-function emitWarning(warning: Error | string): void;
+function emitWarning(warning: Error): void;
 ```
 
-发出一个警告。如果传入字符串，Rspack 会将它包装为 `Error` 对象。
+发出一个警告。
 
 ## this.experiments.emitDiagnostic()
 

--- a/website/docs/zh/api/loader-api/context.mdx
+++ b/website/docs/zh/api/loader-api/context.mdx
@@ -115,7 +115,9 @@ export default function loader(source) {
 function cacheable(flag: boolean = true): void;
 ```
 
-默认情况下，loader 的处理结果会被标记为可缓存。调用这个方法然后传入 `false`，可以关闭 loader 处理结果的缓存能力。
+默认情况下，当前模块经过整条 loader 链生成的最终构建结果可以被缓存。调用 `this.cacheable(false)` 会将该结果标记为不可缓存。
+
+设置后，后续 loader 即使调用 `this.cacheable(true)` 或 `this.cacheable()` 也无法重新启用缓存。只有 [`this.clearDependencies()`](#thiscleardependencies) 会重置这个状态。
 
 ```js title="loader.mjs"
 export default function loader(source) {
@@ -183,7 +185,7 @@ export default function loader(source) {
 }
 ```
 
-如果被处理的是模块不是来自文件系统，例如虚拟模块，那么 `this.context` 的值为 `null`。
+如果正在处理的模块没有资源路径，`this.context` 的值为 `null`。
 
 ## this.loaderIndex
 
@@ -227,20 +229,22 @@ function dependency(file: string): void;
 - **类型：**
 
 ```ts
-function emitError(err: Error): void;
+function emitError(error: Error | string): void;
 ```
 
-发出一个错误，与在 loader 中 `throw` 和 `this.callback(err)` 不同，它不会标记当前模块为编译失败，只会在 Rspack 的 Compilation 上添加一个错误，并在此次编译结束后显示在命令行中。
+发出一个错误。如果传入字符串，Rspack 会将它包装为 `Error` 对象。
+
+与在 loader 中 `throw` 和 `this.callback(err)` 不同，它不会将当前模块标记为编译失败，只会向 Rspack 的 Compilation 添加一个错误，并在本次编译结束后显示在命令行中。
 
 ## this.emitWarning()
 
 - **类型：**
 
 ```ts
-function emitWarning(warning: Error): void;
+function emitWarning(warning: Error | string): void;
 ```
 
-发出一个警告。
+发出一个警告。如果传入字符串，Rspack 会将它包装为 `Error` 对象。
 
 ## this.experiments.emitDiagnostic()
 
@@ -280,15 +284,15 @@ interface Diagnostic {
 function emitDiagnostic(diagnostic: Diagnostic): void;
 ```
 
-格式化并输出一个诊断信息（错误或警告日志），支持显示模块路径、源代码片段和行列号。
+格式化并输出错误或警告诊断信息，支持显示模块路径、源代码片段和行列号。
 
 ::: info
-与在 loader 中 `throw` 和 `this.callback(err)` 不同，它不会标记当前模块为编译失败，只会在 Rspack 的 Compilation 上添加一个错误，并在此次编译结束后显示在命令行中。
+与在 loader 中 `throw` 和 `this.callback(err)` 不同，它不会将当前模块标记为编译失败，而是根据 `severity` 向 Rspack 的 Compilation 添加错误或警告，并在本次编译结束后显示在命令行中。
 :::
 
 - 基础示例：
 
-当仅使用 `message` 和 `severity` 时，仅会打印基础的模块错误信息。
+只提供 `message` 和 `severity` 时，仅会输出基本的诊断信息。
 
 ```js title="loader.mjs"
 /** @type {import("@rspack/core").LoaderDefinition} */
@@ -532,10 +536,37 @@ export default function myLoader(
 - **类型：**
 
 ```ts
-function getResolve(options: ResolveOptions): resolve;
+type ResolveFunction = {
+  (
+    context: string,
+    request: string,
+    callback: (
+      err: Error | null,
+      result?: string | false,
+      resolveRequest?: ResolveRequest,
+    ) => void,
+  ): void;
+  (context: string, request: string): Promise<string | false | undefined>;
+};
+
+function getResolve(options?: ResolveOptions): ResolveFunction;
 ```
 
-创建一个类似于 `this.resolve` 的解析函数。
+创建一个类似于 [`this.resolve()`](#thisresolve) 的解析函数。可以通过 `options` 自定义解析行为；省略时使用不带额外选项的普通解析器。
+
+返回的解析函数同时支持回调和 Promise 两种调用方式。不传回调函数时，它会返回 Promise。
+
+```js title="loader.mjs"
+export default async function loader(source) {
+  const resolve = this.getResolve({
+    extensions: ['.js', '.json'],
+  });
+  const result = await resolve(this.context, './dependency');
+
+  console.log(result);
+  return source;
+}
+```
 
 ## this.hot
 
@@ -657,11 +688,47 @@ export default function loader(source) {
 
 它通常用于构造内联请求，避免再次执行当前 loader。可以参考 [Inline matchResource](/api/loader-api/inline-match-resource) 中的示例。
 
+## this.currentRequest
+
+- **类型：** `string`
+
+`this.currentRequest` 由当前 loader、loader 链中位于它之后的所有 loader 和当前资源组成，各部分使用 `!` 连接。
+
+例如，假设 loader 链为：
+
+```text
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
+```
+
+执行到 `loader2.mjs` 时，`this.currentRequest` 为：
+
+```text
+/path/to/loader2.mjs!/path/to/resource.js
+```
+
+## this.previousRequest
+
+- **类型：** `string`
+
+`this.previousRequest` 由 loader 链中位于当前 loader 之前的所有 loader 组成，各部分使用 `!` 连接。它不包含当前资源。
+
+例如，假设 loader 链为：
+
+```text
+/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js
+```
+
+执行到 `loader2.mjs` 时，`this.previousRequest` 为：
+
+```text
+/path/to/loader1.mjs
+```
+
 ## this.request
 
 - **类型：** `string`
 
-解析后的 module specifier 字符串。
+完整的请求字符串，由所有 loader 和当前资源组成，各部分使用 `!` 连接。
 
 例如，如果 `resource.js` 被 `loader1.mjs` 和 `loader2.mjs` 处理，那么 `this.request` 的值为 `/path/to/loader1.mjs!/path/to/loader2.mjs!/path/to/resource.js`。
 
@@ -673,7 +740,11 @@ export default function loader(source) {
 function resolve(
   context: string,
   request: string,
-  callback: (err: Error | null, result: string) => void,
+  callback: (
+    err: Error | null,
+    result?: string | false,
+    resolveRequest?: ResolveRequest,
+  ) => void,
 ): void;
 ```
 
@@ -681,26 +752,26 @@ function resolve(
 
 - `context` 必须是一个目录的绝对路径。此目录用作解析的起始位置。
 - `request` 是要被解析的模块标识符。
-- `callback` 是一个处理解析路径的回调函数。
+- `callback` 会接收错误、解析后的路径（请求被忽略时为 `false`），以及可选的解析详情。
 
 ## this.mode
 
-- **类型：** `Mode`
+- **类型：** `Mode | undefined`
 
-当 Rspack 运行时读取 [mode](/config/mode) 的值，可能的值为：`'production'`、`'development'`、`'none'`。
+[`mode`](/config/mode) 配置的值，可能为 `'production'`、`'development'`、`'none'` 或 `undefined`。如果没有配置 `mode`，`this.mode` 为 `undefined`，但 Rspack 仍会应用偏向生产环境的默认配置。
 
 ```js title="loader.mjs"
 export default function loader(source) {
-  console.log(this.mode); // 'production' or other values
+  console.log(this.mode); // 'production'、'development'、'none' 或 undefined
   return source;
 }
 ```
 
 ## this.target
 
-- **类型：** `Target`
+- **类型：** `Target | undefined`
 
-当前编译的目标。对应 [`target`](/config/target) 配置项的值。
+默认情况下，Rspack 会根据 [`target`](/config/target) 所描述的运行环境能力，为 loader 生成一个更简单的目标值。能够判断目标环境时，该值会是 `'web'`、`'node'`、`'nwjs'` 或 `'electron-main'` 等。因此，`this.target` 不一定与原始的 `target` 配置完全相同。
 
 ```js title="loader.mjs"
 export default function loader(source) {
@@ -713,7 +784,7 @@ export default function loader(source) {
 
 - **类型：** `Environment`
 
-描述目标运行环境支持的能力。该值是最终生效的 [`output.environment`](/config/output#outputenvironment)：Rspack 会根据 [`target`](/config/target) 自动判断目标环境支持的能力，再应用 `output.environment` 中的显式配置。
+描述目标运行环境支持的能力。默认情况下，该值是最终生效的 [`output.environment`](/config/output#outputenvironment)：Rspack 会根据 [`target`](/config/target) 判断目标环境支持的能力，再应用 `output.environment` 中的显式配置。
 
 loader 可以根据这些信息选择输出环境支持的语法。
 


### PR DESCRIPTION
## Summary

This PR aligns the loader context documentation and JSDoc with the runtime behavior for caching, request composition, resolution, mode, target, environment, and diagnostics.
It also corrects the public TypeScript signatures for `getResolve`, `resolve`, `getLogger`, `emitError`, and `emitWarning`, while preserving resolution metadata in parallel loaders.
The English and Chinese documentation are updated together.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).