### PR TITLE
chore: bump `swc_core` from 72 to 76

### DIFF
--- a/.agents/skills/bump-rspack-swc/SKILL.md
+++ b/.agents/skills/bump-rspack-swc/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: bump-rspack-swc
+description: Upgrade the SWC Rust dependencies used by the Rspack repository, regenerate workspace version code, analyze the swc_core tag-to-tag changelog for breaking and Rspack-relevant changes, correlate fixes with Rspack issues, validate the upgrade, and commit, push, and open the GitHub pull request. Use when asked to bump, update, or upgrade swc_core or its aligned SWC crate versions in Rspack and prepare or submit the resulting PR.
+---
+
+# Upgrade Rspack SWC
+
+Perform the upgrade end to end. Keep the patch focused, preserve unrelated work, and base every changelog claim on the SWC tag range.
+
+## Guardrails
+
+- Confirm the checkout is `web-infra-dev/rspack` and read the applicable `AGENTS.md` instructions before editing.
+- Inspect `git status --short`, the current branch, and remotes first. Never overwrite, discard, stage, or commit unrelated user changes. Stop for direction if unrelated changes overlap the files required by the upgrade.
+- Use exact, stable, non-yanked crate versions. Ignore prereleases unless the user explicitly requests one.
+- Treat the root `Cargo.toml` comment `Must be pinned with the same swc versions` as an invariant. Keep SWC direct dependencies on one compatible release set; do not blindly bump only `swc_core`.
+- Treat every `swc_experimental_*` crate as independent and out of scope. Never query, bump, or otherwise change its manifest or lockfile version as part of this workflow.
+- Keep existing `default-features`, feature lists, and unrelated dependency versions unchanged unless the new SWC release requires an adaptation.
+- Do not edit `crates/rspack_workspace/src/generated.rs` by hand. Generate it with `cargo codegen`.
+- Use official sources for release data: crates.io and `swc-project/swc` tags, commits, and pull requests.
+- Do not claim an SWC change fixes a Rspack issue without matching the failure mode and validating the fix when practical. Use “related” or “may fix” for weaker evidence.
+- Use `pnpm run build:binding:dev` as the only validation command. Do not run tests or lint unless the user explicitly requests them.
+- Do not create the PR until the intended diff and required validation have been reviewed. If validation is incomplete or an important risk remains, explain it and open a draft only when the user still wants a PR.
+
+## 1. Establish the version range
+
+1. Read the SWC dependency block in the repository root `Cargo.toml` and record the exact current `swc_core` version as `OLD_VERSION`.
+2. Query crates.io for the newest stable, non-yanked `swc_core` release and record it as `NEW_VERSION`. Cross-check that the tag `swc_core@NEW_VERSION` exists in `https://github.com/swc-project/swc`.
+3. Stop with a no-op report if `OLD_VERSION` already equals `NEW_VERSION`.
+4. Enumerate the in-scope direct root dependencies named `swc` or beginning with `swc_`. At `swc_core@NEW_VERSION`, inspect the SWC workspace and crate manifests to identify their release-compatible versions. Also check crates.io for compatible patch releases published after the tag.
+5. Update only those in-scope entries in the root `Cargo.toml`. If the upgrade cannot resolve without changing an excluded dependency, stop and report the incompatibility instead of expanding scope.
+6. Refresh `Cargo.lock` through Cargo resolution, using a precise `swc_core` update where needed. Inspect resolution errors rather than loosening pins or features speculatively.
+7. Check the resolved SWC graph for unintended duplicate major versions, especially `swc_common`, AST, parser, transform, minifier, plugin, and HTML crates. Resolve incompatible direct pins before proceeding.
+
+Preserve full semantic versions for Cargo and tag operations. For the PR title labels, follow the recent Rspack SWC bump convention: use major-only labels for a major-to-major bump, otherwise use the shortest unambiguous semantic versions.
+
+## 2. Regenerate workspace code
+
+Run from the repository root:
+
+```bash
+cargo codegen
+```
+
+Verify that `crates/rspack_workspace/src/generated.rs` contains `NEW_VERSION` in `rspack_swc_core_version()` and that no unrelated generated values changed.
+
+## 3. Build the tag-to-tag changelog
+
+Use these exact refs:
+
+```text
+swc_core@OLD_VERSION...swc_core@NEW_VERSION
+```
+
+Create the canonical comparison link:
+
+```text
+https://github.com/swc-project/swc/compare/swc_core%40OLD_VERSION...swc_core%40NEW_VERSION
+```
+
+Collect the complete commit list through the GitHub compare API or the exact tag refs in a temporary/local SWC checkout. Paginate and de-duplicate by SHA. If GitHub truncates a large comparison, split it across consecutive `swc_core@...` tags and merge the results. Do not substitute dates, branches, or release-page prose for the tag range.
+
+For commits that reference a pull request, inspect that PR’s title, body, labels, and relevant files. Drop release bookkeeping, dependency noise, and merges with no user-visible impact. Classify the remaining changes as:
+
+- breaking or required Rspack adaptations;
+- parser, AST, resolver, codegen, source-map, transform, React compiler, TypeScript, minifier, plugin, HTML, performance, or correctness changes relevant to Rspack;
+- small fixes that can be combined into one concise sentence.
+
+For every breaking or notable item, link the upstream PR or commit and explain the concrete Rspack surface it affects. Search the Rspack checkout for changed SWC API names and behavior so the summary reflects actual integration points instead of repeating upstream titles.
+
+Search open and recent Rspack issues using the symptoms, syntax, transform names, and error text from notable SWC fixes. Read candidate issues and confirm the behavior matches from the available issue details, upstream fix, and local integration code. Do not run tests as part of this workflow. Record verified issue links for the PR; distinguish confirmed fixes from plausible connections.
+
+## 4. Adapt and validate
+
+Fix compilation changes caused by the new SWC release with the smallest compatible patch. Validate the upgrade by running only:
+
+```bash
+pnpm run build:binding:dev
+```
+
+Do not run unit tests, integration tests, end-to-end tests, lint, or additional validation commands unless the user explicitly requests them. If the build fails because of the SWC upgrade, make the smallest necessary compatibility fix and rerun the same build command. If an environment failure prevents the build, capture the exact failure; never present it as passing.
+
+Review the final diff. Expected files are normally root `Cargo.toml`, `Cargo.lock`, and `crates/rspack_workspace/src/generated.rs`, plus only necessary compatibility changes. Confirm the generated version is correct and inspect the resolved SWC versions one final time.
+
+## 5. Commit and open the PR
+
+Use this exact title shape, retaining the backticks:
+
+```text
+chore: bump `swc_core` from FROM_LABEL to TO_LABEL
+```
+
+Use the same subject for the commit unless repository history indicates a necessary commit-only variation. Stage only intended paths, review the staged diff, commit, push the current feature branch, and open the PR against `main`.
+
+Build the PR description from `.github/PULL_REQUEST_TEMPLATE.md`. Keep it brief and evidence-based:
+
+```markdown
+## Summary
+
+Bumps `swc_core` from `OLD_VERSION` to `NEW_VERSION` and aligns the compatible SWC dependency pins.
+
+[Upstream tag comparison](COMPARE_URL)
+
+- **Rspack-relevant / breaking:** <only the important changes and required adaptations, with upstream links>
+- **Fixes:** <group small fixes into one sentence; call out verified Rspack bugs separately>
+
+## Related links
+
+<Use `Fixes #NNNN` only for verified fixes; otherwise use `Related to #NNNN` or `N/A`.>
+
+## Checklist
+
+- [x] Tests updated (or not required).
+- [x] Documentation updated (or not required).
+
+## Validation
+
+- `<exact command>`
+```
+
+Include only useful changelog detail in the PR body; do not dump the raw commit list. Mark a checklist item complete only when true, and state why tests or docs are not required when that is not obvious. After creation, report the PR URL, exact version range, changed files, validation results, and any remaining risks.

--- a/.agents/skills/bump-rspack-swc/SKILL.md
+++ b/.agents/skills/bump-rspack-swc/SKILL.md
@@ -17,7 +17,7 @@ Perform the upgrade end to end. Keep the patch focused, preserve unrelated work,
 - Keep existing `default-features`, feature lists, and unrelated dependency versions unchanged unless the new SWC release requires an adaptation.
 - Do not edit `crates/rspack_workspace/src/generated.rs` by hand. Generate it with `cargo codegen`.
 - Use official sources for release data: crates.io and `swc-project/swc` tags, commits, and pull requests.
-- Do not claim an SWC change fixes a Rspack issue without matching the failure mode and validating the fix when practical. Use “related” or “may fix” for weaker evidence.
+- Mention an upstream bug fix in the PR description only when it matches a Rspack issue's failure mode and the fix is validated when practical. Omit plausible, weak, or unverified bug connections instead of using “related” or “may fix”.
 - Use `pnpm run build:binding:dev` as the only validation command. Do not run tests or lint unless the user explicitly requests them.
 - Do not create the PR until the intended diff and required validation have been reviewed. If validation is incomplete or an important risk remains, explain it and open a draft only when the user still wants a PR.
 
@@ -61,13 +61,16 @@ Collect the complete commit list through the GitHub compare API or the exact tag
 
 For commits that reference a pull request, inspect that PR’s title, body, labels, and relevant files. Drop release bookkeeping, dependency noise, and merges with no user-visible impact. Classify the remaining changes as:
 
-- breaking or required Rspack adaptations;
-- parser, AST, resolver, codegen, source-map, transform, React compiler, TypeScript, minifier, plugin, HTML, performance, or correctness changes relevant to Rspack;
-- small fixes that can be combined into one concise sentence.
+- breaking changes that require a Rspack adaptation or materially affect a Rspack integration surface;
+- new features available through a Rspack integration surface;
+- performance improvements that plausibly benefit Rspack;
+- bug fixes that match a verified Rspack issue.
 
-For every breaking or notable item, link the upstream PR or commit and explain the concrete Rspack surface it affects. Search the Rspack checkout for changed SWC API names and behavior so the summary reflects actual integration points instead of repeating upstream titles.
+For every included item, link the upstream PR or commit and explain the concrete Rspack surface it affects. Search the Rspack checkout for changed SWC API names and behavior so the summary reflects actual integration points instead of repeating upstream titles. Omit changes with no meaningful Rspack impact. Do not add empty categories or state that there are no relevant changes.
 
-Search open and recent Rspack issues using the symptoms, syntax, transform names, and error text from notable SWC fixes. Read candidate issues and confirm the behavior matches from the available issue details, upstream fix, and local integration code. Do not run tests as part of this workflow. Record verified issue links for the PR; distinguish confirmed fixes from plausible connections.
+Search open and recent Rspack issues using the symptoms, syntax, transform names, and error text from notable SWC fixes. Read candidate issues and confirm the behavior matches from the available issue details, upstream fix, and local integration code. Do not run tests as part of this workflow. Record verified issue links for the PR.
+
+Keep issue correlation as an analysis step, not a reporting requirement. If no Rspack issue is verified, omit the bug fix and omit the related-links section entirely. Never list upstream bug fixes solely to summarize the SWC release.
 
 ## 4. Adapt and validate
 
@@ -100,12 +103,14 @@ Bumps `swc_core` from `OLD_VERSION` to `NEW_VERSION` and aligns the compatible S
 
 [Upstream tag comparison](COMPARE_URL)
 
-- **Rspack-relevant / breaking:** <only the important changes and required adaptations, with upstream links>
-- **Fixes:** <group small fixes into one sentence; call out verified Rspack bugs separately>
+- **Breaking:** <only Rspack-impacting breaking changes or required adaptations; omit when empty>
+- **Features:** <new capabilities available through Rspack; omit when empty>
+- **Performance:** <improvements likely to benefit Rspack; omit when empty>
+- **Fixes:** <only fixes matched to verified Rspack issues; omit when empty>
 
 ## Related links
 
-<Use `Fixes #NNNN` only for verified fixes; otherwise use `Related to #NNNN` or `N/A`.>
+<Include this section only when verified Rspack issue links exist. Use `Fixes #NNNN` only for confirmed fixes.>
 
 ## Checklist
 
@@ -117,4 +122,4 @@ Bumps `swc_core` from `OLD_VERSION` to `NEW_VERSION` and aligns the compatible S
 - `<exact command>`
 ```
 
-Include only useful changelog detail in the PR body; do not dump the raw commit list. Mark a checklist item complete only when true, and state why tests or docs are not required when that is not obvious. After creation, report the PR URL, exact version range, changed files, validation results, and any remaining risks.
+Include only useful changelog detail in the PR body; do not dump the raw commit list. Prefer omitting a low-confidence or low-impact item over making reviewers evaluate it. Remove empty optional bullets and sections from the final body. Mark a checklist item complete only when true, and state why tests or docs are not required when that is not obvious. After creation, report the PR URL, exact version range, changed files, validation results, and any remaining risks.

--- a/.agents/skills/bump-rspack-swc/agents/openai.yaml
+++ b/.agents/skills/bump-rspack-swc/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: 'Bump Rspack SWC'
+  short_description: 'Upgrade Rspack SWC pins and open a focused PR'
+  default_prompt: 'Use $bump-rspack-swc to upgrade this Rspack checkout to the latest swc_core release and open the PR.'
+
+policy:
+  allow_implicit_invocation: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,16 +381,6 @@ dependencies = [
 
 [[package]]
 name = "browserslist-data"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f42db7dd1800856ac32d4a08c2915de9a9a2a72ce1fdd86189daed368729fd4"
-dependencies = [
- "ahash 0.8.12",
- "chrono",
-]
-
-[[package]]
-name = "browserslist-data"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77d121add86b74ceac9755a74ec3b4abc1f4935711aede468f26a36dc685dc80"
@@ -401,33 +391,16 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd48a6ca358df4f7000e3fb5f08738b1b91a0e5d5f862e2f77b2b14647547f5"
-dependencies = [
- "ahash 0.8.12",
- "browserslist-data 0.1.0",
- "chrono",
- "either",
- "itertools 0.13.0",
- "nom 7.1.3",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "browserslist-rs"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec54e3c5c50eae1f8d771c7ffc311c1cc8e5e3c85b9fd87b557633bbe9b7cb01"
 dependencies = [
  "ahash 0.8.12",
- "browserslist-data 0.2.0",
+ "browserslist-data",
  "chrono",
  "either",
  "itertools 0.15.0",
- "nom 8.0.0",
+ "nom",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -2299,15 +2272,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2670,12 +2634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2816,16 +2774,6 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nom"
@@ -3241,7 +3189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413aea50b6c88e7f47da0b1efc078f19d1f9f86d38ba3b828f19e6fb29e715d8"
 dependencies = [
  "anyhow",
- "browserslist-rs 0.20.0",
+ "browserslist-rs",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -3533,16 +3481,6 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
-
-[[package]]
-name = "regress"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
-dependencies = [
- "hashbrown 0.16.1",
- "memchr",
-]
 
 [[package]]
 name = "regress"
@@ -3901,7 +3839,7 @@ dependencies = [
 name = "rspack_browserslist"
 version = "0.101.8"
 dependencies = [
- "browserslist-rs 0.19.0",
+ "browserslist-rs",
  "lightningcss",
  "regex",
 ]
@@ -4739,7 +4677,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "regex",
- "regress 0.10.5",
+ "regress",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -5284,7 +5222,7 @@ dependencies = [
  "napi",
  "regex",
  "regex-syntax",
- "regress 0.10.5",
+ "regress",
  "rspack_cacheable",
  "rspack_error",
  "swc_core",
@@ -6099,7 +6037,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "regex",
- "regress 0.11.1",
+ "regress",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "5.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb025ef00a6da925cf40870b9c8d008526b6004ece399cb0974209720f0b194"
+checksum = "b127110e8724bd19447ac72f31a66a9c06ac6b2b1372d81b6f5f0a2bddc6d1bb"
 dependencies = [
  "quote",
  "swc_macros_common",
@@ -390,17 +390,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "browserslist-data"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d121add86b74ceac9755a74ec3b4abc1f4935711aede468f26a36dc685dc80"
+dependencies = [
+ "ahash 0.8.12",
+ "chrono",
+]
+
+[[package]]
 name = "browserslist-rs"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd48a6ca358df4f7000e3fb5f08738b1b91a0e5d5f862e2f77b2b14647547f5"
 dependencies = [
  "ahash 0.8.12",
- "browserslist-data",
+ "browserslist-data 0.1.0",
  "chrono",
  "either",
  "itertools 0.13.0",
- "nom",
+ "nom 7.1.3",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "browserslist-rs"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec54e3c5c50eae1f8d771c7ffc311c1cc8e5e3c85b9fd87b557633bbe9b7cb01"
+dependencies = [
+ "ahash 0.8.12",
+ "browserslist-data 0.2.0",
+ "chrono",
+ "either",
+ "itertools 0.15.0",
+ "nom 8.0.0",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -489,7 +516,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c60b5ce37e0b883c37eb89f79a1e26fbe9c1081945d024eee93e8d91a7e18b3"
 dependencies = [
  "bytes",
- "rkyv 0.8.16",
  "serde",
 ]
 
@@ -1305,9 +1331,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embedded-io"
@@ -1969,9 +1995,9 @@ checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "hstr"
-version = "3.0.6"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bb87e4b300d73412f6dcc7022ee7741452b51b155c2b06e5994d0770c2dbe2"
+checksum = "23efb2e58d2f27a96edfa907c26016deb120b7ac8c66a19d2748f0e9c145f3cb"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -2285,6 +2311,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -2793,6 +2828,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonmax"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,12 +3236,12 @@ checksum = "84350ffee5cedfabf9bee3e8825721f651da8ff79d50fe7a37cf0ca015c428ee"
 
 [[package]]
 name = "preset_env_base"
-version = "8.0.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60adf10563cacffccfca95751404e8870b552b31ac0e2e559612e240a562ecfe"
+checksum = "413aea50b6c88e7f47da0b1efc078f19d1f9f86d38ba3b828f19e6fb29e715d8"
 dependencies = [
  "anyhow",
- "browserslist-rs",
+ "browserslist-rs 0.20.0",
  "dashmap",
  "from_variant",
  "once_cell",
@@ -3495,6 +3539,16 @@ name = "regress"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+dependencies = [
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "regress"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
  "hashbrown 0.16.1",
  "memchr",
@@ -3847,7 +3901,7 @@ dependencies = [
 name = "rspack_browserslist"
 version = "0.101.8"
 dependencies = [
- "browserslist-rs",
+ "browserslist-rs 0.19.0",
  "lightningcss",
  "regex",
 ]
@@ -4685,7 +4739,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "regex",
- "regress",
+ "regress 0.10.5",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_core",
@@ -5230,7 +5284,7 @@ dependencies = [
  "napi",
  "regex",
  "regex-syntax",
- "regress",
+ "regress 0.10.5",
  "rspack_cacheable",
  "rspack_error",
  "swc_core",
@@ -5904,9 +5958,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "70.0.0"
+version = "74.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d74164468c1bc8cc1ab46df40d9575396fbb94a8c39ee67ed2afad37b6485"
+checksum = "6db0b4ef250cae068222634751f69c348927f23d79c2224f1b332dfef6ab3148"
 dependencies = [
  "anyhow",
  "base64",
@@ -5956,9 +6010,9 @@ dependencies = [
 
 [[package]]
 name = "swc_allocator"
-version = "4.0.1"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d7eefd2c8b228a8c73056482b2ae4b3a1071fbe07638e3b55ceca8570cc48bb"
+checksum = "eb41c2f41afa7357a86109f7e058f6b140ab415b8cd196c1a7b54f2703c85417"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -5968,29 +6022,25 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "9.0.3"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845f31910b5236db42dba106e8277681098d183b9b65b8dfa88ca8abe464aeff"
+checksum = "c70a493080ceb12dabddb96905a3ddac679fbe9c71ddc81a2a769126e8cde7c4"
 dependencies = [
- "bytecheck 0.8.0",
  "cbor4ii",
  "hstr",
  "once_cell",
- "rancor",
- "rkyv 0.8.16",
  "serde",
 ]
 
 [[package]]
 name = "swc_common"
-version = "23.0.2"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176fb11b1abd0a175e8ac47d4b061c5c8a9ae13b9196f30d44fe5db9cb7dfcbd"
+checksum = "872e3beee92f0d63a7948ac03266c72a91cabf4c54d660ce992d448135ab5aec"
 dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
- "bytecheck 0.8.0",
  "bytes-str",
  "cbor4ii",
  "either",
@@ -5998,8 +6048,6 @@ dependencies = [
  "num-bigint",
  "once_cell",
  "parking_lot",
- "rancor",
- "rkyv 0.8.16",
  "rustc-hash",
  "serde",
  "siphasher",
@@ -6015,9 +6063,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "60.0.0"
+version = "63.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282b3ebc1f9ab4cc9c6a6cbc06089143b69355bb17d081e9072afec1cb8275c1"
+checksum = "26573f00356a5455d50a117232c08926d6ba1162da78f0a775b7541368294d1f"
 dependencies = [
  "anyhow",
  "base64",
@@ -6040,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "swc_config"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee60aaa4eaea81fb9c730e64a0b88c363b5c237b774d114c97cba82f8655fdb"
+checksum = "733985ad1340ea469d0d4366bae9664aa8f246006fa822a7d9365b41e48d7986"
 dependencies = [
  "anyhow",
  "bytes-str",
@@ -6051,7 +6099,7 @@ dependencies = [
  "indexmap",
  "once_cell",
  "regex",
- "regress",
+ "regress 0.11.1",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -6073,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "72.0.0"
+version = "76.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcb4f8cfebf7587501a5c1d93957f1208ba9aa212aa00f5b0a97f4adf2c0b056"
+checksum = "52af5f6afc54b2746e92dab457951e2b4621c7b3bf8c96d2ee66358e124b81aa"
 dependencies = [
  "par-core",
  "swc",
@@ -6102,9 +6150,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "25.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207e09f23885ff1f4354ebfdd4e715ccd4a68fca2e7e0df09baafbca850762e"
+checksum = "08b25e2e91491e0e82f932c7a5a07f5c90bd227dbde0c34aeb231d5b3a5e5107"
 dependencies = [
  "bitflags 2.11.1",
  "cbor4ii",
@@ -6123,9 +6171,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "28.0.2"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a2fbf46c8cc66e112b6d8226ae0dacc6b983589df6192b38c7669d7721e02a"
+checksum = "ad0f512e8afa1eb427f87913a0d918f5c509a6d8b26027275025e2856a14883c"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6141,6 +6189,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
+ "swc_ecma_utils",
  "tracing",
 ]
 
@@ -6157,9 +6206,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "52.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b335205bbf1782cf046a9326e396f65457147a363f247fbb61283575b31940"
+checksum = "2c56a6fd2674b7fc18248e597ad039bb4f43a601c7944361a58892bfb743a5ff"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6174,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "41.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c1a6fe36c70258ad72a7be2c0926cbb10c923f18ae55382e79c15d1dc743e2"
+checksum = "4bb423e4863bcf4edc391bbcc61dfbd4b99126c6fb18e04296d1b7994126775d"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6186,9 +6235,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a7d8076b0c18992d9b422af2f2cb5acdf55631450c3a5e6e7c914d96f2c5fb"
+checksum = "3770a6524c4898f747dd8c880cc8fdc8457de8fdccbf160b4802034e40fed69f"
 dependencies = [
  "arrayvec",
  "indexmap",
@@ -6213,9 +6262,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "46.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d26ac165afc33e2fe9006621d94b1309575023b1ee5c03432edf6790c522eb"
+checksum = "90b3ec2211a8a625387e931f9868b7e2bd63e08d7c3543812617cb5593123c83"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6226,9 +6275,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "46.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b095edde1ee28cc7dd3a1fbc4f3a58a165b70cc1ae1155025a7e8ac809f385bb"
+checksum = "1c405e7e2d1c991646065000e3d0e04cf75863a7e1566a39a64433f9a1f34335"
 dependencies = [
  "serde",
  "swc_common",
@@ -6241,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "47.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa51ba8bbd73bea90a8b7e4c7dcb5ef73a871f583b72b8291c7d5dd31f86795e"
+checksum = "3256226830071d3a56e83f45309eca14e68d65141167c0531a0478049baa6d0a"
 dependencies = [
  "serde",
  "swc_ecma_ast",
@@ -6255,9 +6304,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "46.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc9197fee7b86c36b0438ea2a825645b39b28f077e4773d8ca6a31e659596182"
+checksum = "4535bc4cd87a4dbbaea03b41908f36046d618d6432a29da6634ff08856f9c09c"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6269,9 +6318,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "49.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333fc4143baa1481395c7759b563c3b41c04a8b8b3963003ab9aa4557fc54846"
+checksum = "a4d73cb98f448617b4827c342c2fe07c6eb4bd6a41f435d6d67e80f4084c484e"
 dependencies = [
  "serde",
  "swc_common",
@@ -6286,9 +6335,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "46.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5599df8df2a6ca050b1b76acef9ad517595803cac04081f992733869765ef6"
+checksum = "1a97e7bddbb77e015d18b2f2f5f7cbc1f037e7ba187b5abab68d62d4b25fd990"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6299,9 +6348,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "49.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723c84f14496e4ebe49077ff1fdc0b3dbd5ed07e097c09d9266dd21919fbce92"
+checksum = "0cb7be1edb39487ad02aee31329ed00465922636b9993dd22c6502b7f975e254"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6318,9 +6367,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_regexp"
-version = "6.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d7b5fa1ab8ad0380ee19c120f3969122bc049a1baad01e3d01490f5c46b70a"
+checksum = "3aad8391849b826fba38c2788e70b85197f2bd9bff3e7f21593acd1c263b4b2d"
 dependencies = [
  "icu_properties",
  "swc_ecma_regexp_ast",
@@ -6329,9 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "31.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2ef55e6c17a5bcae3967ec8b6ef26e2b6e10c5437bc23bfc5eb97d0efcdc94"
+checksum = "ffc2e49ad776b5d0315ae2e0bb5fe70a218ee468ac70f7bb472dc2ab4386f420"
 dependencies = [
  "phf",
  "swc_common",
@@ -6342,9 +6391,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_hooks"
-version = "0.9.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3085866c59066b1346b50a70e12f28b9c06e44048370f7b20a25a769be92a0"
+checksum = "59ab2d337400963b24f764b3630eaa31cd28bd0c7f408ca9f41cf3a8fcadb917"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6354,9 +6403,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "24.0.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6c6932d6d6caa14d525defbea8c1307dd3032ba0a02618acd909326b648857"
+checksum = "b6692f0223b181325ad3e2f96401c1215a8a4c6ca55ced17ef74d41f30625923"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6376,9 +6425,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "57.0.1"
+version = "60.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fe5390a3c4891658f8a76a19e4af1c797b559c28414e2da9f95b3429c6f71c"
+checksum = "310ab13e49dd014e2f050213d10ddfc34c5684e438bf81844a6e7ae7f7ba91d8"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6411,18 +6460,18 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "41.1.2"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f6c9c63026f4d1a70c3c6703446d42ce7b0fe83d4c33b6fe985faf96753f3e"
+checksum = "53c83ff3be8652d2caf9f074853f8c33a4a05b17079c1586f195eec17d3ec553"
 dependencies = [
  "bitflags 2.11.1",
+ "compact_str",
  "either",
  "num-bigint",
  "phf",
  "rustc-hash",
  "seq-macro",
  "serde",
- "smartstring",
  "stacker",
  "swc_atoms",
  "swc_common",
@@ -6432,9 +6481,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "58.0.0"
+version = "62.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7e28e11f6efa306ba0843c281815d81fc0a7c3a7a073e3c76dc4be2080e6451"
+checksum = "28d3bbd3fe0815a3642631b17848861d07d9b92b85b6341e02f4e8bd8d1c2491"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
@@ -6457,9 +6506,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "41.0.0"
+version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a143bab46df2e56f7e16e592c1558cd0a60a1505dffe250bcbdf17724a66657"
+checksum = "9940ba4ef303aeebbba66267f7de9deca4e5471b49f1bb090887c633de16fa1a"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6475,9 +6524,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_react_compiler"
-version = "20.1.0"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6f1610db414a30a7602f760895b9209bd850dccf093ba802502773e481791c"
+checksum = "34b3563be7dd3d5e9717816d82bdf9494811900dacd3b7c0d363056eba2bb2db"
 dependencies = [
  "forked_react_compiler",
  "forked_react_compiler_ast",
@@ -6496,9 +6545,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e66cd49fcb866106ea9ef2a1eb7a5f6b8df040d72608843f53c0ffc49fc0078"
+checksum = "005fabc950f92781ba0e18c7065daccc4353cf0ab94186b3b2098cb94f94083c"
 dependencies = [
  "phf",
  "rustc-hash",
@@ -6512,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp_ast"
-version = "0.12.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429aaacc280961f655de0ac729acdb55a9a8eddcf73f46720dc06deb8f29f295"
+checksum = "614932a326aa5a588d5c50e3858667250f0ba5914fa2ff725016b8a355cd2892"
 dependencies = [
  "bitflags 2.11.1",
  "is-macro",
@@ -6531,9 +6580,9 @@ checksum = "0a0a09a9e4dc09c97f07273695bd4b58e46b99dbb0cb788ce0dad2a181eb1e94"
 
 [[package]]
 name = "swc_ecma_regexp_visit"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3420f8be5be14854a7481773d5f96dc2b15992e9865ab541493ef36c2ab0cf9"
+checksum = "9ea5d3926e65aa44766b9e45014e77c8ad4149438996adb2146d6915aaf52a88"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6544,9 +6593,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "24.0.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91988c76b96fa85b2fc1d0831baf9d0ac5b2ddd8db43217322e5ca284e49908"
+checksum = "0c265d11f2a7bb5186bcdfe20a71d8d208f786691965f97d6f2cbcb387c0de36"
 dependencies = [
  "anyhow",
  "hex",
@@ -6557,9 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transformer"
-version = "17.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a682cf36ed060e7a591549fb864284a4e5f059387bb1b456b059f0cd7694ba6"
+checksum = "503863f74566bbe63be8144daaf73de7a9271889a43c967a5a5e26ad1f0582fb"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6576,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "57.0.0"
+version = "61.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582ac0454abff7b50350341eb082d18abd048f60538946ee050f5a4c267bc30"
+checksum = "16f4b84cbfd592c654261083be67f450169680ccb10ca3b2a05b8411529c78c7"
 dependencies = [
  "par-core",
  "swc_common",
@@ -6595,9 +6644,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "45.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b61d73ff2b8c5d023cd97ff0026a50edf4e70f72d6acf93d65d7a6a9bde4a86a"
+checksum = "2b847c1419056e271c11a2fe1d36f988c9f121d0239ec401cbb3e622480ee3e8"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -6618,9 +6667,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "45.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9745b17d59c897ea6ea9d013dd6d2dee01237630616908af35e8f3b3cfb1d6"
+checksum = "14764cea2eb983732fb908c075aff0769cc27ae148fa812867fa1fa337506fa2"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6631,9 +6680,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "53.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c4f3f8e4a7b7939ce42df555f2c5bdde6fe612e1d4c70e18dd0d6bf041e4ef"
+checksum = "c0237fee1a78c87bfdb4c06723feedb99610b61703f13956d02594683c10540d"
 dependencies = [
  "indexmap",
  "par-core",
@@ -6671,9 +6720,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "50.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ef805d03fee6bd5c600128da304d7c4c32701c4faba6375970ef8105d4e2b2"
+checksum = "c0dadea6bc10d0085ceda08e7964245f4ab5c2bdcb1871226d3dd45bb95f15dc"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6699,9 +6748,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "48.0.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0a8f9234abb112b4346c7f903bbd401177b37acbb41f07f025b262f0e227fc"
+checksum = "5afbe52092d7b1b929156762f986294a559bba0221ef80a1017e806b1d8f9c34"
 dependencies = [
  "bytes-str",
  "dashmap",
@@ -6710,6 +6759,7 @@ dependencies = [
  "par-core",
  "petgraph",
  "rustc-hash",
+ "serde",
  "serde_json",
  "swc_atoms",
  "swc_common",
@@ -6723,9 +6773,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "45.0.0"
+version = "48.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adebcaef6209a15806cb5a24b0bd45a5cc9ae23a88d443be1528d7cbeb30c372"
+checksum = "e5cb9f6274985f2626fdad2dac2c876052a7aee540394d0c9297a9149652b55d"
 dependencies = [
  "either",
  "rustc-hash",
@@ -6741,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71661a8f91f22d2dd33add8d08f0bbef0e942868d6fad1e664593c10c9d8f74"
+checksum = "46fa764bc0ea6a9ca6683fe5c32faf50accc8a6b86b96d4b124429473307ef30"
 dependencies = [
  "base64",
  "bytes-str",
@@ -6766,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "49.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09430b9feb05501d57c0e7a50347b056e540b2c7075c052e1f2ea2297d798cce"
+checksum = "5b952ab0bec3f94c9b4424b63c4144ea19bd8f88defb3b22b0003098163f7933"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -6792,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "51.0.0"
+version = "54.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74bf3cc7e20997e2918144504ecebc0f0c79af13cfa04feac5a55699e2cb5a5d"
+checksum = "c4f5e4792f858bd3751db6407e7e230927897e716078c885f8a18c0ab28939cf"
 dependencies = [
  "bytes-str",
  "rustc-hash",
@@ -6810,9 +6860,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "31.0.2"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04108a8cd1db73a46e8703e146568e4966b4afbecd238fe5cc4a10bf7e39a42e"
+checksum = "ff0adbc5dd5676057ce6b0f63618838ba8691240972e3374189463f64214dd5e"
 dependencies = [
  "dragonbox_ecma",
  "indexmap",
@@ -6829,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "25.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f9cb1e958e57fa6427c106674a12190c4578684beee783e3a0508f048d1b372"
+checksum = "a3a8e8f80fdada267a6b556199be3f11ef491184e12270877c76cf2dca522ac0"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -6855,9 +6905,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac58facadaaf3cc9084503feaa5adb6299f12332a5f82045086fedc006f2b9ed"
+checksum = "f81f7728b17b0cf39aa968e2f4b6315150e1c649c136401fdcb0ce95d39d4ad5"
 dependencies = [
  "anyhow",
  "miette",
@@ -6966,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "35.0.0"
+version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ccc97cc53ccf090a80039842ec8a7e1bb597c572b2db0d86efd997dab03fa4f"
+checksum = "df54b4b34d0933be1a8dc89db1aa3a9200306373c0443351286ef908ee582e27"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -6978,9 +7028,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_ast"
-version = "23.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4ed220315fa61e60d554af1b8d640ae089f83275714a6faab97782928656a1"
+checksum = "1ed5be7b8b8dab4e34eb95440ca38dc2ae83b6741c48344badeb1b690f248ac4"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -6990,9 +7040,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_codegen"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ab8b936e848eec9fe5cd5ace16dbc0d07fe6a7fd16e0919de0e607decae26b"
+checksum = "077c866859dad8af83d1e0e2fc4d08101b40cb0c06bbbe628a17c8e92f48d5f4"
 dependencies = [
  "auto_impl",
  "bitflags 2.11.1",
@@ -7016,9 +7066,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "57.0.0"
+version = "60.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d555e6cc373b33e4cff488fa0c6ad9a55fc3b0cab343528bda865b775008a21"
+checksum = "0d4c533febfeec24e6f00f669b62305cca03c47c0c63d1449811acf1520a3cf2"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -7042,9 +7092,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_parser"
-version = "23.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bf94b37403fd4bdcbf517d845b65faa9f1a7de067cb2e49128155f2f742148"
+checksum = "69ed92f4763a7658ba34d2707a62adc847c83a1fd5e8a52e612db4cd53d8cba2"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -7055,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_utils"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb1627e0e88ee72bcda640a807751af2bf4a841da12ca284679e076340602e2"
+checksum = "0ce2f51482abdf97cf252137a1683f7df9000f0521532bfb0fee9d8ec46a468d"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -7068,9 +7118,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_visit"
-version = "23.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f226dddfbbd242700007248784900dd3e163800ef73ecd8c7567a669793b66"
+checksum = "e8fdedea88cd4bb3e57352c6005f3a6ef6749f3aedd2a120aba65184a3959ab2"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7092,9 +7142,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "24.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4728a8561457494b84e0c54ef602b1d712b51ba79750da0e9e38c13163a89cfe"
+checksum = "6bd898d9aa14c05211a183b92c05d94ec427c8b559bc362706900b6f02e57375"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -7104,9 +7154,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "26.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083ac69beff14ed7f44f5ca710c79d8eef82f62489c8b8e0f1f3aa27b88268f9"
+checksum = "2aa1cb6476767e09b3580f60f1a052051716678bc2b698ef1284dabc75464513"
 dependencies = [
  "better_scoped_tls",
  "cbor4ii",
@@ -7118,9 +7168,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "30.0.1"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7087d664f3ba30d19aec5472eec0ac0c0df5934a0b34f3f40b7e45d9d48553b6"
+checksum = "6ff3ca76d6d8db374780265ad47a4e532732d7ca93dcda6e4e04d1226d84dc16"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7157,9 +7207,9 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "17.0.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4f1334cb6c6642de10080d9be47180f3536946968ee6f8ae8d0c2760111354"
+checksum = "a573180abbfd2fae241d1e1974b33aef36a562d440f27fca5fd0229aaeabff03"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",
@@ -7169,9 +7219,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "30.0.1"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a02560417501b8e9ca478b24d67500cc1ceb51cc5a7c5a288b459ff527348ee"
+checksum = "b6eaa22935edad4c9409d11192f705ad8da91369adf59e547ce5328bd2da1f85"
 dependencies = [
  "bitflags 2.11.1",
  "petgraph",
@@ -7294,9 +7344,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "24.0.1"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16937aa763ff6a4374024bbaa338c5867b687f3d1b84a79dbf71e0053a62b2eb"
+checksum = "8ba142c2b1905b5210b110f6f48a4e2732395eb17bad0097a087b1a5783f145d"
 dependencies = [
  "cargo_metadata",
  "difference",
@@ -7315,9 +7365,9 @@ dependencies = [
 
 [[package]]
 name = "testing_macros"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7442bd3ca09f38d4788dc5ebafbc1967c3717726b4b074db011d470b353548b"
+checksum = "5c21fb13b703fb0bf466ec891704055ec18e2a8c8d2d47c31b65d7006044e146"
 dependencies = [
  "anyhow",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ async-trait     = { version = "0.1.89", default-features = false }
 atomic_refcell  = { version = "0.1.14", default-features = false }
 base64-simd     = { version = "0.8.0", default-features = false, features = ["alloc"] }
 bitflags        = { version = "2.11.1", default-features = false }
-browserslist-rs = { version = "0.19.0", default-features = false }
+browserslist-rs = { version = "0.20.0", default-features = false }
 bytes           = { version = "1.12.0", default-features = false }
 camino          = { version = "1.2.3", default-features = false }
 cargo_toml      = { version = "0.22.3", default-features = false }
@@ -82,7 +82,7 @@ quote               = { version = "1.0.45", default-features = false }
 rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.4", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.11", default-features = false, features = ["std"] }
-regress             = { version = "0.10.5", default-features = false, features = ["pattern"] }
+regress             = { version = "0.11.1", default-features = false, features = ["pattern"] }
 rspack_resolver     = { version = "=0.9.4", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,16 +134,16 @@ rkyv      = { version = "=0.8.16", default-features = false, features = ["std", 
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.9", default-features = false }
-swc                 = { version = "70.0.0", default-features = false }
-swc_atoms           = { version = "9.0.3", default-features = false }
-swc_config          = { version = "5.0.0", default-features = false }
-swc_core            = { version = "72.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "57.0.1", default-features = false }
-swc_error_reporters = { version = "25.0.0", default-features = false }
-swc_html            = { version = "35.0.0", default-features = false }
-swc_html_minifier   = { version = "57.0.0", default-features = false }
-swc_plugin_runner   = { version = "30.0.1", default-features = false }
-swc_typescript      = { version = "30.0.1", default-features = false }
+swc                 = { version = "74.0.0", default-features = false }
+swc_atoms           = { version = "10.0.0", default-features = false }
+swc_config          = { version = "6.0.0", default-features = false }
+swc_core            = { version = "76.0.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "60.0.0", default-features = false }
+swc_error_reporters = { version = "27.0.0", default-features = false }
+swc_html            = { version = "37.0.0", default-features = false }
+swc_html_minifier   = { version = "60.0.0", default-features = false }
+swc_plugin_runner   = { version = "33.0.0", default-features = false }
+swc_typescript      = { version = "33.0.0", default-features = false }
 
 swc_experimental_allocator            = { version = "0.11.0", default-features = false }
 swc_experimental_ecma_ast             = { version = "0.11.0", default-features = false }

--- a/crates/rspack_plugin_javascript/src/utils/object_properties.rs
+++ b/crates/rspack_plugin_javascript/src/utils/object_properties.rs
@@ -411,7 +411,6 @@ mod tests {
   #[ast_object(rename_all = "camelCase")]
   struct TestRegexOptions {
     reg_exp: Option<RspackRegex>,
-    recursive: Option<bool>,
   }
 
   #[test]
@@ -431,39 +430,6 @@ mod tests {
         .unwrap()
         .reg_exp
         .is_none()
-    );
-  }
-
-  #[test]
-  fn preserves_regex_conversion_errors() {
-    let allocator = Allocator::new();
-    let expr = parse_expr(
-      &allocator,
-      "{ regExp: /(?<name>a)|(?<name>b)/, recursive: false }",
-    );
-    let error = TestRegexOptions::from_ast_object(expr.as_object().unwrap())
-      .expect_err("regex conversion failures should not be treated as an absent option");
-
-    assert!(error.to_string().contains("/(?<name>a)|(?<name>b)/"));
-  }
-
-  #[test]
-  fn preserves_valid_fields_when_collecting_conversion_diagnostics() {
-    let allocator = Allocator::new();
-    let expr = parse_expr(
-      &allocator,
-      "{ regExp: /(?<name>a)|(?<name>b)/, recursive: false }",
-    );
-    let (options, diagnostics) =
-      TestRegexOptions::from_ast_object_with_diagnostics(expr.as_object().unwrap());
-
-    assert!(options.reg_exp.is_none());
-    assert_eq!(options.recursive, Some(false));
-    assert_eq!(diagnostics.len(), 1);
-    assert!(
-      diagnostics[0]
-        .to_string()
-        .contains("/(?<name>a)|(?<name>b)/")
     );
   }
 }

--- a/crates/rspack_plugin_javascript/src/utils/object_properties.rs
+++ b/crates/rspack_plugin_javascript/src/utils/object_properties.rs
@@ -411,6 +411,7 @@ mod tests {
   #[ast_object(rename_all = "camelCase")]
   struct TestRegexOptions {
     reg_exp: Option<RspackRegex>,
+    recursive: Option<bool>,
   }
 
   #[test]
@@ -430,6 +431,39 @@ mod tests {
         .unwrap()
         .reg_exp
         .is_none()
+    );
+  }
+
+  #[test]
+  fn preserves_regex_conversion_errors() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(
+      &allocator,
+      "{ regExp: /(?<name>a)(?<name>b)/, recursive: false }",
+    );
+    let error = TestRegexOptions::from_ast_object(expr.as_object().unwrap())
+      .expect_err("regex conversion failures should not be treated as an absent option");
+
+    assert!(error.to_string().contains("/(?<name>a)(?<name>b)/"));
+  }
+
+  #[test]
+  fn preserves_valid_fields_when_collecting_conversion_diagnostics() {
+    let allocator = Allocator::new();
+    let expr = parse_expr(
+      &allocator,
+      "{ regExp: /(?<name>a)(?<name>b)/, recursive: false }",
+    );
+    let (options, diagnostics) =
+      TestRegexOptions::from_ast_object_with_diagnostics(expr.as_object().unwrap());
+
+    assert!(options.reg_exp.is_none());
+    assert_eq!(options.recursive, Some(false));
+    assert_eq!(diagnostics.len(), 1);
+    assert!(
+      diagnostics[0]
+        .to_string()
+        .contains("/(?<name>a)(?<name>b)/")
     );
   }
 }

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "72.0.0"
+  "76.0.0"
 }
 
 /// The version of the JavaScript `@rspack/core` package.

--- a/deny.toml
+++ b/deny.toml
@@ -215,12 +215,10 @@ skip = [
     { crate = "ahash", reason = "external dependency"},
     { crate = "base64-simd", reason = "external dependency"},
     { crate = "convert_case", reason = "external dependency"},
-    { crate = "dashmap", reason = "external dependency"},
     { crate = "getrandom", reason = "external dependency"},
     { crate = "hashbrown", reason = "external dependency"},
     { crate = "itertools", reason = "external dependency"},
     { crate = "outref", reason = "external dependency"},
-    { crate = "path-clean", reason = "external dependency"},
     { crate = "ptr_meta", reason = "external dependency"},
     { crate = "ptr_meta_derive", reason = "external dependency"},
     { crate = "rkyv", reason = "FIXME: need to be fixed"},
@@ -249,7 +247,6 @@ skip = [
     { crate = "linux-raw-sys", reason = "external dependency"},
     { crate = "rustix", reason = "external dependency"},
     { crate = "ctor", reason = "external dependency"},
-    { crate = "cargo_metadata", reason = "dev-only duplicate from SWC testing fixtures in rspack_loader_swc; not used by production crates"},
     { crate = "windows-link", reason = "external dependency"},
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/tests/rspack-test/configCases/ecmaVersion/browserslist-query-with-config-file/rspack.config.js
+++ b/tests/rspack-test/configCases/ecmaVersion/browserslist-query-with-config-file/rspack.config.js
@@ -19,7 +19,7 @@ module.exports = {
             dynamicImportInWorker: false,
             forOf: true,
             globalThis: true,
-            importMetaDirnameAndFilename: false,
+            importMetaDirnameAndFilename: true,
             logicalAssignment: true,
             methodShorthand: true,
             module: true,

--- a/tests/rspack-test/configCases/ecmaVersion/browserslist/rspack.config.js
+++ b/tests/rspack-test/configCases/ecmaVersion/browserslist/rspack.config.js
@@ -17,7 +17,7 @@ module.exports = {
             dynamicImportInWorker: false,
             forOf: true,
             globalThis: true,
-            importMetaDirnameAndFilename: false,
+            importMetaDirnameAndFilename: true,
             logicalAssignment: true,
             methodShorthand: true,
             module: true,

--- a/tests/rspack-test/configCases/parsing/import-meta-webpack-context-invalid-regexp/index.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-webpack-context-invalid-regexp/index.js
@@ -1,5 +1,5 @@
 const contextRequire = import.meta.webpackContext(".", {
-	regExp: /(?<name>a)|(?<name>b)/,
+	regExp: /(?<name>a)(?<name>b)/,
 	recursive: false
 });
 

--- a/tests/rspack-test/configCases/parsing/import-meta-webpack-context-invalid-regexp/warnings.js
+++ b/tests/rspack-test/configCases/parsing/import-meta-webpack-context-invalid-regexp/warnings.js
@@ -1,3 +1,3 @@
 module.exports = [
-	/Can't construct regex `\/\(\?<name>a\)\|\(\?<name>b\)\/`/
+	/Can't construct regex `\/\(\?<name>a\)\(\?<name>b\)\/`/
 ];

--- a/tests/rspack-test/statsAPICases/basic.js
+++ b/tests/rspack-test/statsAPICases/basic.js
@@ -69,7 +69,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: b5cd62d7f1e244c4,
+			      hash: 234bad6d2f940bcc,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -199,7 +199,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: f36e50fd765d4017,
+			  hash: f32cbf233644ec95,
 			  modules: Array [
 			    Object {
 			      assets: Array [],
@@ -319,7 +319,7 @@ module.exports = {
 			  entry ./fixtures/a
 			  cjs self exports reference self [195] ./fixtures/a.js
 			  
-			Rspack compiled successfully (f36e50fd765d4017)
+			Rspack compiled successfully (f32cbf233644ec95)
 		`);
 	}
 };

--- a/tests/rspack-test/statsAPICases/exports.js
+++ b/tests/rspack-test/statsAPICases/exports.js
@@ -79,7 +79,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 01b216cf5147ae81,
+			      hash: 28d1d136c7d576d3,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -467,7 +467,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 5a1a86e0fbb6505a,
+			  hash: d16943738075d76d,
 			  modules: Array [
 			    Object {
 			      assets: Array [],

--- a/tests/rspack-test/statsAPICases/ids.js
+++ b/tests/rspack-test/statsAPICases/ids.js
@@ -58,7 +58,7 @@ module.exports = {
 			      files: Array [
 			        main.js,
 			      ],
-			      hash: b5cd62d7f1e244c4,
+			      hash: 234bad6d2f940bcc,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,

--- a/tests/rspack-test/statsAPICases/with-query.js
+++ b/tests/rspack-test/statsAPICases/with-query.js
@@ -63,7 +63,7 @@ module.exports = {
 			        main.js,
 			      ],
 			      filteredModules: undefined,
-			      hash: 216c30c6b146db6a,
+			      hash: 6e2452151244342e,
 			      id: 889,
 			      idHints: Array [],
 			      initial: true,
@@ -432,7 +432,7 @@ module.exports = {
 			  errorsCount: 0,
 			  filteredAssets: undefined,
 			  filteredModules: undefined,
-			  hash: 0cf5aaf453d712ad,
+			  hash: 5111d061111767fc,
 			  modules: Array [
 			    Object {
 			      assets: Array [],


### PR DESCRIPTION
## Summary

Bumps `swc_core` from `72.0.0` to `76.0.0` and aligns the compatible SWC dependency pins, including `browserslist-rs 0.20.0` and `regress 0.11.1`, to avoid duplicate crate versions.

[Upstream tag comparison](https://github.com/swc-project/swc/compare/swc_core%40v72.0.0...swc_core%40v76.0.0)

- **Features:** `builtin:swc-loader` accepts [`reactCompiler.environment.enableFunctionOutlining`](https://github.com/swc-project/swc/pull/12030), while the SWC minifier adds unused-parameter removal for `new` function/class expressions and folding for trivial object spreads ([#12017](https://github.com/swc-project/swc/pull/12017), [#12027](https://github.com/swc-project/swc/pull/12027), [#12068](https://github.com/swc-project/swc/pull/12068)).
- **Performance:** The SWC renamer skips identity mappings, reducing no-op work in Rspack's transform and minification paths ([#12041](https://github.com/swc-project/swc/pull/12041)).

## Test updates

- Refreshed the browserslist snapshots because [`browserslist-rs 0.20.0` updates its target data](https://github.com/browserslist/browserslist-rs/compare/v0.19.0...v0.20.0). The maintained Node targets now meet the version where [`import.meta.dirname` and `import.meta.filename` became stable in Node 22.16](https://nodejs.org/download/release/v22.18.0/docs/api/esm.html#importmetafilename), so `importMetaDirnameAndFilename` changes to `true`.
- Refreshed hash-only Stats API snapshots after the [SWC 72 to 76 upgrade](https://github.com/swc-project/swc/compare/swc_core%40v72.0.0...swc_core%40v76.0.0) changed the generated compilation and chunk hashes; the stats shape and non-hash values are unchanged.
- Updated the regex conversion-error fixtures because [`regress 0.11.1` allows duplicate named capture groups across alternatives but still rejects duplicates in the same alternative](https://github.com/ridiculousfish/regress/pull/136). The tests now use a same-alternative duplicate and continue covering error propagation and preservation of other options.

## Related links

Closes #15035

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test` in `tests/rspack-test` (9033 passed, 4 skipped)
- `cargo test -p rspack_plugin_javascript --lib utils::object_properties::tests::` (9 passed)