### PR TITLE
docs: fix invalid code examples

### DIFF
--- a/website/docs/en/api/javascript-api/browser.mdx
+++ b/website/docs/en/api/javascript-api/browser.mdx
@@ -306,6 +306,8 @@ When using ModuleFederationPlugin in the browser, please note the following:
 2. Shared modules set in ModuleFederationPlugin also need to be configured with `external` and specified versions in BrowserHttpImportEsmPlugin. If you're using `esm.sh` as CDN, you can refer to the following code:
 
 ```js title="rspack.config.mjs"
+import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
+
 new BrowserHttpImportEsmPlugin({
   domain: 'https://esm.sh',
   dependencyVersions: {

--- a/website/docs/en/api/javascript-api/browser.mdx
+++ b/website/docs/en/api/javascript-api/browser.mdx
@@ -306,19 +306,22 @@ When using ModuleFederationPlugin in the browser, please note the following:
 2. Shared modules set in ModuleFederationPlugin also need to be configured with `external` and specified versions in BrowserHttpImportEsmPlugin. If you're using `esm.sh` as CDN, you can refer to the following code:
 
 ```js title="rspack.config.mjs"
-new rspack.BrowserHttpImportEsmPlugin({
-  domain: "https://esm.sh",
+new BrowserHttpImportEsmPlugin({
+  domain: 'https://esm.sh',
   dependencyVersions: {
-    "react": "19.1.1"
+    react: '19.1.1',
   },
   postprocess: (request) => {
     // Set the `dev` parameter for `react-dom` here as well, as you need to ensure that the provider and consumer projects use the same mode of `react` and `react-dom`.
-    if (request.packageName === "@module-federation/webpack-bundler-runtime" || request.packageName === "react-dom") {
-      request.url.searchParams.set("dev", "");
+    if (
+      request.packageName === '@module-federation/webpack-bundler-runtime' ||
+      request.packageName === 'react-dom'
+    ) {
+      request.url.searchParams.set('dev', '');
     }
-    request.url.searchParams.set("external", "react");
-  }
-}),
+    request.url.searchParams.set('external', 'react');
+  },
+});
 ```
 
 3. All [ModuleFederationPlugin.shared](/plugins/webpack/module-federation-plugin#shared) configurations must set `import: false`, meaning that consumer projects bundled online cannot bundle shared modules themselves; shared modules must be provided by pre-bundled provider projects.

--- a/website/docs/en/api/loader-api/writing-loaders.mdx
+++ b/website/docs/en/api/loader-api/writing-loaders.mdx
@@ -107,6 +107,7 @@ By exporting `raw: true` in the loader file, a loader can receive the original `
 - CJS:
 
 ```js title="raw-loader.js"
+module.exports = function (source) {
   // Process binary content
   // Here source is a Buffer instance
   const processed = someBufferOperation(source);

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -539,10 +539,7 @@ When a module is not imported via `import` or `import()`, Rspack will use `"modu
 export default {
   externalsType: 'module-import',
   externals: [
-    function (
-      { request, dependencyType },
-      callback
-    ) {
+    function ({ request, dependencyType }, callback) {
       if (dependencyType === 'commonjs') {
         return callback(null, `node-commonjs ${request}`);
       }

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -537,18 +537,19 @@ When a module is not imported via `import` or `import()`, Rspack will use `"modu
 
 ```js title="rspack.config.mjs"
 export default {
-  externalsType: "module-import",
+  externalsType: 'module-import',
   externals: [
     function (
       { request, dependencyType },
       callback
     ) {
-      if (dependencyType === "commonjs") {
+      if (dependencyType === 'commonjs') {
         return callback(null, `node-commonjs ${request}`);
       }
       callback();
     },
-  ]
+  ],
+};
 ```
 
 ### externalsType['modern-module']

--- a/website/docs/en/config/infrastructure-logging.mdx
+++ b/website/docs/en/config/infrastructure-logging.mdx
@@ -79,7 +79,7 @@ Enable debug information of specified loggers such as plugins or loaders. Simila
 export default {
   infrastructureLogging: {
     level: 'info',
-    debug: ['MyPlugin', /MyPlugin/, (name) => name.contains('MyPlugin')],
+    debug: ['MyPlugin', /MyPlugin/, (name) => name.includes('MyPlugin')],
   },
 };
 ```

--- a/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/rspack/html-rspack-plugin.mdx
@@ -347,7 +347,7 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
+      title: 'My HTML Template',
       templateContent: `
         <!DOCTYPE html>
         <html>
@@ -374,7 +374,7 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
+      title: 'My HTML Template',
       templateContent: ({ htmlRspackPlugin }) => `
         <!DOCTYPE html>
         <html>
@@ -409,8 +409,8 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
-      template: "template.js",
+      title: 'My HTML Template',
+      template: 'template.js',
     }),
   ],
 };

--- a/website/docs/en/plugins/webpack/ignore-plugin.mdx
+++ b/website/docs/en/plugins/webpack/ignore-plugin.mdx
@@ -41,7 +41,7 @@ export default {
     new rspack.IgnorePlugin({
       resourceRegExp: /^\.\/locale$/,
       contextRegExp: /moment$/,
-    });
+    }),
   ],
 };
 ```

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -311,6 +311,8 @@ function uselessExecute(_code: string, runtime: CommonJsRuntime) {
 2. ModuleFederationPlugin 中设置的共享依赖，还需要在 BrowserHttpImportEsmPlugin 相应地配置 `external` 和指定版本号。如果你使用的是 `esm.sh` 作为 CDN，可以参考以下代码：
 
 ```js title="rspack.config.mjs"
+import { BrowserHttpImportEsmPlugin } from '@rspack/browser';
+
 new BrowserHttpImportEsmPlugin({
   domain: 'https://esm.sh',
   dependencyVersions: {

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -311,19 +311,22 @@ function uselessExecute(_code: string, runtime: CommonJsRuntime) {
 2. ModuleFederationPlugin 中设置的共享依赖，还需要在 BrowserHttpImportEsmPlugin 相应地配置 `external` 和指定版本号。如果你使用的是 `esm.sh` 作为 CDN，可以参考以下代码：
 
 ```js title="rspack.config.mjs"
-new rspack.BrowserHttpImportEsmPlugin({
-  domain: "https://esm.sh",
+new BrowserHttpImportEsmPlugin({
+  domain: 'https://esm.sh',
   dependencyVersions: {
-    "react": "19.1.1"
+    react: '19.1.1',
   },
   postprocess: (request) => {
     // 这里也设置 `react-dom` 的 `dev` 参数，因为你需要确保模块联邦的生产者项目和消费者项目使用相同模式的 `react` 和 `react-dom`。
-    if (request.packageName === "@module-federation/webpack-bundler-runtime" || request.packageName === "react-dom") {
-      request.url.searchParams.set("dev", "");
+    if (
+      request.packageName === '@module-federation/webpack-bundler-runtime' ||
+      request.packageName === 'react-dom'
+    ) {
+      request.url.searchParams.set('dev', '');
     }
-    request.url.searchParams.set("external", "react");
-  }
-}),
+    request.url.searchParams.set('external', 'react');
+  },
+});
 ```
 
 3. 所有 [ModuleFederationPlugin.shared](/plugins/webpack/module-federation-plugin#shared) 配置必须设置 `import: false`，即在线打包的消费者项目不能打包共享模块，共享模块必须由预先打包好的生产者项目提供。

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -538,10 +538,7 @@ async function foo() {
 export default {
   externalsType: 'module-import',
   externals: [
-    function (
-      { request, dependencyType },
-      callback
-    ) {
+    function ({ request, dependencyType }, callback) {
       if (dependencyType === 'commonjs') {
         return callback(null, `node-commonjs ${request}`);
       }

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -536,18 +536,19 @@ async function foo() {
 
 ```js title="rspack.config.mjs"
 export default {
-  externalsType: "module-import",
+  externalsType: 'module-import',
   externals: [
     function (
       { request, dependencyType },
       callback
     ) {
-      if (dependencyType === "commonjs") {
+      if (dependencyType === 'commonjs') {
         return callback(null, `node-commonjs ${request}`);
       }
       callback();
     },
-  ]
+  ],
+};
 ```
 
 ### externalsType['modern-module']

--- a/website/docs/zh/config/infrastructure-logging.mdx
+++ b/website/docs/zh/config/infrastructure-logging.mdx
@@ -79,7 +79,7 @@ export default {
 export default {
   infrastructureLogging: {
     level: 'info',
-    debug: ['MyPlugin', /MyPlugin/, (name) => name.contains('MyPlugin')],
+    debug: ['MyPlugin', /MyPlugin/, (name) => name.includes('MyPlugin')],
   },
 };
 ```

--- a/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/rspack/html-rspack-plugin.mdx
@@ -327,7 +327,7 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
+      title: 'My HTML Template',
       template: 'index.html',
     }),
   ],
@@ -344,7 +344,7 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
+      title: 'My HTML Template',
       templateContent: `
         <!DOCTYPE html>
         <html>
@@ -371,7 +371,7 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
+      title: 'My HTML Template',
       templateContent: ({ htmlRspackPlugin }) => `
         <!DOCTYPE html>
         <html>
@@ -406,8 +406,8 @@ import { rspack } from '@rspack/core';
 export default {
   plugins: [
     new rspack.HtmlRspackPlugin({
-      title: "My HTML Template"
-      template: "template.js",
+      title: 'My HTML Template',
+      template: 'template.js',
     }),
   ],
 };

--- a/website/docs/zh/plugins/webpack/ignore-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/ignore-plugin.mdx
@@ -41,7 +41,7 @@ export default {
     new rspack.IgnorePlugin({
       resourceRegExp: /^\.\/locale$/,
       contextRegExp: /moment$/,
-    });
+    }),
   ],
 };
 ```


### PR DESCRIPTION
## Summary

Fix invalid and incomplete JavaScript examples across the English and Chinese documentation so the copyable snippets parse and run as shown. This completes missing configuration structure and imports, and corrects syntax and API mistakes without changing the separately identified `__dirname` examples.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).