### PR TITLE
chore: document memory profiling workflows

### DIFF
--- a/website/docs/en/contribute/development/profiling.md
+++ b/website/docs/en/contribute/development/profiling.md
@@ -88,7 +88,7 @@ heaptrack_gui ./rspack-heaptrack.gz
 
 The exact output filename is printed when Heaptrack exits. `--record-only` prevents Heaptrack from trying to open the GUI automatically, which is useful in WSL, containers, and remote shells.
 
-The system allocator used by `@rspack-debug/core` allows Heaptrack to capture Rspack and SWC allocations. The regular release package uses mimalloc and bypasses the system allocator hooks, so its Rust allocation data is incomplete. Depending on the Heaptrack version, the GUI may show Rust v0 symbol names beginning with `_R` instead of demangled names; this affects display only, not the recorded stacks. For a demangled text report, install [`rustfilt`](https://github.com/luser/rustfilt) and pipe the output through it:
+The system allocator used by `@rspack-debug/core` allows Heaptrack to capture allocations from the Rspack native binding. The regular release package uses mimalloc and bypasses the system allocator hooks, so its Rust allocation data is incomplete. Depending on the Heaptrack version, the GUI may show Rust v0 symbol names beginning with `_R` instead of demangled names; this affects display only, not the recorded stacks. For a demangled text report, install [`rustfilt`](https://github.com/luser/rustfilt) and pipe the output through it:
 
 ```sh
 heaptrack_print ./rspack-heaptrack.gz | rustfilt | less

--- a/website/docs/en/contribute/development/profiling.md
+++ b/website/docs/en/contribute/development/profiling.md
@@ -40,15 +40,26 @@ pnpm install
 
 ## Memory profiling
 
-Memory profilers observe allocations at the allocator boundary. The regular Rspack release binding uses mimalloc, while `@rspack-debug/core` and a local `release-debug` binding use the system allocator. Use the debug binding when collecting Heaptrack data or dynamically injecting jemalloc.
+Memory profilers observe allocations at the allocator boundary. The regular Rspack release package uses mimalloc, while `@rspack-debug/core` uses the system allocator. Use `@rspack-debug/core` when collecting Heaptrack data or dynamically injecting jemalloc.
 
-For a local Rspack checkout, build the debug binding with:
+In the project you want to profile, override `@rspack/core` with the same version of `@rspack-debug/core` as described in [Debugging](/contribute/development/debugging#using-rspack-debugcore), then reinstall the dependencies. For example, if the project uses `@rspack/core@2.1.0` with pnpm:
 
-```sh
-pnpm build:binding:debug
+```json title="package.json"
+{
+  "pnpm": {
+    "overrides": {
+      "@rspack/core": "npm:@rspack-debug/core@2.1.0"
+    },
+    "peerDependencyRules": {
+      "allowAny": ["@rspack/*"]
+    }
+  }
+}
 ```
 
-To profile an existing project, override `@rspack/core` with the matching version of `@rspack-debug/core` as described in [Debugging](/contribute/development/debugging#using-rspack-debugcore), and reinstall the dependencies.
+```sh
+pnpm install
+```
 
 | Profiler           | Output   | Analyzer                           | Best used for                                      |
 | ------------------ | -------- | ---------------------------------- | -------------------------------------------------- |
@@ -77,7 +88,7 @@ heaptrack_gui ./rspack-heaptrack.gz
 
 The exact output filename is printed when Heaptrack exits. `--record-only` prevents Heaptrack from trying to open the GUI automatically, which is useful in WSL, containers, and remote shells.
 
-The debug binding's system allocator allows Heaptrack to capture Rspack and SWC allocations. A regular release binding uses mimalloc and bypasses the system allocator hooks, so its Rust allocation data is incomplete. Depending on the Heaptrack version, the GUI may show Rust v0 symbol names beginning with `_R` instead of demangled names; this affects display only, not the recorded stacks. For a demangled text report, install [`rustfilt`](https://github.com/luser/rustfilt) and pipe the output through it:
+The system allocator used by `@rspack-debug/core` allows Heaptrack to capture Rspack and SWC allocations. The regular release package uses mimalloc and bypasses the system allocator hooks, so its Rust allocation data is incomplete. Depending on the Heaptrack version, the GUI may show Rust v0 symbol names beginning with `_R` instead of demangled names; this affects display only, not the recorded stacks. For a demangled text report, install [`rustfilt`](https://github.com/luser/rustfilt) and pipe the output through it:
 
 ```sh
 heaptrack_print ./rspack-heaptrack.gz | rustfilt | less
@@ -163,7 +174,7 @@ Node.js currently only supports `--perf-prof` on Linux platforms. JavaScript pro
 
 Rspack’s JavaScript typically runs in the Node.js thread. Select the Node.js thread to view the time distribution on the Node.js side.
 
-![JavaScript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
+![Javascript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
 
 #### Rust profiling
 

--- a/website/docs/en/contribute/development/profiling.md
+++ b/website/docs/en/contribute/development/profiling.md
@@ -38,6 +38,109 @@ pnpm build:binding:profiling
 pnpm install
 ```
 
+## Memory profiling
+
+Memory profilers observe allocations at the allocator boundary. The regular Rspack release binding uses mimalloc, while `@rspack-debug/core` and a local `release-debug` binding use the system allocator. Use the debug binding when collecting Heaptrack data or dynamically injecting jemalloc.
+
+For a local Rspack checkout, build the debug binding with:
+
+```sh
+pnpm build:binding:debug
+```
+
+To profile an existing project, override `@rspack/core` with the matching version of `@rspack-debug/core` as described in [Debugging](/contribute/development/debugging#using-rspack-debugcore), and reinstall the dependencies.
+
+| Profiler           | Output   | Analyzer                           | Best used for                                      |
+| ------------------ | -------- | ---------------------------------- | -------------------------------------------------- |
+| Heaptrack          | `*.gz`   | `heaptrack_print`, `heaptrack_gui` | Allocation call stacks and temporary allocations   |
+| jemalloc profiling | `*.heap` | `jeprof`                           | Live memory and cumulative allocation flame graphs |
+
+:::warning
+Heaptrack and jemalloc use different data formats. `jeprof` cannot read a Heaptrack data file. Do not enable Heaptrack and jemalloc profiling in the same run.
+:::
+
+### Heaptrack
+
+[Heaptrack](https://github.com/KDE/heaptrack) intercepts system allocator calls and records allocation call stacks. Install it using your Linux distribution's package manager, then run the build under Heaptrack:
+
+```sh
+heaptrack --record-only -o ./rspack-heaptrack \
+  node ./node_modules/@rspack/cli/bin/rspack.js build
+```
+
+Inspect the generated file from the terminal or GUI:
+
+```sh
+heaptrack_print ./rspack-heaptrack.gz | less
+heaptrack_gui ./rspack-heaptrack.gz
+```
+
+The exact output filename is printed when Heaptrack exits. `--record-only` prevents Heaptrack from trying to open the GUI automatically, which is useful in WSL, containers, and remote shells.
+
+The debug binding's system allocator allows Heaptrack to capture Rspack and SWC allocations. A regular release binding uses mimalloc and bypasses the system allocator hooks, so its Rust allocation data is incomplete. Depending on the Heaptrack version, the GUI may show Rust v0 symbol names beginning with `_R` instead of demangled names; this affects display only, not the recorded stacks. For a demangled text report, install [`rustfilt`](https://github.com/luser/rustfilt) and pipe the output through it:
+
+```sh
+heaptrack_print ./rspack-heaptrack.gz | rustfilt | less
+```
+
+### jemalloc profiling
+
+On Linux, a build that uses the system allocator can be redirected to a profiling-enabled shared jemalloc with `LD_PRELOAD`. Install jemalloc, `jeprof`, and Graphviz using your distribution's packages. On Debian or Ubuntu, the shared library is provided by `libjemalloc2`; the development package commonly provides the profiling tools.
+
+For example, on Debian or Ubuntu:
+
+```sh
+sudo apt install heaptrack libjemalloc-dev graphviz
+```
+
+Locate the installed library and collect profiles:
+
+```sh
+mkdir -p /tmp/rspack-jemalloc
+JEMALLOC=$(ldconfig -p | awk '/libjemalloc.so.2/{print $NF; exit}')
+
+MALLOC_CONF='prof:true,prof_active:true,prof_final:true,lg_prof_sample:19,lg_prof_interval:26,prof_prefix:/tmp/rspack-jemalloc/rspack' \
+  LD_PRELOAD="$JEMALLOC" \
+  node ./node_modules/@rspack/cli/bin/rspack.js build
+```
+
+The important options are:
+
+- `prof:true` enables profiling.
+- `prof_active:true` starts sampling immediately.
+- `prof_final:true` writes a final dump when the process exits.
+- `lg_prof_sample:19` samples approximately every 512 KiB of allocations.
+- `lg_prof_interval:26` writes a dump after approximately every 64 MiB of allocation activity.
+- `prof_prefix` controls where profile files are written.
+
+Find the native Rspack binding loaded by the project:
+
+```sh
+RSPACK_BINDING=$(node -e 'require("@rspack/core"); const binding = Object.keys(require.cache).find(file => /rspack\..+\.node$/.test(file)); if (!binding) throw new Error("Rspack native binding not found"); process.stdout.write(binding)')
+PROFILE=$(ls -t /tmp/rspack-jemalloc/rspack.*.heap | head -n 1)
+```
+
+Generate an SVG for a selected dump and open it in a browser:
+
+```sh
+jeprof --show_bytes --functions --svg \
+  "$RSPACK_BINDING" \
+  "$PROFILE" \
+  > rspack-memory.svg
+```
+
+For a text report sorted by cumulative memory:
+
+```sh
+jeprof --show_bytes --functions --text --cum \
+  "$RSPACK_BINDING" \
+  "$PROFILE"
+```
+
+The default `inuse_space` report describes memory that was live when the dump was written. To investigate allocation traffic, add `prof_accum:true` to `MALLOC_CONF` and pass `--alloc_space` to `jeprof`. Cumulative allocated bytes are not peak memory.
+
+jemalloc only reports allocations routed through jemalloc. Node.js, V8, native libraries, memory mappings, and profiler metadata can also contribute to process RSS. Compare the profile with `/usr/bin/time -v` when investigating total or peak process memory.
+
 ## CPU profiling
 
 ### Samply
@@ -60,7 +163,7 @@ Node.js currently only supports `--perf-prof` on Linux platforms. JavaScript pro
 
 Rspack’s JavaScript typically runs in the Node.js thread. Select the Node.js thread to view the time distribution on the Node.js side.
 
-![Javascript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
+![JavaScript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
 
 #### Rust profiling
 

--- a/website/docs/zh/contribute/development/profiling.md
+++ b/website/docs/zh/contribute/development/profiling.md
@@ -19,7 +19,7 @@ description: '性能分析应基于包含调试信息的发布版本进行。这
 1. 构建带有调试信息的发布版本：
 
 ```sh
-just build release-debug
+pnpm build:binding:profiling
 ```
 
 2. 更改 `@rspack/core` 和 `@rspack/cli`，使用 `link` 协议链接到本地​​构建的 Rspack：
@@ -40,6 +40,109 @@ just build release-debug
 pnpm install
 ```
 
+## 内存分析
+
+内存分析器在 allocator 边界记录分配。Rspack 的常规 release binding 使用 mimalloc，而 `@rspack-debug/core` 和本地 `release-debug` binding 使用 system allocator。采集 Heaptrack 数据或动态注入 jemalloc 时，应使用 debug binding。
+
+在本地 Rspack 仓库中执行以下命令构建 debug binding：
+
+```sh
+pnpm build:binding:debug
+```
+
+分析现有项目时，按照[调试文档](/contribute/development/debugging#使用-rspack-debugcore)将 `@rspack/core` override 为相同版本的 `@rspack-debug/core`，然后重新安装依赖。
+
+| 分析器             | 输出格式 | 分析工具                           | 适用场景                 |
+| ------------------ | -------- | ---------------------------------- | ------------------------ |
+| Heaptrack          | `*.gz`   | `heaptrack_print`、`heaptrack_gui` | 分配调用栈和临时分配     |
+| jemalloc profiling | `*.heap` | `jeprof`                           | 存活内存和累计分配火焰图 |
+
+:::warning
+Heaptrack 和 jemalloc 使用不同的数据格式，`jeprof` 无法读取 Heaptrack 数据。不要在同一次运行中同时启用 Heaptrack 和 jemalloc profiling。
+:::
+
+### Heaptrack
+
+[Heaptrack](https://github.com/KDE/heaptrack) 通过拦截 system allocator 调用记录分配调用栈。使用 Linux 发行版的包管理器安装 Heaptrack，然后执行：
+
+```sh
+heaptrack --record-only -o ./rspack-heaptrack \
+  node ./node_modules/@rspack/cli/bin/rspack.js build
+```
+
+可以在终端或 GUI 中分析生成的数据：
+
+```sh
+heaptrack_print ./rspack-heaptrack.gz | less
+heaptrack_gui ./rspack-heaptrack.gz
+```
+
+Heaptrack 退出时会打印实际的输出文件名。`--record-only` 可以避免自动打开 GUI，适合 WSL、容器和远程终端。
+
+debug binding 使用 system allocator，因此 Heaptrack 能够采集 Rspack 和 SWC 的分配。常规 release binding 使用 mimalloc，会绕过 system allocator 的拦截点，因此其中的 Rust 分配数据不完整。根据 Heaptrack 版本不同，GUI 可能显示以 `_R` 开头的 Rust v0 mangled 符号，而不是 demangle 后的名称；这只影响展示，不影响已记录的调用栈。如需生成 demangle 后的文本报告，可以安装 [`rustfilt`](https://github.com/luser/rustfilt) 并执行：
+
+```sh
+heaptrack_print ./rspack-heaptrack.gz | rustfilt | less
+```
+
+### jemalloc profiling
+
+在 Linux 上，可以通过 `LD_PRELOAD` 将使用 system allocator 的构建重定向到启用了 profiling 的 jemalloc 动态库。请使用发行版的软件包安装 jemalloc、`jeprof` 和 Graphviz。在 Debian 或 Ubuntu 中，`libjemalloc2` 提供动态库，开发包通常会提供 profiling 工具。
+
+例如，在 Debian 或 Ubuntu 中执行：
+
+```sh
+sudo apt install heaptrack libjemalloc-dev graphviz
+```
+
+定位动态库并采集 profile：
+
+```sh
+mkdir -p /tmp/rspack-jemalloc
+JEMALLOC=$(ldconfig -p | awk '/libjemalloc.so.2/{print $NF; exit}')
+
+MALLOC_CONF='prof:true,prof_active:true,prof_final:true,lg_prof_sample:19,lg_prof_interval:26,prof_prefix:/tmp/rspack-jemalloc/rspack' \
+  LD_PRELOAD="$JEMALLOC" \
+  node ./node_modules/@rspack/cli/bin/rspack.js build
+```
+
+主要配置项如下：
+
+- `prof:true`：启用 profiling。
+- `prof_active:true`：进程启动后立即开始采样。
+- `prof_final:true`：进程退出时写入最终 dump。
+- `lg_prof_sample:19`：大约每分配 512 KiB 采样一次。
+- `lg_prof_interval:26`：每产生大约 64 MiB 分配活动写入一次 dump。
+- `prof_prefix`：指定 profile 文件的输出位置。
+
+查找项目实际加载的 Rspack native binding：
+
+```sh
+RSPACK_BINDING=$(node -e 'require("@rspack/core"); const binding = Object.keys(require.cache).find(file => /rspack\..+\.node$/.test(file)); if (!binding) throw new Error("Rspack native binding not found"); process.stdout.write(binding)')
+PROFILE=$(ls -t /tmp/rspack-jemalloc/rspack.*.heap | head -n 1)
+```
+
+选择一个 dump 并生成 SVG，然后使用浏览器打开：
+
+```sh
+jeprof --show_bytes --functions --svg \
+  "$RSPACK_BINDING" \
+  "$PROFILE" \
+  > rspack-memory.svg
+```
+
+生成按累计内存排序的文本报告：
+
+```sh
+jeprof --show_bytes --functions --text --cum \
+  "$RSPACK_BINDING" \
+  "$PROFILE"
+```
+
+默认的 `inuse_space` 报告表示写入 dump 时仍然存活的内存。分析累计分配流量时，在 `MALLOC_CONF` 中增加 `prof_accum:true`，并向 `jeprof` 传入 `--alloc_space`。累计分配字节数并不等于峰值内存。
+
+jemalloc 只统计经过 jemalloc 的分配。Node.js、V8、其他 native library、内存映射以及 profiler 自身的元数据也会占用进程 RSS。分析总内存或峰值内存时，应同时使用 `/usr/bin/time -v` 对照进程级数据。
+
 ## CPU profiling
 
 ### Samply
@@ -55,14 +158,14 @@ samply record -- node --perf-prof --perf-basic-prof --interpreted-frames-native-
 - 命令执行完毕后会自动在 [Firefox profiler](https://profiler.firefox.com/) 打开分析结果，如下截图来自 [Samply profiler](https://profiler.firefox.com/public/5fkasm1wcddddas3amgys3eg6sbp70n82q6gn1g/calltree/?globalTrackOrder=0&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F2fjyrylqc9ifil3s7ppsmbwm6lfd3p9gddnqgx1&thread=2&v=10)。
 
 :::warning
-Node.js 目前仅在 Linux 平台支持 `--perf-prof`，而 Samply 里的 JavaScript Profiling 依赖 `--perf-prof`的支持，如果你需要在其他平台使用 Samply 进行 JavaScript Profiling，可以选择使用 docker 里进行 profiling，或者可以基于 [node-perf-maps](https://github.com/tmm1/node/tree/v8-perf-maps) 自行在 macOs 平台编译 Node.js 用于 profiling。
+Node.js 目前仅在 Linux 平台支持 `--perf-prof`，而 Samply 里的 JavaScript Profiling 依赖 `--perf-prof`的支持，如果你需要在其他平台使用 Samply 进行 JavaScript Profiling，可以选择使用 docker 里进行 profiling，或者可以基于 [node-perf-maps](https://github.com/tmm1/node/tree/v8-perf-maps) 自行在 macOS 平台编译 Node.js 用于 profiling。
 :::
 
 #### JavaScript profiler
 
 Rspack 的 JavaScript 代码通常执行在 Node.js 线程里，选择 Node.js 线程查看 Node.js 侧的耗时分布。
 
-![Javascript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
+![JavaScript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
 
 #### Rust profiler
 

--- a/website/docs/zh/contribute/development/profiling.md
+++ b/website/docs/zh/contribute/development/profiling.md
@@ -42,15 +42,26 @@ pnpm install
 
 ## 内存分析
 
-内存分析器在 allocator 边界记录分配。Rspack 的常规 release binding 使用 mimalloc，而 `@rspack-debug/core` 和本地 `release-debug` binding 使用 system allocator。采集 Heaptrack 数据或动态注入 jemalloc 时，应使用 debug binding。
+内存分析器在 allocator 边界记录分配。Rspack 的常规 release 包使用 mimalloc，而 `@rspack-debug/core` 使用 system allocator。采集 Heaptrack 数据或动态注入 jemalloc 时，应使用 `@rspack-debug/core`。
 
-在本地 Rspack 仓库中执行以下命令构建 debug binding：
+在需要分析的项目中，按照[调试文档](/contribute/development/debugging#使用-rspack-debugcore)将 `@rspack/core` override 为相同版本的 `@rspack-debug/core`，然后重新安装依赖。例如，使用 pnpm 的项目依赖 `@rspack/core@2.1.0` 时：
 
-```sh
-pnpm build:binding:debug
+```json title="package.json"
+{
+  "pnpm": {
+    "overrides": {
+      "@rspack/core": "npm:@rspack-debug/core@2.1.0"
+    },
+    "peerDependencyRules": {
+      "allowAny": ["@rspack/*"]
+    }
+  }
+}
 ```
 
-分析现有项目时，按照[调试文档](/contribute/development/debugging#使用-rspack-debugcore)将 `@rspack/core` override 为相同版本的 `@rspack-debug/core`，然后重新安装依赖。
+```sh
+pnpm install
+```
 
 | 分析器             | 输出格式 | 分析工具                           | 适用场景                 |
 | ------------------ | -------- | ---------------------------------- | ------------------------ |
@@ -79,7 +90,7 @@ heaptrack_gui ./rspack-heaptrack.gz
 
 Heaptrack 退出时会打印实际的输出文件名。`--record-only` 可以避免自动打开 GUI，适合 WSL、容器和远程终端。
 
-debug binding 使用 system allocator，因此 Heaptrack 能够采集 Rspack 和 SWC 的分配。常规 release binding 使用 mimalloc，会绕过 system allocator 的拦截点，因此其中的 Rust 分配数据不完整。根据 Heaptrack 版本不同，GUI 可能显示以 `_R` 开头的 Rust v0 mangled 符号，而不是 demangle 后的名称；这只影响展示，不影响已记录的调用栈。如需生成 demangle 后的文本报告，可以安装 [`rustfilt`](https://github.com/luser/rustfilt) 并执行：
+`@rspack-debug/core` 使用 system allocator，因此 Heaptrack 能够采集 Rspack 和 SWC 的分配。常规 release 包使用 mimalloc，会绕过 system allocator 的拦截点，因此其中的 Rust 分配数据不完整。根据 Heaptrack 版本不同，GUI 可能显示以 `_R` 开头的 Rust v0 mangled 符号，而不是 demangle 后的名称；这只影响展示，不影响已记录的调用栈。如需生成 demangle 后的文本报告，可以安装 [`rustfilt`](https://github.com/luser/rustfilt) 并执行：
 
 ```sh
 heaptrack_print ./rspack-heaptrack.gz | rustfilt | less
@@ -158,14 +169,14 @@ samply record -- node --perf-prof --perf-basic-prof --interpreted-frames-native-
 - 命令执行完毕后会自动在 [Firefox profiler](https://profiler.firefox.com/) 打开分析结果，如下截图来自 [Samply profiler](https://profiler.firefox.com/public/5fkasm1wcddddas3amgys3eg6sbp70n82q6gn1g/calltree/?globalTrackOrder=0&symbolServer=http%3A%2F%2F127.0.0.1%3A3000%2F2fjyrylqc9ifil3s7ppsmbwm6lfd3p9gddnqgx1&thread=2&v=10)。
 
 :::warning
-Node.js 目前仅在 Linux 平台支持 `--perf-prof`，而 Samply 里的 JavaScript Profiling 依赖 `--perf-prof`的支持，如果你需要在其他平台使用 Samply 进行 JavaScript Profiling，可以选择使用 docker 里进行 profiling，或者可以基于 [node-perf-maps](https://github.com/tmm1/node/tree/v8-perf-maps) 自行在 macOS 平台编译 Node.js 用于 profiling。
+Node.js 目前仅在 Linux 平台支持 `--perf-prof`，而 Samply 里的 JavaScript Profiling 依赖 `--perf-prof`的支持，如果你需要在其他平台使用 Samply 进行 JavaScript Profiling，可以选择使用 docker 里进行 profiling，或者可以基于 [node-perf-maps](https://github.com/tmm1/node/tree/v8-perf-maps) 自行在 macOs 平台编译 Node.js 用于 profiling。
 :::
 
 #### JavaScript profiler
 
 Rspack 的 JavaScript 代码通常执行在 Node.js 线程里，选择 Node.js 线程查看 Node.js 侧的耗时分布。
 
-![JavaScript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
+![Javascript Profiling](https://assets.rspack.rs/rspack/assets/profiling-javascript.png)
 
 #### Rust profiler
 

--- a/website/docs/zh/contribute/development/profiling.md
+++ b/website/docs/zh/contribute/development/profiling.md
@@ -19,7 +19,7 @@ description: '性能分析应基于包含调试信息的发布版本进行。这
 1. 构建带有调试信息的发布版本：
 
 ```sh
-pnpm build:binding:profiling
+just build release-debug
 ```
 
 2. 更改 `@rspack/core` 和 `@rspack/cli`，使用 `link` 协议链接到本地​​构建的 Rspack：
@@ -90,7 +90,7 @@ heaptrack_gui ./rspack-heaptrack.gz
 
 Heaptrack 退出时会打印实际的输出文件名。`--record-only` 可以避免自动打开 GUI，适合 WSL、容器和远程终端。
 
-`@rspack-debug/core` 使用 system allocator，因此 Heaptrack 能够采集 Rspack 和 SWC 的分配。常规 release 包使用 mimalloc，会绕过 system allocator 的拦截点，因此其中的 Rust 分配数据不完整。根据 Heaptrack 版本不同，GUI 可能显示以 `_R` 开头的 Rust v0 mangled 符号，而不是 demangle 后的名称；这只影响展示，不影响已记录的调用栈。如需生成 demangle 后的文本报告，可以安装 [`rustfilt`](https://github.com/luser/rustfilt) 并执行：
+`@rspack-debug/core` 使用 system allocator，因此 Heaptrack 能够采集 Rspack native binding 的内存分配。常规 release 包使用 mimalloc，会绕过 system allocator 的拦截点，因此其中的 Rust 分配数据不完整。根据 Heaptrack 版本不同，GUI 可能显示以 `_R` 开头的 Rust v0 mangled 符号，而不是 demangle 后的名称；这只影响展示，不影响已记录的调用栈。如需生成 demangle 后的文本报告，可以安装 [`rustfilt`](https://github.com/luser/rustfilt) 并执行：
 
 ```sh
 heaptrack_print ./rspack-heaptrack.gz | rustfilt | less

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -1,5 +1,6 @@
 aarch
 absolutify
+accum
 ahabhgk
 Akait
 alexander-akait
@@ -37,6 +38,8 @@ cssextractrspackplugin
 dail
 darwin
 deconflict
+demangle
+demangled
 devongovett
 devserverdevmiddleware
 devserverhot
@@ -77,9 +80,13 @@ innovatively
 inottn
 intellild
 intlify
+inuse
 IWANABETHATGUY
 jantimon
 JavaScript
+jemalloc
+JEMALLOC
+jeprof
 jerrykingxyz
 Jiahan
 jkzing
@@ -89,6 +96,8 @@ jserfeng
 kaffi
 kuaishou
 Kyrylo
+ldconfig
+libjemalloc
 lightningcss
 Lingyu
 lingyucoder
@@ -181,6 +190,7 @@ ruid
 ruleoneof
 ruleparserdataurlcondition
 Rust
+rustfilt
 rustup
 s390x
 samply


### PR DESCRIPTION
## Summary

- document Heaptrack-based memory profiling for the system-allocator debug binding
- document dynamically injected jemalloc profiling with `LD_PRELOAD`, including `jeprof` text and SVG reports
- clarify allocator coverage, Rust symbol demangling, profile formats, and the difference between live, cumulative, and RSS measurements
- keep the English and Chinese profiling guides aligned

The regular release binding uses mimalloc, so allocator-interposition tools do not capture complete Rust allocation data. The debug binding uses the system allocator and provides the required interception point for both Heaptrack and dynamically injected jemalloc.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15080

## Validation

- `pnpm exec rs fmt --check website/docs/en/contribute/development/profiling.md website/docs/zh/contribute/development/profiling.md`
- `pnpm --dir website exec cspell docs/en/contribute/development/profiling.md docs/zh/contribute/development/profiling.md`
- `pnpm --dir website exec case-police 'docs/{en,zh}/contribute/development/profiling.md'`
- `pnpm --dir website build`

## Checklist

- [x] Tests updated (not required for documentation-only changes).
- [x] Documentation updated.
