### PR TITLE
feat: new cache system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rspack-turbo-persistence"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a6b89c4a40a7362e0919667a83e053d31561201e95dfc42dc9bb7228f44708"
+dependencies = [
+ "anyhow",
+ "bitfield",
+ "byteorder",
+ "crc32fast",
+ "dashmap",
+ "either",
+ "fs-err",
+ "jiff",
+ "lzzzz",
+ "memmap2",
+ "nohash-hasher",
+ "parking_lot",
+ "postcard",
+ "qfilter",
+ "quick_cache",
+ "rustc-hash",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "xxhash-rust",
+ "zerocopy 0.8.25",
+]
+
+[[package]]
 name = "rspack_allocator"
 version = "0.101.9"
 dependencies = [
@@ -4184,6 +4213,7 @@ dependencies = [
  "rayon",
  "regex",
  "rkyv 0.8.18",
+ "rspack-turbo-persistence",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_dojang",
@@ -4221,7 +4251,6 @@ dependencies = [
  "swc_experimental_ecma_semantic",
  "tokio",
  "tracing",
- "turbo-persistence",
  "urlencoding",
  "ustr-fxhash",
  "winnow",
@@ -7883,34 +7912,6 @@ dependencies = [
  "target-triple",
  "termcolor",
  "toml 1.0.2+spec-1.1.0",
-]
-
-[[package]]
-name = "turbo-persistence"
-version = "0.1.0"
-source = "git+https://github.com/vercel/next.js?rev=f3edea1b06730ce507aeb1b10c8e4f652ca5540d#f3edea1b06730ce507aeb1b10c8e4f652ca5540d"
-dependencies = [
- "anyhow",
- "bitfield",
- "byteorder",
- "crc32fast",
- "dashmap",
- "either",
- "fs-err",
- "jiff",
- "lzzzz",
- "memmap2",
- "nohash-hasher",
- "parking_lot",
- "postcard",
- "qfilter",
- "quick_cache",
- "rustc-hash",
- "smallvec",
- "thread_local",
- "tracing",
- "xxhash-rust",
- "zerocopy 0.8.25",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +325,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "unty",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +347,26 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitfield"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45721c9db4c7a20899d05efb7ad9235f50b256e980db30ffb229abf732934c3"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0cb6f3d4773a2107b94cbeccaa5b5f0b35a88389b5d522d13d659f64317b22d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "bitflags"
@@ -628,6 +666,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1052,9 +1092,9 @@ checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1068,6 +1108,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1206,6 +1252,37 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "serde",
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1463,6 +1540,12 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foldhash-portable"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631c01cdb9b602a84f0ef5e813d3691936aade6d390dba117f28aa03eb4d0e09"
 
 [[package]]
 name = "forked_react_compiler"
@@ -1823,8 +1906,19 @@ checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1874,6 +1968,15 @@ checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
 dependencies = [
  "hashbrown 0.16.1",
  "serde",
+]
+
+[[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1934,6 +2037,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2295,6 +2412,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2694,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzzzz"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb42ba2edf1f0491b2e2c85fd49cf2a7adad3cab92ea0e29bff82d6fdafcefda"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2754,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix 0.38.42",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3141,6 +3339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,6 +3356,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -3315,6 +3523,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "qfilter"
+version = "0.3.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd9c903cd64233eb97cf95d96d58645c2b1c0154d30ff835f3bb4be417158b1"
+dependencies = [
+ "foldhash-portable",
+ "serde",
+ "serde_bytes",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.6.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9c6658afe513a3b484e3abfdaa0d03ef3c0bbf017542c178dd55f94eb3051f9"
+dependencies = [
+ "ahash 0.8.12",
+ "equivalent",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3328,6 +3559,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3984,6 +4221,7 @@ dependencies = [
  "swc_experimental_ecma_semantic",
  "tokio",
  "tracing",
+ "turbo-persistence",
  "urlencoding",
  "ustr-fxhash",
  "winnow",
@@ -5553,6 +5791,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5734,7 +5982,9 @@ version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
+ "bincode",
  "serde",
+ "unty",
 ]
 
 [[package]]
@@ -5753,6 +6003,15 @@ name = "smol_str"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "st-map"
@@ -7627,6 +7886,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "turbo-persistence"
+version = "0.1.0"
+source = "git+https://github.com/vercel/next.js?rev=f3edea1b06730ce507aeb1b10c8e4f652ca5540d#f3edea1b06730ce507aeb1b10c8e4f652ca5540d"
+dependencies = [
+ "anyhow",
+ "bitfield",
+ "byteorder",
+ "crc32fast",
+ "dashmap",
+ "either",
+ "fs-err",
+ "jiff",
+ "lzzzz",
+ "memmap2",
+ "nohash-hasher",
+ "parking_lot",
+ "postcard",
+ "qfilter",
+ "quick_cache",
+ "rustc-hash",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "xxhash-rust",
+ "zerocopy 0.8.25",
+]
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7691,6 +7978,12 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ tokio               = { version = "1.53.1", default-features = false, features =
 tracing             = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
 tracing-subscriber  = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
 trybuild            = { version = "1.0.116", default-features = false, features = ["diff"] }
-turbo-persistence   = { git = "https://github.com/vercel/next.js", rev = "f3edea1b06730ce507aeb1b10c8e4f652ca5540d" }
+turbo-persistence   = { package = "rspack-turbo-persistence", version = "0.1.0", default-features = false }
 twox-hash           = { version = "2.1.2", default-features = false }
 unicase             = { version = "2.9.0", default-features = false }
 unicode-width       = { version = "0.2.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ tokio               = { version = "1.53.1", default-features = false, features =
 tracing             = { version = "0.1.44", default-features = false, features = ["max_level_trace", "release_max_level_trace"] }
 tracing-subscriber  = { version = "0.3.23", default-features = false, features = ["fmt", "registry"] }
 trybuild            = { version = "1.0.116", default-features = false, features = ["diff"] }
+turbo-persistence   = { git = "https://github.com/vercel/next.js", rev = "f3edea1b06730ce507aeb1b10c8e4f652ca5540d" }
 twox-hash           = { version = "2.1.2", default-features = false }
 unicase             = { version = "2.9.0", default-features = false }
 unicode-width       = { version = "0.2.2", default-features = false }

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2288,6 +2288,7 @@ export interface RawEvalDevToolModulePluginOptions {
 export interface RawExperiments {
   useInputFileSystem?: false | Array<RegExp>
   css?: boolean
+  newCache: boolean
   deferImport: boolean
   sourceImport: boolean
   pureFunctions: boolean

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3676,6 +3676,8 @@ pub struct ExperimentsBuilder {
   future_defaults: Option<bool>,
   /// Whether to enable css.
   css: Option<bool>,
+  /// Whether to enable the new cache implementation.
+  new_cache: Option<bool>,
   /// Whether to enable async web assembly.
   async_web_assembly: Option<bool>,
   /// Whether to enable defer import.
@@ -3692,6 +3694,7 @@ impl From<Experiments> for ExperimentsBuilder {
     ExperimentsBuilder {
       future_defaults: None,
       css: Some(value.css),
+      new_cache: Some(value.new_cache),
       async_web_assembly: None,
       defer_import: Some(value.defer_import),
       source_import: Some(value.source_import),
@@ -3706,6 +3709,7 @@ impl From<&mut ExperimentsBuilder> for ExperimentsBuilder {
     ExperimentsBuilder {
       future_defaults: value.future_defaults.take(),
       css: value.css.take(),
+      new_cache: value.new_cache.take(),
       async_web_assembly: value.async_web_assembly.take(),
       defer_import: value.defer_import.take(),
       source_import: value.source_import.take(),
@@ -3725,6 +3729,12 @@ impl ExperimentsBuilder {
   /// Set whether to enable css.
   pub fn css(&mut self, css: bool) -> &mut Self {
     self.css = Some(css);
+    self
+  }
+
+  /// Set whether to enable the new cache implementation.
+  pub fn new_cache(&mut self, new_cache: bool) -> &mut Self {
+    self.new_cache = Some(new_cache);
     self
   }
 
@@ -3762,6 +3772,7 @@ impl ExperimentsBuilder {
 
     Ok(Experiments {
       css: d!(self.css, false),
+      new_cache: d!(self.new_cache, false),
       defer_import: d!(self.defer_import, false),
       source_import: d!(self.source_import, false),
       pure_functions: d!(self.pure_functions, _production),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1748,6 +1748,7 @@ CompilerOptions {
     cache: Disabled,
     experiments: Experiments {
         css: false,
+        new_cache: false,
         defer_import: false,
         source_import: false,
         pure_functions: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -13,6 +13,7 @@ pub struct RawExperiments {
   #[napi(ts_type = "false | Array<RegExp>")]
   pub use_input_file_system: Option<WithFalse<Vec<RspackRegex>>>,
   pub css: Option<bool>,
+  pub new_cache: bool,
   pub defer_import: bool,
   pub source_import: bool,
   pub pure_functions: bool,
@@ -30,6 +31,7 @@ impl From<RawExperiments> for Experiments {
 
     Self {
       css: value.css.unwrap_or(false),
+      new_cache: value.new_cache,
       defer_import: value.defer_import,
       source_import: value.source_import,
       pure_functions: value.pure_functions,

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -68,6 +68,7 @@ sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
 tokio                      = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing                    = { workspace = true }
+turbo-persistence          = { workspace = true }
 urlencoding                = { workspace = true }
 ustr                       = { workspace = true }
 winnow                     = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -68,7 +68,6 @@ sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
 tokio                      = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing                    = { workspace = true }
-turbo-persistence          = { workspace = true }
 urlencoding                = { workspace = true }
 ustr                       = { workspace = true }
 winnow                     = { workspace = true }
@@ -77,6 +76,9 @@ swc_experimental_allocator     = { workspace = true }
 swc_experimental_ecma_ast      = { workspace = true }
 swc_experimental_ecma_parser   = { workspace = true }
 swc_experimental_ecma_semantic = { workspace = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+turbo-persistence = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -66,7 +66,7 @@ smallvec                   = { workspace = true }
 smol_str                   = { workspace = true }
 sugar_path                 = { workspace = true }
 swc_core                   = { workspace = true, features = ["__ecma", "__visit", "__utils", "__ecma_transforms", "ecma_ast", "ecma_parser", "ecma_codegen", "ecma_quote", "common_concurrent", "swc_ecma_ast", "ecma_transforms_react", "ecma_transforms_module", "swc_ecma_codegen", "swc_ecma_visit"] }
-tokio                      = { workspace = true, features = ["rt", "macros"] }
+tokio                      = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing                    = { workspace = true }
 urlencoding                = { workspace = true }
 ustr                       = { workspace = true }

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -106,6 +106,10 @@ pub fn new_cache(
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Box<dyn Cache> {
+  if compiler_option.experiments.new_cache {
+    return Box::new(DisableCache);
+  }
+
   match &compiler_option.cache {
     CacheOptions::Disabled => Box::new(DisableCache),
     CacheOptions::Memory { .. } => Box::<MemoryCache>::default(),

--- a/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/build_dependencies/mod.rs
@@ -7,7 +7,7 @@ use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 use rustc_hash::FxHashSet as HashSet;
 
-use self::helper::{Helper, is_node_package_path};
+pub(crate) use self::helper::{Helper, is_node_package_path};
 use super::{
   snapshot::{Snapshot, SnapshotScope},
   storage::Storage,

--- a/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/snapshot/mod.rs
@@ -9,7 +9,7 @@ use rspack_fs::ReadableFileSystem;
 use rspack_parallel::TryFutureConsumer;
 use rspack_paths::{ArcPath, ArcPathSet};
 
-use self::strategy::{StrategyHelper, ValidateResult};
+pub(crate) use self::strategy::{StrategyHelper, ValidateResult};
 pub use self::{
   option::{PathMatcher, SnapshotOptions, SnapshotStrategyOptions},
   scope::SnapshotScope,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -9,6 +9,7 @@ use crate::{
   Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
   RuntimeTemplate, SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
+  new_cache::Cache,
 };
 
 #[derive(Debug)]
@@ -28,6 +29,7 @@ pub struct TaskContext {
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
+  cache: Cache,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -54,6 +56,7 @@ impl TaskContext {
       intermediate_fs: compilation.intermediate_filesystem.clone(),
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
+      cache: compilation.cache.clone(),
       artifact,
       exports_info_artifact,
     }
@@ -81,6 +84,7 @@ impl TaskContext {
       Incremental::new_cold(self.compiler_options.incremental),
       None,
       Default::default(),
+      self.cache.clone(),
       Default::default(),
       Default::default(),
       self.fs.clone(),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -95,7 +95,9 @@ use crate::{
   compiler::{CompilationRecords, CompilerId},
   get_runtime_key,
   incremental::{self, Incremental, IncrementalPasses, Mutation},
-  is_source_equal, to_identifier,
+  is_source_equal,
+  new_cache::{Cache, CacheFacade},
+  to_identifier,
 };
 
 define_hook!(CompilationAddEntry: Series(entry_name: Option<&str>, options: &mut EntryOptions));
@@ -235,6 +237,7 @@ pub struct Compilation {
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
+  cache: Cache,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -345,6 +348,7 @@ impl Compilation {
     incremental: Incremental,
     module_executor: Option<ModuleExecutor>,
     logging: CompilationLogging,
+    cache: Cache,
     modified_files: ArcPathSet,
     removed_files: ArcPathSet,
     input_filesystem: Arc<dyn ReadableFileSystem>,
@@ -373,6 +377,7 @@ impl Compilation {
       emitted_assets: Default::default(),
       diagnostics: Default::default(),
       logging,
+      cache,
       plugin_driver,
       buildtime_plugin_driver,
       resolver_factory,
@@ -438,6 +443,10 @@ impl Compilation {
       is_rebuild,
       compiler_context,
     }
+  }
+
+  pub fn get_cache(&self, name: &str) -> CacheFacade {
+    self.cache.facade(name)
   }
 
   pub fn id(&self) -> CompilationId {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -160,6 +160,7 @@ impl Compiler {
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
     let new_cache = create_cache(
+      compiler_path.clone(),
       options.clone(),
       input_filesystem.clone(),
       compilation_logging.clone(),
@@ -178,7 +179,6 @@ impl Compiler {
     let compiler_context = compiler_context.unwrap_or_else(|| Arc::new(CompilerContext::new()));
     Self {
       id,
-      compiler_path,
       options: options.clone(),
       compilation: Compilation::new(
         id,
@@ -192,6 +192,7 @@ impl Compiler {
         incremental,
         Some(module_executor),
         compilation_logging,
+        new_cache.clone(),
         Default::default(),
         Default::default(),
         input_filesystem.clone(),
@@ -200,6 +201,7 @@ impl Compiler {
         false,
         compiler_context.clone(),
       ),
+      compiler_path,
       output_filesystem,
       intermediate_filesystem,
       plugin_driver,
@@ -221,10 +223,7 @@ impl Compiler {
   }
 
   pub fn get_cache(&self, name: &str) -> CacheFacade {
-    let mut cache_name = String::with_capacity(self.compiler_path.len() + name.len());
-    cache_name.push_str(&self.compiler_path);
-    cache_name.push_str(name);
-    CacheFacade::new(self.new_cache.clone(), cache_name)
+    self.new_cache.facade(name)
   }
 
   fn end_idle(&self) -> Result<Instant> {
@@ -308,6 +307,7 @@ impl Compiler {
         Incremental::new_cold(self.options.incremental),
         Some(Default::default()),
         compilation_logging,
+        self.new_cache.clone(),
         Default::default(),
         Default::default(),
         self.input_filesystem.clone(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -26,7 +26,7 @@ use crate::{
   fast_set, include_hash,
   incremental::{Incremental, IncrementalPasses},
   logger::Logger,
-  new_cache::{Cache, CacheFacade},
+  new_cache::{Cache, CacheFacade, create_cache},
   trim_dir,
 };
 
@@ -159,7 +159,11 @@ impl Compiler {
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
-    let new_cache = Cache::default();
+    let new_cache = create_cache(
+      options.clone(),
+      input_filesystem.clone(),
+      compilation_logging.clone(),
+    );
     let cache = create_legacy_cache(
       &compiler_path,
       options.clone(),
@@ -235,18 +239,10 @@ impl Compiler {
       Ok(())
     };
     let store_build_dependencies = if successful && self.new_cache.has_file_cache() {
-      let (dependencies, _, _, _) = self.compilation.build_dependencies();
-      dependencies
-        .map(|dependency| {
-          Utf8PathBuf::from_path_buf(dependency.to_path_buf()).map_err(|path| {
-            rspack_error::error!(
-              "Build dependency path is not valid UTF-8: {}",
-              path.display()
-            )
-          })
-        })
-        .collect::<Result<Vec<_>>>()
-        .and_then(|dependencies| self.new_cache.store_build_dependencies(dependencies))
+      let (build_dependencies, _, _, _) = self.compilation.build_dependencies();
+      self
+        .new_cache
+        .store_build_dependencies(build_dependencies.cloned().collect())
     } else {
       Ok(())
     };

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,5 +1,8 @@
 mod rebuild;
-use std::sync::{Arc, atomic::AtomicU32};
+use std::{
+  sync::{Arc, atomic::AtomicU32},
+  time::Instant,
+};
 
 use futures::future::join_all;
 use rspack_cacheable::cacheable;
@@ -18,11 +21,12 @@ use crate::{
   BoxPlugin, CleanOptions, Compilation, CompilationAsset, CompilationLogging, CompilerOptions,
   CompilerPlatform, ContextModuleFactory, Filename, KeepPattern, NormalModuleFactory, PluginDriver,
   ResolverFactory, SharedPluginDriver,
-  cache::{Cache, new_cache},
+  cache::{Cache as LegacyCache, new_cache as create_legacy_cache},
   compilation::build_module_graph::ModuleExecutor,
   fast_set, include_hash,
   incremental::{Incremental, IncrementalPasses},
   logger::Logger,
+  new_cache::{Cache, CacheFacade},
   trim_dir,
 };
 
@@ -95,7 +99,8 @@ pub struct Compiler {
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
   pub loader_resolver_factory: Arc<ResolverFactory>,
-  pub cache: Box<dyn Cache>,
+  pub cache: Box<dyn LegacyCache>,
+  new_cache: Cache,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
   pub emitted_asset_versions: HashMap<String, String>,
@@ -154,7 +159,8 @@ impl Compiler {
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
-    let cache = new_cache(
+    let new_cache = Cache::default();
+    let cache = create_legacy_cache(
       &compiler_path,
       options.clone(),
       input_filesystem.clone(),
@@ -197,6 +203,7 @@ impl Compiler {
       resolver_factory,
       loader_resolver_factory,
       cache,
+      new_cache,
       emitted_asset_versions: Default::default(),
       input_filesystem,
       platform,
@@ -209,33 +216,76 @@ impl Compiler {
     self.id
   }
 
+  pub fn get_cache(&self, name: &str) -> CacheFacade {
+    let mut cache_name = String::with_capacity(self.compiler_path.len() + name.len());
+    cache_name.push_str(&self.compiler_path);
+    cache_name.push_str(name);
+    CacheFacade::new(self.new_cache.clone(), cache_name)
+  }
+
+  fn end_idle(&self) -> Result<Instant> {
+    self.new_cache.end_idle()?;
+    Ok(Instant::now())
+  }
+
+  fn begin_idle(&self, started_at: Instant, successful: bool) -> Result<()> {
+    let record_build_time = if successful {
+      self.new_cache.record_build_time(started_at.elapsed())
+    } else {
+      Ok(())
+    };
+    let store_build_dependencies = if successful && self.new_cache.has_file_cache() {
+      let (dependencies, _, _, _) = self.compilation.build_dependencies();
+      dependencies
+        .map(|dependency| {
+          Utf8PathBuf::from_path_buf(dependency.to_path_buf()).map_err(|path| {
+            rspack_error::error!(
+              "Build dependency path is not valid UTF-8: {}",
+              path.display()
+            )
+          })
+        })
+        .collect::<Result<Vec<_>>>()
+        .and_then(|dependencies| self.new_cache.store_build_dependencies(dependencies))
+    } else {
+      Ok(())
+    };
+    let begin_idle = self.new_cache.begin_idle();
+
+    record_build_time
+      .and(store_build_dependencies)
+      .and(begin_idle)
+  }
+
   pub async fn run(&mut self) -> Result<()> {
     self.build().await?;
     Ok(())
   }
 
   pub async fn build(&mut self) -> Result<()> {
+    let start = self.end_idle()?;
     let compiler_context = self.compiler_context.clone();
-    match within_compiler_context(compiler_context, self.build_inner()).await {
+    let result = match within_compiler_context(compiler_context, self.build_inner()).await {
       Ok(_) => {
         self
           .plugin_driver
           .compiler_hooks
           .done
           .call(&self.compilation)
-          .await?;
-        Ok(())
+          .await
       }
       Err(e) => {
-        self
+        let failed = self
           .plugin_driver
           .compiler_hooks
           .failed
           .call(&self.compilation)
-          .await?;
-        Err(e)
+          .await;
+        failed.and(Err(e))
       }
-    }
+    };
+    let cache_result = self.begin_idle(start, result.is_ok());
+    result.and(cache_result)
   }
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
@@ -582,8 +632,7 @@ impl Compiler {
       .await?;
 
     self.cache.close().await;
-
-    Ok(())
+    self.new_cache.shutdown().await
   }
 }
 

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -87,6 +87,7 @@ impl Compiler {
         Incremental::new_hot(self.options.incremental),
         Some(ModuleExecutor::default()),
         compilation_logging,
+        self.new_cache.clone(),
         modified_files,
         removed_files,
         self.input_filesystem.clone(),

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -21,7 +21,8 @@ impl Compiler {
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
   ) -> Result<()> {
-    match within_compiler_context(
+    let start = self.end_idle()?;
+    let result = match within_compiler_context(
       self.compiler_context.clone(),
       self.rebuild_inner(changed_files, deleted_files),
     )
@@ -33,19 +34,20 @@ impl Compiler {
           .compiler_hooks
           .done
           .call(&self.compilation)
-          .await?;
-        Ok(())
+          .await
       }
       Err(e) => {
-        self
+        let failed = self
           .plugin_driver
           .compiler_hooks
           .failed
           .call(&self.compilation)
-          .await?;
-        Err(e)
+          .await;
+        failed.and(Err(e))
       }
-    }
+    };
+    let cache_result = self.begin_idle(start, result.is_ok());
+    result.and(cache_result)
   }
 
   #[tracing::instrument("Compiler:rebuild", skip_all, fields(

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -14,7 +14,7 @@ pub use compilation::{
   *,
 };
 pub use exports::*;
-pub use new_cache::{CacheFacade, CacheValue, Etag, ItemCacheFacade};
+pub use new_cache::{Cache, CacheFacade, CacheValue, Etag, ItemCacheFacade};
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;
 mod dependencies_block;

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -5,6 +5,7 @@ mod compilation;
 mod transient_cache;
 
 mod exports;
+mod new_cache;
 mod value_cache_versions;
 pub use artifacts::*;
 pub use binding::*;

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -14,6 +14,7 @@ pub use compilation::{
   *,
 };
 pub use exports::*;
+pub use new_cache::{CacheFacade, CacheValue, Etag, ItemCacheFacade};
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;
 mod dependencies_block;

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -4,7 +4,7 @@ use rspack_error::Result;
 use rspack_paths::ArcPathSet;
 
 use super::{
-  CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
+  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
 };
 
@@ -14,57 +14,80 @@ use super::{
 /// an unknown key falls through to the filesystem cache. Filesystem results,
 /// including misses, are recorded in memory for subsequent reads.
 #[derive(Debug)]
-struct CacheInner {
+struct CacheStorage {
   memory_cache: MemoryCache,
   idle_file_cache: Option<IdleFileCache>,
+}
+
+#[derive(Debug)]
+struct CacheInner {
+  compiler_path: String,
+  storage: Option<CacheStorage>,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
 #[derive(Debug, Clone)]
 pub struct Cache {
-  inner: Arc<Option<CacheInner>>,
+  inner: Arc<CacheInner>,
 }
 
 impl Cache {
-  pub fn new(memory_cache: MemoryCache, idle_file_cache: Option<IdleFileCache>) -> Self {
+  pub fn new(
+    compiler_path: String,
+    memory_cache: MemoryCache,
+    idle_file_cache: Option<IdleFileCache>,
+  ) -> Self {
     Self {
-      inner: Arc::new(Some(CacheInner {
-        memory_cache,
-        idle_file_cache,
-      })),
+      inner: Arc::new(CacheInner {
+        compiler_path,
+        storage: Some(CacheStorage {
+          memory_cache,
+          idle_file_cache,
+        }),
+      }),
     }
   }
 
-  pub fn new_disabled() -> Self {
+  pub fn new_disabled(compiler_path: String) -> Self {
     Self {
-      inner: Arc::new(None),
+      inner: Arc::new(CacheInner {
+        compiler_path,
+        storage: None,
+      }),
     }
   }
 
-  pub async fn get<T: CacheValueData>(
+  pub(crate) fn facade(&self, name: &str) -> CacheFacade {
+    let mut cache_name = String::with_capacity(self.inner.compiler_path.len() + name.len());
+    cache_name.push_str(&self.inner.compiler_path);
+    cache_name.push_str(name);
+    CacheFacade::new(self.clone(), cache_name)
+  }
+
+  pub fn get<T: CacheValueData>(
     &self,
     key: CacheKey,
     etag: Option<Etag>,
   ) -> Result<Option<CacheValue<T>>> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(None);
     };
-    match inner.memory_cache.get(&key, etag.as_ref()) {
+    match storage.memory_cache.get(&key, etag.as_ref()) {
       MemoryCacheGetResult::Hit(value) => Ok(Some(value)),
       MemoryCacheGetResult::Miss => Ok(None),
       MemoryCacheGetResult::NotCached => {
-        let Some(file_cache) = &inner.idle_file_cache else {
-          inner.memory_cache.store_miss(key);
+        let Some(file_cache) = &storage.idle_file_cache else {
+          storage.memory_cache.store_miss(key);
           return Ok(None);
         };
 
-        match file_cache.restore::<T>(key.clone(), etag.clone()).await? {
+        match file_cache.restore::<T>(key.clone(), etag.clone())? {
           Some(value) => {
-            inner.memory_cache.store(key, etag, value.clone());
+            storage.memory_cache.store(key, etag, value.clone());
             Ok(Some(value))
           }
           None => {
-            inner.memory_cache.store_miss(key);
+            storage.memory_cache.store_miss(key);
             Ok(None)
           }
         }
@@ -78,25 +101,25 @@ impl Cache {
     etag: Option<Etag>,
     value: CacheValue<T>,
   ) -> Result<()> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_cache) = &inner.idle_file_cache {
-      inner
+    if let Some(file_cache) = &storage.idle_file_cache {
+      storage
         .memory_cache
         .store(key.clone(), etag.clone(), value.clone());
       file_cache.store(key, etag, value)
     } else {
-      inner.memory_cache.store(key, etag, value);
+      storage.memory_cache.store(key, etag, value);
       Ok(())
     }
   }
 
   pub fn store_build_dependencies(&self, dependencies: ArcPathSet) -> Result<()> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_cache) = &inner.idle_file_cache {
+    if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.store_build_dependencies(dependencies)
     } else {
       Ok(())
@@ -106,16 +129,16 @@ impl Cache {
   pub fn has_file_cache(&self) -> bool {
     self
       .inner
+      .storage
       .as_ref()
-      .as_ref()
-      .is_some_and(|inner| inner.idle_file_cache.is_some())
+      .is_some_and(|storage| storage.idle_file_cache.is_some())
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_cache) = &inner.idle_file_cache {
+    if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.record_build_time(build_time)
     } else {
       Ok(())
@@ -123,10 +146,10 @@ impl Cache {
   }
 
   pub fn begin_idle(&self) -> Result<()> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_cache) = &inner.idle_file_cache {
+    if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.begin_idle()
     } else {
       Ok(())
@@ -134,10 +157,10 @@ impl Cache {
   }
 
   pub fn end_idle(&self) -> Result<()> {
-    let Some(inner) = self.inner.as_ref() else {
+    let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_cache) = &inner.idle_file_cache {
+    if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.end_idle()
     } else {
       Ok(())
@@ -145,9 +168,9 @@ impl Cache {
   }
 
   pub async fn shutdown(&self) -> Result<()> {
-    if let Some(inner) = self.inner.as_ref() {
-      inner.memory_cache.clear();
-      if let Some(file_cache) = &inner.idle_file_cache {
+    if let Some(storage) = &self.inner.storage {
+      storage.memory_cache.clear();
+      if let Some(file_cache) = &storage.idle_file_cache {
         file_cache.shutdown().await?;
       }
     }

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -19,7 +19,7 @@ struct CacheInner {
   idle_file_cache: Option<IdleFileCache>,
 }
 
-/// Cheaply clonable handle to the shared cache state.
+/// Cheaply cloneable handle to the shared cache state.
 #[derive(Debug, Clone)]
 pub struct Cache {
   inner: Arc<Option<CacheInner>>,

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,0 +1,127 @@
+use std::{sync::Arc, time::Duration};
+
+use rspack_error::Result;
+use rspack_paths::Utf8PathBuf;
+
+use super::{
+  CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
+  cache_value::CacheValueData,
+};
+
+/// Cache entry point backed by memory and optional filesystem storage.
+///
+/// Reads follow webpack's cache stage order: memory is queried first and only
+/// an unknown key falls through to the filesystem cache. Filesystem results,
+/// including misses, are recorded in memory for subsequent reads.
+#[derive(Debug, Default)]
+struct CacheInner {
+  memory_cache: MemoryCache,
+  idle_file_cache: Option<IdleFileCache>,
+}
+
+/// Cheaply clonable handle to the shared cache state.
+#[derive(Debug, Clone, Default)]
+pub struct Cache {
+  inner: Arc<CacheInner>,
+}
+
+impl Cache {
+  pub fn new(idle_file_cache: Option<IdleFileCache>) -> Self {
+    Self {
+      inner: Arc::new(CacheInner {
+        memory_cache: MemoryCache::default(),
+        idle_file_cache,
+      }),
+    }
+  }
+
+  pub async fn get<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Result<Option<CacheValue<T>>> {
+    match self.inner.memory_cache.get(&key, etag.as_ref()) {
+      MemoryCacheGetResult::Hit(value) => Ok(Some(value)),
+      MemoryCacheGetResult::Miss => Ok(None),
+      MemoryCacheGetResult::NotCached => {
+        let Some(file_cache) = &self.inner.idle_file_cache else {
+          self.inner.memory_cache.store_miss(key);
+          return Ok(None);
+        };
+
+        match file_cache.restore::<T>(key.clone(), etag.clone()).await? {
+          Some(value) => {
+            self.inner.memory_cache.store(key, etag, value.clone());
+            Ok(Some(value))
+          }
+          None => {
+            self.inner.memory_cache.store_miss(key);
+            Ok(None)
+          }
+        }
+      }
+    }
+  }
+
+  pub fn store<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      self
+        .inner
+        .memory_cache
+        .store(key.clone(), etag.clone(), value.clone());
+      file_cache.store(key, etag, value)
+    } else {
+      self.inner.memory_cache.store(key, etag, value);
+      Ok(())
+    }
+  }
+
+  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      file_cache.store_build_dependencies(dependencies)
+    } else {
+      Ok(())
+    }
+  }
+
+  pub(crate) fn has_file_cache(&self) -> bool {
+    self.inner.idle_file_cache.is_some()
+  }
+
+  pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      file_cache.record_build_time(build_time)
+    } else {
+      Ok(())
+    }
+  }
+
+  pub fn begin_idle(&self) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      file_cache.begin_idle()
+    } else {
+      Ok(())
+    }
+  }
+
+  pub fn end_idle(&self) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      file_cache.end_idle()
+    } else {
+      Ok(())
+    }
+  }
+
+  pub async fn shutdown(&self) -> Result<()> {
+    self.inner.memory_cache.clear();
+    if let Some(file_cache) = &self.inner.idle_file_cache {
+      file_cache.shutdown().await?;
+    }
+    Ok(())
+  }
+}

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,7 +1,7 @@
 use std::{sync::Arc, time::Duration};
 
 use rspack_error::Result;
-use rspack_paths::Utf8PathBuf;
+use rspack_paths::ArcPathSet;
 
 use super::{
   CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
@@ -13,25 +13,31 @@ use super::{
 /// Reads follow webpack's cache stage order: memory is queried first and only
 /// an unknown key falls through to the filesystem cache. Filesystem results,
 /// including misses, are recorded in memory for subsequent reads.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct CacheInner {
   memory_cache: MemoryCache,
   idle_file_cache: Option<IdleFileCache>,
 }
 
 /// Cheaply clonable handle to the shared cache state.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Cache {
-  inner: Arc<CacheInner>,
+  inner: Arc<Option<CacheInner>>,
 }
 
 impl Cache {
-  pub fn new(idle_file_cache: Option<IdleFileCache>) -> Self {
+  pub fn new(memory_cache: MemoryCache, idle_file_cache: Option<IdleFileCache>) -> Self {
     Self {
-      inner: Arc::new(CacheInner {
-        memory_cache: MemoryCache::default(),
+      inner: Arc::new(Some(CacheInner {
+        memory_cache,
         idle_file_cache,
-      }),
+      })),
+    }
+  }
+
+  pub fn new_disabled() -> Self {
+    Self {
+      inner: Arc::new(None),
     }
   }
 
@@ -40,22 +46,25 @@ impl Cache {
     key: CacheKey,
     etag: Option<Etag>,
   ) -> Result<Option<CacheValue<T>>> {
-    match self.inner.memory_cache.get(&key, etag.as_ref()) {
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(None);
+    };
+    match inner.memory_cache.get(&key, etag.as_ref()) {
       MemoryCacheGetResult::Hit(value) => Ok(Some(value)),
       MemoryCacheGetResult::Miss => Ok(None),
       MemoryCacheGetResult::NotCached => {
-        let Some(file_cache) = &self.inner.idle_file_cache else {
-          self.inner.memory_cache.store_miss(key);
+        let Some(file_cache) = &inner.idle_file_cache else {
+          inner.memory_cache.store_miss(key);
           return Ok(None);
         };
 
         match file_cache.restore::<T>(key.clone(), etag.clone()).await? {
           Some(value) => {
-            self.inner.memory_cache.store(key, etag, value.clone());
+            inner.memory_cache.store(key, etag, value.clone());
             Ok(Some(value))
           }
           None => {
-            self.inner.memory_cache.store_miss(key);
+            inner.memory_cache.store_miss(key);
             Ok(None)
           }
         }
@@ -69,32 +78,44 @@ impl Cache {
     etag: Option<Etag>,
     value: CacheValue<T>,
   ) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
-      self
-        .inner
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &inner.idle_file_cache {
+      inner
         .memory_cache
         .store(key.clone(), etag.clone(), value.clone());
       file_cache.store(key, etag, value)
     } else {
-      self.inner.memory_cache.store(key, etag, value);
+      inner.memory_cache.store(key, etag, value);
       Ok(())
     }
   }
 
-  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
+  pub fn store_build_dependencies(&self, dependencies: ArcPathSet) -> Result<()> {
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &inner.idle_file_cache {
       file_cache.store_build_dependencies(dependencies)
     } else {
       Ok(())
     }
   }
 
-  pub(crate) fn has_file_cache(&self) -> bool {
-    self.inner.idle_file_cache.is_some()
+  pub fn has_file_cache(&self) -> bool {
+    self
+      .inner
+      .as_ref()
+      .as_ref()
+      .is_some_and(|inner| inner.idle_file_cache.is_some())
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &inner.idle_file_cache {
       file_cache.record_build_time(build_time)
     } else {
       Ok(())
@@ -102,7 +123,10 @@ impl Cache {
   }
 
   pub fn begin_idle(&self) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &inner.idle_file_cache {
       file_cache.begin_idle()
     } else {
       Ok(())
@@ -110,7 +134,10 @@ impl Cache {
   }
 
   pub fn end_idle(&self) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
+    let Some(inner) = self.inner.as_ref() else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &inner.idle_file_cache {
       file_cache.end_idle()
     } else {
       Ok(())
@@ -118,9 +145,11 @@ impl Cache {
   }
 
   pub async fn shutdown(&self) -> Result<()> {
-    self.inner.memory_cache.clear();
-    if let Some(file_cache) = &self.inner.idle_file_cache {
-      file_cache.shutdown().await?;
+    if let Some(inner) = self.inner.as_ref() {
+      inner.memory_cache.clear();
+      if let Some(file_cache) = &inner.idle_file_cache {
+        file_cache.shutdown().await?;
+      }
     }
     Ok(())
   }

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -37,12 +37,12 @@ impl CacheFacade {
     }
   }
 
-  pub async fn get<T: CacheValueData>(
+  pub fn get<T: CacheValueData>(
     &self,
     identifier: &str,
     etag: Option<Etag>,
   ) -> Result<Option<CacheValue<T>>> {
-    self.cache.get(self.key(identifier), etag).await
+    self.cache.get(self.key(identifier), etag)
   }
 
   pub fn store<T: CacheValueData>(
@@ -68,8 +68,8 @@ pub struct ItemCacheFacade {
 }
 
 impl ItemCacheFacade {
-  pub async fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
-    self.cache.get(self.key.clone(), self.etag.clone()).await
+  pub fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
+    self.cache.get(self.key.clone(), self.etag.clone())
   }
 
   pub fn store<T: CacheValueData>(&self, value: CacheValue<T>) -> Result<()> {

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -1,0 +1,90 @@
+use std::sync::Arc;
+
+use rspack_error::Result;
+
+use super::{Cache, CacheKey, CacheValue, Etag, cache_value::CacheValueData};
+
+/// A namespaced view of the shared cache.
+///
+/// This is the minimal equivalent of webpack's `CacheFacade`: it prefixes
+/// identifiers with a fixed namespace and creates child or item facades.
+#[derive(Debug, Clone)]
+pub struct CacheFacade {
+  cache: Cache,
+  name: Arc<str>,
+}
+
+#[allow(private_bounds)]
+impl CacheFacade {
+  pub(crate) fn new(cache: Cache, name: impl Into<Arc<str>>) -> Self {
+    Self {
+      cache,
+      name: name.into(),
+    }
+  }
+
+  pub fn get_child_cache(&self, name: &str) -> Self {
+    Self {
+      cache: self.cache.clone(),
+      name: join_name(&self.name, name, true),
+    }
+  }
+
+  pub fn get_item_cache(&self, identifier: &str, etag: Option<Etag>) -> ItemCacheFacade {
+    ItemCacheFacade {
+      cache: self.cache.clone(),
+      key: self.key(identifier),
+      etag,
+    }
+  }
+
+  pub async fn get<T: CacheValueData>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+  ) -> Result<Option<CacheValue<T>>> {
+    self.cache.get(self.key(identifier), etag).await
+  }
+
+  pub fn store<T: CacheValueData>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) -> Result<()> {
+    self.cache.store(self.key(identifier), etag, value)
+  }
+
+  fn key(&self, identifier: &str) -> CacheKey {
+    CacheKey::from(join_name(&self.name, identifier, true))
+  }
+}
+
+/// A cache facade with a fixed identifier and etag.
+#[derive(Debug, Clone)]
+pub struct ItemCacheFacade {
+  cache: Cache,
+  key: CacheKey,
+  etag: Option<Etag>,
+}
+
+#[allow(private_bounds)]
+impl ItemCacheFacade {
+  pub async fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
+    self.cache.get(self.key.clone(), self.etag.clone()).await
+  }
+
+  pub fn store<T: CacheValueData>(&self, value: CacheValue<T>) -> Result<()> {
+    self.cache.store(self.key.clone(), self.etag.clone(), value)
+  }
+}
+
+fn join_name(prefix: &str, name: &str, with_separator: bool) -> Arc<str> {
+  let mut result = String::with_capacity(prefix.len() + name.len() + usize::from(with_separator));
+  result.push_str(prefix);
+  if with_separator {
+    result.push('|');
+  }
+  result.push_str(name);
+  result.into()
+}

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -14,7 +14,6 @@ pub struct CacheFacade {
   name: Arc<str>,
 }
 
-#[allow(private_bounds)]
 impl CacheFacade {
   pub(crate) fn new(cache: Cache, name: impl Into<Arc<str>>) -> Self {
     Self {
@@ -68,7 +67,6 @@ pub struct ItemCacheFacade {
   etag: Option<Etag>,
 }
 
-#[allow(private_bounds)]
 impl ItemCacheFacade {
   pub async fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
     self.cache.get(self.key.clone(), self.etag.clone()).await

--- a/crates/rspack_core/src/new_cache/cache_key.rs
+++ b/crates/rspack_core/src/new_cache/cache_key.rs
@@ -1,16 +1,10 @@
 use std::{fmt, ops::Deref, sync::Arc};
 
-use rspack_cacheable::cacheable;
-use rspack_util::fx_hash::BuildFxHasher;
-
-pub(super) type CacheKeyHasher = BuildFxHasher;
-
 /// Immutable, reference-counted cache identifier.
 ///
 /// Cloning a key only increments its reference count. The string is released
 /// when its last key is dropped.
-#[cacheable]
-#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, Hash, PartialEq)]
 pub struct CacheKey(Arc<str>);
 
 impl CacheKey {

--- a/crates/rspack_core/src/new_cache/cache_key.rs
+++ b/crates/rspack_core/src/new_cache/cache_key.rs
@@ -1,0 +1,75 @@
+use std::{fmt, ops::Deref, sync::Arc};
+
+use rspack_cacheable::cacheable;
+use rspack_util::fx_hash::BuildFxHasher;
+
+pub(super) type CacheKeyHasher = BuildFxHasher;
+
+/// Immutable, reference-counted cache identifier.
+///
+/// Cloning a key only increments its reference count. The string is released
+/// when its last key is dropped.
+#[cacheable]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CacheKey(Arc<str>);
+
+impl CacheKey {
+  pub fn new(value: &str) -> Self {
+    Self(Arc::from(value))
+  }
+
+  pub fn as_str(&self) -> &str {
+    self.0.as_ref()
+  }
+
+  pub fn as_bytes(&self) -> &[u8] {
+    self.as_str().as_bytes()
+  }
+}
+
+impl fmt::Debug for CacheKey {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter
+      .debug_tuple("CacheKey")
+      .field(&self.as_str())
+      .finish()
+  }
+}
+
+impl fmt::Display for CacheKey {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(self.as_str())
+  }
+}
+
+impl AsRef<str> for CacheKey {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
+
+impl Deref for CacheKey {
+  type Target = str;
+
+  fn deref(&self) -> &Self::Target {
+    self.as_str()
+  }
+}
+
+impl From<&str> for CacheKey {
+  fn from(value: &str) -> Self {
+    Self::new(value)
+  }
+}
+
+impl From<String> for CacheKey {
+  fn from(value: String) -> Self {
+    Self(value.into())
+  }
+}
+
+impl From<Arc<str>> for CacheKey {
+  fn from(value: Arc<str>) -> Self {
+    Self(value)
+  }
+}

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -1,0 +1,115 @@
+use std::{any::Any, fmt, ops::Deref, sync::Arc};
+
+use rspack_cacheable::{cacheable, cacheable_dyn};
+
+use super::etag::Etag;
+
+/// Actual data stored in [`CacheValue`].
+///
+/// Concrete data types must be cacheable, and their implementations must use
+/// `#[rspack_cacheable::cacheable_dyn]` so they can be restored through this
+/// trait object.
+#[cacheable_dyn]
+pub trait CacheValueData: Any + fmt::Debug + Send + Sync {}
+
+/// Shared immutable cache value.
+///
+/// Cloning this wrapper only increments an `Arc`; the cached object itself is
+/// never cloned.
+pub struct CacheValue<T>(Arc<T>);
+
+impl<T> CacheValue<T> {
+  pub fn new(value: T) -> Self {
+    Self(Arc::new(value))
+  }
+
+  pub fn from_arc(value: Arc<T>) -> Self {
+    Self(value)
+  }
+
+  pub fn as_arc(&self) -> &Arc<T> {
+    &self.0
+  }
+
+  pub fn into_arc(self) -> Arc<T> {
+    self.0
+  }
+}
+
+impl<T: CacheValueData> CacheValue<T> {
+  pub(super) fn erase(self) -> ErasedCacheValue {
+    ErasedCacheValue(self.0)
+  }
+}
+
+impl<T> Clone for CacheValue<T> {
+  fn clone(&self) -> Self {
+    Self(self.0.clone())
+  }
+}
+
+impl<T: fmt::Debug> fmt::Debug for CacheValue<T> {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0.fmt(formatter)
+  }
+}
+
+impl<T> Deref for CacheValue<T> {
+  type Target = T;
+
+  fn deref(&self) -> &Self::Target {
+    self.0.as_ref()
+  }
+}
+
+impl<T> From<Arc<T>> for CacheValue<T> {
+  fn from(value: Arc<T>) -> Self {
+    Self::from_arc(value)
+  }
+}
+
+/// Type-erased value used only inside the shared cache layers.
+///
+/// Serialization is performed by the filesystem strategy only when the
+/// background job processes idle writes.
+#[cacheable]
+#[derive(Clone)]
+pub(super) struct ErasedCacheValue(Arc<dyn CacheValueData>);
+
+impl ErasedCacheValue {
+  pub(super) fn downcast<T: CacheValueData>(self) -> Option<CacheValue<T>> {
+    let value: Arc<dyn Any + Send + Sync> = self.0;
+    Arc::downcast(value).ok().map(CacheValue::from_arc)
+  }
+}
+
+impl fmt::Debug for ErasedCacheValue {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0.fmt(formatter)
+  }
+}
+
+#[cacheable]
+#[derive(Debug)]
+pub(super) struct CacheEntry {
+  etag: Option<Etag>,
+  value: ErasedCacheValue,
+}
+
+impl CacheEntry {
+  pub(super) fn new(etag: Option<Etag>, value: ErasedCacheValue) -> Self {
+    Self { etag, value }
+  }
+
+  pub(super) fn matches(&self, etag: &Option<Etag>) -> bool {
+    &self.etag == etag
+  }
+
+  pub(super) fn value(&self) -> &ErasedCacheValue {
+    &self.value
+  }
+
+  pub(super) fn into_value(self) -> ErasedCacheValue {
+    self.value
+  }
+}

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -56,7 +56,7 @@ impl<T> From<Arc<T>> for CacheValue<T> {
 }
 
 /// Internal marker automatically implemented for cacheable values.
-pub(crate) trait CacheValueData:
+pub trait CacheValueData:
   Any
   + Send
   + Sync
@@ -125,7 +125,6 @@ impl CacheEntry {
   }
 }
 
-#[allow(private_bounds)]
 impl<T: CacheValueData> CacheValue<T> {
   pub(super) fn erase(self) -> ErasedCacheValue {
     ErasedCacheValue::new(self.0)

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -125,6 +125,7 @@ impl CacheEntry {
   }
 }
 
+#[allow(private_bounds)]
 impl<T: CacheValueData> CacheValue<T> {
   pub(super) fn erase(self) -> ErasedCacheValue {
     ErasedCacheValue::new(self.0)

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -1,16 +1,13 @@
 use std::{any::Any, fmt, ops::Deref, sync::Arc};
 
-use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_cacheable::{
+  __private::rkyv::{Archive, Deserialize, Serialize, bytecheck::CheckBytes},
+  Deserializer, Serializer, Validator, cacheable,
+};
+use rspack_error::Result;
 
 use super::etag::Etag;
-
-/// Actual data stored in [`CacheValue`].
-///
-/// Concrete data types must be cacheable, and their implementations must use
-/// `#[rspack_cacheable::cacheable_dyn]` so they can be restored through this
-/// trait object.
-#[cacheable_dyn]
-pub trait CacheValueData: Any + fmt::Debug + Send + Sync {}
+use crate::cache::persistent::codec::CacheCodec;
 
 /// Shared immutable cache value.
 ///
@@ -23,22 +20,12 @@ impl<T> CacheValue<T> {
     Self(Arc::new(value))
   }
 
-  pub fn from_arc(value: Arc<T>) -> Self {
-    Self(value)
-  }
-
   pub fn as_arc(&self) -> &Arc<T> {
     &self.0
   }
 
   pub fn into_arc(self) -> Arc<T> {
     self.0
-  }
-}
-
-impl<T: CacheValueData> CacheValue<T> {
-  pub(super) fn erase(self) -> ErasedCacheValue {
-    ErasedCacheValue(self.0)
   }
 }
 
@@ -64,32 +51,60 @@ impl<T> Deref for CacheValue<T> {
 
 impl<T> From<Arc<T>> for CacheValue<T> {
   fn from(value: Arc<T>) -> Self {
-    Self::from_arc(value)
+    Self(value)
   }
 }
 
+/// Internal marker automatically implemented for cacheable values.
+pub(crate) trait CacheValueData:
+  Any
+  + Send
+  + Sync
+  + Sized
+  + Archive<Archived: for<'a> CheckBytes<Validator<'a>> + Deserialize<Self, Deserializer>>
+  + for<'a> Serialize<Serializer<'a>>
+{
+}
+
+impl<T> CacheValueData for T
+where
+  T: Any + Send + Sync + Archive + for<'a> Serialize<Serializer<'a>>,
+  T::Archived: for<'a> CheckBytes<Validator<'a>> + Deserialize<T, Deserializer>,
+{
+}
+
+pub(super) type CacheValueEncoder = fn(&CacheEntry, &CacheCodec) -> Result<Vec<u8>>;
+pub(super) type CacheValueDecoder =
+  fn(&[u8], Option<&Etag>, &CacheCodec) -> Result<Option<ErasedCacheValue>>;
+
 /// Type-erased value used only inside the shared cache layers.
-///
-/// Serialization is performed by the filesystem strategy only when the
-/// background job processes idle writes.
-#[cacheable]
 #[derive(Clone)]
-pub(super) struct ErasedCacheValue(Arc<dyn CacheValueData>);
+pub(super) struct ErasedCacheValue(Arc<dyn Any + Send + Sync>);
 
 impl ErasedCacheValue {
-  pub(super) fn downcast<T: CacheValueData>(self) -> Option<CacheValue<T>> {
-    let value: Arc<dyn Any + Send + Sync> = self.0;
-    Arc::downcast(value).ok().map(CacheValue::from_arc)
+  fn new<T: Any + Send + Sync>(value: Arc<T>) -> Self {
+    Self(value)
+  }
+
+  pub(super) fn downcast<T: Any + Send + Sync>(self) -> Option<CacheValue<T>> {
+    Arc::downcast(self.0).ok().map(CacheValue::from)
   }
 }
 
 impl fmt::Debug for ErasedCacheValue {
   fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-    self.0.fmt(formatter)
+    formatter
+      .debug_struct("ErasedCacheValue")
+      .finish_non_exhaustive()
   }
 }
 
 #[cacheable]
+struct StoredCacheEntry<T> {
+  etag: Option<Etag>,
+  value: Arc<T>,
+}
+
 #[derive(Debug)]
 pub(super) struct CacheEntry {
   etag: Option<Etag>,
@@ -101,15 +116,50 @@ impl CacheEntry {
     Self { etag, value }
   }
 
-  pub(super) fn matches(&self, etag: &Option<Etag>) -> bool {
-    &self.etag == etag
+  pub(super) fn matches(&self, etag: Option<&Etag>) -> bool {
+    self.etag.as_ref() == etag
   }
 
   pub(super) fn value(&self) -> &ErasedCacheValue {
     &self.value
   }
+}
 
-  pub(super) fn into_value(self) -> ErasedCacheValue {
-    self.value
+impl<T: CacheValueData> CacheValue<T> {
+  pub(super) fn erase(self) -> ErasedCacheValue {
+    ErasedCacheValue::new(self.0)
   }
+
+  pub(super) fn encoder() -> CacheValueEncoder {
+    encode_cache_entry::<T>
+  }
+
+  pub(super) fn decoder() -> CacheValueDecoder {
+    decode_cache_entry::<T>
+  }
+}
+
+fn encode_cache_entry<T: CacheValueData>(
+  entry: &CacheEntry,
+  codec: &CacheCodec,
+) -> Result<Vec<u8>> {
+  let value = entry
+    .value
+    .0
+    .clone()
+    .downcast::<T>()
+    .map_err(|_| rspack_error::error!("Cache value type mismatch"))?;
+  codec.encode(&StoredCacheEntry {
+    etag: entry.etag.clone(),
+    value,
+  })
+}
+
+fn decode_cache_entry<T: CacheValueData>(
+  bytes: &[u8],
+  etag: Option<&Etag>,
+  codec: &CacheCodec,
+) -> Result<Option<ErasedCacheValue>> {
+  let entry = codec.decode::<StoredCacheEntry<T>>(bytes)?;
+  Ok((entry.etag.as_ref() == etag).then(|| ErasedCacheValue::new(entry.value)))
 }

--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use rspack_error::Result;
+use rspack_paths::Utf8PathBuf;
+use rustc_hash::FxHashMap;
+
+use super::{DatabaseFamily, DatabaseWrite};
+
+pub type DatabaseValue = Arc<[u8]>;
+
+#[derive(Debug, Default)]
+pub struct Database {
+  families: [FxHashMap<Vec<u8>, DatabaseValue>; DatabaseFamily::COUNT],
+}
+
+impl Database {
+  pub fn open(_base_path: Utf8PathBuf, _path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
+    Ok(Self::default())
+  }
+
+  pub fn get(&self, family: DatabaseFamily, key: &[u8]) -> Result<Option<DatabaseValue>> {
+    Ok(self.families[family.index()].get(key).cloned())
+  }
+
+  pub fn write_batch<'a>(
+    &mut self,
+    writes: impl IntoIterator<Item = DatabaseWrite<'a>>,
+  ) -> Result<()> {
+    for write in writes {
+      self.families[write.family.index()].insert(write.key.to_vec(), Arc::from(write.value));
+    }
+    Ok(())
+  }
+
+  pub fn reset(&mut self) -> Result<()> {
+    for family in &mut self.families {
+      family.clear();
+    }
+    Ok(())
+  }
+
+  pub fn cleanup_stale(&self) {}
+
+  pub fn shutdown(&mut self) -> Result<()> {
+    self.reset()
+  }
+}

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -1,0 +1,39 @@
+#[cfg(target_family = "wasm")]
+mod memory;
+#[cfg(not(target_family = "wasm"))]
+mod turbo;
+
+#[cfg(target_family = "wasm")]
+pub use memory::{Database, DatabaseValue};
+#[cfg(not(target_family = "wasm"))]
+pub use turbo::{Database, DatabaseValue};
+
+#[derive(Debug, Clone, Copy)]
+pub enum DatabaseFamily {
+  Cache,
+  Snapshot,
+}
+
+impl DatabaseFamily {
+  pub const COUNT: usize = 2;
+
+  pub const fn index(self) -> usize {
+    match self {
+      Self::Cache => 0,
+      Self::Snapshot => 1,
+    }
+  }
+}
+
+#[derive(Debug)]
+pub struct DatabaseWrite<'a> {
+  pub family: DatabaseFamily,
+  pub key: &'a [u8],
+  pub value: &'a [u8],
+}
+
+impl<'a> DatabaseWrite<'a> {
+  pub fn new(family: DatabaseFamily, key: &'a [u8], value: &'a [u8]) -> Self {
+    Self { family, key, value }
+  }
+}

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -1,0 +1,178 @@
+use std::{
+  fmt,
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use rspack_error::Result;
+use rspack_paths::Utf8PathBuf;
+use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, TurboPersistence};
+
+use super::DatabaseWrite;
+use crate::new_cache::db::DatabaseFamily;
+
+const STALE_DIRECTORY: &str = "_stale";
+
+type Inner = TurboPersistence<SerialScheduler, { DatabaseFamily::COUNT }>;
+pub type DatabaseValue = turbo_persistence::ArcBytes;
+
+pub struct Database {
+  inner: Inner,
+  base_path: Utf8PathBuf,
+  path: Utf8PathBuf,
+  readonly: bool,
+}
+
+impl fmt::Debug for Database {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter
+      .debug_struct("Database")
+      .field("path", &self.path)
+      .field("readonly", &self.readonly)
+      .finish_non_exhaustive()
+  }
+}
+
+impl Database {
+  pub fn open(base_path: Utf8PathBuf, path: Utf8PathBuf, readonly: bool) -> Result<Self> {
+    let inner = open_database(&path, readonly)?;
+    Ok(Self {
+      inner,
+      base_path,
+      path,
+      readonly,
+    })
+  }
+
+  pub fn get(&self, family: super::DatabaseFamily, key: &[u8]) -> Result<Option<DatabaseValue>> {
+    Ok(self.inner.get(family.index(), &key)?)
+  }
+
+  pub fn write_batch<'a>(
+    &mut self,
+    writes: impl IntoIterator<Item = DatabaseWrite<'a>>,
+  ) -> Result<()> {
+    let batch = self.inner.write_batch::<&[u8]>()?;
+    for write in writes {
+      batch.put(write.family.index() as u32, write.key, write.value.into())?;
+    }
+    self.inner.commit_write_batch(batch)?;
+    Ok(())
+  }
+
+  pub fn reset(&mut self) -> Result<()> {
+    let old_database = std::mem::replace(
+      &mut self.inner,
+      Inner::empty_in_memory_with_config(database_config()),
+    );
+    old_database.clear_cache();
+    old_database.shutdown()?;
+    drop(old_database);
+
+    if !self.readonly {
+      self.move_to_stale()?;
+      self.inner = open_database(&self.path, false)?;
+    }
+    Ok(())
+  }
+
+  pub fn cleanup_stale(&self) {
+    let stale_directory = self.stale_directory();
+    match std::fs::remove_dir_all(stale_directory.as_std_path()) {
+      Ok(()) => {
+        tracing::debug!(
+          path = %stale_directory,
+          "Removed stale persistent cache databases"
+        );
+      }
+      Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+      Err(error) => {
+        tracing::warn!(
+          path = %stale_directory,
+          "Removing stale persistent cache databases failed: {error}"
+        );
+      }
+    }
+  }
+
+  pub fn shutdown(&mut self) -> Result<()> {
+    self.inner.clear_cache();
+    self.inner.shutdown()?;
+    Ok(())
+  }
+
+  fn move_to_stale(&self) -> Result<()> {
+    let path = self.path.as_std_path();
+    if !path.is_dir() {
+      return Ok(());
+    }
+
+    let file_name = path.file_name().ok_or_else(|| {
+      rspack_error::error!(
+        "Persistent cache path has no directory name: {}",
+        path.display()
+      )
+    })?;
+    let stale_directory = self.stale_directory();
+    std::fs::create_dir_all(stale_directory.as_std_path()).map_err(|error| {
+      rspack_error::error!(
+        "Failed to create stale cache directory {}: {error}",
+        stale_directory
+      )
+    })?;
+    let timestamp = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_nanos();
+    let stale_path = stale_directory.join(format!(
+      "{}-{}-{timestamp}",
+      file_name.to_string_lossy(),
+      std::process::id()
+    ));
+    std::fs::rename(path, stale_path.as_std_path()).map_err(|error| {
+      rspack_error::error!(
+        "Failed to move invalid persistent cache database {} to {}: {error}",
+        path.display(),
+        stale_path
+      )
+    })?;
+    Ok(())
+  }
+
+  fn stale_directory(&self) -> Utf8PathBuf {
+    self.base_path.join(STALE_DIRECTORY)
+  }
+}
+
+fn open_database(path: &Utf8PathBuf, readonly: bool) -> Result<Inner> {
+  let config = database_config();
+  if readonly {
+    if path.as_std_path().is_dir() {
+      Ok(Inner::open_read_only_with_config(
+        path.as_std_path().to_path_buf(),
+        config,
+      )?)
+    } else {
+      Ok(Inner::empty_in_memory_with_config(config))
+    }
+  } else {
+    Ok(Inner::open_with_config(
+      path.as_std_path().to_path_buf(),
+      config,
+    )?)
+  }
+}
+
+fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
+  DbConfig {
+    family_configs: [
+      FamilyConfig {
+        name: "cache",
+        kind: FamilyKind::SingleValue,
+      },
+      FamilyConfig {
+        name: "snapshot",
+        kind: FamilyKind::SingleValue,
+      },
+    ],
+  }
+}

--- a/crates/rspack_core/src/new_cache/etag.rs
+++ b/crates/rspack_core/src/new_cache/etag.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::cacheable;
 
 /// Immutable validation token associated with a cached value.
 #[cacheable]
-#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Etag(Arc<str>);
 
 impl Etag {

--- a/crates/rspack_core/src/new_cache/etag.rs
+++ b/crates/rspack_core/src/new_cache/etag.rs
@@ -1,0 +1,62 @@
+use std::{fmt, ops::Deref, sync::Arc};
+
+use rspack_cacheable::cacheable;
+
+/// Immutable validation token associated with a cached value.
+#[cacheable]
+#[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Etag(Arc<str>);
+
+impl Etag {
+  pub fn new(value: &str) -> Self {
+    Self(Arc::from(value))
+  }
+
+  pub fn as_str(&self) -> &str {
+    self.0.as_ref()
+  }
+}
+
+impl fmt::Debug for Etag {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.debug_tuple("Etag").field(&self.as_str()).finish()
+  }
+}
+
+impl fmt::Display for Etag {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter.write_str(self.as_str())
+  }
+}
+
+impl AsRef<str> for Etag {
+  fn as_ref(&self) -> &str {
+    self.as_str()
+  }
+}
+
+impl Deref for Etag {
+  type Target = str;
+
+  fn deref(&self) -> &Self::Target {
+    self.as_str()
+  }
+}
+
+impl From<&str> for Etag {
+  fn from(value: &str) -> Self {
+    Self::new(value)
+  }
+}
+
+impl From<String> for Etag {
+  fn from(value: String) -> Self {
+    Self(value.into())
+  }
+}
+
+impl From<Arc<str>> for Etag {
+  fn from(value: Arc<str>) -> Self {
+    Self(value)
+  }
+}

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,39 +1,47 @@
 use std::{
-  collections::hash_map::DefaultHasher,
   fmt,
   hash::{Hash, Hasher},
 };
 
 use once_cell::sync::OnceCell;
+use rspack_cacheable::{
+  cacheable,
+  utils::PortablePath,
+  with::{As, AsVec},
+};
 use rspack_error::Result;
 use rspack_paths::Utf8PathBuf;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, TurboPersistence};
 
-use super::{CacheData, Etag};
+use super::{
+  CacheKey, Etag,
+  cache_value::{CacheEntry, ErasedCacheValue},
+};
+use crate::cache::persistent::codec::CacheCodec;
 
 const CACHE_FAMILY: usize = 0;
 const META_FAMILY: usize = 1;
 const FAMILY_COUNT: usize = 2;
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
-const NO_ETAG: u32 = u32::MAX;
 
 type Database = TurboPersistence<SerialScheduler, FAMILY_COUNT>;
 
-#[derive(Debug, Clone)]
-struct CacheEntry {
-  etag: Option<Etag>,
-  data: CacheData,
+#[cacheable]
+struct StoredBuildDependencies {
+  #[cacheable(with=AsVec<As<PortablePath>>)]
+  dependencies: Vec<Utf8PathBuf>,
 }
 
 #[derive(Debug, Default)]
 struct PendingWrites {
-  entries: HashMap<String, CacheEntry>,
-  build_dependencies: HashSet<Utf8PathBuf>,
+  entries: FxHashMap<CacheKey, CacheEntry>,
+  build_dependencies: FxHashSet<Utf8PathBuf>,
 }
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
+  codec: CacheCodec,
   database: OnceCell<Database>,
   database_path: Utf8PathBuf,
   pending_writes: PendingWrites,
@@ -51,8 +59,14 @@ impl fmt::Debug for FileCacheStrategy {
 }
 
 impl FileCacheStrategy {
-  pub fn new(cache_location: Utf8PathBuf, version: &str, readonly: bool) -> Self {
+  pub fn new(
+    cache_location: Utf8PathBuf,
+    version: &str,
+    readonly: bool,
+    codec: CacheCodec,
+  ) -> Self {
     Self {
+      codec,
       database: OnceCell::new(),
       database_path: cache_location.join(version_directory(version)),
       pending_writes: PendingWrites::default(),
@@ -60,11 +74,11 @@ impl FileCacheStrategy {
     }
   }
 
-  pub async fn store(
+  pub(super) async fn store(
     &mut self,
-    identifier: String,
+    key: CacheKey,
     etag: Option<Etag>,
-    data: CacheData,
+    value: ErasedCacheValue,
   ) -> Result<()> {
     if self.readonly {
       return Ok(());
@@ -72,20 +86,25 @@ impl FileCacheStrategy {
     self
       .pending_writes
       .entries
-      .insert(identifier, CacheEntry { etag, data });
+      .insert(key, CacheEntry::new(etag, value));
     Ok(())
   }
 
-  pub async fn restore(&self, identifier: &str, etag: Option<&str>) -> Result<Option<CacheData>> {
-    if let Some(entry) = self.pending_writes.entries.get(identifier) {
-      return Ok((entry.etag.as_deref() == etag).then(|| entry.data.clone()));
+  pub(super) async fn restore(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Result<Option<ErasedCacheValue>> {
+    if let Some(entry) = self.pending_writes.entries.get(&key) {
+      return Ok(entry.matches(&etag).then(|| entry.value().clone()));
     }
 
-    let key = identifier.as_bytes();
-    let Some(entry) = self.database()?.get(CACHE_FAMILY, &key)? else {
+    let database_key = key.as_bytes();
+    let Some(entry) = self.database()?.get(CACHE_FAMILY, &database_key)? else {
       return Ok(None);
     };
-    decode_cache_entry(&entry, etag)
+    let entry = self.codec.decode::<CacheEntry>(&entry)?;
+    Ok(entry.matches(&etag).then(|| entry.into_value()))
   }
 
   pub async fn store_build_dependencies(&mut self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
@@ -111,16 +130,16 @@ impl FileCacheStrategy {
     } else {
       let mut dependencies = self.load_build_dependencies()?;
       dependencies.extend(pending.build_dependencies.iter().cloned());
-      Some(encode_build_dependencies(&dependencies)?)
+      Some(self.encode_build_dependencies(dependencies)?)
     };
 
     let database = self.database()?;
     let batch = database.write_batch::<Vec<u8>>()?;
-    for (identifier, entry) in &pending.entries {
+    for (key, entry) in &pending.entries {
       batch.put(
         CACHE_FAMILY as u32,
-        identifier.as_bytes().to_vec(),
-        encode_cache_entry(entry)?.into(),
+        key.as_bytes().to_vec(),
+        self.codec.encode(entry)?.into(),
       )?;
     }
     if let Some(build_dependencies) = build_dependencies {
@@ -173,12 +192,24 @@ impl FileCacheStrategy {
     })
   }
 
-  fn load_build_dependencies(&self) -> Result<HashSet<Utf8PathBuf>> {
+  fn load_build_dependencies(&self) -> Result<FxHashSet<Utf8PathBuf>> {
     let key = BUILD_DEPENDENCIES_KEY;
     let Some(dependencies) = self.database()?.get(META_FAMILY, &key)? else {
-      return Ok(HashSet::default());
+      return Ok(FxHashSet::default());
     };
-    decode_build_dependencies(&dependencies)
+    Ok(
+      self
+        .codec
+        .decode::<StoredBuildDependencies>(&dependencies)?
+        .dependencies
+        .into_iter()
+        .collect(),
+    )
+  }
+
+  fn encode_build_dependencies(&self, dependencies: FxHashSet<Utf8PathBuf>) -> Result<Vec<u8>> {
+    let dependencies = dependencies.into_iter().collect::<Vec<_>>();
+    self.codec.encode(&StoredBuildDependencies { dependencies })
   }
 }
 
@@ -198,99 +229,7 @@ fn database_config() -> DbConfig<FAMILY_COUNT> {
 }
 
 fn version_directory(version: &str) -> String {
-  let mut hasher = DefaultHasher::new();
+  let mut hasher = rustc_hash::FxHasher::default();
   version.hash(&mut hasher);
   format!("{:016x}", hasher.finish())
-}
-
-fn encode_cache_entry(entry: &CacheEntry) -> Result<Vec<u8>> {
-  let etag_len = match &entry.etag {
-    Some(etag) => {
-      u32::try_from(etag.len()).map_err(|_| rspack_error::error!("File cache etag is too large"))?
-    }
-    None => NO_ETAG,
-  };
-  let mut bytes = Vec::with_capacity(
-    size_of::<u32>() + entry.etag.as_ref().map_or(0, |etag| etag.len()) + entry.data.len(),
-  );
-  bytes.extend_from_slice(&etag_len.to_le_bytes());
-  if let Some(etag) = &entry.etag {
-    bytes.extend_from_slice(etag.as_bytes());
-  }
-  bytes.extend_from_slice(&entry.data);
-  Ok(bytes)
-}
-
-fn decode_cache_entry(bytes: &[u8], etag: Option<&str>) -> Result<Option<CacheData>> {
-  let mut offset = 0;
-  let etag_len = read_u32(bytes, &mut offset)?;
-  let stored_etag = if etag_len == NO_ETAG {
-    None
-  } else {
-    let etag = take_bytes(bytes, &mut offset, etag_len as usize)?;
-    Some(
-      std::str::from_utf8(etag)
-        .map_err(|_| rspack_error::error!("File cache contains an invalid etag"))?,
-    )
-  };
-  if stored_etag != etag {
-    return Ok(None);
-  }
-  Ok(Some(bytes[offset..].into()))
-}
-
-fn encode_build_dependencies(dependencies: &HashSet<Utf8PathBuf>) -> Result<Vec<u8>> {
-  let count = u32::try_from(dependencies.len())
-    .map_err(|_| rspack_error::error!("Too many file cache build dependencies"))?;
-  let mut dependencies = dependencies.iter().collect::<Vec<_>>();
-  dependencies.sort_unstable();
-
-  let mut bytes = Vec::new();
-  bytes.extend_from_slice(&count.to_le_bytes());
-  for dependency in dependencies {
-    let dependency = dependency.as_str().as_bytes();
-    let len = u32::try_from(dependency.len())
-      .map_err(|_| rspack_error::error!("File cache build dependency path is too large"))?;
-    bytes.extend_from_slice(&len.to_le_bytes());
-    bytes.extend_from_slice(dependency);
-  }
-  Ok(bytes)
-}
-
-fn decode_build_dependencies(bytes: &[u8]) -> Result<HashSet<Utf8PathBuf>> {
-  let mut offset = 0;
-  let count = read_u32(bytes, &mut offset)?;
-  let mut dependencies = HashSet::default();
-  for _ in 0..count {
-    let len = read_u32(bytes, &mut offset)?;
-    let dependency = take_bytes(bytes, &mut offset, len as usize)?;
-    let dependency = std::str::from_utf8(dependency)
-      .map_err(|_| rspack_error::error!("File cache contains an invalid build dependency"))?;
-    dependencies.insert(dependency.into());
-  }
-  if offset != bytes.len() {
-    return Err(rspack_error::error!(
-      "File cache contains trailing build dependency data"
-    ));
-  }
-  Ok(dependencies)
-}
-
-fn read_u32(bytes: &[u8], offset: &mut usize) -> Result<u32> {
-  let bytes = take_bytes(bytes, offset, size_of::<u32>())?;
-  Ok(u32::from_le_bytes(
-    bytes
-      .try_into()
-      .expect("four bytes should convert to a u32"),
-  ))
-}
-
-fn take_bytes<'a>(bytes: &'a [u8], offset: &mut usize, len: usize) -> Result<&'a [u8]> {
-  let end = offset
-    .checked_add(len)
-    .filter(|end| *end <= bytes.len())
-    .ok_or_else(|| rspack_error::error!("File cache contains truncated data"))?;
-  let value = &bytes[*offset..end];
-  *offset = end;
-  Ok(value)
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,0 +1,35 @@
+use rspack_error::Result;
+use rspack_paths::Utf8PathBuf;
+
+use super::{CacheData, Etag};
+
+/// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
+#[derive(Debug, Default)]
+pub struct FileCacheStrategy;
+
+impl FileCacheStrategy {
+  pub async fn store(
+    &self,
+    _identifier: String,
+    _etag: Option<Etag>,
+    _data: CacheData,
+  ) -> Result<()> {
+    todo!("implement filesystem cache store")
+  }
+
+  pub async fn restore(&self, _identifier: &str, _etag: Option<&str>) -> Result<Option<CacheData>> {
+    todo!("implement filesystem cache restore")
+  }
+
+  pub async fn store_build_dependencies(&self, _dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+    todo!("implement filesystem cache build dependencies store")
+  }
+
+  pub async fn after_all_stored(&self) -> Result<()> {
+    todo!("implement filesystem cache finalization")
+  }
+
+  pub async fn clear(&self) -> Result<()> {
+    todo!("implement filesystem cache clear")
+  }
+}

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,42 +1,29 @@
-use std::{
-  fmt,
-  hash::{Hash, Hasher},
-};
+use std::{fmt, sync::Arc};
 
 use once_cell::unsync::OnceCell;
-use rspack_cacheable::{
-  cacheable,
-  utils::PortablePath,
-  with::{As, AsVec},
-};
 use rspack_error::Result;
-use rspack_paths::Utf8PathBuf;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rspack_paths::{ArcPathSet, Utf8PathBuf};
+use rustc_hash::FxHashMap;
 use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, TurboPersistence};
 
 use super::{
   CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
+  snapshot::{BuildDeps, BuildDepsValidationResult, Snapshot},
 };
 use crate::cache::persistent::codec::CacheCodec;
 
 const CACHE_FAMILY: usize = 0;
-const META_FAMILY: usize = 1;
+const SNAPSHOT_FAMILY: usize = 1;
 const FAMILY_COUNT: usize = 2;
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
 
 type Database = TurboPersistence<SerialScheduler, FAMILY_COUNT>;
 
-#[cacheable]
-struct StoredBuildDependencies {
-  #[cacheable(with=AsVec<As<PortablePath>>)]
-  dependencies: Vec<Utf8PathBuf>,
-}
-
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
-  build_dependencies: FxHashSet<Utf8PathBuf>,
+  build_dependencies: Option<ArcPathSet>,
 }
 
 #[derive(Debug)]
@@ -47,7 +34,9 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
-  codec: CacheCodec,
+  codec: Arc<CacheCodec>,
+  snapshot: Snapshot,
+  build_deps: BuildDeps,
   database: OnceCell<Database>,
   database_path: Utf8PathBuf,
   pending_writes: PendingWrites,
@@ -67,17 +56,55 @@ impl fmt::Debug for FileCacheStrategy {
 impl FileCacheStrategy {
   pub fn new(
     cache_location: Utf8PathBuf,
-    version: &str,
     readonly: bool,
-    codec: CacheCodec,
+    codec: Arc<CacheCodec>,
+    snapshot: Snapshot,
+    build_deps: BuildDeps,
   ) -> Self {
     Self {
       codec,
+      snapshot,
+      build_deps,
       database: OnceCell::new(),
-      database_path: cache_location.join(version_directory(version)),
+      database_path: cache_location,
       pending_writes: PendingWrites::default(),
       readonly,
     }
+  }
+
+  /// Opens the current pack and validates its build dependencies once before
+  /// the background job starts serving commands.
+  pub async fn initialize(&mut self) -> Result<()> {
+    let build_snapshot = self
+      .database()?
+      .get(SNAPSHOT_FAMILY, &BUILD_DEPENDENCIES_KEY)?;
+    match self
+      .build_deps
+      .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
+      .await
+    {
+      Ok(BuildDepsValidationResult::Valid { tracked_files }) => {
+        tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
+      }
+      Ok(BuildDepsValidationResult::Invalid {
+        modified_files,
+        removed_files,
+      }) => {
+        tracing::info!(
+          modified_files = modified_files.len(),
+          removed_files = removed_files.len(),
+          "Creating a new persistent cache pack because build dependencies changed"
+        );
+        self.create_new_pack()?;
+      }
+      Err(error) => {
+        tracing::warn!(
+          "Creating a new persistent cache pack because build dependencies validation failed: {error}"
+        );
+        self.create_new_pack()?;
+      }
+    }
+    Ok(())
   }
 
   pub(super) fn store(
@@ -99,6 +126,17 @@ impl FileCacheStrategy {
     );
   }
 
+  pub fn store_build_dependencies(&mut self, dependencies: ArcPathSet) {
+    if self.readonly {
+      return;
+    }
+    self
+      .pending_writes
+      .build_dependencies
+      .get_or_insert_default()
+      .extend(dependencies);
+  }
+
   pub(super) fn restore(
     &self,
     key: &CacheKey,
@@ -114,63 +152,59 @@ impl FileCacheStrategy {
       );
     }
 
-    let database_key = key.as_bytes();
-    let Some(entry) = self.database()?.get(CACHE_FAMILY, &database_key)? else {
+    let Some(entry) = self.database()?.get(CACHE_FAMILY, &key.as_bytes())? else {
       return Ok(None);
     };
     decoder(&entry, etag, &self.codec)
   }
 
-  pub fn store_build_dependencies(&mut self, dependencies: Vec<Utf8PathBuf>) {
-    if self.readonly {
-      return;
-    }
-    self.pending_writes.build_dependencies.extend(dependencies);
-  }
-
-  pub fn after_all_stored(&mut self) -> Result<()> {
-    if self.readonly {
+  pub async fn after_all_stored(&mut self) -> Result<()> {
+    if self.readonly || !self.has_pending_writes() {
       return Ok(());
     }
 
-    let pending = &self.pending_writes;
-    if pending.entries.is_empty() && pending.build_dependencies.is_empty() {
-      return Ok(());
-    }
-
-    let build_dependencies = if pending.build_dependencies.is_empty() {
-      None
+    let build_snapshot = if let Some(dependencies) = &self.pending_writes.build_dependencies {
+      Some(
+        self
+          .build_deps
+          .create_snapshot(&self.codec, &self.snapshot, dependencies.iter().cloned())
+          .await?,
+      )
     } else {
-      let mut dependencies = self.load_build_dependencies()?;
-      dependencies.extend(pending.build_dependencies.iter().cloned());
-      Some(self.encode_build_dependencies(dependencies)?)
+      None
     };
+    let cache_entries = self
+      .pending_writes
+      .entries
+      .iter()
+      .map(|(key, pending)| Ok((key, (pending.encoder)(&pending.entry, &self.codec)?)))
+      .collect::<Result<Vec<_>>>()?;
+
+    if cache_entries.is_empty() && build_snapshot.is_none() {
+      return Ok(());
+    }
 
     let database = self.database()?;
     let batch = database.write_batch::<&[u8]>()?;
-    for (key, pending) in &pending.entries {
-      batch.put(
-        CACHE_FAMILY as u32,
-        key.as_bytes(),
-        (pending.encoder)(&pending.entry, &self.codec)?.into(),
-      )?;
+    for (key, value) in &cache_entries {
+      batch.put(CACHE_FAMILY as u32, key.as_bytes(), value.as_slice().into())?;
     }
-    if let Some(build_dependencies) = build_dependencies {
+    if let Some(build_snapshot) = &build_snapshot {
       batch.put(
-        META_FAMILY as u32,
+        SNAPSHOT_FAMILY as u32,
         BUILD_DEPENDENCIES_KEY,
-        build_dependencies.into(),
+        build_snapshot.as_slice().into(),
       )?;
     }
     database.commit_write_batch(batch)?;
 
     self.pending_writes.entries.clear();
-    self.pending_writes.build_dependencies.clear();
+    self.pending_writes.build_dependencies = None;
     Ok(())
   }
 
-  pub fn shutdown(&mut self) -> Result<()> {
-    self.after_all_stored()?;
+  pub async fn shutdown(&mut self) -> Result<()> {
+    self.after_all_stored().await?;
 
     if let Some(database) = self.database.get() {
       database.clear_cache();
@@ -179,8 +213,34 @@ impl FileCacheStrategy {
     Ok(())
   }
 
-  pub(super) fn has_pending_writes(&self) -> bool {
-    !self.pending_writes.entries.is_empty() || !self.pending_writes.build_dependencies.is_empty()
+  pub fn has_pending_writes(&self) -> bool {
+    !self.pending_writes.entries.is_empty() || self.pending_writes.build_dependencies.is_some()
+  }
+
+  fn create_new_pack(&mut self) -> Result<()> {
+    if let Some(database) = self.database.take() {
+      database.clear_cache();
+      database.shutdown()?;
+    }
+
+    let database = if self.readonly {
+      Database::empty_in_memory_with_config(database_config())
+    } else {
+      let path = self.database_path.as_std_path();
+      if path.is_dir() {
+        std::fs::remove_dir_all(path).map_err(|error| {
+          rspack_error::error!(
+            "Failed to remove invalid persistent cache pack {}: {error}",
+            path.display()
+          )
+        })?;
+      }
+      Database::open_with_config(path.to_path_buf(), database_config())?
+    };
+    if self.database.set(database).is_err() {
+      unreachable!("persistent cache database must be empty before creating a new pack");
+    }
+    Ok(())
   }
 
   fn database(&self) -> Result<&Database> {
@@ -203,26 +263,6 @@ impl FileCacheStrategy {
       }
     })
   }
-
-  fn load_build_dependencies(&self) -> Result<FxHashSet<Utf8PathBuf>> {
-    let key = BUILD_DEPENDENCIES_KEY;
-    let Some(dependencies) = self.database()?.get(META_FAMILY, &key)? else {
-      return Ok(FxHashSet::default());
-    };
-    Ok(
-      self
-        .codec
-        .decode::<StoredBuildDependencies>(&dependencies)?
-        .dependencies
-        .into_iter()
-        .collect(),
-    )
-  }
-
-  fn encode_build_dependencies(&self, dependencies: FxHashSet<Utf8PathBuf>) -> Result<Vec<u8>> {
-    let dependencies = dependencies.into_iter().collect::<Vec<_>>();
-    self.codec.encode(&StoredBuildDependencies { dependencies })
-  }
 }
 
 fn database_config() -> DbConfig<FAMILY_COUNT> {
@@ -233,15 +273,9 @@ fn database_config() -> DbConfig<FAMILY_COUNT> {
         kind: FamilyKind::SingleValue,
       },
       FamilyConfig {
-        name: "metadata",
+        name: "snapshot",
         kind: FamilyKind::SingleValue,
       },
     ],
   }
-}
-
-fn version_directory(version: &str) -> String {
-  let mut hasher = rustc_hash::FxHasher::default();
-  version.hash(&mut hasher);
-  format!("{:016x}", hasher.finish())
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,28 +1,18 @@
-use std::{
-  fmt,
-  sync::Arc,
-  time::{SystemTime, UNIX_EPOCH},
-};
+use std::{fmt, sync::Arc};
 
 use rspack_error::Result;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rustc_hash::FxHashMap;
-use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, TurboPersistence};
 
 use super::{
   CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
+  db::{Database, DatabaseFamily, DatabaseValue, DatabaseWrite},
   snapshot::{BuildDeps, BuildDepsValidationResult, Snapshot},
 };
 use crate::cache::persistent::codec::CacheCodec;
 
-const CACHE_FAMILY: usize = 0;
-const SNAPSHOT_FAMILY: usize = 1;
-const FAMILY_COUNT: usize = 2;
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
-const STALE_DIRECTORY: &str = "_stale";
-
-type Database = TurboPersistence<SerialScheduler, FAMILY_COUNT>;
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -42,8 +32,6 @@ pub struct FileCacheStrategy {
   snapshot: Snapshot,
   build_deps: BuildDeps,
   database: Database,
-  base_path: Utf8PathBuf,
-  database_path: Utf8PathBuf,
   pending_writes: PendingWrites,
   readonly: bool,
 }
@@ -52,8 +40,7 @@ impl fmt::Debug for FileCacheStrategy {
   fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     formatter
       .debug_struct("FileCacheStrategy")
-      .field("base_path", &self.base_path)
-      .field("database_path", &self.database_path)
+      .field("database", &self.database)
       .field("readonly", &self.readonly)
       .finish_non_exhaustive()
   }
@@ -68,14 +55,12 @@ impl FileCacheStrategy {
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
-    let database = Self::open_database(&database_path, readonly)?;
+    let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
       codec,
       snapshot,
       build_deps,
       database,
-      base_path,
-      database_path,
       pending_writes: PendingWrites::default(),
       readonly,
     })
@@ -85,9 +70,9 @@ impl FileCacheStrategy {
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
     let validation = {
-      let build_snapshot = self
+      let build_snapshot: Option<DatabaseValue> = self
         .database
-        .get(SNAPSHOT_FAMILY, &BUILD_DEPENDENCIES_KEY)?;
+        .get(DatabaseFamily::Snapshot, BUILD_DEPENDENCIES_KEY)?;
       self
         .build_deps
         .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
@@ -106,13 +91,13 @@ impl FileCacheStrategy {
           removed_files = removed_files.len(),
           "Resetting persistent cache database because build dependencies changed"
         );
-        self.reset_database()?;
+        self.database.reset()?;
       }
       Err(error) => {
         tracing::warn!(
           "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
-        self.reset_database()?;
+        self.database.reset()?;
       }
     }
     Ok(())
@@ -163,7 +148,7 @@ impl FileCacheStrategy {
       );
     }
 
-    let Some(entry) = self.database.get(CACHE_FAMILY, &key.as_bytes())? else {
+    let Some(entry) = self.database.get(DatabaseFamily::Cache, key.as_bytes())? else {
       return Ok(None);
     };
     decoder(&entry, etag, &self.codec)
@@ -192,147 +177,36 @@ impl FileCacheStrategy {
         .map(|(key, pending)| Ok((key, (pending.encoder)(&pending.entry, &self.codec)?)))
         .collect::<Result<Vec<_>>>()?;
 
-      let batch = self.database.write_batch::<&[u8]>()?;
-      for (key, value) in &cache_entries {
-        batch.put(CACHE_FAMILY as u32, key.as_bytes(), value.as_slice().into())?;
-      }
-      if let Some(build_snapshot) = &build_snapshot {
-        batch.put(
-          SNAPSHOT_FAMILY as u32,
-          BUILD_DEPENDENCIES_KEY,
-          build_snapshot.as_slice().into(),
-        )?;
-      }
-      self.database.commit_write_batch(batch)?;
+      let writes = cache_entries
+        .iter()
+        .map(|(key, value)| {
+          DatabaseWrite::new(DatabaseFamily::Cache, key.as_bytes(), value.as_slice())
+        })
+        .chain(build_snapshot.iter().map(|snapshot| {
+          DatabaseWrite::new(
+            DatabaseFamily::Snapshot,
+            BUILD_DEPENDENCIES_KEY,
+            snapshot.as_slice(),
+          )
+        }));
+      self.database.write_batch(writes)?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
     }
 
-    self.cleanup_stale();
+    self.database.cleanup_stale();
     Ok(())
   }
 
   pub async fn shutdown(&mut self) -> Result<()> {
     self.after_all_stored().await?;
 
-    self.database.clear_cache();
     self.database.shutdown()?;
     Ok(())
   }
 
   pub fn has_pending_writes(&self) -> bool {
     !self.pending_writes.entries.is_empty() || self.pending_writes.build_dependencies.is_some()
-  }
-
-  fn reset_database(&mut self) -> Result<()> {
-    let old_database = std::mem::replace(
-      &mut self.database,
-      Database::empty_in_memory_with_config(database_config()),
-    );
-    old_database.clear_cache();
-    old_database.shutdown()?;
-    drop(old_database);
-
-    if !self.readonly {
-      self.move_database_to_stale()?;
-      self.database = Self::open_database(&self.database_path, false)?;
-    }
-    Ok(())
-  }
-
-  fn open_database(database_path: &Utf8PathBuf, readonly: bool) -> Result<Database> {
-    let config = database_config();
-    if readonly {
-      if database_path.as_std_path().is_dir() {
-        Ok(Database::open_read_only_with_config(
-          database_path.as_std_path().to_path_buf(),
-          config,
-        )?)
-      } else {
-        Ok(Database::empty_in_memory_with_config(config))
-      }
-    } else {
-      Ok(Database::open_with_config(
-        database_path.as_std_path().to_path_buf(),
-        config,
-      )?)
-    }
-  }
-
-  fn move_database_to_stale(&self) -> Result<()> {
-    let database_path = self.database_path.as_std_path();
-    if !database_path.is_dir() {
-      return Ok(());
-    }
-
-    let file_name = database_path.file_name().ok_or_else(|| {
-      rspack_error::error!(
-        "Persistent cache path has no directory name: {}",
-        database_path.display()
-      )
-    })?;
-    let stale_directory = self.stale_directory();
-    std::fs::create_dir_all(stale_directory.as_std_path()).map_err(|error| {
-      rspack_error::error!(
-        "Failed to create stale cache directory {}: {error}",
-        stale_directory
-      )
-    })?;
-    let timestamp = SystemTime::now()
-      .duration_since(UNIX_EPOCH)
-      .unwrap_or_default()
-      .as_nanos();
-    let stale_path = stale_directory.join(format!(
-      "{}-{}-{timestamp}",
-      file_name.to_string_lossy(),
-      std::process::id()
-    ));
-    std::fs::rename(database_path, stale_path.as_std_path()).map_err(|error| {
-      rspack_error::error!(
-        "Failed to move invalid persistent cache pack {} to {}: {error}",
-        database_path.display(),
-        stale_path
-      )
-    })?;
-    Ok(())
-  }
-
-  fn stale_directory(&self) -> Utf8PathBuf {
-    self.base_path.join(STALE_DIRECTORY)
-  }
-
-  fn cleanup_stale(&self) {
-    let stale_directory = self.stale_directory();
-    match std::fs::remove_dir_all(stale_directory.as_std_path()) {
-      Ok(()) => {
-        tracing::debug!(
-          path = %stale_directory,
-          "Removed stale persistent cache packs"
-        );
-      }
-      Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-      Err(error) => {
-        tracing::warn!(
-          path = %stale_directory,
-          "Removing stale persistent cache packs failed: {error}"
-        );
-      }
-    }
-  }
-}
-
-fn database_config() -> DbConfig<FAMILY_COUNT> {
-  DbConfig {
-    family_configs: [
-      FamilyConfig {
-        name: "cache",
-        kind: FamilyKind::SingleValue,
-      },
-      FamilyConfig {
-        name: "snapshot",
-        kind: FamilyKind::SingleValue,
-      },
-    ],
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -3,7 +3,7 @@ use std::{
   hash::{Hash, Hasher},
 };
 
-use once_cell::sync::OnceCell;
+use once_cell::unsync::OnceCell;
 use rspack_cacheable::{
   cacheable,
   utils::PortablePath,
@@ -16,7 +16,7 @@ use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, Tur
 
 use super::{
   CacheKey, Etag,
-  cache_value::{CacheEntry, ErasedCacheValue},
+  cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
 };
 use crate::cache::persistent::codec::CacheCodec;
 
@@ -35,8 +35,14 @@ struct StoredBuildDependencies {
 
 #[derive(Debug, Default)]
 struct PendingWrites {
-  entries: FxHashMap<CacheKey, CacheEntry>,
+  entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: FxHashSet<Utf8PathBuf>,
+}
+
+#[derive(Debug)]
+struct PendingWrite {
+  entry: CacheEntry,
+  encoder: CacheValueEncoder,
 }
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
@@ -74,48 +80,55 @@ impl FileCacheStrategy {
     }
   }
 
-  pub(super) async fn store(
+  pub(super) fn store(
     &mut self,
     key: CacheKey,
     etag: Option<Etag>,
     value: ErasedCacheValue,
-  ) -> Result<()> {
+    encoder: CacheValueEncoder,
+  ) {
     if self.readonly {
-      return Ok(());
+      return;
     }
-    self
-      .pending_writes
-      .entries
-      .insert(key, CacheEntry::new(etag, value));
-    Ok(())
+    self.pending_writes.entries.insert(
+      key,
+      PendingWrite {
+        entry: CacheEntry::new(etag, value),
+        encoder,
+      },
+    );
   }
 
-  pub(super) async fn restore(
+  pub(super) fn restore(
     &self,
-    key: CacheKey,
-    etag: Option<Etag>,
+    key: &CacheKey,
+    etag: Option<&Etag>,
+    decoder: CacheValueDecoder,
   ) -> Result<Option<ErasedCacheValue>> {
-    if let Some(entry) = self.pending_writes.entries.get(&key) {
-      return Ok(entry.matches(&etag).then(|| entry.value().clone()));
+    if let Some(pending) = self.pending_writes.entries.get(key) {
+      return Ok(
+        pending
+          .entry
+          .matches(etag)
+          .then(|| pending.entry.value().clone()),
+      );
     }
 
     let database_key = key.as_bytes();
     let Some(entry) = self.database()?.get(CACHE_FAMILY, &database_key)? else {
       return Ok(None);
     };
-    let entry = self.codec.decode::<CacheEntry>(&entry)?;
-    Ok(entry.matches(&etag).then(|| entry.into_value()))
+    decoder(&entry, etag, &self.codec)
   }
 
-  pub async fn store_build_dependencies(&mut self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+  pub fn store_build_dependencies(&mut self, dependencies: Vec<Utf8PathBuf>) {
     if self.readonly {
-      return Ok(());
+      return;
     }
     self.pending_writes.build_dependencies.extend(dependencies);
-    Ok(())
   }
 
-  pub async fn after_all_stored(&mut self) -> Result<()> {
+  pub fn after_all_stored(&mut self) -> Result<()> {
     if self.readonly {
       return Ok(());
     }
@@ -134,18 +147,18 @@ impl FileCacheStrategy {
     };
 
     let database = self.database()?;
-    let batch = database.write_batch::<Vec<u8>>()?;
-    for (key, entry) in &pending.entries {
+    let batch = database.write_batch::<&[u8]>()?;
+    for (key, pending) in &pending.entries {
       batch.put(
         CACHE_FAMILY as u32,
-        key.as_bytes().to_vec(),
-        self.codec.encode(entry)?.into(),
+        key.as_bytes(),
+        (pending.encoder)(&pending.entry, &self.codec)?.into(),
       )?;
     }
     if let Some(build_dependencies) = build_dependencies {
       batch.put(
         META_FAMILY as u32,
-        BUILD_DEPENDENCIES_KEY.to_vec(),
+        BUILD_DEPENDENCIES_KEY,
         build_dependencies.into(),
       )?;
     }
@@ -156,9 +169,8 @@ impl FileCacheStrategy {
     Ok(())
   }
 
-  pub async fn shutdown(&mut self) -> Result<()> {
-    self.pending_writes.entries.clear();
-    self.pending_writes.build_dependencies.clear();
+  pub fn shutdown(&mut self) -> Result<()> {
+    self.after_all_stored()?;
 
     if let Some(database) = self.database.get() {
       database.clear_cache();

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -83,7 +83,7 @@ impl FileCacheStrategy {
 
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
-  pub async fn validate_build_dependencies(&mut self) -> Result<()> {
+  pub async fn db_validation(&mut self) -> Result<()> {
     let validation = {
       let build_snapshot = self
         .database

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,6 +1,9 @@
-use std::{fmt, sync::Arc};
+use std::{
+  fmt,
+  sync::Arc,
+  time::{SystemTime, UNIX_EPOCH},
+};
 
-use once_cell::unsync::OnceCell;
 use rspack_error::Result;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rustc_hash::FxHashMap;
@@ -17,6 +20,7 @@ const CACHE_FAMILY: usize = 0;
 const SNAPSHOT_FAMILY: usize = 1;
 const FAMILY_COUNT: usize = 2;
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
+const STALE_DIRECTORY: &str = "_stale";
 
 type Database = TurboPersistence<SerialScheduler, FAMILY_COUNT>;
 
@@ -37,7 +41,8 @@ pub struct FileCacheStrategy {
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
-  database: OnceCell<Database>,
+  database: Database,
+  base_path: Utf8PathBuf,
   database_path: Utf8PathBuf,
   pending_writes: PendingWrites,
   readonly: bool,
@@ -47,6 +52,7 @@ impl fmt::Debug for FileCacheStrategy {
   fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
     formatter
       .debug_struct("FileCacheStrategy")
+      .field("base_path", &self.base_path)
       .field("database_path", &self.database_path)
       .field("readonly", &self.readonly)
       .finish_non_exhaustive()
@@ -55,34 +61,39 @@ impl fmt::Debug for FileCacheStrategy {
 
 impl FileCacheStrategy {
   pub fn new(
-    cache_location: Utf8PathBuf,
+    base_path: Utf8PathBuf,
+    database_path: Utf8PathBuf,
     readonly: bool,
     codec: Arc<CacheCodec>,
     snapshot: Snapshot,
     build_deps: BuildDeps,
-  ) -> Self {
-    Self {
+  ) -> Result<Self> {
+    let database = Self::open_database(&database_path, readonly)?;
+    Ok(Self {
       codec,
       snapshot,
       build_deps,
-      database: OnceCell::new(),
-      database_path: cache_location,
+      database,
+      base_path,
+      database_path,
       pending_writes: PendingWrites::default(),
       readonly,
-    }
+    })
   }
 
-  /// Opens the current pack and validates its build dependencies once before
-  /// the background job starts serving commands.
-  pub async fn initialize(&mut self) -> Result<()> {
-    let build_snapshot = self
-      .database()?
-      .get(SNAPSHOT_FAMILY, &BUILD_DEPENDENCIES_KEY)?;
-    match self
-      .build_deps
-      .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
-      .await
-    {
+  /// Validates the current database's build dependencies once before the
+  /// background job starts serving commands.
+  pub async fn validate_build_dependencies(&mut self) -> Result<()> {
+    let validation = {
+      let build_snapshot = self
+        .database
+        .get(SNAPSHOT_FAMILY, &BUILD_DEPENDENCIES_KEY)?;
+      self
+        .build_deps
+        .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
+        .await
+    };
+    match validation {
       Ok(BuildDepsValidationResult::Valid { tracked_files }) => {
         tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
       }
@@ -93,15 +104,15 @@ impl FileCacheStrategy {
         tracing::info!(
           modified_files = modified_files.len(),
           removed_files = removed_files.len(),
-          "Creating a new persistent cache pack because build dependencies changed"
+          "Resetting persistent cache database because build dependencies changed"
         );
-        self.create_new_pack()?;
+        self.reset_database()?;
       }
       Err(error) => {
         tracing::warn!(
-          "Creating a new persistent cache pack because build dependencies validation failed: {error}"
+          "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
-        self.create_new_pack()?;
+        self.reset_database()?;
       }
     }
     Ok(())
@@ -152,64 +163,61 @@ impl FileCacheStrategy {
       );
     }
 
-    let Some(entry) = self.database()?.get(CACHE_FAMILY, &key.as_bytes())? else {
+    let Some(entry) = self.database.get(CACHE_FAMILY, &key.as_bytes())? else {
       return Ok(None);
     };
     decoder(&entry, etag, &self.codec)
   }
 
   pub async fn after_all_stored(&mut self) -> Result<()> {
-    if self.readonly || !self.has_pending_writes() {
+    if self.readonly {
       return Ok(());
     }
 
-    let build_snapshot = if let Some(dependencies) = &self.pending_writes.build_dependencies {
-      Some(
-        self
-          .build_deps
-          .create_snapshot(&self.codec, &self.snapshot, dependencies.iter().cloned())
-          .await?,
-      )
-    } else {
-      None
-    };
-    let cache_entries = self
-      .pending_writes
-      .entries
-      .iter()
-      .map(|(key, pending)| Ok((key, (pending.encoder)(&pending.entry, &self.codec)?)))
-      .collect::<Result<Vec<_>>>()?;
+    if self.has_pending_writes() {
+      let build_snapshot = if let Some(dependencies) = &self.pending_writes.build_dependencies {
+        Some(
+          self
+            .build_deps
+            .create_snapshot(&self.codec, &self.snapshot, dependencies.iter().cloned())
+            .await?,
+        )
+      } else {
+        None
+      };
+      let cache_entries = self
+        .pending_writes
+        .entries
+        .iter()
+        .map(|(key, pending)| Ok((key, (pending.encoder)(&pending.entry, &self.codec)?)))
+        .collect::<Result<Vec<_>>>()?;
 
-    if cache_entries.is_empty() && build_snapshot.is_none() {
-      return Ok(());
+      let batch = self.database.write_batch::<&[u8]>()?;
+      for (key, value) in &cache_entries {
+        batch.put(CACHE_FAMILY as u32, key.as_bytes(), value.as_slice().into())?;
+      }
+      if let Some(build_snapshot) = &build_snapshot {
+        batch.put(
+          SNAPSHOT_FAMILY as u32,
+          BUILD_DEPENDENCIES_KEY,
+          build_snapshot.as_slice().into(),
+        )?;
+      }
+      self.database.commit_write_batch(batch)?;
+
+      self.pending_writes.entries.clear();
+      self.pending_writes.build_dependencies = None;
     }
 
-    let database = self.database()?;
-    let batch = database.write_batch::<&[u8]>()?;
-    for (key, value) in &cache_entries {
-      batch.put(CACHE_FAMILY as u32, key.as_bytes(), value.as_slice().into())?;
-    }
-    if let Some(build_snapshot) = &build_snapshot {
-      batch.put(
-        SNAPSHOT_FAMILY as u32,
-        BUILD_DEPENDENCIES_KEY,
-        build_snapshot.as_slice().into(),
-      )?;
-    }
-    database.commit_write_batch(batch)?;
-
-    self.pending_writes.entries.clear();
-    self.pending_writes.build_dependencies = None;
+    self.cleanup_stale();
     Ok(())
   }
 
   pub async fn shutdown(&mut self) -> Result<()> {
     self.after_all_stored().await?;
 
-    if let Some(database) = self.database.get() {
-      database.clear_cache();
-      database.shutdown()?;
-    }
+    self.database.clear_cache();
+    self.database.shutdown()?;
     Ok(())
   }
 
@@ -217,51 +225,100 @@ impl FileCacheStrategy {
     !self.pending_writes.entries.is_empty() || self.pending_writes.build_dependencies.is_some()
   }
 
-  fn create_new_pack(&mut self) -> Result<()> {
-    if let Some(database) = self.database.take() {
-      database.clear_cache();
-      database.shutdown()?;
-    }
+  fn reset_database(&mut self) -> Result<()> {
+    let old_database = std::mem::replace(
+      &mut self.database,
+      Database::empty_in_memory_with_config(database_config()),
+    );
+    old_database.clear_cache();
+    old_database.shutdown()?;
+    drop(old_database);
 
-    let database = if self.readonly {
-      Database::empty_in_memory_with_config(database_config())
-    } else {
-      let path = self.database_path.as_std_path();
-      if path.is_dir() {
-        std::fs::remove_dir_all(path).map_err(|error| {
-          rspack_error::error!(
-            "Failed to remove invalid persistent cache pack {}: {error}",
-            path.display()
-          )
-        })?;
-      }
-      Database::open_with_config(path.to_path_buf(), database_config())?
-    };
-    if self.database.set(database).is_err() {
-      unreachable!("persistent cache database must be empty before creating a new pack");
+    if !self.readonly {
+      self.move_database_to_stale()?;
+      self.database = Self::open_database(&self.database_path, false)?;
     }
     Ok(())
   }
 
-  fn database(&self) -> Result<&Database> {
-    self.database.get_or_try_init(|| {
-      let config = database_config();
-      if self.readonly {
-        if self.database_path.as_std_path().is_dir() {
-          Ok(Database::open_read_only_with_config(
-            self.database_path.as_std_path().to_path_buf(),
-            config,
-          )?)
-        } else {
-          Ok(Database::empty_in_memory_with_config(config))
-        }
-      } else {
-        Ok(Database::open_with_config(
-          self.database_path.as_std_path().to_path_buf(),
+  fn open_database(database_path: &Utf8PathBuf, readonly: bool) -> Result<Database> {
+    let config = database_config();
+    if readonly {
+      if database_path.as_std_path().is_dir() {
+        Ok(Database::open_read_only_with_config(
+          database_path.as_std_path().to_path_buf(),
           config,
         )?)
+      } else {
+        Ok(Database::empty_in_memory_with_config(config))
       }
-    })
+    } else {
+      Ok(Database::open_with_config(
+        database_path.as_std_path().to_path_buf(),
+        config,
+      )?)
+    }
+  }
+
+  fn move_database_to_stale(&self) -> Result<()> {
+    let database_path = self.database_path.as_std_path();
+    if !database_path.is_dir() {
+      return Ok(());
+    }
+
+    let file_name = database_path.file_name().ok_or_else(|| {
+      rspack_error::error!(
+        "Persistent cache path has no directory name: {}",
+        database_path.display()
+      )
+    })?;
+    let stale_directory = self.stale_directory();
+    std::fs::create_dir_all(stale_directory.as_std_path()).map_err(|error| {
+      rspack_error::error!(
+        "Failed to create stale cache directory {}: {error}",
+        stale_directory
+      )
+    })?;
+    let timestamp = SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_nanos();
+    let stale_path = stale_directory.join(format!(
+      "{}-{}-{timestamp}",
+      file_name.to_string_lossy(),
+      std::process::id()
+    ));
+    std::fs::rename(database_path, stale_path.as_std_path()).map_err(|error| {
+      rspack_error::error!(
+        "Failed to move invalid persistent cache pack {} to {}: {error}",
+        database_path.display(),
+        stale_path
+      )
+    })?;
+    Ok(())
+  }
+
+  fn stale_directory(&self) -> Utf8PathBuf {
+    self.base_path.join(STALE_DIRECTORY)
+  }
+
+  fn cleanup_stale(&self) {
+    let stale_directory = self.stale_directory();
+    match std::fs::remove_dir_all(stale_directory.as_std_path()) {
+      Ok(()) => {
+        tracing::debug!(
+          path = %stale_directory,
+          "Removed stale persistent cache packs"
+        );
+      }
+      Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+      Err(error) => {
+        tracing::warn!(
+          path = %stale_directory,
+          "Removing stale persistent cache packs failed: {error}"
+        );
+      }
+    }
   }
 }
 

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,35 +1,296 @@
+use std::{
+  collections::hash_map::DefaultHasher,
+  fmt,
+  hash::{Hash, Hasher},
+};
+
+use once_cell::sync::OnceCell;
 use rspack_error::Result;
 use rspack_paths::Utf8PathBuf;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use turbo_persistence::{DbConfig, FamilyConfig, FamilyKind, SerialScheduler, TurboPersistence};
 
 use super::{CacheData, Etag};
 
-/// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
+const CACHE_FAMILY: usize = 0;
+const META_FAMILY: usize = 1;
+const FAMILY_COUNT: usize = 2;
+const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
+const NO_ETAG: u32 = u32::MAX;
+
+type Database = TurboPersistence<SerialScheduler, FAMILY_COUNT>;
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+  etag: Option<Etag>,
+  data: CacheData,
+}
+
 #[derive(Debug, Default)]
-pub struct FileCacheStrategy;
+struct PendingWrites {
+  entries: HashMap<String, CacheEntry>,
+  build_dependencies: HashSet<Utf8PathBuf>,
+}
+
+/// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
+pub struct FileCacheStrategy {
+  database: OnceCell<Database>,
+  database_path: Utf8PathBuf,
+  pending_writes: PendingWrites,
+  readonly: bool,
+}
+
+impl fmt::Debug for FileCacheStrategy {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter
+      .debug_struct("FileCacheStrategy")
+      .field("database_path", &self.database_path)
+      .field("readonly", &self.readonly)
+      .finish_non_exhaustive()
+  }
+}
 
 impl FileCacheStrategy {
+  pub fn new(cache_location: Utf8PathBuf, version: &str, readonly: bool) -> Self {
+    Self {
+      database: OnceCell::new(),
+      database_path: cache_location.join(version_directory(version)),
+      pending_writes: PendingWrites::default(),
+      readonly,
+    }
+  }
+
   pub async fn store(
-    &self,
-    _identifier: String,
-    _etag: Option<Etag>,
-    _data: CacheData,
+    &mut self,
+    identifier: String,
+    etag: Option<Etag>,
+    data: CacheData,
   ) -> Result<()> {
-    todo!("implement filesystem cache store")
+    if self.readonly {
+      return Ok(());
+    }
+    self
+      .pending_writes
+      .entries
+      .insert(identifier, CacheEntry { etag, data });
+    Ok(())
   }
 
-  pub async fn restore(&self, _identifier: &str, _etag: Option<&str>) -> Result<Option<CacheData>> {
-    todo!("implement filesystem cache restore")
+  pub async fn restore(&self, identifier: &str, etag: Option<&str>) -> Result<Option<CacheData>> {
+    if let Some(entry) = self.pending_writes.entries.get(identifier) {
+      return Ok((entry.etag.as_deref() == etag).then(|| entry.data.clone()));
+    }
+
+    let key = identifier.as_bytes();
+    let Some(entry) = self.database()?.get(CACHE_FAMILY, &key)? else {
+      return Ok(None);
+    };
+    decode_cache_entry(&entry, etag)
   }
 
-  pub async fn store_build_dependencies(&self, _dependencies: Vec<Utf8PathBuf>) -> Result<()> {
-    todo!("implement filesystem cache build dependencies store")
+  pub async fn store_build_dependencies(&mut self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+    if self.readonly {
+      return Ok(());
+    }
+    self.pending_writes.build_dependencies.extend(dependencies);
+    Ok(())
   }
 
-  pub async fn after_all_stored(&self) -> Result<()> {
-    todo!("implement filesystem cache finalization")
+  pub async fn after_all_stored(&mut self) -> Result<()> {
+    if self.readonly {
+      return Ok(());
+    }
+
+    let pending = &self.pending_writes;
+    if pending.entries.is_empty() && pending.build_dependencies.is_empty() {
+      return Ok(());
+    }
+
+    let build_dependencies = if pending.build_dependencies.is_empty() {
+      None
+    } else {
+      let mut dependencies = self.load_build_dependencies()?;
+      dependencies.extend(pending.build_dependencies.iter().cloned());
+      Some(encode_build_dependencies(&dependencies)?)
+    };
+
+    let database = self.database()?;
+    let batch = database.write_batch::<Vec<u8>>()?;
+    for (identifier, entry) in &pending.entries {
+      batch.put(
+        CACHE_FAMILY as u32,
+        identifier.as_bytes().to_vec(),
+        encode_cache_entry(entry)?.into(),
+      )?;
+    }
+    if let Some(build_dependencies) = build_dependencies {
+      batch.put(
+        META_FAMILY as u32,
+        BUILD_DEPENDENCIES_KEY.to_vec(),
+        build_dependencies.into(),
+      )?;
+    }
+    database.commit_write_batch(batch)?;
+
+    self.pending_writes.entries.clear();
+    self.pending_writes.build_dependencies.clear();
+    Ok(())
   }
 
-  pub async fn clear(&self) -> Result<()> {
-    todo!("implement filesystem cache clear")
+  pub async fn shutdown(&mut self) -> Result<()> {
+    self.pending_writes.entries.clear();
+    self.pending_writes.build_dependencies.clear();
+
+    if let Some(database) = self.database.get() {
+      database.clear_cache();
+      database.shutdown()?;
+    }
+    Ok(())
   }
+
+  pub(super) fn has_pending_writes(&self) -> bool {
+    !self.pending_writes.entries.is_empty() || !self.pending_writes.build_dependencies.is_empty()
+  }
+
+  fn database(&self) -> Result<&Database> {
+    self.database.get_or_try_init(|| {
+      let config = database_config();
+      if self.readonly {
+        if self.database_path.as_std_path().is_dir() {
+          Ok(Database::open_read_only_with_config(
+            self.database_path.as_std_path().to_path_buf(),
+            config,
+          )?)
+        } else {
+          Ok(Database::empty_in_memory_with_config(config))
+        }
+      } else {
+        Ok(Database::open_with_config(
+          self.database_path.as_std_path().to_path_buf(),
+          config,
+        )?)
+      }
+    })
+  }
+
+  fn load_build_dependencies(&self) -> Result<HashSet<Utf8PathBuf>> {
+    let key = BUILD_DEPENDENCIES_KEY;
+    let Some(dependencies) = self.database()?.get(META_FAMILY, &key)? else {
+      return Ok(HashSet::default());
+    };
+    decode_build_dependencies(&dependencies)
+  }
+}
+
+fn database_config() -> DbConfig<FAMILY_COUNT> {
+  DbConfig {
+    family_configs: [
+      FamilyConfig {
+        name: "cache",
+        kind: FamilyKind::SingleValue,
+      },
+      FamilyConfig {
+        name: "metadata",
+        kind: FamilyKind::SingleValue,
+      },
+    ],
+  }
+}
+
+fn version_directory(version: &str) -> String {
+  let mut hasher = DefaultHasher::new();
+  version.hash(&mut hasher);
+  format!("{:016x}", hasher.finish())
+}
+
+fn encode_cache_entry(entry: &CacheEntry) -> Result<Vec<u8>> {
+  let etag_len = match &entry.etag {
+    Some(etag) => {
+      u32::try_from(etag.len()).map_err(|_| rspack_error::error!("File cache etag is too large"))?
+    }
+    None => NO_ETAG,
+  };
+  let mut bytes = Vec::with_capacity(
+    size_of::<u32>() + entry.etag.as_ref().map_or(0, |etag| etag.len()) + entry.data.len(),
+  );
+  bytes.extend_from_slice(&etag_len.to_le_bytes());
+  if let Some(etag) = &entry.etag {
+    bytes.extend_from_slice(etag.as_bytes());
+  }
+  bytes.extend_from_slice(&entry.data);
+  Ok(bytes)
+}
+
+fn decode_cache_entry(bytes: &[u8], etag: Option<&str>) -> Result<Option<CacheData>> {
+  let mut offset = 0;
+  let etag_len = read_u32(bytes, &mut offset)?;
+  let stored_etag = if etag_len == NO_ETAG {
+    None
+  } else {
+    let etag = take_bytes(bytes, &mut offset, etag_len as usize)?;
+    Some(
+      std::str::from_utf8(etag)
+        .map_err(|_| rspack_error::error!("File cache contains an invalid etag"))?,
+    )
+  };
+  if stored_etag != etag {
+    return Ok(None);
+  }
+  Ok(Some(bytes[offset..].into()))
+}
+
+fn encode_build_dependencies(dependencies: &HashSet<Utf8PathBuf>) -> Result<Vec<u8>> {
+  let count = u32::try_from(dependencies.len())
+    .map_err(|_| rspack_error::error!("Too many file cache build dependencies"))?;
+  let mut dependencies = dependencies.iter().collect::<Vec<_>>();
+  dependencies.sort_unstable();
+
+  let mut bytes = Vec::new();
+  bytes.extend_from_slice(&count.to_le_bytes());
+  for dependency in dependencies {
+    let dependency = dependency.as_str().as_bytes();
+    let len = u32::try_from(dependency.len())
+      .map_err(|_| rspack_error::error!("File cache build dependency path is too large"))?;
+    bytes.extend_from_slice(&len.to_le_bytes());
+    bytes.extend_from_slice(dependency);
+  }
+  Ok(bytes)
+}
+
+fn decode_build_dependencies(bytes: &[u8]) -> Result<HashSet<Utf8PathBuf>> {
+  let mut offset = 0;
+  let count = read_u32(bytes, &mut offset)?;
+  let mut dependencies = HashSet::default();
+  for _ in 0..count {
+    let len = read_u32(bytes, &mut offset)?;
+    let dependency = take_bytes(bytes, &mut offset, len as usize)?;
+    let dependency = std::str::from_utf8(dependency)
+      .map_err(|_| rspack_error::error!("File cache contains an invalid build dependency"))?;
+    dependencies.insert(dependency.into());
+  }
+  if offset != bytes.len() {
+    return Err(rspack_error::error!(
+      "File cache contains trailing build dependency data"
+    ));
+  }
+  Ok(dependencies)
+}
+
+fn read_u32(bytes: &[u8], offset: &mut usize) -> Result<u32> {
+  let bytes = take_bytes(bytes, offset, size_of::<u32>())?;
+  Ok(u32::from_le_bytes(
+    bytes
+      .try_into()
+      .expect("four bytes should convert to a u32"),
+  ))
+}
+
+fn take_bytes<'a>(bytes: &'a [u8], offset: &mut usize, len: usize) -> Result<&'a [u8]> {
+  let end = offset
+    .checked_add(len)
+    .filter(|end| *end <= bytes.len())
+    .ok_or_else(|| rspack_error::error!("File cache contains truncated data"))?;
+  let value = &bytes[*offset..end];
+  *offset = end;
+  Ok(value)
 }

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -1,18 +1,16 @@
 use std::{
-  future::pending,
+  sync::mpsc::{self, RecvTimeoutError},
+  thread,
   time::{Duration, Instant},
 };
 
 use rspack_error::Result;
 use rspack_paths::Utf8PathBuf;
-use tokio::{
-  sync::{mpsc, oneshot},
-  time::Instant as TokioInstant,
-};
+use tokio::sync::oneshot;
 
 use super::{
   CacheKey, CacheValue, Etag, FileCacheStrategy,
-  cache_value::{CacheValueData, ErasedCacheValue},
+  cache_value::{CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
 };
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
@@ -25,11 +23,13 @@ enum Command {
     key: CacheKey,
     etag: Option<Etag>,
     value: ErasedCacheValue,
+    encoder: CacheValueEncoder,
   },
   StoreBuildDependencies(Vec<Utf8PathBuf>),
   Restore {
     key: CacheKey,
     etag: Option<Etag>,
+    decoder: CacheValueDecoder,
     result: oneshot::Sender<Result<Option<ErasedCacheValue>>>,
   },
   RecordBuildTime(Duration),
@@ -40,8 +40,8 @@ enum Command {
 
 struct BackgroundJob {
   strategy: FileCacheStrategy,
-  command_receiver: mpsc::UnboundedReceiver<Command>,
-  idle_deadline: Option<TokioInstant>,
+  command_receiver: mpsc::Receiver<Command>,
+  idle_deadline: Option<Instant>,
   idle_timeout: Duration,
   idle_timeout_for_initial_store: Duration,
   idle_timeout_after_large_changes: Duration,
@@ -50,45 +50,58 @@ struct BackgroundJob {
 }
 
 impl BackgroundJob {
-  async fn run(mut self) {
+  fn run(mut self) {
     loop {
-      let idle_deadline = self.idle_deadline;
+      let command = match self.idle_deadline {
+        Some(deadline) => self
+          .command_receiver
+          .recv_timeout(deadline.saturating_duration_since(Instant::now())),
+        None => self
+          .command_receiver
+          .recv()
+          .map_err(|_| RecvTimeoutError::Disconnected),
+      };
 
-      tokio::select! {
-        biased;
-        command = self.command_receiver.recv() => {
-          let Some(command) = command else {
-            if self.strategy.has_pending_writes() {
-              tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
-            }
-            return;
-          };
-          if self.handle_command(command).await {
+      match command {
+        Ok(command) => {
+          if self.handle_command(command) {
             return;
           }
         }
-        _ = wait_for_idle_deadline(idle_deadline) => {
+        Err(RecvTimeoutError::Timeout) => {
           self.idle_deadline = None;
-          self.process_idle_tasks().await;
+          self.process_idle_tasks();
+        }
+        Err(RecvTimeoutError::Disconnected) => {
+          if self.strategy.has_pending_writes() {
+            tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
+          }
+          return;
         }
       }
     }
   }
 
-  async fn handle_command(&mut self, command: Command) -> bool {
+  fn handle_command(&mut self, command: Command) -> bool {
     match command {
-      Command::Store { key, etag, value } => {
-        if let Err(error) = self.strategy.store(key, etag, value).await {
-          tracing::warn!("Storing file cache item failed: {error}");
-        }
+      Command::Store {
+        key,
+        etag,
+        value,
+        encoder,
+      } => {
+        self.strategy.store(key, etag, value, encoder);
       }
       Command::StoreBuildDependencies(dependencies) => {
-        if let Err(error) = self.strategy.store_build_dependencies(dependencies).await {
-          tracing::warn!("Storing file cache build dependencies failed: {error}");
-        }
+        self.strategy.store_build_dependencies(dependencies);
       }
-      Command::Restore { key, etag, result } => {
-        let _ = result.send(self.strategy.restore(key, etag).await);
+      Command::Restore {
+        key,
+        etag,
+        decoder,
+        result,
+      } => {
+        let _ = result.send(self.strategy.restore(&key, etag.as_ref(), decoder));
       }
       Command::RecordBuildTime(build_time) => {
         self.time_spent_in_build = self
@@ -110,23 +123,23 @@ impl BackgroundJob {
         if is_large_change {
           timeout = timeout.min(self.idle_timeout_after_large_changes);
         }
-        self.idle_deadline = Some(TokioInstant::now() + timeout);
+        self.idle_deadline = Some(Instant::now() + timeout);
       }
       Command::EndIdle => {
         self.idle_deadline = None;
       }
       Command::Shutdown(result) => {
         self.idle_deadline = None;
-        let _ = result.send(self.shutdown().await);
+        let _ = result.send(self.strategy.shutdown());
         return true;
       }
     }
     false
   }
 
-  async fn process_idle_tasks(&mut self) {
+  fn process_idle_tasks(&mut self) {
     let start = Instant::now();
-    if let Err(error) = self.strategy.after_all_stored().await {
+    if let Err(error) = self.strategy.after_all_stored() {
       tracing::warn!("Finalizing idle file cache store failed: {error}");
       return;
     }
@@ -141,24 +154,12 @@ impl BackgroundJob {
     );
     self.time_spent_in_build = Duration::ZERO;
   }
-
-  async fn shutdown(&mut self) -> Result<()> {
-    self.strategy.after_all_stored().await?;
-    self.strategy.shutdown().await
-  }
-}
-
-async fn wait_for_idle_deadline(idle_deadline: Option<TokioInstant>) {
-  match idle_deadline {
-    Some(idle_deadline) => tokio::time::sleep_until(idle_deadline).await,
-    None => pending().await,
-  }
 }
 
 /// Runs filesystem cache operations in one persistent background job.
 #[derive(Debug)]
 pub struct IdleFileCache {
-  command_sender: mpsc::UnboundedSender<Command>,
+  command_sender: mpsc::Sender<Command>,
 }
 
 impl IdleFileCache {
@@ -177,28 +178,30 @@ impl IdleFileCache {
     idle_timeout_for_initial_store: Duration,
     idle_timeout_after_large_changes: Duration,
   ) -> Self {
-    let (command_sender, command_receiver) = mpsc::unbounded_channel();
-    let _ = rspack_tasks::spawn_in_context(
-      BackgroundJob {
-        strategy,
-        command_receiver,
-        idle_deadline: None,
-        idle_timeout,
-        idle_timeout_for_initial_store: idle_timeout.min(idle_timeout_for_initial_store),
-        idle_timeout_after_large_changes,
-        time_spent_in_build: Duration::ZERO,
-        avg_time_spent_in_store: None,
-      }
-      .run(),
-    );
+    let (command_sender, command_receiver) = mpsc::channel();
+    let background_job = BackgroundJob {
+      strategy,
+      command_receiver,
+      idle_deadline: None,
+      idle_timeout,
+      idle_timeout_for_initial_store,
+      idle_timeout_after_large_changes,
+      time_spent_in_build: Duration::ZERO,
+      avg_time_spent_in_store: None,
+    };
+    let _ = thread::Builder::new()
+      .name("rspack-idle-file-cache".to_string())
+      .spawn(move || background_job.run())
+      .expect("failed to spawn idle file cache background thread");
 
     Self { command_sender }
   }
 
-  fn send(&self, command: Command) {
-    if self.command_sender.send(command).is_err() {
-      tracing::warn!("Idle file cache background job has stopped");
-    }
+  fn send(&self, command: Command) -> Result<()> {
+    self
+      .command_sender
+      .send(command)
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
   }
 
   async fn request<T>(
@@ -215,12 +218,18 @@ impl IdleFileCache {
       .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
   }
 
-  pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
+  pub fn store<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) -> Result<()> {
     self.send(Command::Store {
       key,
       etag,
       value: value.erase(),
-    });
+      encoder: CacheValue::<T>::encoder(),
+    })
   }
 
   pub async fn restore<T: CacheValueData>(
@@ -230,26 +239,31 @@ impl IdleFileCache {
   ) -> Result<Option<CacheValue<T>>> {
     Ok(
       self
-        .request(|result| Command::Restore { key, etag, result })
+        .request(|result| Command::Restore {
+          key,
+          etag,
+          decoder: CacheValue::<T>::decoder(),
+          result,
+        })
         .await?
         .and_then(ErasedCacheValue::downcast),
     )
   }
 
-  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) {
-    self.send(Command::StoreBuildDependencies(dependencies));
+  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+    self.send(Command::StoreBuildDependencies(dependencies))
   }
 
-  pub fn record_build_time(&self, build_time: Duration) {
-    self.send(Command::RecordBuildTime(build_time));
+  pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
+    self.send(Command::RecordBuildTime(build_time))
   }
 
-  pub fn begin_idle(&self) {
-    self.send(Command::BeginIdle);
+  pub fn begin_idle(&self) -> Result<()> {
+    self.send(Command::BeginIdle)
   }
 
-  pub fn end_idle(&self) {
-    self.send(Command::EndIdle);
+  pub fn end_idle(&self) -> Result<()> {
+    self.send(Command::EndIdle)
   }
 
   pub async fn shutdown(&self) -> Result<()> {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -1,12 +1,11 @@
-use std::{
-  sync::mpsc::{self, RecvTimeoutError},
-  thread,
-  time::{Duration, Instant},
-};
+use std::{thread, time::Duration};
 
 use rspack_error::Result;
-use rspack_paths::Utf8PathBuf;
-use tokio::sync::oneshot;
+use rspack_paths::ArcPathSet;
+use tokio::{
+  sync::{mpsc, oneshot},
+  time::{Instant, sleep_until},
+};
 
 use super::{
   CacheKey, CacheValue, Etag, FileCacheStrategy,
@@ -25,7 +24,7 @@ enum Command {
     value: ErasedCacheValue,
     encoder: CacheValueEncoder,
   },
-  StoreBuildDependencies(Vec<Utf8PathBuf>),
+  StoreBuildDependencies(ArcPathSet),
   Restore {
     key: CacheKey,
     etag: Option<Etag>,
@@ -40,7 +39,7 @@ enum Command {
 
 struct BackgroundJob {
   strategy: FileCacheStrategy,
-  command_receiver: mpsc::Receiver<Command>,
+  command_receiver: mpsc::UnboundedReceiver<Command>,
   idle_deadline: Option<Instant>,
   idle_timeout: Duration,
   idle_timeout_for_initial_store: Duration,
@@ -50,39 +49,40 @@ struct BackgroundJob {
 }
 
 impl BackgroundJob {
-  fn run(mut self) {
+  async fn run(mut self) {
+    if let Err(error) = self.strategy.initialize().await {
+      tracing::warn!("Initializing persistent cache background job failed: {error}");
+      return;
+    }
+
     loop {
-      let command = match self.idle_deadline {
-        Some(deadline) => self
-          .command_receiver
-          .recv_timeout(deadline.saturating_duration_since(Instant::now())),
-        None => self
-          .command_receiver
-          .recv()
-          .map_err(|_| RecvTimeoutError::Disconnected),
+      let command = if let Some(deadline) = self.idle_deadline {
+        tokio::select! {
+          biased;
+          command = self.command_receiver.recv() => command,
+          _ = sleep_until(deadline) => {
+            self.idle_deadline = None;
+            self.process_idle_tasks().await;
+            continue;
+          }
+        }
+      } else {
+        self.command_receiver.recv().await
       };
 
-      match command {
-        Ok(command) => {
-          if self.handle_command(command) {
-            return;
-          }
+      let Some(command) = command else {
+        if self.strategy.has_pending_writes() {
+          tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
         }
-        Err(RecvTimeoutError::Timeout) => {
-          self.idle_deadline = None;
-          self.process_idle_tasks();
-        }
-        Err(RecvTimeoutError::Disconnected) => {
-          if self.strategy.has_pending_writes() {
-            tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
-          }
-          return;
-        }
+        return;
+      };
+      if self.handle_command(command).await {
+        return;
       }
     }
   }
 
-  fn handle_command(&mut self, command: Command) -> bool {
+  async fn handle_command(&mut self, command: Command) -> bool {
     match command {
       Command::Store {
         key,
@@ -130,16 +130,16 @@ impl BackgroundJob {
       }
       Command::Shutdown(result) => {
         self.idle_deadline = None;
-        let _ = result.send(self.strategy.shutdown());
+        let _ = result.send(self.strategy.shutdown().await);
         return true;
       }
     }
     false
   }
 
-  fn process_idle_tasks(&mut self) {
+  async fn process_idle_tasks(&mut self) {
     let start = Instant::now();
-    if let Err(error) = self.strategy.after_all_stored() {
+    if let Err(error) = self.strategy.after_all_stored().await {
       tracing::warn!("Finalizing idle file cache store failed: {error}");
       return;
     }
@@ -159,7 +159,7 @@ impl BackgroundJob {
 /// Runs filesystem cache operations in one persistent background job.
 #[derive(Debug)]
 pub struct IdleFileCache {
-  command_sender: mpsc::Sender<Command>,
+  command_sender: mpsc::UnboundedSender<Command>,
 }
 
 impl IdleFileCache {
@@ -178,7 +178,7 @@ impl IdleFileCache {
     idle_timeout_for_initial_store: Duration,
     idle_timeout_after_large_changes: Duration,
   ) -> Self {
-    let (command_sender, command_receiver) = mpsc::channel();
+    let (command_sender, command_receiver) = mpsc::unbounded_channel();
     let background_job = BackgroundJob {
       strategy,
       command_receiver,
@@ -191,7 +191,13 @@ impl IdleFileCache {
     };
     let _ = thread::Builder::new()
       .name("rspack-idle-file-cache".to_string())
-      .spawn(move || background_job.run())
+      .spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+          .enable_time()
+          .build()
+          .expect("failed to create idle file cache runtime");
+        runtime.block_on(background_job.run());
+      })
       .expect("failed to spawn idle file cache background thread");
 
     Self { command_sender }
@@ -209,10 +215,7 @@ impl IdleFileCache {
     command: impl FnOnce(oneshot::Sender<Result<T>>) -> Command,
   ) -> Result<T> {
     let (result, result_receiver) = oneshot::channel();
-    self
-      .command_sender
-      .send(command(result))
-      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?;
+    self.send(command(result))?;
     result_receiver
       .await
       .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
@@ -250,7 +253,7 @@ impl IdleFileCache {
     )
   }
 
-  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) -> Result<()> {
+  pub fn store_build_dependencies(&self, dependencies: ArcPathSet) -> Result<()> {
     self.send(Command::StoreBuildDependencies(dependencies))
   }
 

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -1,4 +1,4 @@
-use std::{thread, time::Duration};
+use std::{sync::mpsc as sync_mpsc, thread, time::Duration};
 
 use rspack_error::Result;
 use rspack_paths::ArcPathSet;
@@ -29,7 +29,7 @@ enum Command {
     key: CacheKey,
     etag: Option<Etag>,
     decoder: CacheValueDecoder,
-    result: oneshot::Sender<Result<Option<ErasedCacheValue>>>,
+    result: sync_mpsc::SyncSender<Result<Option<ErasedCacheValue>>>,
   },
   RecordBuildTime(Duration),
   BeginIdle,
@@ -210,17 +210,6 @@ impl IdleFileCache {
       .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
   }
 
-  async fn request<T>(
-    &self,
-    command: impl FnOnce(oneshot::Sender<Result<T>>) -> Command,
-  ) -> Result<T> {
-    let (result, result_receiver) = oneshot::channel();
-    self.send(command(result))?;
-    result_receiver
-      .await
-      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
-  }
-
   pub fn store<T: CacheValueData>(
     &self,
     key: CacheKey,
@@ -235,20 +224,22 @@ impl IdleFileCache {
     })
   }
 
-  pub async fn restore<T: CacheValueData>(
+  pub fn restore<T: CacheValueData>(
     &self,
     key: CacheKey,
     etag: Option<Etag>,
   ) -> Result<Option<CacheValue<T>>> {
+    let (result, result_receiver) = sync_mpsc::sync_channel(1);
+    self.send(Command::Restore {
+      key,
+      etag,
+      decoder: CacheValue::<T>::decoder(),
+      result,
+    })?;
     Ok(
-      self
-        .request(|result| Command::Restore {
-          key,
-          etag,
-          decoder: CacheValue::<T>::decoder(),
-          result,
-        })
-        .await?
+      result_receiver
+        .recv()
+        .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))??
         .and_then(ErasedCacheValue::downcast),
     )
   }
@@ -270,6 +261,10 @@ impl IdleFileCache {
   }
 
   pub async fn shutdown(&self) -> Result<()> {
-    self.request(Command::Shutdown).await
+    let (result, result_receiver) = oneshot::channel();
+    self.send(Command::Shutdown(result))?;
+    result_receiver
+      .await
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
   }
 }

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -50,8 +50,8 @@ struct BackgroundJob {
 
 impl BackgroundJob {
   async fn run(mut self) {
-    if let Err(error) = self.strategy.initialize().await {
-      tracing::warn!("Initializing persistent cache background job failed: {error}");
+    if let Err(error) = self.strategy.validate_build_dependencies().await {
+      tracing::warn!("Validating persistent cache build dependencies failed: {error}");
       return;
     }
 

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -50,7 +50,7 @@ struct BackgroundJob {
 
 impl BackgroundJob {
   async fn run(mut self) {
-    if let Err(error) = self.strategy.validate_build_dependencies().await {
+    if let Err(error) = self.strategy.db_validation().await {
       tracing::warn!("Validating persistent cache build dependencies failed: {error}");
       return;
     }

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -1,0 +1,387 @@
+use std::{
+  future::pending,
+  time::{Duration, Instant},
+};
+
+use futures::future::join_all;
+use rspack_error::Result;
+use rspack_paths::Utf8PathBuf;
+use rustc_hash::FxHashMap as HashMap;
+use tokio::{
+  sync::{mpsc, oneshot},
+  time::Instant as TokioInstant,
+};
+
+use super::{CacheData, Etag, FileCacheStrategy};
+
+const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
+const DEFAULT_IDLE_TIMEOUT_AFTER_LARGE_CHANGES: Duration = Duration::from_secs(1);
+const MAX_IDLE_TASKS_PER_BATCH: usize = 100;
+
+#[derive(Debug)]
+struct PendingStore {
+  etag: Option<Etag>,
+  data: CacheData,
+}
+
+#[derive(Debug)]
+enum IdleTask {
+  Store {
+    identifier: String,
+    entry: PendingStore,
+  },
+  StoreBuildDependencies(Vec<Utf8PathBuf>),
+}
+
+#[derive(Debug, Default)]
+struct PendingIdleTasks {
+  stores: HashMap<String, PendingStore>,
+  build_dependencies: Option<Vec<Utf8PathBuf>>,
+}
+
+impl PendingIdleTasks {
+  fn is_empty(&self) -> bool {
+    self.stores.is_empty() && self.build_dependencies.is_none()
+  }
+
+  fn take_batch(&mut self) -> Vec<IdleTask> {
+    let mut tasks = Vec::with_capacity(MAX_IDLE_TASKS_PER_BATCH);
+
+    while tasks.len() < MAX_IDLE_TASKS_PER_BATCH {
+      let Some(identifier) = self.stores.keys().next().cloned() else {
+        break;
+      };
+      let entry = self
+        .stores
+        .remove(&identifier)
+        .expect("pending idle task should exist");
+      tasks.push(IdleTask::Store { identifier, entry });
+    }
+
+    if tasks.len() < MAX_IDLE_TASKS_PER_BATCH
+      && let Some(dependencies) = self.build_dependencies.take()
+    {
+      tasks.push(IdleTask::StoreBuildDependencies(dependencies));
+    }
+
+    tasks
+  }
+}
+
+#[derive(Debug)]
+enum Command {
+  Store {
+    identifier: String,
+    entry: PendingStore,
+  },
+  StoreBuildDependencies(Vec<Utf8PathBuf>),
+  Restore {
+    identifier: String,
+    etag: Option<Etag>,
+    result: oneshot::Sender<Result<Option<CacheData>>>,
+  },
+  RecordBuildTime(Duration),
+  BeginIdle,
+  EndIdle,
+  Shutdown(oneshot::Sender<Result<()>>),
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+enum IdleState {
+  #[default]
+  Active,
+  Idle,
+  Waiting(TokioInstant),
+}
+
+struct BackgroundJob {
+  strategy: FileCacheStrategy,
+  command_receiver: mpsc::UnboundedReceiver<Command>,
+  pending_tasks: PendingIdleTasks,
+  idle_state: IdleState,
+  idle_timeout: Duration,
+  idle_timeout_for_initial_store: Duration,
+  idle_timeout_after_large_changes: Duration,
+  time_spent_in_build: Duration,
+  time_spent_in_store: Duration,
+  avg_time_spent_in_store: Option<Duration>,
+}
+
+impl BackgroundJob {
+  async fn run(mut self) {
+    loop {
+      let idle_deadline = match self.idle_state {
+        IdleState::Waiting(deadline) => Some(deadline),
+        IdleState::Active | IdleState::Idle => None,
+      };
+
+      tokio::select! {
+        biased;
+        command = self.command_receiver.recv() => {
+          let Some(command) = command else {
+            if !self.pending_tasks.is_empty() {
+              tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
+            }
+            return;
+          };
+          if self.handle_command(command).await {
+            return;
+          }
+        }
+        _ = wait_for_idle_deadline(idle_deadline) => {
+          self.idle_state = IdleState::Idle;
+          self.process_idle_tasks().await;
+        }
+      }
+    }
+  }
+
+  async fn handle_command(&mut self, command: Command) -> bool {
+    match command {
+      Command::Store { identifier, entry } => {
+        self.pending_tasks.stores.insert(identifier, entry);
+        self.schedule_pending_tasks();
+      }
+      Command::StoreBuildDependencies(dependencies) => {
+        self.pending_tasks.build_dependencies = Some(dependencies);
+        self.schedule_pending_tasks();
+      }
+      Command::Restore {
+        identifier,
+        etag,
+        result,
+      } => {
+        let _ = result.send(self.restore(identifier, etag).await);
+      }
+      Command::RecordBuildTime(build_time) => {
+        self.time_spent_in_build = self
+          .time_spent_in_build
+          .mul_f64(0.9)
+          .saturating_add(build_time);
+      }
+      Command::BeginIdle => {
+        let is_initial_store = self.avg_time_spent_in_store.is_none();
+        let is_large_change = self.time_spent_in_build
+          > self
+            .avg_time_spent_in_store
+            .unwrap_or_default()
+            .saturating_mul(2);
+        let mut timeout = self.idle_timeout;
+        if is_initial_store {
+          timeout = timeout.min(self.idle_timeout_for_initial_store);
+        }
+        if is_large_change {
+          timeout = timeout.min(self.idle_timeout_after_large_changes);
+        }
+        self.idle_state = IdleState::Waiting(TokioInstant::now() + timeout);
+      }
+      Command::EndIdle => {
+        self.idle_state = IdleState::Active;
+      }
+      Command::Shutdown(result) => {
+        self.idle_state = IdleState::Active;
+        let _ = result.send(self.flush_and_clear().await);
+        return true;
+      }
+    }
+    false
+  }
+
+  fn schedule_pending_tasks(&mut self) {
+    if matches!(self.idle_state, IdleState::Idle) {
+      self.idle_state = IdleState::Waiting(TokioInstant::now());
+    }
+  }
+
+  async fn run_pending_tasks(&self, tasks: Vec<IdleTask>) -> Result<()> {
+    let strategy = &self.strategy;
+    let results = join_all(tasks.into_iter().map(|task| async move {
+      match task {
+        IdleTask::Store { identifier, entry } => {
+          strategy.store(identifier, entry.etag, entry.data).await
+        }
+        IdleTask::StoreBuildDependencies(dependencies) => {
+          strategy.store_build_dependencies(dependencies).await
+        }
+      }
+    }))
+    .await;
+
+    for result in results {
+      result?;
+    }
+    Ok(())
+  }
+
+  async fn process_idle_tasks(&mut self) {
+    let tasks = self.pending_tasks.take_batch();
+    if tasks.is_empty() {
+      self.finish_idle_cycle().await;
+      return;
+    }
+
+    let start = Instant::now();
+    if let Err(error) = self.run_pending_tasks(tasks).await {
+      tracing::warn!("Background tasks during idle failed: {error}");
+    }
+    self.time_spent_in_store = self.time_spent_in_store.saturating_add(start.elapsed());
+
+    // Return to the command loop between batches. Its biased select gives
+    // EndIdle, Restore, and Shutdown priority over more background work.
+    if !matches!(self.idle_state, IdleState::Active) {
+      self.idle_state = IdleState::Waiting(TokioInstant::now());
+    }
+  }
+
+  async fn finish_idle_cycle(&mut self) {
+    let start = Instant::now();
+    if let Err(error) = self.strategy.after_all_stored().await {
+      tracing::warn!("Finalizing idle file cache store failed: {error}");
+      return;
+    }
+    self.time_spent_in_store = self.time_spent_in_store.saturating_add(start.elapsed());
+    let time_spent_in_store = self.time_spent_in_store;
+    self.avg_time_spent_in_store = Some(
+      self
+        .avg_time_spent_in_store
+        .unwrap_or_default()
+        .max(time_spent_in_store)
+        .mul_f64(0.9)
+        .saturating_add(time_spent_in_store.mul_f64(0.1)),
+    );
+    self.time_spent_in_store = Duration::ZERO;
+    self.time_spent_in_build = Duration::ZERO;
+  }
+
+  async fn restore(&mut self, identifier: String, etag: Option<Etag>) -> Result<Option<CacheData>> {
+    if let Some(pending) = self.pending_tasks.stores.remove(&identifier) {
+      let result = self
+        .strategy
+        .store(identifier.clone(), pending.etag, pending.data)
+        .await;
+      self.schedule_pending_tasks();
+      result?;
+    }
+    self.strategy.restore(&identifier, etag.as_deref()).await
+  }
+
+  async fn flush_and_clear(&mut self) -> Result<()> {
+    loop {
+      let tasks = self.pending_tasks.take_batch();
+      if tasks.is_empty() {
+        break;
+      }
+      self.run_pending_tasks(tasks).await?;
+    }
+    self.strategy.after_all_stored().await?;
+    self.strategy.clear().await
+  }
+}
+
+async fn wait_for_idle_deadline(idle_deadline: Option<TokioInstant>) {
+  match idle_deadline {
+    Some(idle_deadline) => tokio::time::sleep_until(idle_deadline).await,
+    None => pending().await,
+  }
+}
+
+/// Runs filesystem cache operations in one persistent background job.
+#[derive(Debug)]
+pub struct IdleFileCache {
+  command_sender: mpsc::UnboundedSender<Command>,
+}
+
+impl IdleFileCache {
+  pub fn new(strategy: FileCacheStrategy) -> Self {
+    Self::with_timeouts(
+      strategy,
+      DEFAULT_IDLE_TIMEOUT,
+      DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE,
+      DEFAULT_IDLE_TIMEOUT_AFTER_LARGE_CHANGES,
+    )
+  }
+
+  pub fn with_timeouts(
+    strategy: FileCacheStrategy,
+    idle_timeout: Duration,
+    idle_timeout_for_initial_store: Duration,
+    idle_timeout_after_large_changes: Duration,
+  ) -> Self {
+    let (command_sender, command_receiver) = mpsc::unbounded_channel();
+    let _ = rspack_tasks::spawn_in_context(
+      BackgroundJob {
+        strategy,
+        command_receiver,
+        pending_tasks: PendingIdleTasks::default(),
+        idle_state: IdleState::Active,
+        idle_timeout,
+        idle_timeout_for_initial_store: idle_timeout.min(idle_timeout_for_initial_store),
+        idle_timeout_after_large_changes,
+        time_spent_in_build: Duration::ZERO,
+        time_spent_in_store: Duration::ZERO,
+        avg_time_spent_in_store: None,
+      }
+      .run(),
+    );
+
+    Self { command_sender }
+  }
+
+  fn send(&self, command: Command) {
+    if self.command_sender.send(command).is_err() {
+      tracing::warn!("Idle file cache background job has stopped");
+    }
+  }
+
+  async fn request<T>(
+    &self,
+    command: impl FnOnce(oneshot::Sender<Result<T>>) -> Command,
+  ) -> Result<T> {
+    let (result, result_receiver) = oneshot::channel();
+    self
+      .command_sender
+      .send(command(result))
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?;
+    result_receiver
+      .await
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
+  }
+
+  pub fn store(&self, identifier: impl Into<String>, etag: Option<Etag>, data: CacheData) {
+    self.send(Command::Store {
+      identifier: identifier.into(),
+      entry: PendingStore { etag, data },
+    });
+  }
+
+  pub async fn restore(&self, identifier: &str, etag: Option<&str>) -> Result<Option<CacheData>> {
+    self
+      .request(|result| Command::Restore {
+        identifier: identifier.to_string(),
+        etag: etag.map(Into::into),
+        result,
+      })
+      .await
+  }
+
+  pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) {
+    self.send(Command::StoreBuildDependencies(dependencies));
+  }
+
+  pub fn record_build_time(&self, build_time: Duration) {
+    self.send(Command::RecordBuildTime(build_time));
+  }
+
+  pub fn begin_idle(&self) {
+    self.send(Command::BeginIdle);
+  }
+
+  pub fn end_idle(&self) {
+    self.send(Command::EndIdle);
+  }
+
+  pub async fn shutdown(&self) -> Result<()> {
+    self.request(Command::Shutdown).await
+  }
+}

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -10,7 +10,10 @@ use tokio::{
   time::Instant as TokioInstant,
 };
 
-use super::{CacheData, Etag, FileCacheStrategy};
+use super::{
+  CacheKey, CacheValue, Etag, FileCacheStrategy,
+  cache_value::{CacheValueData, ErasedCacheValue},
+};
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
@@ -19,15 +22,15 @@ const DEFAULT_IDLE_TIMEOUT_AFTER_LARGE_CHANGES: Duration = Duration::from_secs(1
 #[derive(Debug)]
 enum Command {
   Store {
-    identifier: String,
+    key: CacheKey,
     etag: Option<Etag>,
-    data: CacheData,
+    value: ErasedCacheValue,
   },
   StoreBuildDependencies(Vec<Utf8PathBuf>),
   Restore {
-    identifier: String,
+    key: CacheKey,
     etag: Option<Etag>,
-    result: oneshot::Sender<Result<Option<CacheData>>>,
+    result: oneshot::Sender<Result<Option<ErasedCacheValue>>>,
   },
   RecordBuildTime(Duration),
   BeginIdle,
@@ -74,12 +77,8 @@ impl BackgroundJob {
 
   async fn handle_command(&mut self, command: Command) -> bool {
     match command {
-      Command::Store {
-        identifier,
-        etag,
-        data,
-      } => {
-        if let Err(error) = self.strategy.store(identifier, etag, data).await {
+      Command::Store { key, etag, value } => {
+        if let Err(error) = self.strategy.store(key, etag, value).await {
           tracing::warn!("Storing file cache item failed: {error}");
         }
       }
@@ -88,12 +87,8 @@ impl BackgroundJob {
           tracing::warn!("Storing file cache build dependencies failed: {error}");
         }
       }
-      Command::Restore {
-        identifier,
-        etag,
-        result,
-      } => {
-        let _ = result.send(self.strategy.restore(&identifier, etag.as_deref()).await);
+      Command::Restore { key, etag, result } => {
+        let _ = result.send(self.strategy.restore(key, etag).await);
       }
       Command::RecordBuildTime(build_time) => {
         self.time_spent_in_build = self
@@ -220,22 +215,25 @@ impl IdleFileCache {
       .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
   }
 
-  pub fn store(&self, identifier: impl Into<String>, etag: Option<Etag>, data: CacheData) {
+  pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
     self.send(Command::Store {
-      identifier: identifier.into(),
+      key,
       etag,
-      data,
+      value: value.erase(),
     });
   }
 
-  pub async fn restore(&self, identifier: &str, etag: Option<&str>) -> Result<Option<CacheData>> {
-    self
-      .request(|result| Command::Restore {
-        identifier: identifier.to_string(),
-        etag: etag.map(Into::into),
-        result,
-      })
-      .await
+  pub async fn restore<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Result<Option<CacheValue<T>>> {
+    Ok(
+      self
+        .request(|result| Command::Restore { key, etag, result })
+        .await?
+        .and_then(ErasedCacheValue::downcast),
+    )
   }
 
   pub fn store_build_dependencies(&self, dependencies: Vec<Utf8PathBuf>) {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -3,10 +3,8 @@ use std::{
   time::{Duration, Instant},
 };
 
-use futures::future::join_all;
 use rspack_error::Result;
 use rspack_paths::Utf8PathBuf;
-use rustc_hash::FxHashMap as HashMap;
 use tokio::{
   sync::{mpsc, oneshot},
   time::Instant as TokioInstant,
@@ -17,63 +15,13 @@ use super::{CacheData, Etag, FileCacheStrategy};
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
 const DEFAULT_IDLE_TIMEOUT_AFTER_LARGE_CHANGES: Duration = Duration::from_secs(1);
-const MAX_IDLE_TASKS_PER_BATCH: usize = 100;
-
-#[derive(Debug)]
-struct PendingStore {
-  etag: Option<Etag>,
-  data: CacheData,
-}
-
-#[derive(Debug)]
-enum IdleTask {
-  Store {
-    identifier: String,
-    entry: PendingStore,
-  },
-  StoreBuildDependencies(Vec<Utf8PathBuf>),
-}
-
-#[derive(Debug, Default)]
-struct PendingIdleTasks {
-  stores: HashMap<String, PendingStore>,
-  build_dependencies: Option<Vec<Utf8PathBuf>>,
-}
-
-impl PendingIdleTasks {
-  fn is_empty(&self) -> bool {
-    self.stores.is_empty() && self.build_dependencies.is_none()
-  }
-
-  fn take_batch(&mut self) -> Vec<IdleTask> {
-    let mut tasks = Vec::with_capacity(MAX_IDLE_TASKS_PER_BATCH);
-
-    while tasks.len() < MAX_IDLE_TASKS_PER_BATCH {
-      let Some(identifier) = self.stores.keys().next().cloned() else {
-        break;
-      };
-      let entry = self
-        .stores
-        .remove(&identifier)
-        .expect("pending idle task should exist");
-      tasks.push(IdleTask::Store { identifier, entry });
-    }
-
-    if tasks.len() < MAX_IDLE_TASKS_PER_BATCH
-      && let Some(dependencies) = self.build_dependencies.take()
-    {
-      tasks.push(IdleTask::StoreBuildDependencies(dependencies));
-    }
-
-    tasks
-  }
-}
 
 #[derive(Debug)]
 enum Command {
   Store {
     identifier: String,
-    entry: PendingStore,
+    etag: Option<Etag>,
+    data: CacheData,
   },
   StoreBuildDependencies(Vec<Utf8PathBuf>),
   Restore {
@@ -87,40 +35,27 @@ enum Command {
   Shutdown(oneshot::Sender<Result<()>>),
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-enum IdleState {
-  #[default]
-  Active,
-  Idle,
-  Waiting(TokioInstant),
-}
-
 struct BackgroundJob {
   strategy: FileCacheStrategy,
   command_receiver: mpsc::UnboundedReceiver<Command>,
-  pending_tasks: PendingIdleTasks,
-  idle_state: IdleState,
+  idle_deadline: Option<TokioInstant>,
   idle_timeout: Duration,
   idle_timeout_for_initial_store: Duration,
   idle_timeout_after_large_changes: Duration,
   time_spent_in_build: Duration,
-  time_spent_in_store: Duration,
   avg_time_spent_in_store: Option<Duration>,
 }
 
 impl BackgroundJob {
   async fn run(mut self) {
     loop {
-      let idle_deadline = match self.idle_state {
-        IdleState::Waiting(deadline) => Some(deadline),
-        IdleState::Active | IdleState::Idle => None,
-      };
+      let idle_deadline = self.idle_deadline;
 
       tokio::select! {
         biased;
         command = self.command_receiver.recv() => {
           let Some(command) = command else {
-            if !self.pending_tasks.is_empty() {
+            if self.strategy.has_pending_writes() {
               tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
             }
             return;
@@ -130,7 +65,7 @@ impl BackgroundJob {
           }
         }
         _ = wait_for_idle_deadline(idle_deadline) => {
-          self.idle_state = IdleState::Idle;
+          self.idle_deadline = None;
           self.process_idle_tasks().await;
         }
       }
@@ -139,20 +74,26 @@ impl BackgroundJob {
 
   async fn handle_command(&mut self, command: Command) -> bool {
     match command {
-      Command::Store { identifier, entry } => {
-        self.pending_tasks.stores.insert(identifier, entry);
-        self.schedule_pending_tasks();
+      Command::Store {
+        identifier,
+        etag,
+        data,
+      } => {
+        if let Err(error) = self.strategy.store(identifier, etag, data).await {
+          tracing::warn!("Storing file cache item failed: {error}");
+        }
       }
       Command::StoreBuildDependencies(dependencies) => {
-        self.pending_tasks.build_dependencies = Some(dependencies);
-        self.schedule_pending_tasks();
+        if let Err(error) = self.strategy.store_build_dependencies(dependencies).await {
+          tracing::warn!("Storing file cache build dependencies failed: {error}");
+        }
       }
       Command::Restore {
         identifier,
         etag,
         result,
       } => {
-        let _ = result.send(self.restore(identifier, etag).await);
+        let _ = result.send(self.strategy.restore(&identifier, etag.as_deref()).await);
       }
       Command::RecordBuildTime(build_time) => {
         self.time_spent_in_build = self
@@ -174,74 +115,27 @@ impl BackgroundJob {
         if is_large_change {
           timeout = timeout.min(self.idle_timeout_after_large_changes);
         }
-        self.idle_state = IdleState::Waiting(TokioInstant::now() + timeout);
+        self.idle_deadline = Some(TokioInstant::now() + timeout);
       }
       Command::EndIdle => {
-        self.idle_state = IdleState::Active;
+        self.idle_deadline = None;
       }
       Command::Shutdown(result) => {
-        self.idle_state = IdleState::Active;
-        let _ = result.send(self.flush_and_clear().await);
+        self.idle_deadline = None;
+        let _ = result.send(self.shutdown().await);
         return true;
       }
     }
     false
   }
 
-  fn schedule_pending_tasks(&mut self) {
-    if matches!(self.idle_state, IdleState::Idle) {
-      self.idle_state = IdleState::Waiting(TokioInstant::now());
-    }
-  }
-
-  async fn run_pending_tasks(&self, tasks: Vec<IdleTask>) -> Result<()> {
-    let strategy = &self.strategy;
-    let results = join_all(tasks.into_iter().map(|task| async move {
-      match task {
-        IdleTask::Store { identifier, entry } => {
-          strategy.store(identifier, entry.etag, entry.data).await
-        }
-        IdleTask::StoreBuildDependencies(dependencies) => {
-          strategy.store_build_dependencies(dependencies).await
-        }
-      }
-    }))
-    .await;
-
-    for result in results {
-      result?;
-    }
-    Ok(())
-  }
-
   async fn process_idle_tasks(&mut self) {
-    let tasks = self.pending_tasks.take_batch();
-    if tasks.is_empty() {
-      self.finish_idle_cycle().await;
-      return;
-    }
-
-    let start = Instant::now();
-    if let Err(error) = self.run_pending_tasks(tasks).await {
-      tracing::warn!("Background tasks during idle failed: {error}");
-    }
-    self.time_spent_in_store = self.time_spent_in_store.saturating_add(start.elapsed());
-
-    // Return to the command loop between batches. Its biased select gives
-    // EndIdle, Restore, and Shutdown priority over more background work.
-    if !matches!(self.idle_state, IdleState::Active) {
-      self.idle_state = IdleState::Waiting(TokioInstant::now());
-    }
-  }
-
-  async fn finish_idle_cycle(&mut self) {
     let start = Instant::now();
     if let Err(error) = self.strategy.after_all_stored().await {
       tracing::warn!("Finalizing idle file cache store failed: {error}");
       return;
     }
-    self.time_spent_in_store = self.time_spent_in_store.saturating_add(start.elapsed());
-    let time_spent_in_store = self.time_spent_in_store;
+    let time_spent_in_store = start.elapsed();
     self.avg_time_spent_in_store = Some(
       self
         .avg_time_spent_in_store
@@ -250,32 +144,12 @@ impl BackgroundJob {
         .mul_f64(0.9)
         .saturating_add(time_spent_in_store.mul_f64(0.1)),
     );
-    self.time_spent_in_store = Duration::ZERO;
     self.time_spent_in_build = Duration::ZERO;
   }
 
-  async fn restore(&mut self, identifier: String, etag: Option<Etag>) -> Result<Option<CacheData>> {
-    if let Some(pending) = self.pending_tasks.stores.remove(&identifier) {
-      let result = self
-        .strategy
-        .store(identifier.clone(), pending.etag, pending.data)
-        .await;
-      self.schedule_pending_tasks();
-      result?;
-    }
-    self.strategy.restore(&identifier, etag.as_deref()).await
-  }
-
-  async fn flush_and_clear(&mut self) -> Result<()> {
-    loop {
-      let tasks = self.pending_tasks.take_batch();
-      if tasks.is_empty() {
-        break;
-      }
-      self.run_pending_tasks(tasks).await?;
-    }
+  async fn shutdown(&mut self) -> Result<()> {
     self.strategy.after_all_stored().await?;
-    self.strategy.clear().await
+    self.strategy.shutdown().await
   }
 }
 
@@ -313,13 +187,11 @@ impl IdleFileCache {
       BackgroundJob {
         strategy,
         command_receiver,
-        pending_tasks: PendingIdleTasks::default(),
-        idle_state: IdleState::Active,
+        idle_deadline: None,
         idle_timeout,
         idle_timeout_for_initial_store: idle_timeout.min(idle_timeout_for_initial_store),
         idle_timeout_after_large_changes,
         time_spent_in_build: Duration::ZERO,
-        time_spent_in_store: Duration::ZERO,
         avg_time_spent_in_store: None,
       }
       .run(),
@@ -351,7 +223,8 @@ impl IdleFileCache {
   pub fn store(&self, identifier: impl Into<String>, etag: Option<Etag>, data: CacheData) {
     self.send(Command::Store {
       identifier: identifier.into(),
-      entry: PendingStore { etag, data },
+      etag,
+      data,
     });
   }
 

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,53 +1,69 @@
 use dashmap::DashMap;
+use rspack_util::fx_hash::FxDashMap;
 
-use super::{CacheData, Etag};
-
-#[derive(Debug, Clone)]
-struct MemoryCacheEntry {
-  etag: Option<Etag>,
-  data: CacheData,
-}
+use super::{
+  CacheKey, CacheValue, Etag,
+  cache_value::{CacheEntry, CacheValueData},
+};
 
 /// Result of looking up an item in the memory cache.
 ///
 /// `NotCached` lets the caller continue with the filesystem cache. `Miss`
 /// records a known miss and stops lower cache layers from being queried.
-#[derive(Debug, Clone)]
-pub enum MemoryCacheGetResult {
+#[derive(Debug)]
+pub enum MemoryCacheGetResult<T> {
   NotCached,
   Miss,
-  Hit(CacheData),
+  Hit(CacheValue<T>),
+}
+
+impl<T> Clone for MemoryCacheGetResult<T> {
+  fn clone(&self) -> Self {
+    match self {
+      Self::NotCached => Self::NotCached,
+      Self::Miss => Self::Miss,
+      Self::Hit(value) => Self::Hit(value.clone()),
+    }
+  }
 }
 
 /// In-memory cache equivalent to webpack's `MemoryCachePlugin`.
 #[derive(Debug, Default)]
 pub struct MemoryCache {
-  entries: DashMap<String, Option<MemoryCacheEntry>>,
+  entries: FxDashMap<CacheKey, Option<CacheEntry>>,
 }
 
 impl MemoryCache {
-  pub fn get(&self, identifier: &str, etag: Option<&str>) -> MemoryCacheGetResult {
-    let Some(entry) = self.entries.get(identifier) else {
+  pub fn get<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> MemoryCacheGetResult<T> {
+    let Some(entry) = self.entries.get(&key) else {
       return MemoryCacheGetResult::NotCached;
     };
     let Some(entry) = entry.value() else {
       return MemoryCacheGetResult::Miss;
     };
-    if entry.etag.as_deref() == etag {
-      MemoryCacheGetResult::Hit(entry.data.clone())
+    if entry.matches(&etag) {
+      entry
+        .value()
+        .clone()
+        .downcast()
+        .map_or(MemoryCacheGetResult::Miss, MemoryCacheGetResult::Hit)
     } else {
       MemoryCacheGetResult::Miss
     }
   }
 
-  pub fn store(&self, identifier: impl Into<String>, etag: Option<Etag>, data: CacheData) {
+  pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
     self
       .entries
-      .insert(identifier.into(), Some(MemoryCacheEntry { etag, data }));
+      .insert(key, Some(CacheEntry::new(etag, value.erase())));
   }
 
-  pub fn store_miss(&self, identifier: impl Into<String>) {
-    self.entries.insert(identifier.into(), None);
+  pub fn store_miss(&self, key: CacheKey) {
+    self.entries.insert(key, None);
   }
 
   pub fn clear(&self) {

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,4 +1,3 @@
-use dashmap::DashMap;
 use rspack_util::fx_hash::FxDashMap;
 
 use super::{
@@ -36,16 +35,16 @@ pub struct MemoryCache {
 impl MemoryCache {
   pub fn get<T: CacheValueData>(
     &self,
-    key: CacheKey,
-    etag: Option<Etag>,
+    key: &CacheKey,
+    etag: Option<&Etag>,
   ) -> MemoryCacheGetResult<T> {
-    let Some(entry) = self.entries.get(&key) else {
+    let Some(entry) = self.entries.get(key) else {
       return MemoryCacheGetResult::NotCached;
     };
     let Some(entry) = entry.value() else {
       return MemoryCacheGetResult::Miss;
     };
-    if entry.matches(&etag) {
+    if entry.matches(etag) {
       entry
         .value()
         .clone()

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,0 +1,56 @@
+use dashmap::DashMap;
+
+use super::{CacheData, Etag};
+
+#[derive(Debug, Clone)]
+struct MemoryCacheEntry {
+  etag: Option<Etag>,
+  data: CacheData,
+}
+
+/// Result of looking up an item in the memory cache.
+///
+/// `NotCached` lets the caller continue with the filesystem cache. `Miss`
+/// records a known miss and stops lower cache layers from being queried.
+#[derive(Debug, Clone)]
+pub enum MemoryCacheGetResult {
+  NotCached,
+  Miss,
+  Hit(CacheData),
+}
+
+/// In-memory cache equivalent to webpack's `MemoryCachePlugin`.
+#[derive(Debug, Default)]
+pub struct MemoryCache {
+  entries: DashMap<String, Option<MemoryCacheEntry>>,
+}
+
+impl MemoryCache {
+  pub fn get(&self, identifier: &str, etag: Option<&str>) -> MemoryCacheGetResult {
+    let Some(entry) = self.entries.get(identifier) else {
+      return MemoryCacheGetResult::NotCached;
+    };
+    let Some(entry) = entry.value() else {
+      return MemoryCacheGetResult::Miss;
+    };
+    if entry.etag.as_deref() == etag {
+      MemoryCacheGetResult::Hit(entry.data.clone())
+    } else {
+      MemoryCacheGetResult::Miss
+    }
+  }
+
+  pub fn store(&self, identifier: impl Into<String>, etag: Option<Etag>, data: CacheData) {
+    self
+      .entries
+      .insert(identifier.into(), Some(MemoryCacheEntry { etag, data }));
+  }
+
+  pub fn store_miss(&self, identifier: impl Into<String>) {
+    self.entries.insert(identifier.into(), None);
+  }
+
+  pub fn clear(&self) {
+    self.entries.clear();
+  }
+}

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -1,18 +1,16 @@
 // The compiler integration is added after these foundational cache layers.
 #![allow(dead_code, unused_imports)]
 
+mod cache_key;
+mod cache_value;
+mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 
-use std::sync::Arc;
-
+pub use cache_key::CacheKey;
+pub use cache_value::{CacheValue, CacheValueData};
+pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
-
-/// Serialized cache payload shared by the memory and filesystem cache layers.
-pub type CacheData = Arc<[u8]>;
-
-/// String representation of the inputs used to validate a cache entry.
-pub type Etag = Arc<str>;

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -1,5 +1,5 @@
 // The compiler integration is added after these foundational cache layers.
-#![allow(dead_code, unused_imports)]
+#![allow(dead_code)]
 
 mod cache_key;
 mod cache_value;
@@ -9,8 +9,10 @@ mod idle_file_cache;
 mod memory_cache;
 
 pub use cache_key::CacheKey;
-pub use cache_value::{CacheValue, CacheValueData};
+pub use cache_value::CacheValue;
 pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
+#[allow(unused_imports)]
 pub use idle_file_cache::IdleFileCache;
+#[allow(unused_imports)]
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -2,6 +2,7 @@ mod cache;
 mod cache_facade;
 mod cache_key;
 mod cache_value;
+mod db;
 mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
@@ -26,18 +27,19 @@ use crate::{
 };
 
 pub fn create_cache(
+  compiler_path: String,
   compiler_options: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Cache {
   if !compiler_options.experiments.new_cache {
-    return Cache::new_disabled();
+    return Cache::new_disabled(compiler_path);
   }
 
   let options = match &compiler_options.cache {
-    crate::CacheOptions::Disabled => return Cache::new_disabled(),
+    crate::CacheOptions::Disabled => return Cache::new_disabled(compiler_path),
     crate::CacheOptions::Memory { max_generations: _ } => {
-      return Cache::new(MemoryCache::default(), None);
+      return Cache::new(compiler_path, MemoryCache::default(), None);
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -71,10 +73,10 @@ pub fn create_cache(
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      return Cache::new(MemoryCache::default(), None);
+      return Cache::new(compiler_path, MemoryCache::default(), None);
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy);
 
-  Cache::new(MemoryCache::default(), Some(idle_file_cache))
+  Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 mod cache;
 mod cache_facade;
 mod cache_key;
@@ -8,15 +6,73 @@ mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
+mod snapshot;
 
-#[allow(unused_imports)]
+use std::sync::Arc;
+
 pub use cache::Cache;
 pub use cache_facade::{CacheFacade, ItemCacheFacade};
 pub use cache_key::CacheKey;
 pub use cache_value::CacheValue;
 pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
-#[allow(unused_imports)]
 pub use idle_file_cache::IdleFileCache;
-#[allow(unused_imports)]
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
+use rspack_fs::ReadableFileSystem;
+
+use self::snapshot::{BuildDeps, Snapshot};
+use crate::{
+  CompilationLogger, CompilationLogging, CompilerOptions, cache::persistent::codec::CacheCodec,
+};
+
+pub fn create_cache(
+  compiler_options: Arc<CompilerOptions>,
+  input_filesystem: Arc<dyn ReadableFileSystem>,
+  compilation_logging: CompilationLogging,
+) -> Cache {
+  if !compiler_options.experiments.new_cache {
+    return Cache::new_disabled();
+  }
+
+  fn version_directory(version: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = rustc_hash::FxHasher::default();
+    version.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+  }
+
+  let options = match &compiler_options.cache {
+    crate::CacheOptions::Disabled => return Cache::new_disabled(),
+    crate::CacheOptions::Memory { max_generations: _ } => {
+      return Cache::new(MemoryCache::default(), None);
+    }
+    crate::CacheOptions::Persistent(options) => options,
+  };
+
+  let project_root = if options.portable {
+    Some(compiler_options.context.as_path().to_path_buf())
+  } else {
+    None
+  };
+  let codec = Arc::new(CacheCodec::new(project_root));
+  let snapshot = Snapshot::new(options.snapshot.clone(), input_filesystem.clone());
+  let build_deps = BuildDeps::new(
+    &options.build_dependencies,
+    input_filesystem,
+    CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
+  );
+  let cache_location = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
+      directory.join(version_directory(rspack_workspace::rspack_pkg_version!()))
+    }
+  };
+  let idle_file_cache = IdleFileCache::new(FileCacheStrategy::new(
+    cache_location,
+    options.readonly,
+    codec,
+    snapshot,
+    build_deps,
+  ));
+
+  Cache::new(MemoryCache::default(), Some(idle_file_cache))
+}

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -1,6 +1,7 @@
-// The compiler integration is added after these foundational cache layers.
 #![allow(dead_code)]
 
+mod cache;
+mod cache_facade;
 mod cache_key;
 mod cache_value;
 mod etag;
@@ -8,6 +9,9 @@ mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 
+#[allow(unused_imports)]
+pub use cache::Cache;
+pub use cache_facade::{CacheFacade, ItemCacheFacade};
 pub use cache_key::CacheKey;
 pub use cache_value::CacheValue;
 pub use etag::Etag;

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -34,13 +34,6 @@ pub fn create_cache(
     return Cache::new_disabled();
   }
 
-  fn version_directory(version: &str) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = rustc_hash::FxHasher::default();
-    version.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
-  }
-
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => return Cache::new_disabled(),
     crate::CacheOptions::Memory { max_generations: _ } => {
@@ -61,18 +54,27 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let cache_location = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
-      directory.join(version_directory(rspack_workspace::rspack_pkg_version!()))
-    }
+  let (base_path, database_path) = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
+      directory.clone(),
+      directory.join(rspack_workspace::rspack_pkg_version!()),
+    ),
   };
-  let idle_file_cache = IdleFileCache::new(FileCacheStrategy::new(
-    cache_location,
+  let strategy = match FileCacheStrategy::new(
+    base_path,
+    database_path,
     options.readonly,
     codec,
     snapshot,
     build_deps,
-  ));
+  ) {
+    Ok(strategy) => strategy,
+    Err(error) => {
+      tracing::warn!("Opening persistent cache database failed: {error}");
+      return Cache::new(MemoryCache::default(), None);
+    }
+  };
+  let idle_file_cache = IdleFileCache::new(strategy);
 
   Cache::new(MemoryCache::default(), Some(idle_file_cache))
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -1,0 +1,18 @@
+// The compiler integration is added after these foundational cache layers.
+#![allow(dead_code, unused_imports)]
+
+mod file_cache_strategy;
+mod idle_file_cache;
+mod memory_cache;
+
+use std::sync::Arc;
+
+pub use file_cache_strategy::FileCacheStrategy;
+pub use idle_file_cache::IdleFileCache;
+pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
+
+/// Serialized cache payload shared by the memory and filesystem cache layers.
+pub type CacheData = Arc<[u8]>;
+
+/// String representation of the inputs used to validate a cache entry.
+pub type Etag = Arc<str>;

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -1,0 +1,119 @@
+use std::{collections::VecDeque, path::PathBuf, sync::Arc};
+
+use rspack_error::Result;
+use rspack_fs::ReadableFileSystem;
+use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
+
+use super::{BuildDependenciesSnapshot, Snapshot};
+use crate::{
+  CompilationLogger,
+  cache::persistent::{
+    build_dependencies::{Helper, is_node_package_path},
+    codec::CacheCodec,
+  },
+};
+
+pub type BuildDepsOptions = Vec<PathBuf>;
+
+#[derive(Debug)]
+pub enum BuildDepsValidationResult {
+  Valid {
+    tracked_files: usize,
+  },
+  Invalid {
+    modified_files: ArcPathSet,
+    removed_files: ArcPathSet,
+  },
+}
+
+/// Build dependencies manager.
+#[derive(Debug)]
+pub struct BuildDeps {
+  /// Dependencies configured at startup and added on the next store.
+  pending: ArcPathSet,
+  data: BuildDependenciesSnapshot,
+  fs: Arc<dyn ReadableFileSystem>,
+  logger: CompilationLogger,
+}
+
+impl BuildDeps {
+  pub fn new(
+    options: &BuildDepsOptions,
+    fs: Arc<dyn ReadableFileSystem>,
+    logger: CompilationLogger,
+  ) -> Self {
+    Self {
+      pending: options
+        .iter()
+        .map(|path| ArcPath::from(path.as_path()))
+        .collect(),
+      data: Default::default(),
+      fs,
+      logger,
+    }
+  }
+
+  /// Update build dependencies and serialize the complete snapshot.
+  ///
+  /// For performance reasons, recursive searches stop at dependencies in
+  /// `node_modules`.
+  pub async fn create_snapshot(
+    &mut self,
+    codec: &CacheCodec,
+    snapshot: &Snapshot,
+    data: impl Iterator<Item = ArcPath>,
+  ) -> Result<Vec<u8>> {
+    let mut helper = Helper::new(self.fs.clone(), self.logger.clone());
+    let mut added = ArcPathSet::default();
+    let mut queue = VecDeque::new();
+    queue.extend(self.pending.iter().cloned());
+    queue.extend(data);
+
+    while let Some(current) = queue.pop_front() {
+      if self.data.dependencies.contains(&current) || !added.insert(current.clone()) {
+        continue;
+      }
+      if is_node_package_path(&current) {
+        continue;
+      }
+      if let Some(children) = helper.resolve(current.assert_utf8()).await {
+        queue.extend(
+          children
+            .into_iter()
+            .map(|path| ArcPath::from(path.as_path())),
+        );
+      }
+    }
+
+    let snapshots = snapshot.add(added.iter().cloned()).await;
+    self.data.dependencies.extend(added);
+    self.data.snapshots.extend(snapshots);
+    self.pending.clear();
+    codec.encode(&self.data)
+  }
+
+  /// Validate build dependencies.
+  ///
+  /// If any build dependency changed, this method returns an invalid result.
+  pub async fn validate_snapshot(
+    &mut self,
+    codec: &CacheCodec,
+    snapshot: &Snapshot,
+    data: Option<&[u8]>,
+  ) -> Result<BuildDepsValidationResult> {
+    let Some(data) = data else {
+      return Ok(BuildDepsValidationResult::Valid { tracked_files: 0 });
+    };
+    let data = codec.decode::<BuildDependenciesSnapshot>(data)?;
+    let (modified_files, removed_files) = snapshot.calc_modified_paths(&data.snapshots).await;
+    if !modified_files.is_empty() || !removed_files.is_empty() {
+      return Ok(BuildDepsValidationResult::Invalid {
+        modified_files,
+        removed_files,
+      });
+    }
+    let tracked_files = data.dependencies.len();
+    self.data = data;
+    Ok(BuildDepsValidationResult::Valid { tracked_files })
+  }
+}

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -1,0 +1,90 @@
+mod build_deps;
+
+use std::sync::Arc;
+
+use rspack_cacheable::cacheable;
+use rspack_fs::ReadableFileSystem;
+use rspack_paths::{ArcPath, ArcPathSet};
+
+pub use self::build_deps::{BuildDeps, BuildDepsValidationResult};
+use crate::cache::persistent::snapshot::{
+  SnapshotOptions, SnapshotStrategyOptions, Strategy, StrategyHelper, ValidateResult,
+};
+
+#[cacheable]
+#[derive(Debug)]
+pub struct SnapshotEntry {
+  path: ArcPath,
+  strategy: Strategy,
+}
+
+#[cacheable]
+#[derive(Debug, Default)]
+struct BuildDependenciesSnapshot {
+  dependencies: ArcPathSet,
+  snapshots: Vec<SnapshotEntry>,
+}
+
+/// Creates and validates filesystem snapshots stored by the new cache.
+#[derive(Debug)]
+pub struct Snapshot {
+  options: Arc<SnapshotOptions>,
+  fs: Arc<dyn ReadableFileSystem>,
+}
+
+impl Snapshot {
+  pub fn new(options: SnapshotOptions, fs: Arc<dyn ReadableFileSystem>) -> Self {
+    Self {
+      options: Arc::new(options),
+      fs,
+    }
+  }
+
+  async fn calc_strategy(&self, helper: &StrategyHelper, path: &ArcPath) -> Option<Strategy> {
+    let path_str = path.to_string_lossy();
+    if self.options.is_immutable_path(&path_str) {
+      return None;
+    }
+    if self.options.is_managed_path(&path_str)
+      && let Some(strategy) = helper.package_version(path).await
+    {
+      return Some(strategy);
+    }
+    Some(
+      helper
+        .dir_strategy(path, SnapshotStrategyOptions::hash())
+        .await,
+    )
+  }
+
+  #[tracing::instrument("Cache::Snapshot::add", skip_all)]
+  pub async fn add(&self, paths: impl Iterator<Item = ArcPath>) -> Vec<SnapshotEntry> {
+    let helper = StrategyHelper::new(self.fs.clone(), self.options.clone());
+    let mut entries = Vec::with_capacity(paths.size_hint().0);
+    for path in paths {
+      if let Some(strategy) = self.calc_strategy(&helper, &path).await {
+        entries.push(SnapshotEntry { path, strategy });
+      }
+    }
+    entries
+  }
+
+  #[tracing::instrument("Cache::Snapshot::calc_modified_paths", skip_all)]
+  pub async fn calc_modified_paths(&self, entries: &[SnapshotEntry]) -> (ArcPathSet, ArcPathSet) {
+    let helper = StrategyHelper::new(self.fs.clone(), self.options.clone());
+    let mut modified_files = ArcPathSet::default();
+    let mut removed_files = ArcPathSet::default();
+    for entry in entries {
+      match helper.validate(&entry.path, &entry.strategy).await {
+        ValidateResult::Modified => {
+          modified_files.insert(entry.path.clone());
+        }
+        ValidateResult::Deleted => {
+          removed_files.insert(entry.path.clone());
+        }
+        ValidateResult::NoChanged => {}
+      }
+    }
+    (modified_files, removed_files)
+  }
+}

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -26,6 +26,7 @@ use runtime_mode::RuntimeMode;
 #[derive(Debug)]
 pub struct Experiments {
   pub css: bool,
+  pub new_cache: bool,
   pub defer_import: bool,
   pub source_import: bool,
   pub pure_functions: bool,

--- a/deny.toml
+++ b/deny.toml
@@ -216,6 +216,7 @@ skip = [
     { crate = "base64-simd", reason = "external dependency"},
     { crate = "convert_case", reason = "external dependency"},
     { crate = "getrandom", reason = "external dependency"},
+    { crate = "r-efi", reason = "external dependency" },
     { crate = "hashbrown", reason = "external dependency"},
     { crate = "itertools", reason = "external dependency"},
     { crate = "outref", reason = "external dependency"},

--- a/deny.toml
+++ b/deny.toml
@@ -217,6 +217,7 @@ skip = [
     { crate = "convert_case", reason = "external dependency"},
     { crate = "getrandom", reason = "external dependency"},
     { crate = "r-efi", reason = "external dependency" },
+    { crate = "zerocopy-derive", reason = "external dependency" },
     { crate = "hashbrown", reason = "external dependency"},
     { crate = "itertools", reason = "external dependency"},
     { crate = "outref", reason = "external dependency"},

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -279,6 +279,7 @@ const applyExperimentsDefaults = (
   { production }: { production: boolean },
 ) => {
   D(experiments, 'futureDefaults', false);
+  D(experiments, 'newCache', false);
   D(experiments, 'asyncWebAssembly', true);
   D(experiments, 'deferImport', false);
   D(experiments, 'sourceImport', false);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -648,6 +648,7 @@ export interface ExperimentsNormalized {
   asyncWebAssembly?: boolean;
   css?: boolean;
   futureDefaults?: boolean;
+  newCache?: boolean;
   buildHttp?: HttpUriPluginOptions;
   useInputFileSystem?: false | RegExp[];
   nativeWatcher?: boolean;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3119,6 +3119,11 @@ export type Experiments = {
    */
   futureDefaults?: boolean;
   /**
+   * Enable the experimental new cache implementation.
+   * @default false
+   */
+  newCache?: boolean;
+  /**
    * Enable loading of modules via HTTP/HTTPS requests.
    * @default false
    */

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -24,6 +24,7 @@ module.exports = {
 			    buildHttp: undefined,
 			    deferImport: false,
 			    futureDefaults: false,
+			    newCache: false,
 			    pureFunctions: false,
 			    runtimeMode: webpack,
 			    sourceImport: false,

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -5,7 +5,7 @@ use criterion::BatchSize;
 use rspack::builder::{Builder as _, CompilerBuilder};
 use rspack_benchmark::Criterion;
 use rspack_core::{
-  Compilation, Compiler, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
+  Cache, Compilation, Compiler, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
   ModuleRuleUseLoader, Optimization, RuleSetCondition, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   fast_set,
@@ -380,6 +380,7 @@ fn reset_compilation_state(compiler: &mut Compiler) {
       Incremental::new_cold(compiler.options.incremental),
       Some(Default::default()),
       Default::default(),
+      Cache::new_disabled(compiler.compiler_path.clone()),
       Default::default(),
       Default::default(),
       compiler.input_filesystem.clone(),


### PR DESCRIPTION
## Summary

Introduce an experimental webpack-aligned cache implementation behind `experiments.newCache`.

This PR adds the foundational cache infrastructure required for gradually migrating cache consumers to the new system:

- Add layered memory and filesystem cache implementations.
- Add the core `Cache`, `CacheFacade`, and item cache APIs.
- Store cache keys, values, and etags as immutable, cheaply cloneable types.
- Reuse Rspack's existing cache codec for serialization and deserialization.
- Defer persistent cache serialization and writes to a dedicated idle background worker so they do not block compilation.
- Use `turbo-persistence` as the native persistent storage backend.
- Provide a simple in-memory database backend for WASM targets.
- Validate build dependencies before restoring persistent cache entries.
- Replace invalid persistent cache packs by moving them into `_stale` and cleaning them up during idle time.
- Integrate cache lifecycle management into `Compiler` and expose the cache through `Compiler` and `Compilation`.

The new and legacy cache implementations are mutually exclusive:

- When `experiments.newCache` is enabled, the new cache implementation is used.
- Otherwise, the existing cache behavior remains unchanged.

Example:

```js
module.exports = {
  experiments: {
    newCache: true,
  },
  cache: {
    type: "persistent",
  },
};
```

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
