### PR TITLE
fix: preserve imports in impure class expressions

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -568,13 +568,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           .inner_graph
           .class_with_top_level_symbol
           .insert(init.span(), v);
-      } else if is_pure_expression(
-        parser,
-        self.analyze_pure_annotation,
-        init,
-        parser.ast.comments,
-        Some(&mut callees),
-      ) {
+      } else if !init.is_class()
+        && is_pure_expression(
+          parser,
+          self.analyze_pure_annotation,
+          init,
+          parser.ast.comments,
+          Some(&mut callees),
+        )
+      {
         let v = Self::tag_top_level_symbol(parser, &name);
         for (symbol, span) in callees {
           v.add_depend_on(&mut parser.inner_graph, symbol, span);

--- a/tests/rspack-test/configCases/inner-graph/issue-15089/index.js
+++ b/tests/rspack-test/configCases/inner-graph/issue-15089/index.js
@@ -1,0 +1,5 @@
+import { Used } from "./views";
+
+it("should keep references in unused impure class expressions", () => {
+	expect(Used.getValue()).toBe("value");
+});

--- a/tests/rspack-test/configCases/inner-graph/issue-15089/rspack.config.js
+++ b/tests/rspack-test/configCases/inner-graph/issue-15089/rspack.config.js
@@ -1,0 +1,7 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/configCases/inner-graph/issue-15089/value.js
+++ b/tests/rspack-test/configCases/inner-graph/issue-15089/value.js
@@ -1,0 +1,3 @@
+export function getValue() {
+	return "value";
+}

--- a/tests/rspack-test/configCases/inner-graph/issue-15089/views.js
+++ b/tests/rspack-test/configCases/inner-graph/issue-15089/views.js
@@ -1,0 +1,21 @@
+import { getValue } from "./value";
+
+class View {}
+
+export const Used = class Used extends View {
+	static getValue = getValue;
+};
+
+export const UnusedWithConstructor = class UnusedWithConstructor extends View {
+	constructor() {
+		super();
+	}
+
+	static getValue = getValue;
+};
+
+export const UnusedWithStaticBlock = class UnusedWithStaticBlock extends View {
+	static {}
+
+	static getValue = getValue;
+};


### PR DESCRIPTION
## Summary

- Keep class expressions that fail class-specific purity analysis out of the generic pure-declarator path.
- Preserve imported bindings referenced by eagerly evaluated static fields on unused derived classes.
- Add regression coverage for class expressions with an explicit constructor or static block.

The generic declarator path only guards the `extends` expression when an export is unused. Letting an impure class expression enter that path also made its static-field imports conditional on the unused export, even though the static initializer remained in the output and executed at module load time.

## Detail

### PR Overview

This bug fix corrects inner-graph dependency tracking for exported class expressions that are not eligible for class-specific purity optimization. It does not change public APIs, configuration, or output contracts; it restores valid code generation for an existing production configuration and adds focused regression coverage.

### Problem and Trigger

With `optimization.innerGraph` enabled, the failure occurs when an unused top-level export is initialized with a derived class expression, an explicit constructor or static block makes `is_pure_class` reject the class, and an eagerly evaluated static field references an imported helper that is also used by reachable code. Module concatenation renames the live helper binding and its active references, but the reference associated with the unused export can remain unrewritten. Because the class and its static initializer are still emitted and evaluated, module loading throws a `ReferenceError`.

### Previous Design and Root Cause

`pre_declarator` first routed class expressions that passed `is_pure_class` through `class_with_top_level_symbol`. A rejected class could then fall through to the generic `is_pure_expression` branch and be recorded in `decl_with_top_level_symbol`. For class initializers, that generic path only created a `PureExpressionDependency` for the `extends` expression. Since the class was absent from `class_with_top_level_symbol`, the class-body hooks could not separately model the static initializer, while its import dependency still inherited the unused export's inner-graph condition. This made the dependency inactive without making the eagerly executed source expression inactive.

### Fix Design

The generic pure-declarator fallback now explicitly excludes class expressions. Classes accepted by `is_pure_class` continue through the existing class-specific analysis; rejected classes remain conservatively untagged, so references evaluated during class initialization stay unconditional and module concatenation rewrites them consistently. webpack uses a richer `TopLevelSymbol` that stores purity and routes every `ClassExpression` through class-specific handling. Rspack currently does not model that per-symbol purity state, so the exclusion is a narrow conservative fix that preserves correctness without expanding the inner-graph state model.

### Correctness Risks

No material correctness risk was identified from the inspected changes. The behavioral difference is limited to class expressions that already failed class-specific purity analysis but previously passed the generic expression check. The regression case covers both known triggers—an explicit constructor and a static block—and intentionally shares the imported helper with reachable code to exercise the concatenation rename mismatch. Required remote CI passed across Rust checks and tests, Linux, macOS ARM64, Windows, and WASM.

### Performance Regression Risks

The change may retain unconditional dependency usage for these rejected class expressions instead of applying the generic inner-graph optimization, which is the intended conservative tradeoff. It also avoids a redundant generic purity check for them. No material performance regression is indicated: binary size is unchanged, Rsdoctor reports no bundle changes across five projects, and the reported CodSpeed improvement is not treated as conclusive because the report detected different runtime environments.

<details>
<summary>Translation</summary>

### PR 概述

这个 bug fix 修正了不满足 class 专用纯度优化条件的导出 class expression 的 inner-graph 依赖跟踪。它不改变公共 API、配置或输出契约，而是恢复现有生产配置下的合法代码生成，并增加有针对性的回归覆盖。

### 问题与触发条件

启用 `optimization.innerGraph` 时，如果一个未使用的顶层导出由派生 class expression 初始化，显式 constructor 或 static block 导致 `is_pure_class` 拒绝该 class，同时一个会立即求值的静态字段引用了也被可达代码使用的导入 helper，就会触发问题。Module concatenation 会重命名仍然存活的 helper binding 及其活跃引用，但关联未使用导出的引用可能不会被重写。由于该 class 及其静态初始化器仍会生成并执行，模块加载时会抛出 `ReferenceError`。

### 旧设计与根因

`pre_declarator` 首先把通过 `is_pure_class` 的 class expression 放入 `class_with_top_level_symbol`。被拒绝的 class 随后可能落入通用 `is_pure_expression` 分支，并记录到 `decl_with_top_level_symbol`。对于 class initializer，这条通用路径只会为 `extends` 表达式创建 `PureExpressionDependency`。由于该 class 不在 `class_with_top_level_symbol` 中，class body hooks 无法单独建模静态初始化器，而其中的 import dependency 仍继承了未使用导出的 inner-graph 条件。结果是依赖变为 inactive，但立即执行的源码表达式并没有同步变为 inactive。

### 修复设计

通用 pure-declarator fallback 现在会显式排除 class expression。被 `is_pure_class` 接受的 class 仍沿用现有 class 专用分析；被拒绝的 class 则保守地保持未标记，使 class 初始化期间执行的引用维持 unconditional，module concatenation 因而能一致地重写它们。webpack 使用包含 purity 状态的更丰富 `TopLevelSymbol`，并把所有 `ClassExpression` 交给 class 专用路径。Rspack 当前没有对这种逐 symbol purity 状态建模，因此本次排除是一个范围较小的保守修复，无需扩展 inner-graph 状态模型即可保证正确性。

### 正确性风险

从已检查的变更中未发现实质性正确性风险。行为差异仅限于已经无法通过 class 专用纯度分析、但此前又能通过通用表达式检查的 class expression。回归用例覆盖两个已知触发条件——显式 constructor 和 static block——并有意让不可达 class 与可达代码共享导入 helper，以触发 concatenation 重命名不一致。远端必需 CI 均已通过，包括 Rust 检查与测试，以及 Linux、macOS ARM64、Windows 和 WASM。

### 性能回归风险

对于这些被 class 专用分析拒绝的 class expression，本次变更可能保留 unconditional dependency usage，而不再套用通用 inner-graph 优化；这是预期的保守权衡。同时，它也避免了对这些 class 重复执行通用纯度检查。现有证据没有显示实质性性能回归：二进制大小不变，Rsdoctor 在五个项目中均未检测到 bundle 变化；CodSpeed 报告的性能提升由于运行环境不同，不视为确定性结论。

</details>

## Related links

Fixes #15089.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test -t "inner-graph"` (129 tests passed)
- `cargo check -p rspack_plugin_javascript --locked --target aarch64-apple-darwin`
- `cargo fmt --all --check`
- `pnpm run format-ci:js`

## Checklist

- [x] Tests updated.
- [x] Documentation not required.
