### PR TITLE
docs: correct Module Federation documentation

### DIFF
--- a/website/docs/en/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin.mdx
@@ -29,7 +29,7 @@ export default {
   },
   plugins: [
     new rspack.container.ModuleFederationPlugin({
-      // options
+      name: 'app',
     }),
   ],
 };
@@ -45,9 +45,14 @@ Provide a path as the implementation for Module Federation 1.5 runtime, which de
 
 ### runtimePlugins
 
-- Type: `string[]`
+- Type:
+  ```ts
+  type RuntimePlugins =
+    | string[]
+    | [plugin: string, options: Record<string, unknown>][];
+  ```
 
-Provide the plugin required to run Module Federation 1.5, which can extend the behavior and capabilities of Module Federation.
+Provide the plugins required to run Module Federation 1.5, which can extend its behavior and capabilities. Use an array of module paths, or an array of `[modulePath, options]` tuples when a plugin needs options.
 
 ### name
 
@@ -75,7 +80,7 @@ Define the output format of remote container entry. The default libraryType is "
 
 ### shareScope
 
-- Type: `string`
+- Type: `string | string[]`
 
 Define the namespace for shared dependencies in the current container. By configuring share scopes between different containers, the sharing behavior of modules can be controlled, including determining which modules are shared between different containers. The default share scope is `"default"`.
 
@@ -102,12 +107,13 @@ Defines how to load remote containers, defaulting to `"script"`, which loads via
   type Remotes = (RemotesItem | RemotesObject)[] | RemotesObject;
   type RemotesItem = string;
   type RemotesItems = RemotesItem[];
+  type ShareScope = string | string[];
   interface RemotesObject {
     [k: string]: RemotesConfig | RemotesItem | RemotesItems;
   }
   interface RemotesConfig {
     external: RemotesItem | RemotesItems;
-    shareScope?: string;
+    shareScope?: ShareScope;
   }
   ```
 
@@ -137,6 +143,12 @@ Define how local modules can be referenced by remote containers. The key is the 
   ```ts
   type Shared = (SharedItem | SharedObject)[] | SharedObject;
   type SharedItem = string;
+  type ShareScope = string | string[];
+  interface TreeShakingConfig {
+    usedExports?: string[];
+    mode?: 'server-calc' | 'runtime-infer';
+    filename?: string;
+  }
   interface SharedObject {
     [k: string]: SharedConfig | SharedItem;
   }
@@ -146,10 +158,11 @@ Define how local modules can be referenced by remote containers. The key is the 
     packageName?: string;
     requiredVersion?: false | string;
     shareKey?: string;
-    shareScope?: string;
+    shareScope?: ShareScope;
     singleton?: boolean;
     strictVersion?: boolean;
     version?: false | string;
+    treeShaking?: TreeShakingConfig;
   }
   ```
 
@@ -171,6 +184,7 @@ The SharedConfig can include the following sub-options:
   - mode: Configure the loading strategy for treeshaking.
     - `runtime-infer`: Infer based on the consumer's `usedExports`. If the provider's `usedExports` match the consumer's `usedExports`, the provider's `shared` will be used; otherwise, the consumer's own `shared` will be used. If neither condition is met, the full version is used.
     - `server-calc`: Decide whether to load shared dependencies based on the snapshot sent by the server.
+  - filename: Customize the filename of the generated shared fallback entry.
 
 ### manifest
 
@@ -207,31 +221,31 @@ Whether to inject the exports used by shared into the bundler runtime.
 
 - Type: `boolean`
 - Required: No
-- Default: `undefined`
+- Default: `true`
 
 This option is used to control whether to inject the actual used export information of shared modules into the bundler runtime for more precise dependency management and optimization.
 
 If you are using mode as 'server-calc', it is recommended to set this option to `false`.
 
-### treeShakingDir
+### treeShakingSharedDir
 
 Directory for outputting tree shaking shared fallback resources.
 
 - Type: `string`
 - Required: No
-- Default: `undefined`
+- Default: `'independent-packages'`
 
 When shared dependency tree shaking is enabled, Module Federation splits unused shared module exports. This option specifies the output directory for these fallback resources.
 
 ### treeShakingSharedExcludePlugins
 
-Configure plugin names to exclude during the shared dependency tree shaking/fallback build process.
+Configure additional plugin names to exclude during the shared dependency tree shaking/fallback build process.
 
 - Type: `string[]`
 - Required: No
-- Default: `['HtmlWebpackPlugin','HtmlRspackPlugin']`
+- Default: `[]`
 
-Allows users to specify a set of plugin names that will be ignored or not involved in processing during the shared dependency tree shaking/fallback build process.
+Rspack already excludes its Module Federation and tree-shaking helper plugins, as well as common HTML plugins. Use this option to add more plugin names to that exclusion list.
 
 ### treeShakingSharedPlugins
 

--- a/website/docs/en/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/en/plugins/webpack/module-federation-plugin.mdx
@@ -48,8 +48,7 @@ Provide a path as the implementation for Module Federation 1.5 runtime, which de
 - Type:
   ```ts
   type RuntimePlugins =
-    | string[]
-    | [plugin: string, options: Record<string, unknown>][];
+    string[] | [plugin: string, options: Record<string, unknown>][];
   ```
 
 Provide the plugins required to run Module Federation 1.5, which can extend its behavior and capabilities. Use an array of module paths, or an array of `[modulePath, options]` tuples when a plugin needs options.

--- a/website/docs/en/plugins/webpack/tree-shaking-shared-plugin.mdx
+++ b/website/docs/en/plugins/webpack/tree-shaking-shared-plugin.mdx
@@ -15,17 +15,16 @@ import { Stability, ApiMeta } from '@components/ApiMeta';
 **Options**
 
 - `mfConfig`: `ModuleFederationPluginOptions`, configuration passed to the Module Federation plugin.
-- `plugins`: extra plugins reused during independent builds.
 - `secondary`: whether to perform a second tree-shake during independent builds (typically used when the deployment platform has determined complete dependency info and triggers a fresh build to improve tree-shake accuracy for shared dependencies).
 
 **Usage**
 
 ```js title="rspack.config.mjs"
-import { TreeShakingSharedPlugin } from '@rspack/core';
+import { sharing } from '@rspack/core';
 
 export default {
   plugins: [
-    new TreeShakingSharedPlugin({
+    new sharing.TreeShakingSharedPlugin({
       secondary: true,
       mfConfig: {
         name: 'app',
@@ -35,7 +34,6 @@ export default {
         library: { type: 'var', name: 'App' },
         manifest: true,
       },
-      plugins: [],
     }),
   ],
 };
@@ -45,4 +43,5 @@ export default {
 
 - Normalizes `shared` into `[shareName, SharedConfig][]`.
 - Registers `SharedUsedExportsOptimizerPlugin` when `secondary` is `false` to inject used-exports from the stats manifest.
-- Triggers independent compilation for shared entries with `tree shaking: true`, and writes the produced assets back to the `stats/manifest` (fallback fields).
+- Creates an independent build only for shared dependencies that enable `treeShaking` and retain a local implementation (that is, `import` is not `false`).
+- When `mfConfig.manifest` is enabled, records the independent build output in the stats and manifest files so the runtime can load it as a fallback.

--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -29,7 +29,7 @@ export default {
   },
   plugins: [
     new rspack.container.ModuleFederationPlugin({
-      // options
+      name: 'app',
     }),
   ],
 };
@@ -45,9 +45,14 @@ export default {
 
 ### runtimePlugins
 
-- 类型：`string[]`
+- 类型：
+  ```ts
+  type RuntimePlugins =
+    | string[]
+    | [plugin: string, options: Record<string, unknown>][];
+  ```
 
-传入 Module Federation 1.5 运行时所需的插件，插件可以对 Module Federation 的行为与能力进行扩展。
+传入 Module Federation 1.5 运行时所需的插件，用于扩展 Module Federation 的行为与能力。可以传入一组模块路径；当插件需要配置时，也可以传入一组 `[模块路径, 配置]` 元组。
 
 ### name
 
@@ -75,7 +80,7 @@ export default {
 
 ### shareScope
 
-- 类型：`string`
+- 类型：`string | string[]`
 
 定义当前应用共享依赖的命名空间。通过在不同的应用之间配置命名空间，可以控制模块的共享行为，包括确定哪些模块在不同的应用之间是共享的。默认的命名空间为 `"default"`。
 
@@ -102,12 +107,13 @@ export default {
   type Remotes = (RemotesItem | RemotesObject)[] | RemotesObject;
   type RemotesItem = string;
   type RemotesItems = RemotesItem[];
+  type ShareScope = string | string[];
   interface RemotesObject {
     [k: string]: RemotesConfig | RemotesItem | RemotesItems;
   }
   interface RemotesConfig {
     external: RemotesItem | RemotesItems;
-    shareScope?: string;
+    shareScope?: ShareScope;
   }
   ```
 
@@ -137,6 +143,12 @@ export default {
   ```ts
   type Shared = (SharedItem | SharedObject)[] | SharedObject;
   type SharedItem = string;
+  type ShareScope = string | string[];
+  interface TreeShakingConfig {
+    usedExports?: string[];
+    mode?: 'server-calc' | 'runtime-infer';
+    filename?: string;
+  }
   interface SharedObject {
     [k: string]: SharedConfig | SharedItem;
   }
@@ -146,14 +158,11 @@ export default {
     packageName?: string;
     requiredVersion?: false | string;
     shareKey?: string;
-    shareScope?: string;
+    shareScope?: ShareScope;
     singleton?: boolean;
     strictVersion?: boolean;
     version?: false | string;
-    treeShaking?: {
-      mode: 'runtime-infer' | 'server-calc';
-      usedExports?: string[];
-    };
+    treeShaking?: TreeShakingConfig;
   }
   ```
 
@@ -175,6 +184,7 @@ export default {
   - mode：配置 treeshaking 的加载策略。
     - `runtime-infer`: 根据消费方的 `usedExports` 进行推断，如果提供方的 `usedExports` 符合当前消费方的 `usedExports`，那么就会使用提供方的 `shared`，否则会使用消费方自身的 `shared`，如果都不满足，就使用全量的。
     - `server-calc`: 根据服务端下发的 snapshot 来决定是否加载共享依赖。
+  - filename：自定义生成的 shared fallback 入口文件名。
 
 ### manifest
 
@@ -209,31 +219,31 @@ export default {
 
 - 类型：`boolean`
 - 是否必填：否
-- 默认值：`undefined`
+- 默认值：`true`
 
 此选项用于控制是否将共享模块中实际使用的导出信息注入到打包器的运行时中，以便进行更精确的依赖管理和优化。
 
 如果你使用的是 mode 为 'server-calc'，那么推荐将此选项设置为 `false`。
 
-### treeShakingDir
+### treeShakingSharedDir
 
 用于输出 tree shaking 共享 fallback 资源的目录。
 
 - 类型：`string`
 - 是否必填：否
-- 默认值：`undefined`
+- 默认值：`'independent-packages'`
 
 当启用共享依赖 tree shaking 功能时，Module Federation 会将未使用的共享模块导出拆分出来。该选项指定了这些 fallback 资源的输出目录。
 
 ### treeShakingSharedExcludePlugins
 
-配置在构建共享依赖 tree shaking/fallback 过程中需要排除的插件名称。
+配置在构建共享依赖 tree shaking/fallback 过程中需要额外排除的插件名称。
 
 - 类型：`string[]`
 - 是否必填：否
-- 默认值：`['HtmlWebpackPlugin','HtmlRspackPlugin']`
+- 默认值：`[]`
 
-允许用户指定一组插件名称，这些插件在构建共享依赖 tree shaking/fallback 过程 时将被忽略或不参与处理。
+Rspack 已默认排除 Module Federation、tree shaking 相关的辅助插件及常见 HTML 插件。可以通过此选项向排除列表中添加其他插件名称。
 
 ### treeShakingSharedPlugins
 

--- a/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/module-federation-plugin.mdx
@@ -48,8 +48,7 @@ export default {
 - 类型：
   ```ts
   type RuntimePlugins =
-    | string[]
-    | [plugin: string, options: Record<string, unknown>][];
+    string[] | [plugin: string, options: Record<string, unknown>][];
   ```
 
 传入 Module Federation 1.5 运行时所需的插件，用于扩展 Module Federation 的行为与能力。可以传入一组模块路径；当插件需要配置时，也可以传入一组 `[模块路径, 配置]` 元组。

--- a/website/docs/zh/plugins/webpack/tree-shaking-shared-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/tree-shaking-shared-plugin.mdx
@@ -15,27 +15,25 @@ import { Stability, ApiMeta } from '@components/ApiMeta';
 **选项**
 
 - `mfConfig`：`ModuleFederationPluginOptions`，传入模块联邦插件所需要的配置项。
-- `plugins`：额外插件列表，可在独立编译中复用。
 - `secondary`：是否在独立编译阶段执行二次摇树优化（二次摇树通常在部署平台确定了完整的依赖信息后重新触发的一次全新构建，提高共享依赖 tree shaking 命中的准确率）。
 
 **使用示例**
 
 ```js title="rspack.config.mjs"
-import { TreeShakingSharedPlugin } from '@rspack/core';
+import { sharing } from '@rspack/core';
 
 export default {
   plugins: [
-    new TreeShakingSharedPlugin({
+    new sharing.TreeShakingSharedPlugin({
       secondary: true,
       mfConfig: {
         name: 'app',
         shared: {
-          'lodash-es': { treeShaking: true },
+          'lodash-es': { treeShaking: { mode: 'server-calc' } },
         },
         library: { type: 'var', name: 'App' },
         manifest: true,
       },
-      plugins: [],
     }),
   ],
 };
@@ -45,4 +43,5 @@ export default {
 
 - 读取 `shared` 配置后标准化为 `[shareName, SharedConfig][]`。
 - 当 `secondary` 为 `false` 时，注册 `SharedUsedExportsOptimizerPlugin`，基于 stats 清单注入已用导出集合。
-- 对 `tree shaking` 的共享包触发独立编译，产出回写到 stats/manifest 中的 fallback 字段。
+- 仅当共享依赖启用了 `treeShaking` 且保留本地实现（即未设置 `import: false`）时，插件才会为它创建独立构建。
+- 启用 `mfConfig.manifest` 后，独立构建的产物信息会写入 stats 和 manifest，供运行时作为 fallback 加载。


### PR DESCRIPTION
## Summary

This PR corrects the Module Federation plugin documentation to match the current public types, defaults, and runtime behavior. It also fixes incomplete `TreeShakingSharedPlugin` examples and keeps the English and Chinese references aligned.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).