### PR TITLE
fix(rstest): make import.meta.rstest resolver optional

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2998,7 +2998,7 @@ export interface RawRstestPluginOptions {
   globals?: boolean
   /**
    * Replaces each `import.meta.rstest` with
-   * `globalThis['@rstest/core/import-meta'](<absolute source path>)`.
+   * `globalThis['@rstest/core/import-meta']?.(<absolute source path>)`.
    */
   injectImportMetaRstestOrigin?: boolean
 injectDynamicImportOrigin?: boolean | { functionName?: string }

--- a/crates/rspack_binding_api/src/rstest.rs
+++ b/crates/rspack_binding_api/src/rstest.rs
@@ -40,7 +40,7 @@ pub struct RawRstestPluginOptions {
   // When false, only ESM imported variables are processed. Default is true.
   pub globals: Option<bool>,
   /// Replaces each `import.meta.rstest` with
-  /// `globalThis['@rstest/core/import-meta'](<absolute source path>)`.
+  /// `globalThis['@rstest/core/import-meta']?.(<absolute source path>)`.
   pub inject_import_meta_rstest_origin: Option<bool>,
   // When enabled, rewrite non-string-literal `import()` calls (template
   // literals, variables) to the configured callee and append the source

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -51,8 +51,8 @@ pub struct RstestParserPluginOptions {
   /// Whether to handle global `rs` and `rstest` variables.
   /// When false, only ESM imported variables are processed.
   pub globals: bool,
-  /// Whether to replace `import.meta.rstest` with the runtime resolver call
-  /// carrying the source module's absolute path.
+  /// Whether to replace `import.meta.rstest` with the optional runtime resolver
+  /// call carrying the source module's absolute path.
   pub inject_import_meta_rstest_origin: bool,
   /// Whether to rewrite non-string-literal `import()` calls with origin info.
   /// Pre-resolved at plugin construction — false here covers both "feature
@@ -165,7 +165,7 @@ impl RstestParserPlugin {
     }
     let resource_path = parser.resource_data.path()?;
     Some(format!(
-      "globalThis['@rstest/core/import-meta']({})",
+      "globalThis['@rstest/core/import-meta']?.({})",
       json_stringify_str(resource_path.as_str())
     ))
   }

--- a/tests/rspack-test/configCases/rstest/import-meta-rstest/index.js
+++ b/tests/rspack-test/configCases/rstest/import-meta-rstest/index.js
@@ -28,3 +28,19 @@ it('resolves import.meta.rstest with the source module path', () => {
 		),
 	);
 });
+
+it('returns undefined when the runtime resolver is unavailable', () => {
+	const resolver = globalThis['@rstest/core/import-meta'];
+	delete globalThis['@rstest/core/import-meta'];
+	try {
+		const bundlePath = path.resolve(__dirname, 'withoutResolver.js');
+		const result = eval('require')(bundlePath);
+
+		expect(result.direct).toBeUndefined();
+		expect(result.optional).toBeUndefined();
+		expect(result.type).toBe('undefined');
+		expect(result.branch).toBe(false);
+	} finally {
+		globalThis['@rstest/core/import-meta'] = resolver;
+	}
+});

--- a/tests/rspack-test/configCases/rstest/import-meta-rstest/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/import-meta-rstest/rspack.config.js
@@ -6,10 +6,13 @@ const {
 /** @type {import("@rspack/core").Configuration} */
 module.exports = [
   {
-    entry: './src/index.js',
+    entry: {
+      importMetaRstest: './src/index.js',
+      withoutResolver: './src/imported.js',
+    },
     target: 'node',
     output: {
-      filename: 'importMetaRstest.js',
+      filename: '[name].js',
       library: {
         type: 'commonjs2',
       },


### PR DESCRIPTION
## Summary

This PR prevents transformed `import.meta.rstest` expressions from crashing in runtimes where the Rstest resolver is unavailable.

`injectImportMetaRstestOrigin` is enabled compilation-wide. A module containing an in-source-test guard can therefore be bundled into a separate runtime, such as a `node:worker_threads` worker, while Rstest installs `globalThis['@rstest/core/import-meta']` only in the parent test runtime. The previous output called the missing resolver unconditionally:

```js
if (globalThis['@rstest/core/import-meta']('/absolute/path/to/worker.ts')) {
  // ...
}
```

This throws `TypeError: globalThis.@rstest/core/import-meta is not a function` before the guard can evaluate.

The parser now emits an optional call:

```js
globalThis['@rstest/core/import-meta']?.('/absolute/path/to/worker.ts')
```

When the resolver exists, source-path-aware behavior is unchanged. When it is absent in a child or otherwise isolated runtime, the expression evaluates to `undefined`, matching the expected `import.meta.rstest` guard semantics.

The config case adds a second entry without a resolver and verifies direct access, optional property access, `typeof`, and conditional evaluation in both normal and runtime modes.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15006
- https://github.com/web-infra-dev/rstest/pull/1655
- https://github.com/web-infra-dev/rstest/issues/1637

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).