### PR TITLE
chore(binding): use system allocator for debug builds

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -12,14 +12,15 @@ crate-type = ["cdylib"]
 test       = false
 
 [features]
-allocative    = ["rspack_binding_api/allocative"]
-browser       = ["rspack_binding_api/browser"]
-debug_tool    = ["rspack_binding_api/debug_tool"]
-info-level    = ["tracing/release_max_level_info"]
-perfetto      = ["rspack_binding_api/perfetto"]
-plugin        = ["rspack_binding_api/plugin"]
-sftrace-setup = ["rspack_binding_api/sftrace-setup"]
-tracy-client  = ["rspack_binding_api/tracy-client"]
+allocative       = ["rspack_binding_api/allocative"]
+browser          = ["rspack_binding_api/browser"]
+debug_tool       = ["rspack_binding_api/debug_tool"]
+info-level       = ["tracing/release_max_level_info"]
+perfetto         = ["rspack_binding_api/perfetto"]
+plugin           = ["rspack_binding_api/plugin"]
+sftrace-setup    = ["rspack_binding_api/sftrace-setup"]
+system-allocator = ["rspack_binding_api/system-allocator"]
+tracy-client     = ["rspack_binding_api/tracy-client"]
 
 [package.metadata.cargo-shear]
 # Adding napi-derive as a dependency to workaround an issue where `dts` will no longer work without it.

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -76,6 +76,9 @@ async function build() {
 		if (values.profile !== "release") {
 			features.push("perfetto");
 		}
+		if (values.profile === "release-debug") {
+			features.push("system-allocator");
+		}
 		args.push("--no-dts-cache");
 		if (process.env.SFTRACE) {
 			features.push("sftrace-setup");

--- a/crates/rspack_allocator/Cargo.toml
+++ b/crates/rspack_allocator/Cargo.toml
@@ -6,6 +6,9 @@ name              = "rspack_allocator"
 repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true
 
+[features]
+system-allocator = []
+
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 sftrace-setup = { workspace = true, optional = true }
 tracy-client  = { workspace = true, optional = true }

--- a/crates/rspack_allocator/src/lib.rs
+++ b/crates/rspack_allocator/src/lib.rs
@@ -1,13 +1,23 @@
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]
-#[cfg(not(any(feature = "sftrace-setup", feature = "tracy-client")))]
+#[cfg(not(any(
+  feature = "sftrace-setup",
+  feature = "system-allocator",
+  feature = "tracy-client"
+)))]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]
-#[cfg(feature = "sftrace-setup")]
+#[cfg(all(feature = "sftrace-setup", not(feature = "system-allocator")))]
 static GLOBAL: sftrace_setup::SftraceAllocator<mimalloc::MiMalloc> =
   sftrace_setup::SftraceAllocator(mimalloc::MiMalloc);
+
+#[global_allocator]
+#[cfg(not(any(miri, target_family = "wasm")))]
+#[cfg(all(feature = "sftrace-setup", feature = "system-allocator"))]
+static GLOBAL: sftrace_setup::SftraceAllocator<std::alloc::System> =
+  sftrace_setup::SftraceAllocator(std::alloc::System);
 
 #[global_allocator]
 #[cfg(not(any(miri, target_family = "wasm")))]

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -11,13 +11,14 @@ repository.workspace    = true
 version.workspace       = true
 
 [features]
-allocative    = ["rspack_util/allocative", "rspack_collections/allocative", "rspack_cacheable/allocative", "rspack_tracing_perfetto?/allocative"]
-browser       = []
-debug_tool    = ["rspack_core/debug_tool"]
-perfetto      = ["dep:rspack_tracing_perfetto", "rspack_tracing/perfetto"]
-plugin        = ["rspack_loader_swc/plugin", "rspack_util/plugin"]
-sftrace-setup = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
-tracy-client  = ["dep:tracy-client", "rspack_allocator/tracy-client"]
+allocative       = ["rspack_util/allocative", "rspack_collections/allocative", "rspack_cacheable/allocative", "rspack_tracing_perfetto?/allocative"]
+browser          = []
+debug_tool       = ["rspack_core/debug_tool"]
+perfetto         = ["dep:rspack_tracing_perfetto", "rspack_tracing/perfetto"]
+plugin           = ["rspack_loader_swc/plugin", "rspack_util/plugin"]
+sftrace-setup    = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
+system-allocator = ["rspack_allocator/system-allocator"]
+tracy-client     = ["dep:tracy-client", "rspack_allocator/tracy-client"]
 
 [dependencies]
 anyhow                    = { workspace = true }


### PR DESCRIPTION
## Summary

- use the system allocator for `release-debug` binding packages
- keep mimalloc as the default for other native builds
- preserve allocator profiling support when the system allocator is enabled