### PR TITLE
fix(resolve): support URL aliases with buildHttp

### DIFF
--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -950,9 +950,33 @@ module.exports = "data:,";
             return Ok(Some(ModuleFactoryResult::new_with_module(raw_module)));
           }
           Err(err) => {
-            data.file_dependencies = file_dependencies.into_iter().map(Into::into).collect();
-            data.missing_dependencies = missing_dependencies.into_iter().map(Into::into).collect();
-            return Err(err);
+            let resolver = plugin_driver
+              .resolver_factory
+              .get(ResolveOptionsWithDependencyType {
+                resolve_options: data
+                  .resolve_options
+                  .clone()
+                  .map(|r| Box::new(Arc::unwrap_or_clone(r))),
+                resolve_to_context: false,
+                dependency_category,
+              });
+            if let Some(aliased_resource) = resolver.resolve_alias_to_scheme(&resource) {
+              file_dependencies = Default::default();
+              missing_dependencies = Default::default();
+              let aliased_scheme = get_scheme(&aliased_resource);
+              let mut resource_data = ResourceData::new_with_resource(aliased_resource);
+              plugin_driver
+                .normal_module_factory_hooks
+                .resolve_for_scheme
+                .call(data, &mut resource_data, &aliased_scheme)
+                .await?;
+              resource_data
+            } else {
+              data.file_dependencies = file_dependencies.into_iter().map(Into::into).collect();
+              data.missing_dependencies =
+                missing_dependencies.into_iter().map(Into::into).collect();
+              return Err(err);
+            }
           }
         }
       }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -13,6 +13,7 @@ use rspack_util::location::byte_line_column_to_offset;
 use super::{ResolveResult, Resource, boxfs::BoxFS};
 use crate::{
   Alias, AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
+  get_scheme,
 };
 
 #[derive(Debug, Default, Clone)]
@@ -137,6 +138,48 @@ impl Resolver {
   /// Return the options from the resolver
   pub fn options(&self) -> ResolveInnerOptions<'_> {
     ResolveInnerOptions::RspackResolver(self.resolver.options())
+  }
+
+  /// Resolve an alias target with a scheme after regular path resolution failed.
+  pub(crate) fn resolve_alias_to_scheme(&self, request: &str) -> Option<String> {
+    for (alias_key, alias_values) in &self.resolver.options().alias {
+      let (alias_key, is_exact) = alias_key
+        .strip_suffix('$')
+        .map_or((alias_key.as_str(), false), |key| (key, true));
+      let Some(tail) = request.strip_prefix(alias_key) else {
+        continue;
+      };
+      if !tail.is_empty() && (is_exact || (!tail.starts_with('/') && !tail.starts_with('\\'))) {
+        continue;
+      }
+
+      let mut should_stop = false;
+      for alias_value in alias_values {
+        let rspack_resolver::AliasValue::Path(alias_value) = alias_value else {
+          return None;
+        };
+        if request == alias_value
+          || request
+            .strip_prefix(alias_value)
+            .is_some_and(|tail| tail.starts_with('/') || tail.starts_with('\\'))
+        {
+          continue;
+        }
+
+        should_stop = true;
+        let mut aliased_request = String::with_capacity(alias_value.len() + tail.len());
+        aliased_request.push_str(alias_value);
+        aliased_request.extend(tail.chars().map(|c| if c == '\\' { '/' } else { c }));
+        if !get_scheme(&aliased_request).is_none() {
+          return Some(aliased_request);
+        }
+      }
+
+      if should_stop {
+        return None;
+      }
+    }
+    None
   }
 
   /// Resolve a specifier to a given path.

--- a/tests/rspack-test/configCases/build-http/alias/custom-http-client.js
+++ b/tests/rspack-test/configCases/build-http/alias/custom-http-client.js
@@ -1,0 +1,21 @@
+module.exports = async (url) => {
+	const pathname = new URL(url).pathname;
+
+	if (pathname === "/runtime.js") {
+		return {
+			status: 200,
+			headers: {
+				"content-type": "application/javascript",
+			},
+			body: Buffer.from("export default {};\n"),
+		};
+	}
+
+	return {
+		status: 404,
+		headers: {
+			"content-type": "text/plain",
+		},
+		body: Buffer.from(`Not found: ${pathname}`),
+	};
+};

--- a/tests/rspack-test/configCases/build-http/alias/index.js
+++ b/tests/rspack-test/configCases/build-http/alias/index.js
@@ -1,0 +1,6 @@
+import runtimeFromUrl from "https://test.rspack.rs/runtime.js";
+import runtimeFromAlias from "./local-consumer";
+
+it("should resolve an alias to the same HTTP module", () => {
+	expect(runtimeFromAlias).toBe(runtimeFromUrl);
+});

--- a/tests/rspack-test/configCases/build-http/alias/local-consumer.js
+++ b/tests/rspack-test/configCases/build-http/alias/local-consumer.js
@@ -1,0 +1,3 @@
+import runtime from "remote-runtime";
+
+export default runtime;

--- a/tests/rspack-test/configCases/build-http/alias/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/alias/rspack.config.js
@@ -1,0 +1,21 @@
+const os = require('node:os');
+const path = require('node:path');
+
+const tempDir = path.join(os.tmpdir(), 'rspack-build-http-alias');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  resolve: {
+    alias: {
+      'remote-runtime': 'https://test.rspack.rs/runtime.js',
+    },
+  },
+  experiments: {
+    buildHttp: {
+      allowedUris: ['https://test.rspack.rs/'],
+      cacheLocation: false,
+      lockfileLocation: path.join(tempDir, `lock-${process.pid}.json`),
+      httpClient: require('./custom-http-client'),
+    },
+  },
+};


### PR DESCRIPTION
## Summary

- route aliased requests with URL-scheme targets back through `resolveForScheme` when regular path resolution fails
- preserve existing alias matching and candidate ordering while discarding filesystem dependencies collected from the failed path attempt
- add a `buildHttp` regression case proving a direct HTTP import and an aliased import resolve to the same module instance

`buildHttp` already handles direct HTTP imports, but an alias target such as `https://example.test/runtime.js` was passed to the filesystem resolver and reported as a missing aliased module. This prevented applications from mapping loader-injected bare imports to the same HTTP runtime and could result in duplicate framework runtimes.

With this change, users can combine `resolve.alias` and `experiments.buildHttp` to consistently use one remote module instance.

## Related links

Fixes #9867.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test -t "configCases/build-http"`
- `pnpm run test -t "configCases/resolve/alias"`
- `pnpm run test -t "configCases/resolve/multi-alias"`
- `pnpm run test -t "configCases/resolve/matched-alias-not-found"`
- manually built the linked Vue reproduction with a `vue$` HTTP alias and confirmed the bundle contains only the HTTP Vue runtime

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
