### PR TITLE
fix(types): align public API docs with declarations

### DIFF
--- a/packages/rspack/src/lib/CacheFacade.ts
+++ b/packages/rspack/src/lib/CacheFacade.ts
@@ -296,8 +296,8 @@ export class CacheFacade {
     identifier: string,
     etag: Etag | null,
     computer: () => Promise<T> | T,
-  ) {
-    const cacheEntry = await this.getPromise(identifier, etag);
+  ): Promise<T> {
+    const cacheEntry = await this.getPromise<T>(identifier, etag);
     if (cacheEntry !== undefined) return cacheEntry;
     const result = await computer();
     await this.storePromise(identifier, etag, result);

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -110,7 +110,7 @@ updateAsset(
   source: Source | ((source: Source) => Source), // the new content or a function returns the new content
   info?:  // the new info or a function returns the new info
     | AssetInfo
-    | ((assetInfo: AssetInfo) => AssetInfo)
+    | ((assetInfo: AssetInfo) => AssetInfo | undefined)
 ): void;
 ```
 
@@ -192,7 +192,7 @@ Get the list of asset objects.
 
 ```ts
 getAssets(): ReadonlyArray<{
-  filename: string;
+  name: string;
   source: Source;
   info: AssetInfo;
 }>;
@@ -236,9 +236,9 @@ Get the asset object with the specified name.
 
 ```ts
 getAsset(
-  filename: string // filename of the getting asset
+  name: string // name of the asset
 ): Readonly<{
-  filename: string;
+  name: string;
   source: Source;
   info: AssetInfo;
 }> | void;

--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -6,7 +6,7 @@ import StatsType from '../../types/stats.mdx';
 import CompilerType from '../../types/compiler.mdx';
 import LoggerType from '../../types/logger.mdx';
 import CacheType from '../../types/cache.mdx';
-import ChunkType from '../../types/cache.mdx';
+import ChunkType from '../../types/chunk.mdx';
 import InputFileSystemType from '../../types/input-file-system.mdx';
 import OutputFileSystemType from '../../types/output-file-system.mdx';
 import WatchFileSystemType from '../../types/watch-file-system.mdx';

--- a/website/docs/en/types/asset-info.mdx
+++ b/website/docs/en/types/asset-info.mdx
@@ -2,18 +2,21 @@
 
 ```ts
 type AssetInfo = {
-  immutable: boolean;
-  minimized: boolean;
-  fullhash: Array<string>;
-  chunkhash: Array<string>;
-  contenthash: Array<string>;
+  immutable?: boolean;
+  minimized?: boolean;
+  fullhash?: string | Array<string>;
+  chunkhash?: string | Array<string>;
+  contenthash?: string | Array<string>;
   sourceFilename?: string;
-  development: boolean;
-  hotModuleReplacement: boolean;
+  copied?: boolean;
+  development?: boolean;
+  hotModuleReplacement?: boolean;
   javascriptModule?: boolean;
-  related: JsAssetInfoRelated;
+  related?: AssetInfoRelated;
   cssUnusedIdents?: Array<string>;
-};
+  isOverSizeLimit?: boolean;
+  assetType?: string;
+} & Record<string, any>;
 ```
 
 </>

--- a/website/docs/en/types/asset.mdx
+++ b/website/docs/en/types/asset.mdx
@@ -2,7 +2,7 @@
 
 ```ts
 type Asset = {
-  filename: string;
+  name: string;
   source: Source;
   info: AssetInfo;
 };

--- a/website/docs/en/types/cache.mdx
+++ b/website/docs/en/types/cache.mdx
@@ -3,40 +3,58 @@
 > See [cache object](/api/javascript-api/cache) for more details.
 
 ```ts
+type CallbackCache<T> = (error?: WebpackError | null, result?: T) => void;
+
 type CacheFacade = {
-  getChildCache(name: string): CacheFacade; // create a named child cache object
-  getItemCache(identifier, etag): ItemCacheFacade; // create a cache object for an data item
-  getLazyHashedEtag(obj: HashableObject): Etag; // create a lazy computed etag
-  mergeEtags(a: Etag, b: Etag): Etag; // merge two etags
-  get<T>( // async data getter, callback by function
+  // Returns a child cache scoped by `name`.
+  getChildCache(name: string): CacheFacade;
+
+  // Returns an item cache scoped by `identifier` and `etag`.
+  getItemCache(identifier: string, etag: Etag | null): ItemCacheFacade;
+
+  // Creates a lazily computed ETag for a hashable object.
+  getLazyHashedEtag(obj: HashableObject): Etag;
+
+  // Combines two ETags into one.
+  mergeEtags(a: Etag, b: Etag): Etag;
+
+  // Reads a cached value; a cache miss yields `undefined` in the callback.
+  get<T>(
     identifier: string,
-    etag: Etag,
-    callback: (err: Error, result: T) => void,
+    etag: Etag | null,
+    callback: CallbackCache<T>,
   ): void;
-  getPromise<T>( // async data getter, callback by promise
+
+  // Reads a cached value; resolves to `undefined` on a cache miss.
+  getPromise<T>(identifier: string, etag: Etag | null): Promise<T | undefined>;
+
+  // Stores a value and reports completion through a callback.
+  store<T>(
     identifier: string,
-    etag: Etag,
-  ): Promise<T>;
-  store<T>( // async data setter, callback by function
-    identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     data: T,
-    callback: (err: Error) => void,
+    callback: CallbackCache<void>,
   ): void;
-  storePromise<T>( // async data setter, callback by promise
+
+  // Stores a value and resolves when the write completes.
+  storePromise<T>(
     identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     data: T,
   ): Promise<void>;
-  provide<T>( // try to get the data, use function to compute if not exists, callback by function
+
+  // Reads a cached value; on a miss, invokes the callback-based `computer` and stores its result.
+  provide<T>(
     identifier: string,
-    etag: Etag,
-    computer: () => T | Promise<T>,
-    callback: (err: Error, result: T) => void,
+    etag: Etag | null,
+    computer: (callback: CallbackCache<T>) => void,
+    callback: CallbackCache<T>,
   ): void;
-  providePromise<T>( // try to get the data, use function to compute if not exists, callback by function
+
+  // Reads a cached value; on a miss, invokes `computer`, stores its result, and resolves with it.
+  providePromise<T>(
     identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     computer: () => T | Promise<T>,
   ): Promise<T>;
 };

--- a/website/docs/en/types/compilation.mdx
+++ b/website/docs/en/types/compilation.mdx
@@ -4,31 +4,43 @@
 
 ```ts
 type Compilation = {
-  emitAsset(): void; // add a new asset
-  updateAsset(): void; // update content of the asset
-  renameAsset(): void; // rename the asset
-  deleteAsset(): void; // delete an existing asset
-  getAssets(): Asset[]; // get all assets
-  getAsset(): Asset; // get asset from name
-  getPath(): string; // generate path from template
-  getPathWithInfo(): PathWithInfo; // generate path and asset info from template
+  emitAsset(filename: string, source: Source, assetInfo?: AssetInfo): void; // add a new asset
+  updateAsset(
+    filename: string,
+    newSourceOrFunction: Source | ((source: Source) => Source),
+    assetInfoUpdateOrFunction?:
+      AssetInfo | ((assetInfo: AssetInfo) => AssetInfo | undefined),
+  ): void; // update content of the asset
+  renameAsset(filename: string, newFilename: string): void; // rename the asset
+  deleteAsset(filename: string): void; // delete an existing asset
+  getAssets(): readonly Asset[]; // get all assets
+  getAsset(name: string): Readonly<Asset> | void; // get asset from name
+  getPath(filename: string, data?: PathData): string; // generate path from template
+  getPathWithInfo(filename: string, data?: PathData): PathWithInfo; // generate path and asset info from template
   getStats(): Stats; // get stats object
-  createChildCompiler(): Compiler; // create a child compiler
-  rebuildModule(): void; // run module.build again
-  getLogger(): Logger; // get compilation related logger object
-  getCache(): CacheFacade; // get compilation related cache object
+  createChildCompiler(
+    name: string,
+    outputOptions: OutputNormalized,
+    plugins: RspackPluginInstance[],
+  ): Compiler; // create a child compiler
+  rebuildModule(
+    module: Module,
+    callback: (error: Error | null, module: Module | null) => void,
+  ): void; // run module.build again
+  getLogger(name: string | (() => string)): Logger; // get compilation related logger object
+  getCache(name: string): CacheFacade; // get compilation related cache object
   options: RspackOptionsNormalized; // the compiler options
   compiler: Compiler; // current compiler
-  hooks: CompilationHooks; // hooks of compilation
-  hash: string | null; // hash of this compilation
-  fullhash: string | null; // same as 'hash'
-  assets: Record<string, Source>; // mapping from filename to asset content
-  chunkGroups: ChunkGroup[]; // list of chunk groups
-  entrypoints: Map<string, Entrypoint>; // mapping from name to entrypoint
-  namedChunkGroups: Map<string, ChunkGroup>; // mapping named chunk groups
-  modules: Set<Module>; // set of all modules
-  chunks: Set<Chunk>; // set of all chunks
-  namedChunks: Map<string, Chunk>; // mapping of named chunks
+  hooks: Readonly<CompilationHooks>; // hooks of compilation
+  readonly hash: string | null; // hash of this compilation
+  readonly fullHash: string | null; // same as 'hash'
+  readonly assets: Record<string, Source>; // mapping from filename to asset content
+  readonly chunkGroups: readonly ChunkGroup[]; // list of chunk groups
+  readonly entrypoints: ReadonlyMap<string, Entrypoint>; // mapping from name to entrypoint
+  readonly namedChunkGroups: ReadonlyMap<string, Readonly<ChunkGroup>>; // mapping named chunk groups
+  readonly modules: ReadonlySet<Module>; // set of all modules
+  readonly chunks: ReadonlySet<Chunk>; // set of all chunks
+  readonly namedChunks: ReadonlyMap<string, Readonly<Chunk>>; // mapping of named chunks
   fileDependencies: CompilationDependencies; // dependent files
   contextDependencies: CompilationDependencies; // dependent directories
   missingDependencies: CompilationDependencies; // dependent missing files

--- a/website/docs/en/types/compiler.mdx
+++ b/website/docs/en/types/compiler.mdx
@@ -7,7 +7,7 @@ type Compiler = {
   outputFileSystem: OutputFileSystem | null;
   watchFileSystem: WatchFileSystem | null;
   options: RspackOptionsNormalized;
-  watching: Watching;
+  watching?: Watching;
   target: {
     esVersion?: number | null;
     targets?: Record<string, string> | null;
@@ -18,7 +18,13 @@ type Compiler = {
     watchOptions: Watchpack.WatchOptions,
     handler: liteTapable.Callback<Error, Stats>,
   ): Watching;
-  run(callback: liteTapable.Callback<Error, Stats>): void;
+  run(
+    callback: liteTapable.Callback<Error, Stats>,
+    options?: {
+      modifiedFiles?: ReadonlySet<string>;
+      removedFiles?: ReadonlySet<string>;
+    },
+  ): void;
   runAsChild(
     callback: (
       err?: null | Error,

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -110,7 +110,7 @@ updateAsset(
   source: Source | ((source: Source) => Source), // 变更后的产物内容 或 产物内容获取函数
   info?: // 变更后的产物信息 或 产物信息获取函数
     | AssetInfo
-    | ((assetInfo: AssetInfo) => AssetInfo)
+    | ((assetInfo: AssetInfo) => AssetInfo | undefined)
 ): void;
 ```
 
@@ -192,7 +192,7 @@ compiler.hooks.thisCompilation.tap('MyPlugin', (compilation) => {
 
 ```ts
 getAssets(): ReadonlyArray<{
-  filename: string; // 产物文件名
+  name: string; // 产物文件名
   source: Source; // 产物内容
   info: AssetInfo; // 产物信息
 }>;
@@ -236,9 +236,9 @@ compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
 
 ```ts
 getAsset(
-  filename: string // 产物文件名
+  name: string // 产物文件名
 ): Readonly<{
-  filename: string; // 产物文件名
+  name: string; // 产物文件名
   source: Source; // 产物内容
   info: AssetInfo; // 产物信息
 }> | void;

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -6,7 +6,7 @@ import StatsType from '../../types/stats.mdx';
 import CompilerType from '../../types/compiler.mdx';
 import LoggerType from '../../types/logger.mdx';
 import CacheType from '../../types/cache.mdx';
-import ChunkType from '../../types/cache.mdx';
+import ChunkType from '../../types/chunk.mdx';
 import InputFileSystemType from '../../types/input-file-system.mdx';
 import OutputFileSystemType from '../../types/output-file-system.mdx';
 import WatchFileSystemType from '../../types/watch-file-system.mdx';

--- a/website/docs/zh/types/asset-info.mdx
+++ b/website/docs/zh/types/asset-info.mdx
@@ -2,18 +2,21 @@
 
 ```ts
 type AssetInfo = {
-  immutable: boolean;
-  minimized: boolean;
-  fullhash: Array<string>;
-  chunkhash: Array<string>;
-  contenthash: Array<string>;
+  immutable?: boolean;
+  minimized?: boolean;
+  fullhash?: string | Array<string>;
+  chunkhash?: string | Array<string>;
+  contenthash?: string | Array<string>;
   sourceFilename?: string;
-  development: boolean;
-  hotModuleReplacement: boolean;
+  copied?: boolean;
+  development?: boolean;
+  hotModuleReplacement?: boolean;
   javascriptModule?: boolean;
-  related: JsAssetInfoRelated;
+  related?: AssetInfoRelated;
   cssUnusedIdents?: Array<string>;
-};
+  isOverSizeLimit?: boolean;
+  assetType?: string;
+} & Record<string, any>;
 ```
 
 </>

--- a/website/docs/zh/types/asset.mdx
+++ b/website/docs/zh/types/asset.mdx
@@ -2,7 +2,7 @@
 
 ```ts
 type Asset = {
-  filename: string; // 产物文件名
+  name: string; // 产物文件名
   source: Source; // 产物内容
   info: AssetInfo; // 产物信息
 };

--- a/website/docs/zh/types/cache.mdx
+++ b/website/docs/zh/types/cache.mdx
@@ -3,40 +3,58 @@
 > 详见 [Cache 对象](/api/javascript-api/cache)
 
 ```ts
+type CallbackCache<T> = (error?: WebpackError | null, result?: T) => void;
+
 type CacheFacade = {
-  getChildCache(name: string): CacheFacade; // 创建子缓存对象
-  getItemCache(identifier, etag): ItemCacheFacade; // 获取单个项目的缓存对象
-  getLazyHashedEtag(obj: HashableObject): Etag; // 生成 Etag
-  mergeEtags(a: Etag, b: Etag): Etag; // 合并 Etag
-  get<T>( // 异步获取缓存数据，通过回调获取结果
+  // 返回一个以 `name` 为作用域的子缓存对象。
+  getChildCache(name: string): CacheFacade;
+
+  // 返回一个以 `identifier` 和 `etag` 为作用域的条目缓存对象。
+  getItemCache(identifier: string, etag: Etag | null): ItemCacheFacade;
+
+  // 为可哈希对象创建延迟计算的 ETag。
+  getLazyHashedEtag(obj: HashableObject): Etag;
+
+  // 将两个 ETag 合并为一个。
+  mergeEtags(a: Etag, b: Etag): Etag;
+
+  // 读取缓存值；缓存未命中时，回调中的结果为 `undefined`。
+  get<T>(
     identifier: string,
-    etag: Etag,
-    callback: (err: Error, result: T) => void,
+    etag: Etag | null,
+    callback: CallbackCache<T>,
   ): void;
-  getPromise<T>( // 异步获取缓存数据，通过 Promise 获取结果
+
+  // 读取缓存值；缓存未命中时，返回的 Promise 会 resolve 为 `undefined`。
+  getPromise<T>(identifier: string, etag: Etag | null): Promise<T | undefined>;
+
+  // 存储缓存值，并通过回调通知操作完成。
+  store<T>(
     identifier: string,
-    etag: Etag,
-  ): Promise<T>;
-  store<T>( // 异步存储缓存数据，通过回调获取结果
-    identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     data: T,
-    callback: (err: Error) => void,
+    callback: CallbackCache<void>,
   ): void;
-  storePromise<T>( // 异步存储缓存数据，通过 Promise 获取结果
+
+  // 存储缓存值；写入完成后，返回的 Promise 会 resolve。
+  storePromise<T>(
     identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     data: T,
   ): Promise<void>;
-  provide<T>( // 尝试获取缓存，不存在则生成并存储，通过回调获取结果
+
+  // 读取缓存值；缓存未命中时，调用回调式 `computer` 计算并存储结果。
+  provide<T>(
     identifier: string,
-    etag: Etag,
-    computer: () => T | Promise<T>,
-    callback: (err: Error, result: T) => void,
+    etag: Etag | null,
+    computer: (callback: CallbackCache<T>) => void,
+    callback: CallbackCache<T>,
   ): void;
-  providePromise<T>( // 尝试获取缓存，不存在则生成并存储，通过 Promise 获取结果
+
+  // 读取缓存值；缓存未命中时，调用 `computer` 计算并存储结果，再通过 Promise 返回该结果。
+  providePromise<T>(
     identifier: string,
-    etag: Etag,
+    etag: Etag | null,
     computer: () => T | Promise<T>,
   ): Promise<T>;
 };

--- a/website/docs/zh/types/compilation.mdx
+++ b/website/docs/zh/types/compilation.mdx
@@ -4,31 +4,43 @@
 
 ```ts
 type Compilation = {
-  emitAsset(): void; // 添加产物
-  updateAsset(): void; // 变更产物内容
-  renameAsset(): void; // 更改产物名称
-  deleteAsset(): void; // 移除产物
-  getAssets(): Asset[]; // 获得所有产物信息
-  getAsset(): Asset; // 获得产物信息
-  getPath(): string; // 从模板生成路径
-  getPathWithInfo(): PathWithInfo; // 从模板生成路径和资源信息
+  emitAsset(filename: string, source: Source, assetInfo?: AssetInfo): void; // 添加产物
+  updateAsset(
+    filename: string,
+    newSourceOrFunction: Source | ((source: Source) => Source),
+    assetInfoUpdateOrFunction?:
+      AssetInfo | ((assetInfo: AssetInfo) => AssetInfo | undefined),
+  ): void; // 变更产物内容
+  renameAsset(filename: string, newFilename: string): void; // 更改产物名称
+  deleteAsset(filename: string): void; // 移除产物
+  getAssets(): readonly Asset[]; // 获得所有产物信息
+  getAsset(name: string): Readonly<Asset> | void; // 获得产物信息
+  getPath(filename: string, data?: PathData): string; // 从模板生成路径
+  getPathWithInfo(filename: string, data?: PathData): PathWithInfo; // 从模板生成路径和资源信息
   getStats(): Stats; // 获取 stats 对象
-  createChildCompiler(): Compiler; // 创建子编译器
-  rebuildModule(): void; // 重新编译模块
-  getLogger(): Logger; // 获取 Logger 对象
-  getCache(): CacheFacade; // 获取 Cache 对象
+  createChildCompiler(
+    name: string,
+    outputOptions: OutputNormalized,
+    plugins: RspackPluginInstance[],
+  ): Compiler; // 创建子编译器
+  rebuildModule(
+    module: Module,
+    callback: (error: Error | null, module: Module | null) => void,
+  ): void; // 重新编译模块
+  getLogger(name: string | (() => string)): Logger; // 获取 Logger 对象
+  getCache(name: string): CacheFacade; // 获取 Cache 对象
   options: RspackOptionsNormalized; // 完整构建配置
   compiler: Compiler; // 当前编译器
-  hooks: CompilationHooks; // Compilation 钩子
-  hash: string | null; // 本次构建哈希
-  fullhash: string | null; // 等同于 hash
-  assets: Record<string, Source>; // 产物映射表
-  chunkGroups: ChunkGroup[]; // 所有 ChunkGroup 列表
-  entrypoints: Map<string, Entrypoint>; // Entry 对象映射表
-  namedChunkGroups: Map<string, ChunkGroup>; // 名称与 ChunkGroup 映射表
-  modules: Set<Module>; // 所有模块信息
-  chunks: Set<Chunk>; // 所有 Chunk 信息
-  namedChunks: Map<string, Chunk>; // 名称与 Chunk 的映射表
+  hooks: Readonly<CompilationHooks>; // Compilation 钩子
+  readonly hash: string | null; // 本次构建哈希
+  readonly fullHash: string | null; // 等同于 hash
+  readonly assets: Record<string, Source>; // 产物映射表
+  readonly chunkGroups: readonly ChunkGroup[]; // 所有 ChunkGroup 列表
+  readonly entrypoints: ReadonlyMap<string, Entrypoint>; // Entry 对象映射表
+  readonly namedChunkGroups: ReadonlyMap<string, Readonly<ChunkGroup>>; // 名称与 ChunkGroup 映射表
+  readonly modules: ReadonlySet<Module>; // 所有模块信息
+  readonly chunks: ReadonlySet<Chunk>; // 所有 Chunk 信息
+  readonly namedChunks: ReadonlyMap<string, Readonly<Chunk>>; // 名称与 Chunk 的映射表
   fileDependencies: CompilationDependencies; // 本地文件依赖
   contextDependencies: CompilationDependencies; // 本地目录依赖
   missingDependencies: CompilationDependencies; // 缺失文件依赖

--- a/website/docs/zh/types/compiler.mdx
+++ b/website/docs/zh/types/compiler.mdx
@@ -7,7 +7,7 @@ type Compiler = {
   outputFileSystem: OutputFileSystem | null;
   watchFileSystem: WatchFileSystem | null;
   options: RspackOptionsNormalized;
-  watching: Watching;
+  watching?: Watching;
   target: {
     esVersion?: number | null;
     targets?: Record<string, string> | null;
@@ -18,7 +18,13 @@ type Compiler = {
     watchOptions: Watchpack.WatchOptions,
     handler: liteTapable.Callback<Error, Stats>,
   ): Watching;
-  run(callback: liteTapable.Callback<Error, Stats>): void;
+  run(
+    callback: liteTapable.Callback<Error, Stats>,
+    options?: {
+      modifiedFiles?: ReadonlySet<string>;
+      removedFiles?: ReadonlySet<string>;
+    },
+  ): void;
   runAsChild(
     callback: (
       err?: null | Error,


### PR DESCRIPTION
## Summary

This PR corrects outdated public API type snippets for assets, compilation, compiler, and cache APIs so the English and Chinese documentation matches the emitted declarations. It also fixes `CacheFacade.providePromise` inference to keep its public return type as `Promise<T>` and preserves clearer cache method comments.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).