### PR TITLE
chore(binding): use native binaryen for wasm-opt

### DIFF
--- a/.github/workflows/reusable-build-build.yml
+++ b/.github/workflows/reusable-build-build.yml
@@ -193,13 +193,22 @@ jobs:
           DISABLE_PLUGIN=1 RUST_TARGET=wasm32-wasip1-threads pnpm build:binding:${{ inputs.profile }}
           cp crates/node_binding/rspack.wasm32-wasi.wasm crates/node_binding/rspack.browser.wasm
 
+      - name: Setup binaryen
+        if: ${{ inputs.target == 'wasm32-wasip1-threads' && inputs.profile == 'release' }}
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/binaryen.tar.gz" \
+            "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz"
+          tar xz -C "$RUNNER_TEMP" -f "$RUNNER_TEMP/binaryen.tar.gz" "binaryen-version_$BINARYEN_VERSION/bin/wasm-opt"
+          echo "$RUNNER_TEMP/binaryen-version_$BINARYEN_VERSION/bin" >> "$GITHUB_PATH"
+        env:
+          BINARYEN_VERSION: '131'
+
       # WASM Release (use profile = release-wasi) + wasm-opt
       # The wasi and browser variants are split into two parallel matrix jobs
       # (see reusable-release-npm.yml) and selected here via binding_postfix.
       - name: Build wasm32-wasip1-threads wasi variant (release-wasi) with linux
         if: ${{ inputs.target == 'wasm32-wasip1-threads' && inputs.profile == 'release' && inputs.binding_postfix == '' }}
         run: |
-          npm install -g binaryen
           pnpm --filter @rspack/binding build:release:wasm
           wasm-opt -Oz crates/node_binding/rspack.wasm32-wasi.wasm -o crates/node_binding/rspack.wasm32-wasi.optimized.wasm
           mv crates/node_binding/rspack.wasm32-wasi.optimized.wasm crates/node_binding/rspack.wasm32-wasi.wasm
@@ -207,7 +216,6 @@ jobs:
       - name: Build wasm32-wasip1-threads browser variant (release-wasi) with linux
         if: ${{ inputs.target == 'wasm32-wasip1-threads' && inputs.profile == 'release' && inputs.binding_postfix == '-browser' }}
         run: |
-          npm install -g binaryen
           pnpm --filter @rspack/binding build:release:browser
           wasm-opt -Oz crates/node_binding/rspack.browser.wasm -o crates/node_binding/rspack.browser.optimized.wasm
           mv crates/node_binding/rspack.browser.optimized.wasm crates/node_binding/rspack.browser.wasm


### PR DESCRIPTION
## Why

`npm install -g binaryen` installs a WebAssembly build of binaryen that runs single-threaded inside Node. The upstream release binary is native and multi-threaded.

Measured on the linux self-hosted runner, same input, same binaryen version 131, `-Oz`:

| | wall | output |
|---|---:|---|
| npm `binaryen` (current) | 363,611 ms | 29,809,648 B |
| upstream native | 15,118 ms | 29,809,648 B |

24.1x faster, and the two outputs have the same sha256. That is 5m48s off each of the two wasm matrix jobs. [ref](https://github.com/web-infra-dev/rspack/actions/runs/31151423743/job/92781697242?pr=15101#logs)

## What

- Add a `Setup binaryen` step: download the pinned upstream release tarball, extract only `bin/wasm-opt` onto `PATH`.
- Drop `npm install -g binaryen` from both wasm release build steps. The `wasm-opt -Oz ...` invocations are unchanged.
