### PR TITLE
fix: preserve worker entrypoints when async chunks are disabled

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1574,6 +1574,13 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       ));
     let mut entrypoint: Option<ChunkGroupUkey> = None;
     let mut c: Option<ChunkGroupUkey> = None;
+    // Async entrypoints such as workers need their own chunk group even when regular async chunks
+    // are disabled.
+    let has_entry_options = compilation
+      .get_module_graph()
+      .block_by_id(&block_id)
+      .and_then(|block| block.get_group_options().and_then(|o| o.entry_options()))
+      .is_some();
 
     let cgi = if let Some(cgi) = cgi {
       let cgi = self
@@ -1592,7 +1599,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       }
 
       cgi.ukey
-    } else if !item_async_chunks || !item_chunk_loading {
+    } else if !has_entry_options && (!item_async_chunks || !item_chunk_loading) {
       self.queue.push(QueueAction::ProcessBlock(ProcessBlock {
         block: block_id.into(),
         module: module_id,

--- a/tests/rspack-test/configCases/worker/child-compiler-worker/rspack.config.js
+++ b/tests/rspack-test/configCases/worker/child-compiler-worker/rspack.config.js
@@ -20,7 +20,11 @@ module.exports = {
         (compilation, callback) => {
           const childCompiler = compilation.createChildCompiler(
             'child-compiler-worker-test',
-            { filename: '__child-[name].js', publicPath: '' },
+            {
+              filename: '__child-[name].js',
+              publicPath: '',
+              asyncChunks: false,
+            },
             [
               new compiler.webpack.library.EnableLibraryPlugin('commonjs'),
               new compiler.webpack.EntryPlugin(


### PR DESCRIPTION
## Summary

- Preserve async entrypoint chunk groups, including worker entrypoints, when regular async chunks or chunk loading are disabled.
- Extend the child-compiler worker config case to cover `output.asyncChunks: false`.

## Detail

### Problem and trigger

Worker dependencies are represented as `AsyncDependenciesBlock`s with `GroupOptions::Entrypoint`. A child compiler that pre-bundles a worker can disable regular async chunks with `output.asyncChunks: false` while the worker itself still needs a separate entrypoint chunk. When that worker contains another worker dependency, the nested entrypoint reaches `make_chunk_group` with `item_async_chunks` set to `false`.

### Previous design and root cause

`make_chunk_group` previously handled a new async block in this order:

1. Reuse an existing chunk group when available.
2. If async chunks or chunk loading are disabled, process the block in the current chunk and return.
3. Otherwise, inspect the block's group options and create an async entrypoint when `entry_options` is present.

This ordering treated entrypoint blocks like regular async blocks. With `asyncChunks: false`, the early return skipped async entrypoint creation and never connected the worker block to a chunk group. During `WorkerDependencyTemplate` code generation, `get_block_chunk_group` therefore returned `None`, and the final lookup chain panicked with `failed to get json stringified chunk id`. The failure was not caused by JSON serialization; the worker entrypoint chunk was missing from the lookup path.

### Fix design

The code splitter now checks whether the block carries entry options before applying the regular-async-block fast path:

```rust
!has_entry_options && (!item_async_chunks || !item_chunk_loading)
```

Only non-entrypoint async blocks are folded into the current chunk. Worker entrypoint blocks continue through the existing async entrypoint creation path, which registers the entrypoint, connects the block to its chunk group, and allows worker code generation to resolve the entrypoint chunk and its assigned chunk ID.

This matches [webpack's `buildChunkGraph` ordering](https://github.com/webpack/webpack/blob/e048e5f162c4ac45ec7693b01024bb985d48a42a/lib/buildChunkGraph.js#L575-L680), where `entryOptions` are handled before the `asyncChunks` and `chunkLoading` fallback.

### Coverage and risk assessment

The existing child-compiler worker config case now sets `asyncChunks: false`. Its child entry contains a `new Worker(new URL(...))` dependency, so successful child compilation exercises the previously panicking code-generation path.

The change does not alter public APIs, configuration defaults, or regular async-block behavior. It applies to all async entrypoint blocks rather than special-casing workers, preserving the shared entrypoint invariant and webpack compatibility. The added module-graph lookup is constant time and does not change algorithmic complexity; remote CodSpeed analysis reported no performance change, and the binary-size check reported no size change.

<details>
<summary>Translation</summary>

### 问题与触发条件

Worker 依赖会被表示为带有 `GroupOptions::Entrypoint` 的 `AsyncDependenciesBlock`。预打包 worker 的 child compiler 可以通过 `output.asyncChunks: false` 禁用常规异步分块，但 worker 本身仍然需要一个独立的 entrypoint chunk。当这个 worker 内部又包含另一个 worker 依赖时，嵌套 entrypoint 会在 `item_async_chunks` 为 `false` 的状态下进入 `make_chunk_group`。

### 旧设计与根因

此前，`make_chunk_group` 按以下顺序处理新的异步 block：

1. 如果已有 chunk group，则复用它。
2. 如果禁用了异步分块或 chunk loading，则在当前 chunk 中处理该 block 并直接返回。
3. 否则，检查该 block 的 group options；当存在 `entry_options` 时创建异步 entrypoint。

这个顺序把 entrypoint block 当成了常规异步 block。设置 `asyncChunks: false` 后，提前返回会跳过异步 entrypoint 的创建，也不会建立 worker block 到 chunk group 的连接。因此在 `WorkerDependencyTemplate` 代码生成阶段，`get_block_chunk_group` 返回 `None`，最终的查找链以 `failed to get json stringified chunk id` 触发 panic。失败并不是由 JSON 序列化导致的，而是查找路径中缺少 worker entrypoint chunk。

### 修复设计

Code splitter 现在会在应用常规异步 block 的快速路径之前，先检查该 block 是否带有 entry options：

```rust
!has_entry_options && (!item_async_chunks || !item_chunk_loading)
```

只有非 entrypoint 的异步 block 才会被合并进当前 chunk。Worker entrypoint block 会继续进入原有的异步 entrypoint 创建流程：注册 entrypoint、建立 block 与 chunk group 的连接，并使 worker 代码生成阶段能够解析 entrypoint chunk 及其已分配的 chunk ID。

这与 [webpack 的 `buildChunkGraph` 处理顺序](https://github.com/webpack/webpack/blob/e048e5f162c4ac45ec7693b01024bb985d48a42a/lib/buildChunkGraph.js#L575-L680) 一致：webpack 会先处理 `entryOptions`，之后才进入 `asyncChunks` 和 `chunkLoading` 的回退逻辑。

### 覆盖范围与风险评估

现有的 child-compiler worker config case 现在会设置 `asyncChunks: false`。它的 child entry 包含一个 `new Worker(new URL(...))` 依赖，因此 child compilation 成功即可覆盖此前会触发 panic 的代码生成路径。

该改动不会改变公共 API、配置默认值或常规异步 block 的行为。它适用于所有异步 entrypoint block，而不是只对 worker 做特殊处理，从而保持共享的 entrypoint 不变量以及 webpack 兼容性。新增的 module graph 查找是常数时间操作，不会改变算法复杂度；远端 CodSpeed 分析显示性能没有变化，binary-size 检查也显示产物大小没有变化。

</details>

## Related links

Fixes #15086

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/worker/child-compiler-worker"`
- `cargo fmt --all --check`
- `pnpm run format-ci:js`
- Verified the issue reproduction with both 1 and 1,500 generated worker modules.
- Remote build, lint, Rust test, Linux/Windows/macOS/WASM test, binary-size, and CodSpeed checks passed.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
