### PR TITLE
docs: align more API type docs with declarations

### DIFF
--- a/website/docs/en/types/entrypoint.mdx
+++ b/website/docs/en/types/entrypoint.mdx
@@ -2,19 +2,23 @@
 
 ```ts
 type Entrypoint = {
-  name?: Readonly<string>; // name of this chunk group
-  index?: Readonly<number>; // creating index of chunk group
-  chunks: ReadonlyArray<Chunk>; // chunks in this chunk group
-  origins: ReadonlyArray<{
+  readonly name: string | undefined; // name of this chunk group
+  readonly index: number | undefined; // creating index of chunk group
+  readonly chunks: Chunk[]; // chunks in this chunk group
+  readonly origins: Array<{
     // the origin request of this entrypoint
     module?: Module;
     request?: string;
+    loc?: string | RealDependencyLocation;
   }>;
+  readonly childrenIterable: ChunkGroup[];
   isInitial(): boolean; // whether this chunk group will be loaded on initial page load
-  getFiles(): ReadonlyArray<string>; // the files contained this chunk group
-  getParents(): ReadonlyArray<ChunkGroup>; // returns the parent chunk groups
-  getRuntimeChunk(): Readonly<Chunk | null>; // get the runtime chunk of this entrypoint (runtime chunk refers to a chunk that contains runtime code. Generally, the runtime chunk and the entrypoint chunk are the same chunk. Only when the runtime is split into a separate chunk via `dependOn` or `optimization.runtimeChunk` do they refer to different chunks)
-  getEntrypointChunk(): Readonly<Chunk | null>; // get the entrypoint chunk of this entrypoint (entrypoint chunk refers to a chunk that contains entry modules)
+  getFiles(): string[]; // the files contained this chunk group
+  getParents(): ChunkGroup[]; // returns the parent chunk groups
+  getRuntimeChunk(): Chunk; // get the runtime chunk of this entrypoint (runtime chunk refers to a chunk that contains runtime code. Generally, the runtime chunk and the entrypoint chunk are the same chunk. Only when the runtime is split into a separate chunk via `dependOn` or `optimization.runtimeChunk` do they refer to different chunks)
+  getEntrypointChunk(): Chunk; // get the entrypoint chunk of this entrypoint (entrypoint chunk refers to a chunk that contains entry modules)
+  getModulePreOrderIndex(module: Module): number | null;
+  getModulePostOrderIndex(module: Module): number | null;
 };
 ```
 

--- a/website/docs/en/types/filename.mdx
+++ b/website/docs/en/types/filename.mdx
@@ -1,7 +1,10 @@
 <>
 
 ```ts
-type Filename = string | (data: PathData, info: AssetInfo) => string;
+type FilenameTemplate = string;
+
+type Filename =
+  FilenameTemplate | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 ```
 
 </>

--- a/website/docs/en/types/input-file-system.mdx
+++ b/website/docs/en/types/input-file-system.mdx
@@ -1,24 +1,25 @@
 <>
 
 ```ts
-import fs from 'node:fs';
-
 type InputFileSystem = {
-  readFile: typeof fs.readFile;
-  readFileSync: typeof fs.readFileSync;
-  readlink: typeof fs.readlink;
-  readlinkSync: typeof fs.readlinkSync;
-  readdir: typeof fs.readdir;
-  readdirSync: typeof fs.readdirSync;
-  stat: typeof fs.stat;
-  statSync: typeof fs.statSync;
-  lstat: typeof fs.lstat;
-  lstatSync: typeof fs.lstatSync;
-  realpath: typeof fs.realpath;
-  realpathSync: typeof fs.realpathSync;
-  readJson: typeof fs.readJson;
-  readJsonSync: typeof fs.readJsonSync;
-  purge: (arg0?: (string | string[] | Set<string>) | undefined) => void;
+  readFile: ReadFile;
+  readFileSync?: ReadFileSync;
+  readlink: Readlink;
+  readlinkSync?: ReadlinkSync;
+  readdir: Readdir;
+  readdirSync?: ReaddirSync;
+  stat: Stat;
+  statSync?: StatSync;
+  lstat?: LStat;
+  lstatSync?: LStatSync;
+  realpath?: RealPath;
+  realpathSync?: RealPathSync;
+  readJson?: ReadJson;
+  readJsonSync?: ReadJsonSync;
+  purge?: Purge;
+  join?: (path1: string, path2: string) => string;
+  relative?: (from: string, to: string) => string;
+  dirname?: (path: string) => string;
 };
 ```
 

--- a/website/docs/en/types/module.mdx
+++ b/website/docs/en/types/module.mdx
@@ -2,22 +2,23 @@
 
 ```ts
 type Module = {
-  context?: string;
-  resource?: string;
-  request?: string;
-  userRequest?: string;
-  rawRequest?: string;
-  factoryMeta?: JsFactoryMeta;
-  buildInfo: Record<string, any>;
+  readonly type: string;
+  readonly context?: string;
+  readonly layer?: string;
+  factoryMeta: JsFactoryMeta;
+  readonly useSourceMap: boolean;
+  readonly useSimpleSourceMap: boolean;
+  buildInfo: BuildInfo;
   buildMeta: Record<string, any>;
-  originalSource(): {
-    isRaw: boolean;
-    isBuffer: boolean;
-    source: Buffer;
-    map?: Buffer;
-  } | null;
+  readonly blocks: AsyncDependenciesBlock[];
+  readonly dependencies: Dependency[];
   identifier(): string;
-  nameForCondition(): string | null;
+  readableIdentifier(): string;
+  originalSource(): Source | null;
+  nameForCondition(): string | undefined;
+  size(type?: string | null): number;
+  libIdent(options: JsLibIdentOptions): string | null;
+  emitFile(filename: string, source: Source, assetInfo?: AssetInfo): void;
 };
 ```
 

--- a/website/docs/en/types/output-file-system.mdx
+++ b/website/docs/en/types/output-file-system.mdx
@@ -1,17 +1,55 @@
 <>
 
 ```ts
-import fs from 'node:fs';
-
 type OutputFileSystem = {
-  writeFile: typeof fs.writeFile;
-  mkdir: typeof fs.mkdir;
-  readdir: typeof fs.readdir;
-  rmdir: typeof fs.rmdir;
-  unlink: typeof fs.unlink;
-  stat: typeof fs.stat;
-  lstat: typeof fs.lstat;
-  readFile: typeof fs.readFile;
+  writeFile: (
+    path: string | number,
+    data: string | Buffer,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  mkdir: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  readdir: (
+    path: string,
+    callback: (
+      error?: NodeJS.ErrnoException | null,
+      files?: Array<string | Buffer> | IDirent[],
+    ) => void,
+  ) => void;
+  rmdir: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  unlink: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  stat: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null, stats?: IStats) => void,
+  ) => void;
+  lstat?: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null, stats?: IStats) => void,
+  ) => void;
+  readFile: (
+    path: string,
+    callback: (
+      error?: NodeJS.ErrnoException | null,
+      data?: string | Buffer,
+    ) => void,
+  ) => void;
+  chmod: (
+    path: string,
+    mode: number,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  join?: (path1: string, path2: string) => string;
+  relative?: (from: string, to: string) => string;
+  dirname?: (path: string) => string;
+  createReadStream?: CreateReadStream;
 };
 ```
 

--- a/website/docs/en/types/path-data.mdx
+++ b/website/docs/en/types/path-data.mdx
@@ -8,7 +8,15 @@ type PathData = {
   runtime?: string;
   url?: string;
   id?: string | number;
-  chunk?: Chunk;
+  chunk?: Chunk | ChunkPathData;
+  contentHashType?: string;
+};
+
+type ChunkPathData = {
+  id?: string | number;
+  name?: string;
+  hash?: string;
+  contentHash?: Record<string, string> | string;
 };
 ```
 

--- a/website/docs/en/types/resolve-data.mdx
+++ b/website/docs/en/types/resolve-data.mdx
@@ -4,6 +4,7 @@
 export type ResolveData = {
   contextInfo: {
     issuer: string;
+    issuerLayer?: string;
   };
   context: string;
   request: string;
@@ -11,9 +12,9 @@ export type ResolveData = {
   missingDependencies: string[];
   contextDependencies: string[];
   createData?: {
-    request?: string;
-    userRequest?: string;
-    resource?: string;
+    request: string;
+    userRequest: string;
+    resource: string;
   };
 };
 ```

--- a/website/docs/en/types/rspack-error.mdx
+++ b/website/docs/en/types/rspack-error.mdx
@@ -1,14 +1,17 @@
 <>
 
 ```ts
-type RspackError = {
+interface RspackError extends Error {
   name: string;
   message: string;
-  moduleIdentifier?: string;
+  details?: string;
+  module?: Module | null;
+  loc?: DependencyLocation;
   file?: string;
   stack?: string;
   hideStack?: boolean;
-};
+  error?: Error;
+}
 ```
 
 </>

--- a/website/docs/en/types/runtime-module.mdx
+++ b/website/docs/en/types/runtime-module.mdx
@@ -1,17 +1,23 @@
 <>
 
 ```ts
-class RuntimeModule {
-  source?: {
-    isRaw: boolean;
-    isBuffer: boolean;
-    source: Buffer;
-    map?: Buffer;
-  };
-  stage: number;
-  name: string;
+declare class RuntimeModule {
+  fullHash: boolean;
+  dependentHash: boolean;
+
+  attach(compilation: Compilation, chunk: Chunk, chunkGraph: ChunkGraph): void;
+  readonly source:
+    | {
+        source: string | Buffer;
+        map?: string;
+      }
+    | undefined;
+  readonly stage: RuntimeModuleStage;
+  readonly name: string;
   identifier(): string;
   readableIdentifier(): string;
+  shouldIsolate(): boolean;
+  generate(): string;
 }
 ```
 

--- a/website/docs/en/types/source.mdx
+++ b/website/docs/en/types/source.mdx
@@ -2,11 +2,14 @@
 
 ```ts
 type Source = {
-  source(): string | ArrayBuffer;
+  source(): string | Buffer;
   buffer(): Buffer;
+  buffers(): Buffer[];
   size(): number;
   map(options?: MapOptions): RawSourceMap | null;
-  sourceAndMap(options?: MapOptions): SourceAndMapResult;
+  sourceAndMap(options?: MapOptions): SourceAndMap;
+  updateHash(hash: HashLike): void;
+  clearCache(options?: ClearCacheOptions, visited?: WeakSet<Source>): void;
 };
 ```
 

--- a/website/docs/en/types/stats.mdx
+++ b/website/docs/en/types/stats.mdx
@@ -2,13 +2,13 @@
 
 ```ts
 type Stats = {
-  compilation: Compilation;
-  hash: Readonly<string | null>;
-  startTime?: number;
-  endTime?: number;
-  hasErrors(): bool;
-  hasWarnings(): bool;
-  toJson(opts?: StatsValue): StatsCompilation;
+  readonly compilation: Compilation;
+  readonly hash: string | null;
+  readonly startTime: number | undefined;
+  readonly endTime: number | undefined;
+  hasErrors(): boolean;
+  hasWarnings(): boolean;
+  toJson(opts?: StatsValue, forToString?: boolean): StatsCompilation;
   toString(opts?: StatsValue): string;
 };
 ```

--- a/website/docs/en/types/watch-file-system.mdx
+++ b/website/docs/en/types/watch-file-system.mdx
@@ -1,34 +1,62 @@
 <>
 
 ```ts
-type WatchFileSystem = {
+type WatchDependencies = Iterable<string> & {
+  added?: Iterable<string>;
+  removed?: Iterable<string>;
+};
+
+type TimeInfoEntries = Map<string, FileSystemInfoEntry | 'ignore'>;
+
+type WatcherInfo = {
+  changes: Set<string>;
+  removals: Set<string>;
+  fileTimeInfoEntries: TimeInfoEntries;
+  contextTimeInfoEntries: TimeInfoEntries;
+};
+
+type Watcher = {
+  close(): void;
+  pause(): void;
+  getInfo(): WatcherInfo;
+};
+
+type WatchFileSystemEvents = {
+  change: [filename: string, mtime: number];
+  remove: [filename: string];
+  aggregated: [changes: Set<string>, removals: Set<string>];
+};
+
+interface WatchFileSystem {
   watch(
-    files: string[],
-    directories: string[],
-    missing: string[],
+    files: WatchDependencies,
+    directories: WatchDependencies,
+    missing: WatchDependencies,
     startTime: number,
     options: WatchOptions,
     callback: (
-      err: Error | null,
-      fileEntries: Map<string, FileSystemInfoEntry>,
-      contextEntries: Map<string, FileSystemInfoEntry>,
-      changes: Set<string>,
-      removals: Set<string>
-    ): void,
-    callbackUndelayed: ( // Triggered immediately after the first change
-      file: string,
-      time: number
-    ): void;
-  ): {
-    close(): void,
-    pause(): void,
-    getAggregatedChanges(): Set<string>,
-    getAggregatedRemovals(): Set<string>,
-    getFileTimeInfoEntries():  Map<string, FileSystemInfoEntry | "ignore">,
-    getContextTimeInfoEntries():  Map<string, FileSystemInfoEntry | "ignore">,
-    getInfo: WatcherInfo
-  }
-};
+      error: Error | null,
+      fileTimeInfoEntries: TimeInfoEntries,
+      contextTimeInfoEntries: TimeInfoEntries,
+      changedFiles: Set<string>,
+      removedFiles: Set<string>,
+    ) => void,
+    callbackUndelayed: (fileName: string, changeTime: number) => void,
+  ): Watcher;
+
+  on?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    listener: (...args: WatchFileSystemEvents[E]) => void,
+  ): this;
+  once?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    listener: (...args: WatchFileSystemEvents[E]) => void,
+  ): this;
+  emit?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    ...args: WatchFileSystemEvents[E]
+  ): boolean;
+}
 ```
 
 </>

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -458,7 +458,7 @@ export default {
 
         class CustomRuntimeModule extends RuntimeModule {
           constructor() {
-            super('custom', RuntimeModule.STAGE_NORMAL);
+            super('custom');
           }
 
           generate() {

--- a/website/docs/zh/types/entrypoint.mdx
+++ b/website/docs/zh/types/entrypoint.mdx
@@ -2,19 +2,23 @@
 
 ```ts
 type Entrypoint = {
-  name?: Readonly<string>; // 名称
-  index?: Readonly<number>; // 索引序
-  chunks: ReadonlyArray<Chunk>; // 包含的 chunk 列表
-  origins: ReadonlyArray<{
+  readonly name: string | undefined; // 名称
+  readonly index: number | undefined; // 索引序
+  readonly chunks: Chunk[]; // 包含的 chunk 列表
+  readonly origins: Array<{
     // entrypoint 被引入的来源
     module?: Module;
     request?: string;
+    loc?: string | RealDependencyLocation;
   }>;
+  readonly childrenIterable: ChunkGroup[];
   isInitial(): boolean; // 是否在页面初始加载
-  getFiles(): ReadonlyArray<string>; // 关联的文件列表
-  getParents(): ReadonlyArray<ChunkGroup>; // 父 chunk group 列表
-  getRuntimeChunk(): Readonly<Chunk | null>; // 获取该 entrypoint 的 runtime chunk（runtime chunk 指包含 runtime 代码的 chunk。一般情况下 runtime chunk 和 entrypoint chunk 是同一个 chunk，只有在通过 dependOn 或 optimization.runtimeChunk 将 runtime 单独拆到一个 chunk 时才指向不同的 chunk）
-  getEntrypointChunk(): Readonly<Chunk | null>; // 获取该 entrypoint 的 entrypoint chunk（指包含 entry 模块的 chunk）
+  getFiles(): string[]; // 关联的文件列表
+  getParents(): ChunkGroup[]; // 父 chunk group 列表
+  getRuntimeChunk(): Chunk; // 获取该 entrypoint 的 runtime chunk（runtime chunk 指包含 runtime 代码的 chunk。一般情况下 runtime chunk 和 entrypoint chunk 是同一个 chunk，只有在通过 dependOn 或 optimization.runtimeChunk 将 runtime 单独拆到一个 chunk 时才指向不同的 chunk）
+  getEntrypointChunk(): Chunk; // 获取该 entrypoint 的 entrypoint chunk（指包含 entry 模块的 chunk）
+  getModulePreOrderIndex(module: Module): number | null;
+  getModulePostOrderIndex(module: Module): number | null;
 };
 ```
 

--- a/website/docs/zh/types/filename.mdx
+++ b/website/docs/zh/types/filename.mdx
@@ -1,7 +1,10 @@
 <>
 
 ```ts
-type Filename = string | (data: PathData, info: AssetInfo) => string;
+type FilenameTemplate = string;
+
+type Filename =
+  FilenameTemplate | ((pathData: PathData, assetInfo?: AssetInfo) => string);
 ```
 
 </>

--- a/website/docs/zh/types/input-file-system.mdx
+++ b/website/docs/zh/types/input-file-system.mdx
@@ -1,24 +1,25 @@
 <>
 
 ```ts
-import fs from 'node:fs';
-
 type InputFileSystem = {
-  readFile: typeof fs.readFile;
-  readFileSync: typeof fs.readFileSync;
-  readlink: typeof fs.readlink;
-  readlinkSync: typeof fs.readlinkSync;
-  readdir: typeof fs.readdir;
-  readdirSync: typeof fs.readdirSync;
-  stat: typeof fs.stat;
-  statSync: typeof fs.statSync;
-  lstat: typeof fs.lstat;
-  lstatSync: typeof fs.lstatSync;
-  realpath: typeof fs.realpath;
-  realpathSync: typeof fs.realpathSync;
-  readJson: typeof fs.readJson;
-  readJsonSync: typeof fs.readJsonSync;
-  purge: (arg0?: (string | string[] | Set<string>) | undefined) => void;
+  readFile: ReadFile;
+  readFileSync?: ReadFileSync;
+  readlink: Readlink;
+  readlinkSync?: ReadlinkSync;
+  readdir: Readdir;
+  readdirSync?: ReaddirSync;
+  stat: Stat;
+  statSync?: StatSync;
+  lstat?: LStat;
+  lstatSync?: LStatSync;
+  realpath?: RealPath;
+  realpathSync?: RealPathSync;
+  readJson?: ReadJson;
+  readJsonSync?: ReadJsonSync;
+  purge?: Purge;
+  join?: (path1: string, path2: string) => string;
+  relative?: (from: string, to: string) => string;
+  dirname?: (path: string) => string;
 };
 ```
 

--- a/website/docs/zh/types/module.mdx
+++ b/website/docs/zh/types/module.mdx
@@ -2,24 +2,23 @@
 
 ```ts
 type Module = {
-  context?: string;
-  resource?: string;
-  request?: string;
-  userRequest?: string;
-  rawRequest?: string;
-  matchResource?: string;
-  loaders?: LoaderItem[];
-  factoryMeta?: JsFactoryMeta;
-  buildInfo: Record<string, any>;
+  readonly type: string;
+  readonly context?: string;
+  readonly layer?: string;
+  factoryMeta: JsFactoryMeta;
+  readonly useSourceMap: boolean;
+  readonly useSimpleSourceMap: boolean;
+  buildInfo: BuildInfo;
   buildMeta: Record<string, any>;
-  originalSource(): {
-    isRaw: boolean;
-    isBuffer: boolean;
-    source: Buffer;
-    map?: Buffer;
-  } | null;
+  readonly blocks: AsyncDependenciesBlock[];
+  readonly dependencies: Dependency[];
   identifier(): string;
-  nameForCondition(): string | null;
+  readableIdentifier(): string;
+  originalSource(): Source | null;
+  nameForCondition(): string | undefined;
+  size(type?: string | null): number;
+  libIdent(options: JsLibIdentOptions): string | null;
+  emitFile(filename: string, source: Source, assetInfo?: AssetInfo): void;
 };
 ```
 

--- a/website/docs/zh/types/output-file-system.mdx
+++ b/website/docs/zh/types/output-file-system.mdx
@@ -1,17 +1,55 @@
 <>
 
 ```ts
-import fs from 'node:fs';
-
 type OutputFileSystem = {
-  writeFile: typeof fs.writeFile;
-  mkdir: typeof fs.mkdir;
-  readdir: typeof fs.readdir;
-  rmdir: typeof fs.rmdir;
-  unlink: typeof fs.unlink;
-  stat: typeof fs.stat;
-  lstat: typeof fs.lstat;
-  readFile: typeof fs.readFile;
+  writeFile: (
+    path: string | number,
+    data: string | Buffer,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  mkdir: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  readdir: (
+    path: string,
+    callback: (
+      error?: NodeJS.ErrnoException | null,
+      files?: Array<string | Buffer> | IDirent[],
+    ) => void,
+  ) => void;
+  rmdir: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  unlink: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  stat: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null, stats?: IStats) => void,
+  ) => void;
+  lstat?: (
+    path: string,
+    callback: (error?: NodeJS.ErrnoException | null, stats?: IStats) => void,
+  ) => void;
+  readFile: (
+    path: string,
+    callback: (
+      error?: NodeJS.ErrnoException | null,
+      data?: string | Buffer,
+    ) => void,
+  ) => void;
+  chmod: (
+    path: string,
+    mode: number,
+    callback: (error?: NodeJS.ErrnoException | null) => void,
+  ) => void;
+  join?: (path1: string, path2: string) => string;
+  relative?: (from: string, to: string) => string;
+  dirname?: (path: string) => string;
+  createReadStream?: CreateReadStream;
 };
 ```
 

--- a/website/docs/zh/types/path-data.mdx
+++ b/website/docs/zh/types/path-data.mdx
@@ -8,7 +8,15 @@ type PathData = {
   runtime?: string; // 关联 runtime，对应 [runtime]
   url?: string; // 路径信息，对应 [url]
   id?: string | number; // 产物的ID，对应 [id]
-  chunk?: Chunk; // 关联 chunk 信息，对应 [chunkhash]
+  chunk?: Chunk | ChunkPathData; // 关联 chunk 信息，对应 [chunkhash]
+  contentHashType?: string; // 内容哈希类型
+};
+
+type ChunkPathData = {
+  id?: string | number;
+  name?: string;
+  hash?: string;
+  contentHash?: Record<string, string> | string;
 };
 ```
 

--- a/website/docs/zh/types/resolve-data.mdx
+++ b/website/docs/zh/types/resolve-data.mdx
@@ -4,6 +4,7 @@
 export type ResolveData = {
   contextInfo: {
     issuer: string;
+    issuerLayer?: string;
   };
   context: string;
   request: string;
@@ -11,9 +12,9 @@ export type ResolveData = {
   missingDependencies: string[];
   contextDependencies: string[];
   createData?: {
-    request?: string;
-    userRequest?: string;
-    resource?: string;
+    request: string;
+    userRequest: string;
+    resource: string;
   };
 };
 ```

--- a/website/docs/zh/types/rspack-error.mdx
+++ b/website/docs/zh/types/rspack-error.mdx
@@ -1,14 +1,17 @@
 <>
 
 ```ts
-type RspackError = {
+interface RspackError extends Error {
   name: string;
   message: string;
-  moduleIdentifier?: string;
+  details?: string;
+  module?: Module | null;
+  loc?: DependencyLocation;
   file?: string;
   stack?: string;
   hideStack?: boolean;
-};
+  error?: Error;
+}
 ```
 
 </>

--- a/website/docs/zh/types/runtime-module.mdx
+++ b/website/docs/zh/types/runtime-module.mdx
@@ -1,17 +1,23 @@
 <>
 
 ```ts
-class RuntimeModule {
-  source?: {
-    isRaw: boolean;
-    isBuffer: boolean;
-    source: Buffer;
-    map?: Buffer;
-  };
-  stage: number;
-  name: string;
+declare class RuntimeModule {
+  fullHash: boolean;
+  dependentHash: boolean;
+
+  attach(compilation: Compilation, chunk: Chunk, chunkGraph: ChunkGraph): void;
+  readonly source:
+    | {
+        source: string | Buffer;
+        map?: string;
+      }
+    | undefined;
+  readonly stage: RuntimeModuleStage;
+  readonly name: string;
   identifier(): string;
   readableIdentifier(): string;
+  shouldIsolate(): boolean;
+  generate(): string;
 }
 ```
 

--- a/website/docs/zh/types/source.mdx
+++ b/website/docs/zh/types/source.mdx
@@ -2,11 +2,14 @@
 
 ```ts
 type Source = {
-  source(): string | ArrayBuffer;
+  source(): string | Buffer;
   buffer(): Buffer;
+  buffers(): Buffer[];
   size(): number;
   map(options?: MapOptions): RawSourceMap | null;
-  sourceAndMap(options?: MapOptions): SourceAndMapResult;
+  sourceAndMap(options?: MapOptions): SourceAndMap;
+  updateHash(hash: HashLike): void;
+  clearCache(options?: ClearCacheOptions, visited?: WeakSet<Source>): void;
 };
 ```
 

--- a/website/docs/zh/types/stats.mdx
+++ b/website/docs/zh/types/stats.mdx
@@ -2,13 +2,13 @@
 
 ```ts
 type Stats = {
-  compilation: Compilation;
-  hash: Readonly<string | null>;
-  startTime?: number;
-  endTime?: number;
-  hasErrors(): bool;
-  hasWarnings(): bool;
-  toJson(opts?: StatsValue): StatsCompilation;
+  readonly compilation: Compilation;
+  readonly hash: string | null;
+  readonly startTime: number | undefined;
+  readonly endTime: number | undefined;
+  hasErrors(): boolean;
+  hasWarnings(): boolean;
+  toJson(opts?: StatsValue, forToString?: boolean): StatsCompilation;
   toString(opts?: StatsValue): string;
 };
 ```

--- a/website/docs/zh/types/watch-file-system.mdx
+++ b/website/docs/zh/types/watch-file-system.mdx
@@ -1,34 +1,62 @@
 <>
 
 ```ts
-type WatchFileSystem = {
+type WatchDependencies = Iterable<string> & {
+  added?: Iterable<string>;
+  removed?: Iterable<string>;
+};
+
+type TimeInfoEntries = Map<string, FileSystemInfoEntry | 'ignore'>;
+
+type WatcherInfo = {
+  changes: Set<string>;
+  removals: Set<string>;
+  fileTimeInfoEntries: TimeInfoEntries;
+  contextTimeInfoEntries: TimeInfoEntries;
+};
+
+type Watcher = {
+  close(): void;
+  pause(): void;
+  getInfo(): WatcherInfo;
+};
+
+type WatchFileSystemEvents = {
+  change: [filename: string, mtime: number];
+  remove: [filename: string];
+  aggregated: [changes: Set<string>, removals: Set<string>];
+};
+
+interface WatchFileSystem {
   watch(
-    files: string[],
-    directories: string[],
-    missing: string[],
+    files: WatchDependencies,
+    directories: WatchDependencies,
+    missing: WatchDependencies,
     startTime: number,
     options: WatchOptions,
     callback: (
-      err: Error | null,
-      fileEntries: Map<string, FileSystemInfoEntry>,
-      contextEntries: Map<string, FileSystemInfoEntry>,
-      changes: Set<string>,
-      removals: Set<string>
-    ): void,
-    callbackUndelayed: ( // 首次变更立即触发
-      file: string,
-      time: number
-    ): void;
-  ): {
-    close(): void,
-    pause(): void,
-    getAggregatedChanges(): Set<string>,
-    getAggregatedRemovals(): Set<string>,
-    getFileTimeInfoEntries():  Map<string, FileSystemInfoEntry | "ignore">,
-    getContextTimeInfoEntries():  Map<string, FileSystemInfoEntry | "ignore">,
-    getInfo: WatcherInfo
-  }
-};
+      error: Error | null,
+      fileTimeInfoEntries: TimeInfoEntries,
+      contextTimeInfoEntries: TimeInfoEntries,
+      changedFiles: Set<string>,
+      removedFiles: Set<string>,
+    ) => void,
+    callbackUndelayed: (fileName: string, changeTime: number) => void,
+  ): Watcher;
+
+  on?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    listener: (...args: WatchFileSystemEvents[E]) => void,
+  ): this;
+  once?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    listener: (...args: WatchFileSystemEvents[E]) => void,
+  ): this;
+  emit?<E extends keyof WatchFileSystemEvents>(
+    event: E,
+    ...args: WatchFileSystemEvents[E]
+  ): boolean;
+}
 ```
 
 </>


### PR DESCRIPTION
## Summary

This PR aligns the remaining public API type references with the current declarations so the documentation no longer exposes outdated or incomplete signatures. It updates the English and Chinese type fragments while keeping low-level runtime and watch implementation details concise.

## Related links

- Follow-up to https://github.com/web-infra-dev/rspack/pull/15107

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).