### PR TITLE
refactor: migrate rspack_dojang into monorepo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3991,9 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_dojang"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9803670afdceac77551ca44c99b9a63c78e77848bc1d5db11d5a9975a290486e"
+version = "0.101.9"
 dependencies = [
  "html-escape",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ futures             = { version = "0.3.32", default-features = false, features =
 hashlink            = { version = "0.11.0", default-features = false }
 heck                = { version = "0.5.0", default-features = false }
 hex                 = { version = "0.4.3", default-features = false, features = ["std"] }
+html-escape         = { version = "0.2.13", default-features = false }
 indexmap            = { version = "2.14.0", default-features = false }
 indicatif           = { version = "0.18.4", default-features = false }
 indoc               = { version = "2.0.7", default-features = false }
@@ -152,10 +153,9 @@ swc_experimental_ecma_semantic        = { version = "0.11.0", default-features =
 swc_experimental_ecma_transforms_base = { version = "0.11.0", default-features = false }
 swc_experimental_ecma_utils           = { version = "0.11.0", default-features = false }
 
-rspack_dojang = { version = "0.1.11", default-features = false }
-tracy-client  = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }
-wasi-common   = { version = "36.0.10", default-features = false }
-wasmtime      = { version = "36.0.10", default-features = false }
+tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }
+wasi-common  = { version = "36.0.10", default-features = false }
+wasmtime     = { version = "36.0.10", default-features = false }
 
 
 # all rspack workspace dependencies
@@ -170,6 +170,7 @@ rspack_cacheable                       = { version = "=0.101.9", path = "crates/
 rspack_cacheable_macros                = { version = "=0.101.9", path = "crates/rspack_cacheable_macros", default-features = false }
 rspack_collections                     = { version = "=0.101.9", path = "crates/rspack_collections", default-features = false }
 rspack_core                            = { version = "=0.101.9", path = "crates/rspack_core", default-features = false }
+rspack_dojang                          = { version = "=0.101.9", path = "crates/rspack_dojang", default-features = false }
 rspack_error                           = { version = "=0.101.9", path = "crates/rspack_error", default-features = false }
 rspack_fs                              = { version = "=0.101.9", path = "crates/rspack_fs", default-features = false }
 rspack_hash                            = { version = "=0.101.9", path = "crates/rspack_hash", default-features = false }

--- a/crates/rspack_dojang/Cargo.toml
+++ b/crates/rspack_dojang/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+authors.workspace       = true
+categories.workspace    = true
+description             = "EJS-like HTML template engine for Rspack"
+documentation.workspace = true
+edition.workspace       = true
+homepage.workspace      = true
+license.workspace       = true
+name                    = "rspack_dojang"
+repository.workspace    = true
+version.workspace       = true
+
+[dependencies]
+html-escape = { workspace = true }
+serde_json  = { workspace = true }
+
+[lints]
+workspace = true
+
+[lib]
+doctest = false

--- a/crates/rspack_dojang/README.md
+++ b/crates/rspack_dojang/README.md
@@ -1,0 +1,51 @@
+# rspack_dojang
+
+This is Rspack's fork of [dojang](https://github.com/kev0960/dojang). It was
+migrated from [rstackjs/rspack-dojang](https://github.com/rstackjs/rspack-dojang)
+at commit [`5b1b5e7c`](https://github.com/rstackjs/rspack-dojang/commit/5b1b5e7c8dcd3f78fc36cd24001bafa8722b7e1c)
+so fixes and Rspack-specific features can be maintained with their consumers.
+
+**Dojang** is an HTML template engine designed as a drop-in replacement for
+[EJS](https://ejs.co/). It does not support all JavaScript syntax, but implements
+the basic syntax used by Rspack.
+
+## Features
+
+- Supports basic JavaScript control flow (`if`, `for`, `while`, etc.).
+- Supports script and output tags (`<%`, `<%-`, `<%=`).
+- Supports calling external functions.
+
+## How to use?
+
+```rust
+use rspack_dojang::Dojang;
+use serde_json::Value;
+
+// Create a template engine Dojang.
+let mut dojang = Dojang::new();
+
+// Load template file under '/my/template/files'
+assert!(dojang.load("/my/template/files").is_ok());
+
+// Render a template. "some_template" is one of the template files under /my/template/files.
+// Note that the context should be provided as a serde_json value.
+assert_eq!(
+    dojang
+        .render(
+            "some_template",
+            serde_json::from_str(r#"{ "a" : 1 }"#).unwrap()
+        )
+        .unwrap(),
+    " Hi "
+    );
+
+assert_eq!(
+    dojang
+        .render(
+            "some_template",
+            serde_json::from_str(r#"{ "a" : 2 }"#).unwrap()
+        )
+        .unwrap(),
+    "2"
+    );
+```

--- a/crates/rspack_dojang/src/context.rs
+++ b/crates/rspack_dojang/src/context.rs
@@ -1,0 +1,1153 @@
+use std::{collections::HashMap, fmt, sync::Mutex};
+
+use serde_json::{Map, Number, Value};
+
+use crate::{eval::*, exec::*, expr::*};
+
+#[derive(Debug)]
+pub struct Context {
+  pub context: Value,
+}
+
+pub enum FunctionContainer {
+  F0(Box<dyn Fn() -> Operand + Send + Sync>),
+  F1(Box<dyn Fn(Operand) -> Operand + Send + Sync>),
+  F2(Box<dyn Fn(Operand, Operand) -> Operand + Send + Sync>),
+  F3(Box<dyn Fn(Operand, Operand, Operand) -> Operand + Send + Sync>),
+  F4(Box<dyn Fn(Operand, Operand, Operand, Operand) -> Operand + Send + Sync>),
+}
+
+impl fmt::Debug for FunctionContainer {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    let mut f = f.debug_struct("FunctionContainer");
+    match self {
+      FunctionContainer::F0(_) => f.field("F0", &0),
+      FunctionContainer::F1(_) => f.field("F1", &1),
+      FunctionContainer::F2(_) => f.field("F2", &2),
+      FunctionContainer::F3(_) => f.field("F3", &3),
+      FunctionContainer::F4(_) => f.field("F4", &4),
+    };
+
+    f.finish()
+  }
+}
+
+impl FunctionContainer {
+  pub fn param_num(&self) -> usize {
+    match self {
+      FunctionContainer::F0(_) => 0,
+      FunctionContainer::F1(_) => 1,
+      FunctionContainer::F2(_) => 2,
+      FunctionContainer::F3(_) => 3,
+      FunctionContainer::F4(_) => 4,
+    }
+  }
+}
+
+impl Context {
+  pub fn new(context: Value) -> Self {
+    Context { context }
+  }
+
+  fn get_value(&self, names: &Vec<&str>) -> Result<&Value, String> {
+    if names.is_empty() {
+      return Err(format!("Mapping not exist : {names:?}"));
+    }
+
+    let mut value;
+    match self.context.get(names.first().unwrap()) {
+      Some(v) => {
+        value = v;
+      }
+      _ => {
+        return Err(format!(
+          "ReferenceError: {} is not defined",
+          names.first().unwrap()
+        ));
+      }
+    }
+
+    for n in names.iter().skip(1) {
+      if value.is_array() {
+        match n.parse::<usize>() {
+          Ok(index) => {
+            match value.as_array().unwrap().get(index) {
+              Some(elem) => value = elem,
+              None => {
+                return Err(format!(
+                  "Element at the specified index of the array does not exist : array {value:?}, index : {n:?}"
+                ));
+              }
+            };
+          }
+          _ => {
+            return Err(format!(
+              "Specified non-number parameter for an array : {value:?}, index : {n:?}"
+            ));
+          }
+        }
+      } else {
+        match value.get(n) {
+          Some(v) => {
+            value = v;
+          }
+          _ => {
+            return Err(format!(
+              "ReferenceError: {} is not defined",
+              names.join(".")
+            ));
+          }
+        }
+      }
+    }
+
+    Ok(value)
+  }
+
+  fn set_value(&mut self, names: &Vec<&str>, provided: &Value) -> Result<(), String> {
+    if names.is_empty() {
+      return Err(format!("Mapping not exist : {names:?}"));
+    }
+
+    let mut value: &mut Value;
+    match self.context.get_mut(names.first().unwrap()) {
+      Some(v) => {
+        value = v;
+      }
+      _ => {
+        if names.len() > 1 {
+          return Err(format!(
+            "Local variable should not use dot operator. {:?}",
+            names.first().unwrap()
+          ));
+        }
+
+        if !self.context.is_object() {
+          self.context = Value::Object(Map::new());
+        }
+
+        self
+          .context
+          .as_object_mut()
+          .unwrap()
+          .insert(names.first().unwrap().to_string(), provided.clone());
+
+        return Ok(());
+      }
+    }
+
+    for n in names.iter().skip(1) {
+      match value.get_mut(n) {
+        Some(v) => {
+          value = v;
+        }
+        _ => return Err(format!("Mapping not exist : {names:?} at {n}")),
+      }
+    }
+
+    *value = provided.clone();
+    Ok(())
+  }
+}
+
+pub trait ComputeExpr {
+  fn run(
+    &self,
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<Operand, String>;
+
+  fn run_for_range(
+    &self,
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<Operand, String>;
+
+  fn run_for_loop(
+    &self,
+    context: &mut Context,
+    range: &Operand,
+    for_index: usize,
+  ) -> Result<bool, String>;
+}
+
+impl ComputeExpr for Eval {
+  fn run(
+    &self,
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<Operand, String> {
+    let mut operands: Vec<Operand> = Vec::new();
+
+    for expr in self.expr.iter().rev() {
+      match expr {
+        Expr::Op(op) => match op {
+          Op::Operand(operand) => {
+            operands.push(operand.clone());
+          }
+          optr => {
+            let num_operands = operator_num_operands(optr);
+            if operands.len() < num_operands {
+              return Err(format!(
+                "Number of operands for {optr:?} is less than {num_operands}"
+              ));
+            }
+
+            if num_operands == 1 {
+              let op = operands.pop().unwrap();
+              match optr.compute_unary(context, op) {
+                Ok(operand) => {
+                  operands.push(operand);
+                }
+                Err(e) => return Err(e),
+              }
+            } else if num_operands == 2 {
+              // Since we are iterating from back, left is the top most operand.
+              let left = operands.pop().unwrap();
+              let right = operands.pop().unwrap();
+
+              match optr.compute_binary(context, left, right) {
+                Ok(operand) => {
+                  operands.push(operand);
+                }
+                Err(e) => return Err(e),
+              }
+            }
+          }
+        },
+        Expr::Function(function) => match function.is_accessor {
+          false => {
+            if let Some(operand) =
+              handle_predefined_functions(function, context, templates, functions, includes)?
+            {
+              operands.push(operand);
+              continue;
+            }
+
+            let function_to_run = match functions.get(&function.name) {
+              Some(f) => f,
+              None => {
+                return Err(format!(
+                  "Function {:?} is not registered; Registered : {:?}",
+                  function.name, functions
+                ));
+              }
+            };
+
+            let params = &function.params;
+            if params.len() != function_to_run.param_num() {
+              return Err(format!(
+                "# of function params mistmatch! {} takes {} params but provided {} params",
+                function.name,
+                function_to_run.param_num(),
+                params.len()
+              ));
+            }
+
+            let mut evals = Vec::new();
+
+            for param in params {
+              evals.push(param.run(context, templates, functions, includes)?);
+            }
+
+            let return_value = match function_to_run {
+              FunctionContainer::F0(f) => f(),
+              FunctionContainer::F1(f) => f(evals.pop().unwrap()),
+              FunctionContainer::F2(f) => {
+                let p2 = evals.pop().unwrap();
+                let p1 = evals.pop().unwrap();
+
+                f(p1, p2)
+              }
+              FunctionContainer::F3(f) => {
+                let p3 = evals.pop().unwrap();
+                let p2 = evals.pop().unwrap();
+                let p1 = evals.pop().unwrap();
+
+                f(p1, p2, p3)
+              }
+              FunctionContainer::F4(f) => {
+                let p4 = evals.pop().unwrap();
+                let p3 = evals.pop().unwrap();
+                let p2 = evals.pop().unwrap();
+                let p1 = evals.pop().unwrap();
+
+                f(p1, p2, p3, p4)
+              }
+            };
+
+            operands.push(return_value);
+          }
+          true => {
+            let params = &function.params;
+
+            let mut obj_name = vec![function.name.clone()];
+            for param in params {
+              obj_name.push(param.run(context, templates, functions, includes)?.to_str())
+            }
+
+            operands.push(convert_value_to_operand(
+              context
+                .get_value(&obj_name.iter().map(String::as_str).collect())?
+                .clone(),
+            ))
+          }
+        },
+      }
+    }
+
+    if operands.len() != 1 {
+      return Err(format!(
+        "# of operands after computing is not zero. {operands:?}"
+      ));
+    }
+
+    match operands.pop().unwrap() {
+      Operand::Object(obj) => Ok(convert_value_to_operand(
+        context.get_value(&obj.name.split(".").collect())?.clone(),
+      )),
+      operand => Ok(operand),
+    }
+  }
+
+  fn run_for_range(
+    &self,
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<Operand, String> {
+    if self.expr.len() != 3 {
+      return Err(format!(
+        "For loop must use 'for a in b' format, yours use {:?}",
+        self.expr
+      ));
+    }
+
+    match self.expr.first().unwrap() {
+      Expr::Op(Op::Operand(Operand::Object(_))) => {}
+      _ => {
+        return Err(format!(
+          "Range declaration in for loop must be an object; Yours : {:?}",
+          self.expr
+        ));
+      }
+    }
+
+    if self.expr[1] != Expr::Op(Op::Operand(Operand::Keyword(Keyword::In))) {
+      return Err(format!(
+        "'in' is missing in your for-loop. Yours : {:?}",
+        self.expr
+      ));
+    }
+
+    let range = Eval {
+      expr: vec![self.expr[2].clone()],
+    };
+
+    range.run(context, templates, functions, includes)
+  }
+
+  // Returns true if the for loop's condition is true.
+  fn run_for_loop(
+    &self,
+    context: &mut Context,
+    range: &Operand,
+    for_index: usize,
+  ) -> Result<bool, String> {
+    if self.expr.len() != 3 {
+      return Err(format!(
+        "For loop must use 'for a in b' format, yours use {:?}",
+        self.expr
+      ));
+    }
+
+    let object_name = match self.expr.first().unwrap() {
+      Expr::Op(Op::Operand(Operand::Object(object))) => &object.name,
+      _ => {
+        return Err(format!(
+          "Range declaration in for loop must be an object; Yours : {:?}",
+          self.expr
+        ));
+      }
+    };
+
+    match get_nth_element_from_operand(range, for_index) {
+      Some(element) => {
+        context.set_value(&object_name.split(".").collect(), &element)?;
+        context.set_value(
+          &vec!["index"],
+          &Value::Number(Number::from(for_index as u64)),
+        )?;
+        Ok(true)
+      }
+      _ => Ok(false),
+    }
+  }
+}
+
+fn handle_predefined_functions(
+  f: &Function,
+  context: &mut Context,
+  templates: &HashMap<String, (Executer, String)>,
+  functions: &HashMap<String, FunctionContainer>,
+  includes: &mut Mutex<HashMap<String, String>>,
+) -> Result<Option<Operand>, String> {
+  if f.name == "include" {
+    if f.params.len() != 1 {
+      return Err(format!(
+        "Predefined function 'includes' must provide 1 string parameter. You gave : {f:?}"
+      ));
+    }
+
+    let file_name = f
+      .params
+      .first()
+      .unwrap()
+      .run(context, templates, functions, includes)?
+      .to_str();
+    if let Some(file_data) = includes.get_mut().unwrap().get(&file_name) {
+      return Ok(Some(Operand::Value(Value::String(file_data.clone()))));
+    } else {
+      let file_content = std::fs::read(&file_name).map_err(|e| e.to_string())?;
+
+      return Ok(Some(Operand::Value(Value::String(
+        String::from_utf8_lossy(&file_content).to_string(),
+      ))));
+    }
+  } else if f.name == "include_template" {
+    if f.params.len() != 1 {
+      return Err(format!(
+        "Predefined function 'includes' must provide 1 string parameter. You gave : {f:?}"
+      ));
+    }
+
+    let file_name = f
+      .params
+      .first()
+      .unwrap()
+      .run(context, templates, functions, includes)?
+      .to_str();
+
+    if let Some((executer, template)) = templates.get(&file_name) {
+      return Ok(Some(Operand::Value(Value::String(
+        executer.render(context, templates, functions, template, includes)?,
+      ))));
+    } else {
+      return Err(format!(
+        "Predefined function 'include_template' must only use the pre-registered template. You gave : {file_name}"
+      ));
+    }
+  }
+
+  Ok(None)
+}
+
+pub trait Convert {
+  fn is_true(&self) -> bool;
+  fn to_str(&self) -> String;
+}
+
+impl Convert for Operand {
+  fn is_true(&self) -> bool {
+    match &self {
+      Operand::Value(v) => value_to_boolean(v),
+      Operand::Array(arr) => !arr.is_empty(),
+      _ => {
+        panic!("Unconvertible object {:?}", &self)
+      }
+    }
+  }
+
+  fn to_str(&self) -> String {
+    match &self {
+      Operand::Value(v) => match v {
+        Value::String(s) => s.clone(),
+        v => v.to_string(),
+      },
+      Operand::Array(arr) => format!("{arr:?}"),
+      _ => {
+        panic!("Unconvertible object {:?}", &self)
+      }
+    }
+  }
+}
+
+trait ComputeOp {
+  fn compute_binary(
+    &self,
+    context: &mut Context,
+    left: Operand,
+    right: Operand,
+  ) -> Result<Operand, String>;
+
+  fn compute_unary(&self, context: &Context, op: Operand) -> Result<Operand, String>;
+}
+
+impl ComputeOp for Op {
+  fn compute_binary(
+    &self,
+    context: &mut Context,
+    left: Operand,
+    right: Operand,
+  ) -> Result<Operand, String> {
+    match self {
+      Op::And => return compute_binary(context, left, right, compute_and),
+      Op::Or => return compute_binary(context, left, right, compute_or),
+      Op::Equal => return compute_binary(context, left, right, compute_eq),
+      Op::NotEqual => return compute_binary(context, left, right, compute_neq),
+      Op::Greater => return compute_binary(context, left, right, compute_greater),
+      Op::GreaterEq => return compute_binary(context, left, right, compute_greater_eq),
+      Op::Less => return compute_binary(context, left, right, compute_less),
+      Op::LessEq => return compute_binary(context, left, right, compute_less_eq),
+      Op::Assign => return compute_simple_assign(context, left, right),
+      Op::Plus => return compute_binary(context, left, right, compute_add),
+      Op::Minus => return compute_binary(context, left, right, compute_minus),
+      Op::Multiply => return compute_binary(context, left, right, compute_multiply),
+      Op::Divide => return compute_binary(context, left, right, compute_divide),
+      _ => {}
+    }
+
+    panic!("Binary {self:?} is not implemented");
+  }
+
+  fn compute_unary(&self, context: &Context, op: Operand) -> Result<Operand, String> {
+    if self == &Op::Not {
+      return compute_unary(context, op, compute_not);
+    }
+
+    panic!("Unary {self:?} is not implemented");
+  }
+}
+
+fn compute_unary<ComputeFunc>(
+  context: &Context,
+  op: Operand,
+  compute_func: ComputeFunc,
+) -> Result<Operand, String>
+where
+  ComputeFunc: Fn(&Value) -> Result<Value, String>,
+{
+  Ok(convert_value_to_operand(compute_func(
+    get_value_from_operand(context, &op)?,
+  )?))
+}
+
+fn get_value_from_operand<'a>(
+  context: &'a Context,
+  operand: &'a Operand,
+) -> Result<&'a Value, String> {
+  if let Operand::Object(obj) = operand {
+    match context.get_value(&obj.name.split(".").collect()) {
+      Ok(v) => Ok(v),
+      Err(e) => Err(e),
+    }
+  } else if let Operand::Value(v) = operand {
+    Ok(v)
+  } else {
+    Err(format!("Unable to extract value from {operand:?}"))
+  }
+}
+
+fn compute_binary<ComputeFunc>(
+  context: &Context,
+  left: Operand,
+  right: Operand,
+  compute_func: ComputeFunc,
+) -> Result<Operand, String>
+where
+  ComputeFunc: Fn(&Value, &Value) -> Result<Value, String>,
+{
+  let left_value = get_value_from_operand(context, &left)?;
+  let right_value = get_value_from_operand(context, &right)?;
+
+  Ok(convert_value_to_operand(compute_func(
+    left_value,
+    right_value,
+  )?))
+}
+
+fn compute_simple_assign(
+  context: &mut Context,
+  left: Operand,
+  right: Operand,
+) -> Result<Operand, String> {
+  if let Operand::Object(ref object) = left {
+    match right {
+      Operand::Object(right_obj) => {
+        let val = context
+          .get_value(&right_obj.name.split(".").collect())?
+          .clone();
+        context.set_value(&object.name.split(".").collect(), &val)?;
+      }
+      _ => {
+        context.set_value(
+          &object.name.split(".").collect(),
+          &convert_operand_to_value(right),
+        )?;
+      }
+    }
+    Ok(left)
+  } else {
+    Err(format!("Cannot assign to non-object {left:?}"))
+  }
+}
+
+/*
+fn compute_binary_assign<ComputeFunc>(
+    context: &mut Context,
+    left: Operand,
+    right: Operand,
+    compute_func: ComputeFunc,
+) -> Result<Operand, String>
+where
+    ComputeFunc: Fn(Operand, Operand) -> Result<Operand, String>,
+{
+    if let Operand::Object(ref object) = left {
+        match right {
+            Operand::Object(right_obj) => {
+                context.set_value(
+                    &object.name,
+                    compute_func(
+                        convert_value_to_operand(context.get_value(&object.name)?),
+                        convert_value_to_operand(context.get_value(&right_obj.name)?),
+                    )?,
+                )?;
+            }
+            _ => {
+                context.set_value(
+                    &object.name,
+                    compute_func(
+                        convert_value_to_operand(context.get_value(&object.name)?),
+                        right,
+                    )?,
+                )?;
+            }
+        }
+        Ok(left)
+    } else {
+        return Err(format!("Cannot assign to non-object {:?}", left));
+    }
+}
+*/
+
+fn value_to_boolean(v: &Value) -> bool {
+  match v {
+    Value::Bool(v) => *v,
+    Value::String(s) => !s.is_empty(),
+    Value::Number(n) => {
+      if n.is_i64() {
+        n.as_i64().unwrap() != 0
+      } else if n.is_f64() {
+        n.as_f64().unwrap() != 0.
+      } else {
+        n.as_u64().unwrap() != 0
+      }
+    }
+    Value::Array(arr) => !arr.is_empty(),
+    Value::Object(_) => true,
+    Value::Null => false,
+  }
+}
+
+fn compute_and(left: &Value, right: &Value) -> Result<Value, String> {
+  Ok(Value::from(
+    value_to_boolean(left) && value_to_boolean(right),
+  ))
+}
+
+fn compute_or(left: &Value, right: &Value) -> Result<Value, String> {
+  Ok(Value::from(
+    value_to_boolean(left) || value_to_boolean(right),
+  ))
+}
+
+fn compute_greater(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from((l > r) as i64));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() > r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() > r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '>' between {left:?} {right:?}"))
+}
+
+fn compute_greater_eq(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from(l >= r));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() >= r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() >= r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '>=' between {left:?} {right:?}"))
+}
+
+fn compute_less(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from(l < r));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() < r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() < r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '<' between {left:?} {right:?}"))
+}
+
+fn compute_less_eq(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from(l <= r));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() <= r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() <= r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '<=' between {left:?} {right:?}"))
+}
+
+fn compute_eq(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::Bool(l), Value::Bool(r)) => return Ok(Value::from(*l == *r)),
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from(l == r));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() == r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() == r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '==' between {left:?} {right:?}"))
+}
+
+fn compute_neq(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::Bool(l), Value::Bool(r)) => return Ok(Value::from(*l != *r)),
+    (Value::String(l), Value::String(r)) => {
+      return Ok(Value::from(l != r));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() != r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() != r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '!=' between {left:?} {right:?}"))
+}
+
+fn compute_add(left: &Value, right: &Value) -> Result<Value, String> {
+  match (&left, &right) {
+    (Value::String(l), Value::String(r)) => {
+      let mut left_clone = l.clone();
+      left_clone.push_str(r);
+      return Ok(Value::from(left_clone));
+    }
+    (Value::Number(l), Value::Number(r)) => {
+      if l.is_i64() && r.is_i64() {
+        return Ok(Value::from(l.as_i64().unwrap() + r.as_i64().unwrap()));
+      } else if l.is_f64() && r.is_f64() {
+        return Ok(Value::from(l.as_f64().unwrap() + r.as_f64().unwrap()));
+      }
+    }
+    _ => {}
+  };
+
+  Err(format!("Invalid operation '+' between {left:?} {right:?}"))
+}
+
+fn compute_minus(left: &Value, right: &Value) -> Result<Value, String> {
+  if let (Value::Number(l), Value::Number(r)) = (&left, &right) {
+    if l.is_i64() && r.is_i64() {
+      return Ok(Value::from(l.as_i64().unwrap() - r.as_i64().unwrap()));
+    } else if l.is_f64() && r.is_f64() {
+      return Ok(Value::from(l.as_f64().unwrap() - r.as_f64().unwrap()));
+    }
+  };
+
+  Err(format!("Invalid operation '-' between {left:?} {right:?}"))
+}
+
+fn compute_multiply(left: &Value, right: &Value) -> Result<Value, String> {
+  if let (Value::Number(l), Value::Number(r)) = (&left, &right) {
+    if l.is_i64() && r.is_i64() {
+      return Ok(Value::from(l.as_i64().unwrap() * r.as_i64().unwrap()));
+    } else if l.is_f64() && r.is_f64() {
+      return Ok(Value::from(l.as_f64().unwrap() * r.as_f64().unwrap()));
+    }
+  };
+
+  Err(format!("Invalid operation '*' between {left:?} {right:?}"))
+}
+
+fn compute_divide(left: &Value, right: &Value) -> Result<Value, String> {
+  if let (Value::Number(l), Value::Number(r)) = (&left, &right) {
+    if l.is_i64() && r.is_i64() {
+      return Ok(Value::from(l.as_i64().unwrap() / r.as_i64().unwrap()));
+    } else if l.is_f64() && r.is_f64() {
+      return Ok(Value::from(l.as_f64().unwrap() / r.as_f64().unwrap()));
+    }
+  };
+
+  Err(format!("Invalid operation '/' between {left:?} {right:?}"))
+}
+
+fn compute_not(operand: &Value) -> Result<Value, String> {
+  Ok(Value::from(!value_to_boolean(operand)))
+}
+
+#[cfg(test)]
+fn get_expr(s: &str) -> Tokens {
+  let mut res = Parser::parse(s).unwrap();
+  match res.parse_tree.pop().unwrap() {
+    Action::Do(expr) => expr,
+    _ => panic!("No expr found"),
+  }
+}
+
+#[test]
+fn compute_and_test() {
+  let context_json = r#"{"a": 1, "b":0, "c":"abc", "d":"", "e": "def"}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let eval = Eval::new(get_expr(r"<% a && b %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(false)));
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% c && d %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(false)));
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% c && e %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  }
+}
+
+#[test]
+fn compute_or_test() {
+  let context_json = r#"{"a": 1, "b":0, "c":"abc", "d":"", "e": "def"}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let eval = Eval::new(get_expr(r"<% (a && b) || (c && e) %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)))
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% (a && b) || (c && d) %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(false)));
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% c || e %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  }
+}
+
+#[test]
+fn compute_complex() {
+  let context_json = r#"{"a": 1, "b":0, "c":"abc", "d":"", "e": "def"}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let eval = Eval::new(get_expr(r"<% !a && ((b != a) || c <= e) %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(false)));
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% !b && ((b != a) || c <= e && !d) %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  }
+  {
+    let eval = Eval::new(get_expr(
+      r#"<% (a == 1) && (b == 0) && (c == "abc") && !d && e == "def" %>"#,
+    ))
+    .unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  }
+}
+
+#[test]
+fn compute_complex_object_name() {
+  let context_json = r#"{"a": {"b" : 2, "c" : {"d" : 3 }}, "b" : 1}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let eval = Eval::new(get_expr(r"<% a.b %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(2)));
+  }
+  {
+    let eval = Eval::new(get_expr(r"<% a.c.d %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(3)));
+  }
+  {
+    let eval = Eval::new(get_expr(r#"<% b %>"#)).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(1)));
+  }
+}
+
+#[test]
+fn compute_assign_test() {
+  let context_json = r#"{"a": 1, "b":0, "c": 1}"#;
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    let eval = Eval::new(get_expr(r"<% a = a && b %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(false)));
+    assert!(!context.context.get("a").unwrap().as_bool().unwrap());
+  }
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    let eval = Eval::new(get_expr(r"<% a = a && c %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+    assert!(context.context.get("a").unwrap().as_bool().unwrap());
+  }
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    let eval = Eval::new(get_expr(r"<% d = a && c %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+    assert!(context.context.get("d").unwrap().as_bool().unwrap());
+  }
+}
+
+#[test]
+fn compute_arithmetic() {
+  let context_json = r#"{"a": 1, "b":2, "c": 3, "d" : 2, "e" : 6, "f" : 2}"#;
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    // (1 + 2 * 3 - 6 / 2) * 2
+    let eval = Eval::new(get_expr(r"<% b = a = (a + b * c - e / d) * f %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(8)));
+    assert_eq!(context.context.get("a").unwrap().as_i64().unwrap(), 8);
+    assert_eq!(context.context.get("b").unwrap().as_i64().unwrap(), 8);
+  }
+}
+
+#[test]
+fn check_array_get() {
+  let context_json = r#"{"a": [1,2,3]}"#;
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    // (1 + 2 * 3 - 6 / 2) * 2
+    let eval = Eval::new(get_expr(r"<% a[1] %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(2)));
+  }
+}
+
+#[test]
+fn convert_object_to_boolean() {
+  let context_json = r#"{"a": {"b" : 1}}"#;
+  let mut includes = Mutex::new(HashMap::new());
+
+  // {
+  //     let context_value: Value = serde_json::from_str(context_json).unwrap();
+  //     let mut context = Context::new(context_value);
+
+  //     let eval = Eval::new(get_expr(r"<% !b %>")).unwrap();
+  //     let result = eval.run(
+  //         &mut context,
+  //         &HashMap::new(),
+  //         &HashMap::new(),
+  //         &mut includes,
+  //     );
+
+  //     assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  // }
+
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    let eval = Eval::new(get_expr(r"<% a || !a %>")).unwrap();
+    let result = eval.run(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      &mut includes,
+    );
+
+    assert_eq!(result.unwrap(), Operand::Value(Value::from(true)));
+  }
+}

--- a/crates/rspack_dojang/src/context.rs
+++ b/crates/rspack_dojang/src/context.rs
@@ -243,7 +243,7 @@ impl ComputeExpr for Eval {
             let params = &function.params;
             if params.len() != function_to_run.param_num() {
               return Err(format!(
-                "# of function params mistmatch! {} takes {} params but provided {} params",
+                "# of function params mismatch! {} takes {} params but provided {} params",
                 function.name,
                 function_to_run.param_num(),
                 params.len()

--- a/crates/rspack_dojang/src/default_functions.rs
+++ b/crates/rspack_dojang/src/default_functions.rs
@@ -1,0 +1,37 @@
+use serde_json::Value;
+
+use crate::expr::{Operand, convert_operand_to_value};
+
+pub fn val_length(op: Operand) -> Operand {
+  match op {
+    Operand::Value(val) => {
+      if val.is_string() {
+        Operand::Value(Value::from(val.as_str().unwrap().len()))
+      } else if val.is_array() {
+        Operand::Value(Value::from(val.as_array().unwrap().len()))
+      } else {
+        Operand::Value(Value::from(0))
+      }
+    }
+    Operand::Array(arr) => Operand::Value(Value::from(arr.len())),
+    _ => Operand::Value(Value::from(0)),
+  }
+}
+
+pub fn val_range(op: Operand) -> Operand {
+  if let Operand::Value(val) = op
+    && val.is_i64()
+  {
+    return Operand::Value(Value::from(
+      (0..val.as_i64().unwrap()).collect::<Vec<i64>>(),
+    ));
+  }
+
+  Operand::Value(Value::from(Vec::<i64>::new()))
+}
+
+pub fn val_stringify(op: Operand) -> Operand {
+  Operand::Value(Value::from(
+    serde_json::to_string(&convert_operand_to_value(op)).unwrap(),
+  ))
+}

--- a/crates/rspack_dojang/src/dojang.rs
+++ b/crates/rspack_dojang/src/dojang.rs
@@ -1,0 +1,564 @@
+use std::{collections::HashMap, fs, io, path::PathBuf, sync::Mutex};
+
+use serde_json::Value;
+
+use crate::{
+  context::*,
+  default_functions::{val_length, val_range, val_stringify},
+  exec::*,
+  expr::*,
+};
+
+#[derive(Debug, Clone)]
+pub struct DojangOptions {
+  pub escape: String,
+  pub unescape: String,
+}
+impl Default for DojangOptions {
+  fn default() -> Self {
+    Self {
+      escape: "=".to_string(),
+      unescape: "-".to_string(),
+    }
+  }
+}
+/// HTML template rendering engine that should be constructed for once.
+pub struct Dojang {
+  /// Mapping between the template file name and the renderer along with the file content.
+  pub templates: HashMap<String, (Executer, String)>,
+
+  /// Map of the registered functions.
+  pub functions: HashMap<String, FunctionContainer>,
+
+  /// Files read from "include". Those are cached here.
+  pub includes: Mutex<HashMap<String, String>>,
+
+  // part of ejs config options, see https://github.com/mde/ejs#options
+  pub options: DojangOptions,
+}
+
+impl Default for Dojang {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl Dojang {
+  pub fn with_options(&mut self, options: DojangOptions) {
+    self.options = options;
+  }
+  /// Creates a template engine.
+  pub fn new() -> Self {
+    let mut functions = HashMap::<String, FunctionContainer>::new();
+    functions.insert(
+      "length".to_string(),
+      FunctionContainer::F1(Box::new(val_length)),
+    );
+
+    functions.insert(
+      "range".to_string(),
+      FunctionContainer::F1(Box::new(val_range)),
+    );
+
+    functions.insert(
+      "json_stringify".to_string(),
+      FunctionContainer::F1(Box::new(val_stringify)),
+    );
+
+    Dojang {
+      templates: HashMap::new(),
+      functions,
+      includes: Mutex::new(HashMap::new()),
+      options: Default::default(),
+    }
+  }
+
+  /// Adds a template file to the engine.
+  ///
+  /// If there is already an existing template with same name, this will return error.
+  ///
+  /// # Arguments
+  ///
+  /// * `file_name` - Name of the template file. Template datas are identified by this name.
+  /// * `template` - Actual template data. Should be using EJS syntax.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// let mut dojang = rspack_dojang::Dojang::new();
+  ///
+  /// // Constructs the template "tmpl" with the content "<%= 1 + 1 %>".
+  /// dojang.add("tmpl".to_string(), "<%= 1 + 1 %>".to_string());
+  /// ```
+  pub fn add(&mut self, file_name: String, template: String) -> Result<&Self, String> {
+    if self.templates.contains_key(&file_name) {
+      return Err(format!("{file_name} is already added as a template"));
+    }
+
+    self.templates.insert(
+      file_name,
+      (Executer::new(Parser::parse(&template)?)?, template),
+    );
+
+    Ok(self)
+  }
+  pub fn add_with_option(&mut self, file_name: String, template: String) -> Result<&Self, String> {
+    if self.templates.contains_key(&file_name) {
+      return Err(format!("{file_name} is already added as a template"));
+    }
+
+    self.templates.insert(
+      file_name,
+      (
+        Executer::new(Parser::parse_with_options(&template, self.options.clone())?)?,
+        template,
+      ),
+    );
+
+    Ok(self)
+  }
+
+  /// Adds a function that can be used in the template.
+  ///
+  /// If there is already an existing function with same name, this will return error.
+  /// Use the appropriate function based on the number of parameters that the function take.
+  /// (e.g for functions taking 2 params, use add_function_2). Functions with 4 params are
+  /// supported at max.
+  ///
+  /// Note that the parameter of the function must be convertible to Value. Supported types are
+  /// String, i64, f64 and boolean.
+  ///
+  /// # Arguments
+  ///
+  /// * `function_name` - Name of the function.
+  /// * `function` - The body of the function.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rspack_dojang::dojang::Dojang;
+  /// use serde_json::Value;
+  ///
+  /// fn func(a: i64) -> i64 {
+  ///   a + 1
+  /// }
+  /// fn func2(mut a: String, b: String) -> String {
+  ///   a.push_str(&b);
+  ///   a.push_str("hi");
+  ///   a
+  /// }
+  ///
+  /// let mut dj = Dojang::new();
+  ///
+  /// dj.add_function_1("func".to_string(), func);
+  /// dj.add_function_2("func2".to_string(), func2);
+  /// ```
+  pub fn add_function_0<V>(
+    &mut self,
+    function_name: String,
+    function: fn() -> V,
+  ) -> Result<&Self, String>
+  where
+    V: 'static + Into<Operand>,
+  {
+    if self.functions.contains_key(&function_name) {
+      return Err(format!("{function_name} is already added as a function"));
+    }
+
+    self
+      .functions
+      .insert(function_name, to_function_container0(function));
+    Ok(self)
+  }
+
+  pub fn add_function_1<T, V>(
+    &mut self,
+    function_name: String,
+    function: fn(T) -> V,
+  ) -> Result<&Self, String>
+  where
+    T: 'static + From<Operand>,
+    V: 'static + Into<Operand>,
+  {
+    if self.functions.contains_key(&function_name) {
+      return Err(format!("{function_name} is already added as a function"));
+    }
+
+    self
+      .functions
+      .insert(function_name, to_function_container1(function));
+    Ok(self)
+  }
+
+  pub fn add_function_2<T1, T2, V>(
+    &mut self,
+    function_name: String,
+    function: fn(T1, T2) -> V,
+  ) -> Result<&Self, String>
+  where
+    T1: 'static + From<Operand>,
+    T2: 'static + From<Operand>,
+    V: 'static + Into<Operand>,
+  {
+    if self.functions.contains_key(&function_name) {
+      return Err(format!("{function_name} is already added as a function"));
+    }
+
+    self
+      .functions
+      .insert(function_name, to_function_container2(function));
+    Ok(self)
+  }
+
+  pub fn add_function_3<T1, T2, T3, V>(
+    &mut self,
+    function_name: String,
+    function: fn(T1, T2, T3) -> V,
+  ) -> Result<&Self, String>
+  where
+    T1: 'static + From<Operand>,
+    T2: 'static + From<Operand>,
+    T3: 'static + From<Operand>,
+    V: 'static + Into<Operand>,
+  {
+    if self.functions.contains_key(&function_name) {
+      return Err(format!("{function_name} is already added as a function"));
+    }
+
+    self
+      .functions
+      .insert(function_name, to_function_container3(function));
+    Ok(self)
+  }
+
+  pub fn add_function_4<T1, T2, T3, T4, V>(
+    &mut self,
+    function_name: String,
+    function: fn(T1, T2, T3, T4) -> V,
+  ) -> Result<&Self, String>
+  where
+    T1: 'static + From<Operand>,
+    T2: 'static + From<Operand>,
+    T3: 'static + From<Operand>,
+    T4: 'static + From<Operand>,
+    V: 'static + Into<Operand>,
+  {
+    if self.functions.contains_key(&function_name) {
+      return Err(format!("{function_name} is already added as a function"));
+    }
+
+    self
+      .functions
+      .insert(function_name, to_function_container4(function));
+    Ok(self)
+  }
+
+  /// Load files under the provided directory as templates.
+  ///
+  /// Note that it does not recursively visit every underlying directories. Only the files that
+  /// live in the current directory will be added to the engine.
+  ///
+  /// If the file is not readable, then it will be ignored (will show an error message)
+  ///
+  /// # Arguments
+  ///
+  /// * `dir_name` - Name of the directory.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// let mut dojang = rspack_dojang::Dojang::new();
+  ///
+  /// // Add every files under ./tests as a template.
+  /// dojang.load("./tests");
+  /// ```
+  pub fn load(&mut self, dir_name: &str) -> Result<&mut Self, String> {
+    match get_all_file_path_under_dir(dir_name) {
+      Ok(files) => {
+        for file in files {
+          let file_name = file
+            .file_name()
+            .unwrap()
+            .to_os_string()
+            .into_string()
+            .unwrap();
+
+          if self.templates.contains_key(&file_name) {
+            println!("Template {file_name} is already added");
+            continue;
+          }
+
+          let file_content = std::fs::read_to_string(&file);
+
+          if file_content.is_err() {
+            println!("Unable to read file '{file:?}', error : {file_content:?}");
+            continue;
+          }
+
+          let file_content = file_content.unwrap();
+          self.templates.insert(
+            file_name,
+            (Executer::new(Parser::parse(&file_content)?)?, file_content),
+          );
+        }
+      }
+      Err(e) => return Err(e.to_string()),
+    }
+
+    Ok(self)
+  }
+
+  /// Render the page with the provided context.
+  ///
+  /// # Arguments
+  ///
+  /// * `file_name` : Name of the template file that should be rendered.
+  /// * `value` : JSON value that is provided as a context. Note that this function consumes the
+  ///   json data.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// let mut dojang = rspack_dojang::Dojang::new();
+  ///
+  /// // Render 'template_file' with the provided context.
+  /// dojang.load("./tests").unwrap().render(
+  ///   "template_file",
+  ///   serde_json::from_str(r#"{ "test" : { "title" : "Welcome to Dojang"} }"#).unwrap(),
+  /// );
+  /// ```
+  pub fn render(&mut self, file_name: &str, value: Value) -> Result<String, String> {
+    if let Some((executer, file_content)) = self.templates.get(file_name) {
+      executer.render(
+        &mut Context::new(value),
+        &self.templates,
+        &self.functions,
+        file_content,
+        &mut self.includes,
+      )
+    } else {
+      Err(format!("Template {file_name} is not found"))
+    }
+  }
+}
+
+fn get_all_file_path_under_dir(dir_name: &str) -> io::Result<Vec<PathBuf>> {
+  fs::read_dir(dir_name)?
+    .map(|x| x.map(|entry| entry.path()))
+    .collect()
+}
+
+pub fn to_function_container0<V: 'static + Into<Operand>>(func: fn() -> V) -> FunctionContainer {
+  FunctionContainer::F0(Box::new(move || -> Operand { func().into() }))
+}
+
+pub fn to_function_container1<T: 'static + From<Operand>, V: 'static + Into<Operand>>(
+  func: fn(T) -> V,
+) -> FunctionContainer {
+  FunctionContainer::F1(Box::new(move |v: Operand| -> Operand {
+    func(v.into()).into()
+  }))
+}
+
+pub fn to_function_container2<
+  T1: 'static + From<Operand>,
+  T2: 'static + From<Operand>,
+  V: 'static + Into<Operand>,
+>(
+  func: fn(T1, T2) -> V,
+) -> FunctionContainer {
+  FunctionContainer::F2(Box::new(move |v1: Operand, v2: Operand| -> Operand {
+    func(v1.into(), v2.into()).into()
+  }))
+}
+
+pub fn to_function_container3<
+  T1: 'static + From<Operand>,
+  T2: 'static + From<Operand>,
+  T3: 'static + From<Operand>,
+  V: 'static + Into<Operand>,
+>(
+  func: fn(T1, T2, T3) -> V,
+) -> FunctionContainer {
+  FunctionContainer::F3(Box::new(
+    move |v1: Operand, v2: Operand, v3: Operand| -> Operand {
+      func(v1.into(), v2.into(), v3.into()).into()
+    },
+  ))
+}
+
+pub fn to_function_container4<
+  T1: 'static + From<Operand>,
+  T2: 'static + From<Operand>,
+  T3: 'static + From<Operand>,
+  T4: 'static + From<Operand>,
+  V: 'static + Into<Operand>,
+>(
+  func: fn(T1, T2, T3, T4) -> V,
+) -> FunctionContainer {
+  FunctionContainer::F4(Box::new(
+    move |v1: Operand, v2: Operand, v3: Operand, v4: Operand| -> Operand {
+      func(v1.into(), v2.into(), v3.into(), v4.into()).into()
+    },
+  ))
+}
+
+#[test]
+fn escape_unescape() {
+  let template = "<%= myHtml %><%- myHtml %>".to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+
+  assert_eq!(
+    dojang
+      .render(
+        "some_template",
+        serde_json::from_str(r#"{ "myHtml": "<span>Rspack</span>" }"#).unwrap()
+      )
+      .unwrap(),
+    "&lt;span&gt;Rspack&lt;&#x2F;span&gt;<span>Rspack</span>"
+  );
+}
+#[test]
+fn custom_escape_unescape() {
+  let template = "<%= myHtml %><%- myHtml %>".to_string();
+  let mut dojang = Dojang::new();
+  dojang.with_options(DojangOptions {
+    escape: "-".to_string(),
+    unescape: "=".to_string(),
+  });
+  assert!(
+    dojang
+      .add_with_option("some_template".to_string(), template)
+      .is_ok()
+  );
+  assert_eq!(
+    dojang
+      .render(
+        "some_template",
+        serde_json::from_str(r#"{ "myHtml": "<span>Rspack</span>" }"#).unwrap()
+      )
+      .unwrap(),
+    "<span>Rspack</span>&lt;span&gt;Rspack&lt;&#x2F;span&gt;"
+  );
+}
+#[test]
+fn render() {
+  let template = "<% if a == 1 { %> Hi <% } else { %><%= a %><% } %>".to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+
+  assert_eq!(
+    dojang
+      .render(
+        "some_template",
+        serde_json::from_str(r#"{ "a" : 1 }"#).unwrap()
+      )
+      .unwrap(),
+    " Hi "
+  );
+
+  assert_eq!(
+    dojang
+      .render(
+        "some_template",
+        serde_json::from_str(r#"{ "a" : 2 }"#).unwrap()
+      )
+      .unwrap(),
+    "2"
+  );
+}
+
+#[test]
+fn render_from_dir() {
+  let mut dojang = Dojang::new();
+  assert!(dojang.load("./tests").is_ok());
+
+  println!(
+    "{}",
+    dojang
+      .render(
+        "test.html",
+        serde_json::from_str(r#"{ "test" : { "title" : "Welcome to Dojang"} }"#).unwrap()
+      )
+      .unwrap()
+  );
+
+  assert_eq!(
+    dojang
+      .render(
+        "test.html",
+        serde_json::from_str(r#"{ "test" : { "title" : "Welcome to Dojang"} }"#).unwrap()
+      )
+      .unwrap(),
+    r#"<html>
+  Welcome to Dojang
+  <body>
+    <p>some content</p><p>x is0</p><p>x is1</p><p>x is2</p><p>x is3</p><p>x is4</p><p>x is5</p><p>x is6</p><p>x is7</p><p>x is8</p><p>x is9</p>
+  </body>
+</html>
+"#
+  );
+}
+
+#[cfg(test)]
+fn func(a: i64, b: i64) -> i64 {
+  a + b
+}
+
+#[test]
+fn render_function() {
+  let template = r#"func(a,b) = <%= func(a, b) %>"#.to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+  assert!(dojang.add_function_2("func".to_string(), func).is_ok());
+
+  assert_eq!(
+    dojang
+      .render("some_template", serde_json::json!({"a" : 1, "b" : 2 }))
+      .unwrap(),
+    "func(a,b) = 3"
+  );
+}
+
+#[test]
+fn for_use_range_function() {
+  let template = r#"<% for i in range(v) { %><%= i %><% } %>"#.to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+
+  assert_eq!(
+    dojang
+      .render("some_template", serde_json::json!({"v" : 10}))
+      .unwrap(),
+    "0123456789"
+  );
+}
+
+#[test]
+fn use_length_function() {
+  let template = r#"<%= length(s) %>"#.to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+
+  assert_eq!(
+    dojang
+      .render("some_template", serde_json::json!({"s" : "abc"}))
+      .unwrap(),
+    "3"
+  );
+}
+
+#[test]
+fn use_json_stringify_function() {
+  let template = r#"<%- json_stringify(s) %>"#.to_string();
+  let mut dojang = Dojang::new();
+  assert!(dojang.add("some_template".to_string(), template).is_ok());
+
+  assert_eq!(
+    dojang
+      .render("some_template", serde_json::json!({"s" : [1,2,3]}))
+      .unwrap(),
+    "[1,2,3]"
+  );
+}

--- a/crates/rspack_dojang/src/dojang.rs
+++ b/crates/rspack_dojang/src/dojang.rs
@@ -79,7 +79,7 @@ impl Dojang {
   ///
   /// # Arguments
   ///
-  /// * `file_name` - Name of the template file. Template datas are identified by this name.
+  /// * `file_name` - Name of the template file. Template data is identified by this name.
   /// * `template` - Actual template data. Should be using EJS syntax.
   ///
   /// # Examples

--- a/crates/rspack_dojang/src/eval.rs
+++ b/crates/rspack_dojang/src/eval.rs
@@ -35,7 +35,7 @@ impl Eval {
     expr.ops.insert(0, Op::ParenOpen);
 
     // Convert function calls into Operand::Function.
-    // The correspoding Expr::Function object will be stored at the map.
+    // The corresponding Expr::Function object will be stored at the map.
     let mut function_name_to_function = HashMap::new();
     Eval::handle_functions(&mut expr, &mut function_name_to_function)?;
 
@@ -256,7 +256,7 @@ fn get_tokens_belong_to_accessor(
       inst_index += 1;
     }
 
-    // Property accessor can be chanined.
+    // Property accessor can be chained.
     // (e.g obj[...][...][...])
     // In this case, entire [...][...][...] will be included.
     match ops.get(inst_index + 1) {

--- a/crates/rspack_dojang/src/eval.rs
+++ b/crates/rspack_dojang/src/eval.rs
@@ -1,0 +1,927 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::expr::*;
+
+// Evaluate the parsed expression.
+#[derive(PartialEq, Debug, Clone)]
+pub struct Eval {
+  pub expr: Vec<Expr>,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Expr {
+  Op(Op),
+  Function(Function),
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct Function {
+  pub name: String,
+  pub params: Vec<Eval>,
+
+  // Accessor (e.g obj[]) is treated as a function.
+  pub is_accessor: bool,
+}
+
+impl Eval {
+  pub fn new(mut expr: Tokens) -> Result<Eval, String> {
+    let mut operands: Vec<Vec<Expr>> = Vec::new();
+    let mut operators = Vec::new();
+
+    // Wrap the expression with ().
+    expr.ops.push(Op::ParenClose);
+    expr.ops.insert(0, Op::ParenOpen);
+
+    // Convert function calls into Operand::Function.
+    // The correspoding Expr::Function object will be stored at the map.
+    let mut function_name_to_function = HashMap::new();
+    Eval::handle_functions(&mut expr, &mut function_name_to_function)?;
+
+    // We have to scan from the back.
+    expr.ops.reverse();
+    while let Some(op) = expr.ops.pop() {
+      match op {
+        Op::Operand(operand) => match operand {
+          Operand::Function(function_name) => {
+            let function = function_name_to_function.remove(&function_name);
+            if function.is_none() {
+              return Err(format!(
+                "Function {function_name:?} does not have matching entry"
+              ));
+            }
+
+            operands.push(vec![Expr::Function(function.unwrap())]);
+          }
+          _ => {
+            operands.push(vec![Expr::Op(Op::Operand(operand))]);
+          }
+        },
+        optr => {
+          if optr == Op::ParenOpen {
+            operators.push(optr);
+            continue;
+          }
+
+          if operators.is_empty() {
+            operators.push(optr);
+            continue;
+          }
+
+          loop {
+            let last_op = operators.last().unwrap();
+            if is_second_priority_higher(last_op, &optr) {
+              operators.push(optr);
+              break;
+            } else if last_op == &Op::ParenOpen && optr == Op::ParenClose {
+              operators.pop();
+              break;
+            } else if (optr == Op::Not || optr == Op::Assign)
+              && is_second_priority_higher_or_equal(last_op, &optr)
+            {
+              operators.push(optr);
+              break;
+            }
+
+            let top_optr = operators.pop().unwrap();
+
+            let mut popped_operands: Vec<Vec<Expr>> = Vec::new();
+            for _ in 0..operator_num_operands(&top_optr) {
+              match operands.pop() {
+                Some(operand) => {
+                  popped_operands.push(operand);
+                }
+                _ => {
+                  break;
+                }
+              }
+            }
+
+            popped_operands.push(vec![Expr::Op(top_optr)]);
+            popped_operands.reverse();
+
+            operands.push(popped_operands.into_iter().flatten().collect());
+          }
+        }
+      }
+    }
+
+    Ok(Eval {
+      expr: operands.into_iter().flatten().collect(),
+    })
+  }
+
+  fn handle_functions(
+    expr: &mut Tokens,
+    function_name_to_function: &mut HashMap<String, Function>,
+  ) -> Result<(), String> {
+    let mut inst_index = 0;
+    while inst_index < expr.ops.len() {
+      if let Op::Operand(operand) = &expr.ops[inst_index]
+        && let Operand::Object(_) = operand
+      {
+        match expr.ops.get(inst_index + 1) {
+          Some(Op::ParenOpen) => {
+            // Then this is the start of the function.
+            let function_tokens = get_tokens_belong_to_function(&mut expr.ops, inst_index)?;
+            let function = handle_function_tokens(function_tokens)?;
+
+            // Now insert the Operand::Function as a placeholder.
+            expr.ops.insert(
+              inst_index,
+              Op::Operand(Operand::Function(function.name.clone())),
+            );
+
+            // Finally, register this function. Operator::Function will be later
+            // replaced by the Expr::Function.
+            function_name_to_function.insert(function.name.clone(), function);
+          }
+          Some(Op::BracketOpen | Op::Dot) => {
+            // Then this is the start of the property accessor ([] or .)
+            let accessor_tokens = get_tokens_belong_to_accessor(&mut expr.ops, inst_index)?;
+            let accessor = handle_accessor_tokens(accessor_tokens)?;
+
+            // Now insert the Operand::Function as a placeholder.
+            expr.ops.insert(
+              inst_index,
+              Op::Operand(Operand::Function(accessor.name.clone())),
+            );
+
+            function_name_to_function.insert(accessor.name.clone(), accessor);
+          }
+          _ => {}
+        }
+      }
+
+      inst_index += 1;
+    }
+    Ok(())
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.expr.is_empty()
+  }
+
+  pub fn get_keyword(&self) -> Option<Keyword> {
+    if self.expr.len() != 1 {
+      return None;
+    }
+
+    match self.expr.first().unwrap() {
+      Expr::Op(Op::Operand(Operand::Keyword(keyword))) => Some(keyword.clone()),
+      _ => None,
+    }
+  }
+}
+
+fn get_tokens_belong_to_function(
+  ops: &mut Vec<Op>,
+  mut inst_index: usize,
+) -> Result<Vec<Op>, String> {
+  let function_start = inst_index;
+
+  inst_index += 2;
+
+  let mut opened_paren = 1;
+
+  while inst_index < ops.len() {
+    match &ops[inst_index] {
+      Op::ParenOpen => {
+        opened_paren += 1;
+      }
+      Op::ParenClose => {
+        opened_paren -= 1;
+        if opened_paren == 0 {
+          break;
+        }
+      }
+      _ => {}
+    }
+
+    inst_index += 1;
+  }
+
+  if opened_paren != 0 {
+    return Err(format!("Function does not have closing ')'. {ops:?}"));
+  }
+
+  Ok(ops.drain(function_start..inst_index + 1).collect())
+}
+
+fn get_tokens_belong_to_accessor(
+  ops: &mut Vec<Op>,
+  mut inst_index: usize,
+) -> Result<Vec<Op>, String> {
+  let function_start = inst_index;
+
+  inst_index += 1;
+
+  let mut opened_paren = 0;
+  'single_property: loop {
+    while inst_index < ops.len() {
+      match &ops[inst_index] {
+        Op::BracketOpen => {
+          opened_paren += 1;
+        }
+        Op::BracketClose => {
+          opened_paren -= 1;
+          if opened_paren == 0 {
+            break;
+          }
+        }
+        Op::Dot => {
+          if opened_paren == 0 {
+            match ops.get(inst_index + 1) {
+              Some(Op::Operand(Operand::Object(_))) => {
+                inst_index += 2;
+                continue;
+              }
+              _ => {
+                return Err(format!(
+                  "Only raw string should come after dot, you gave : {:?}",
+                  ops.get(inst_index + 1)
+                ));
+              }
+            }
+          }
+        }
+        _ => {
+          if opened_paren == 0 {
+            break 'single_property;
+          }
+        }
+      }
+
+      inst_index += 1;
+    }
+
+    // Property accessor can be chanined.
+    // (e.g obj[...][...][...])
+    // In this case, entire [...][...][...] will be included.
+    match ops.get(inst_index + 1) {
+      Some(Op::BracketOpen | Op::Dot) => {
+        inst_index += 1;
+      }
+      _ => {
+        inst_index += 1;
+        break;
+      }
+    }
+  }
+
+  if opened_paren != 0 {
+    return Err(format!("Function does not have closing ']'. {ops:?}"));
+  }
+
+  Ok(ops.drain(function_start..inst_index).collect())
+}
+
+fn handle_function_tokens(mut ops: Vec<Op>) -> Result<Function, String> {
+  // Should be at least function_name, (, ).
+  assert!(ops.len() >= 3);
+
+  let function_name = match ops.first().unwrap() {
+    Op::Operand(operand) => match operand {
+      Operand::Object(object) => object.name.clone(),
+      _ => panic!("Function name is not object."),
+    },
+    _ => panic!("Function name is not proper operator."),
+  };
+
+  let mut inst_index = 0;
+  let mut opened_paren = 0;
+  let mut params = Vec::new();
+
+  // Remove function name and first (.
+  ops.drain(0..2);
+
+  while inst_index < ops.len() {
+    match &ops[inst_index] {
+      Op::ParenOpen => {
+        opened_paren += 1;
+      }
+      Op::ParenClose => {
+        opened_paren -= 1;
+      }
+      Op::Comma if opened_paren == 0 => {
+        let tokens = Tokens {
+          ops: ops.drain(0..inst_index).collect(),
+        };
+
+        params.push(Eval::new(tokens)?);
+        inst_index = 0;
+
+        // Remove comma.
+        ops.drain(0..1);
+
+        continue;
+      }
+      _ => {}
+    }
+
+    inst_index += 1;
+  }
+
+  let last_param: Vec<Op> = ops.drain(0..ops.len() - 1).collect();
+  if !last_param.is_empty() {
+    let tokens = Tokens { ops: last_param };
+
+    params.push(Eval::new(tokens)?);
+  }
+
+  Ok(Function {
+    name: function_name,
+    params,
+    is_accessor: false,
+  })
+}
+
+fn handle_accessor_tokens(mut ops: Vec<Op>) -> Result<Function, String> {
+  // Should be at least accessor_name, [, ].
+  assert!(ops.len() >= 3);
+
+  let accessor_name = match ops.first().unwrap() {
+    Op::Operand(operand) => match operand {
+      Operand::Object(object) => object.name.clone(),
+      _ => panic!("Accessor name is not object."),
+    },
+    _ => panic!("Accessor name is not proper operator."),
+  };
+
+  let mut inst_index = 0;
+  let mut opened_paren = 0;
+  let mut accessors = Vec::new();
+
+  // Remove function name.
+  ops.drain(0..1);
+
+  while inst_index < ops.len() {
+    match &ops[inst_index] {
+      Op::BracketOpen => {
+        opened_paren += 1;
+      }
+      Op::BracketClose => {
+        opened_paren -= 1;
+
+        if opened_paren == 0 {
+          let tokens = Tokens {
+            ops: ops.drain(1..inst_index).collect(),
+          };
+
+          accessors.push(Eval::new(tokens)?);
+          inst_index = 0;
+
+          // Remove '[' and ']'.
+          ops.drain(0..2);
+
+          continue;
+        }
+      }
+      Op::Dot if opened_paren == 0 => {
+        if let Op::Operand(Operand::Object(object)) = &ops[inst_index + 1] {
+          accessors.push(Eval {
+            expr: vec![Expr::Op(Op::Operand(Operand::Value(Value::from(
+              object.name.clone(),
+            ))))],
+          })
+        }
+
+        ops.drain(inst_index..inst_index + 2);
+        continue;
+      }
+      _ => {}
+    }
+
+    inst_index += 1;
+  }
+
+  if !ops.is_empty() {
+    return Err(format!("Accessor parsing error {ops:?}"));
+  }
+
+  Ok(Function {
+    name: accessor_name,
+    params: accessors,
+    is_accessor: true,
+  })
+}
+
+fn is_second_priority_higher(op1: &Op, op2: &Op) -> bool {
+  operator_priority(op1) > operator_priority(op2)
+}
+
+fn is_second_priority_higher_or_equal(op1: &Op, op2: &Op) -> bool {
+  operator_priority(op1) >= operator_priority(op2)
+}
+
+#[test]
+fn create_simple_unary() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Not,
+      Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      }))),
+    ],
+  };
+
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn create_multiple_unary_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Not,
+      Op::Not,
+      Op::Not,
+      Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn create_simple_binary_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      })),
+      Op::Equal,
+      Op::Operand(Operand::Value(Value::from(3))),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Equal),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Value(Value::from(3)))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn create_binary_with_unary_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      })),
+      Op::Equal,
+      Op::Not,
+      Op::Not,
+      Op::Operand(Operand::Value(Value::from(3))),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Equal),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      }))),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Operand(Operand::Value(Value::from(3)))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn create_complex_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Not,
+      Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      })),
+      Op::And,
+      Op::ParenOpen,
+      Op::Not,
+      Op::ParenOpen,
+      Op::Operand(Operand::Object(Object {
+        name: "var1".to_string(),
+      })),
+      Op::NotEqual,
+      Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      })),
+      Op::ParenClose,
+      Op::Or,
+      Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      })),
+      Op::LessEq,
+      Op::Operand(Operand::Object(Object {
+        name: "val".to_string(),
+      })),
+      Op::ParenClose,
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::And),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some_value".to_string(),
+      }))),
+      Expr::Op(Op::Or),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::NotEqual),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var1".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      }))),
+      Expr::Op(Op::LessEq),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "some".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "val".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn create_complex_expr2() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "var1".to_string(),
+      })),
+      Op::GreaterEq,
+      Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      })),
+      Op::And,
+      Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      })),
+      Op::LessEq,
+      Op::Operand(Operand::Object(Object {
+        name: "var3".to_string(),
+      })),
+      Op::Or,
+      Op::Not,
+      Op::Operand(Operand::Object(Object {
+        name: "var3".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Or),
+      Expr::Op(Op::And),
+      Expr::Op(Op::GreaterEq),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var1".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      }))),
+      Expr::Op(Op::LessEq),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var2".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var3".to_string(),
+      }))),
+      Expr::Op(Op::Not),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "var3".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn check_assign_op() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::Assign,
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::And,
+      Op::Operand(Operand::Value(Value::from(3))),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Assign),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      }))),
+      Expr::Op(Op::And),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Value(Value::from(3)))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn check_multiple_assign() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::Assign,
+      Op::Operand(Operand::Object(Object {
+        name: "b".to_string(),
+      })),
+      Op::Assign,
+      Op::Operand(Operand::Object(Object {
+        name: "c".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Assign),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      }))),
+      Expr::Op(Op::Assign),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "b".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "c".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+#[test]
+fn arithmetic_expression() {
+  let expr = Tokens {
+    ops: vec![
+      Op::ParenOpen,
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::Plus,
+      Op::Operand(Operand::Object(Object {
+        name: "b".to_string(),
+      })),
+      Op::Multiply,
+      Op::Operand(Operand::Object(Object {
+        name: "c".to_string(),
+      })),
+      Op::Minus,
+      Op::Operand(Operand::Object(Object {
+        name: "e".to_string(),
+      })),
+      Op::Divide,
+      Op::Operand(Operand::Object(Object {
+        name: "d".to_string(),
+      })),
+      Op::ParenClose,
+      Op::Multiply,
+      Op::Operand(Operand::Object(Object {
+        name: "f".to_string(),
+      })),
+      Op::Plus,
+      Op::Operand(Operand::Value(Value::from(1))),
+      Op::Plus,
+      Op::Operand(Operand::Value(Value::from(2))),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Plus),
+      Expr::Op(Op::Plus),
+      Expr::Op(Op::Multiply),
+      Expr::Op(Op::Minus),
+      Expr::Op(Op::Plus),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      }))),
+      Expr::Op(Op::Multiply),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "b".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "c".to_string(),
+      }))),
+      Expr::Op(Op::Divide),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "e".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "d".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "f".to_string(),
+      }))),
+      Expr::Op(Op::Operand(Operand::Value(Value::from(1)))),
+      Expr::Op(Op::Operand(Operand::Value(Value::from(2)))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn function_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "func".to_string(),
+      })),
+      Op::ParenOpen,
+      Op::Operand(Operand::Value(Value::from(1))),
+      Op::Plus,
+      Op::Operand(Operand::Value(Value::from(1))),
+      Op::Comma,
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::Comma,
+      Op::Operand(Operand::Object(Object {
+        name: "b".to_string(),
+      })),
+      Op::ParenClose,
+      Op::Plus,
+      Op::Operand(Operand::Object(Object {
+        name: "x".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Plus),
+      Expr::Function(Function {
+        name: "func".to_string(),
+        params: vec![
+          Eval {
+            expr: vec![
+              Expr::Op(Op::Plus),
+              Expr::Op(Op::Operand(Operand::Value(Value::from(1)))),
+              Expr::Op(Op::Operand(Operand::Value(Value::from(1)))),
+            ],
+          },
+          Eval {
+            expr: vec![Expr::Op(Op::Operand(Operand::Object(Object {
+              name: "a".to_string(),
+            })))],
+          },
+          Eval {
+            expr: vec![Expr::Op(Op::Operand(Operand::Object(Object {
+              name: "b".to_string(),
+            })))],
+          },
+        ],
+        is_accessor: false,
+      }),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "x".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn bracket_expr() {
+  let expr = Tokens {
+    ops: vec![
+      Op::Operand(Operand::Object(Object {
+        name: "func".to_string(),
+      })),
+      Op::ParenOpen,
+      Op::Operand(Operand::Object(Object {
+        name: "a".to_string(),
+      })),
+      Op::BracketOpen,
+      Op::Operand(Operand::Value(Value::from(1))),
+      Op::BracketClose,
+      Op::BracketOpen,
+      Op::Operand(Operand::Value(Value::from(2))),
+      Op::BracketClose,
+      Op::ParenClose,
+      Op::Plus,
+      Op::Operand(Operand::Object(Object {
+        name: "x".to_string(),
+      })),
+    ],
+  };
+
+  let expected_eval = Eval {
+    expr: vec![
+      Expr::Op(Op::Plus),
+      Expr::Function(Function {
+        name: "func".to_string(),
+        params: vec![Eval {
+          expr: vec![Expr::Function(Function {
+            name: "a".to_string(),
+            params: vec![
+              Eval {
+                expr: vec![Expr::Op(Op::Operand(Operand::Value(Value::from(1))))],
+              },
+              Eval {
+                expr: vec![Expr::Op(Op::Operand(Operand::Value(Value::from(2))))],
+              },
+            ],
+            is_accessor: true,
+          })],
+        }],
+        is_accessor: false,
+      }),
+      Expr::Op(Op::Operand(Operand::Object(Object {
+        name: "x".to_string(),
+      }))),
+    ],
+  };
+  assert_eq!(Eval::new(expr).unwrap(), expected_eval);
+}
+
+#[test]
+fn get_tokens_belong_to_accessor_test() {
+  let mut tokens = vec![
+    Op::Operand(Operand::Object(Object {
+      name: "a".to_string(),
+    })),
+    Op::Dot,
+    Op::Operand(Operand::Object(Object {
+      name: "b".to_string(),
+    })),
+    Op::BracketOpen,
+    Op::Operand(Operand::Value(Value::from(123))),
+    Op::BracketClose,
+    Op::Dot,
+    Op::Operand(Operand::Object(Object {
+      name: "c".to_string(),
+    })),
+    Op::Plus,
+    Op::Operand(Operand::Value(Value::from(123))),
+  ];
+
+  let expected = vec![
+    Op::Operand(Operand::Object(Object {
+      name: "a".to_string(),
+    })),
+    Op::Dot,
+    Op::Operand(Operand::Object(Object {
+      name: "b".to_string(),
+    })),
+    Op::BracketOpen,
+    Op::Operand(Operand::Value(Value::from(123))),
+    Op::BracketClose,
+    Op::Dot,
+    Op::Operand(Operand::Object(Object {
+      name: "c".to_string(),
+    })),
+  ];
+
+  assert_eq!(
+    get_tokens_belong_to_accessor(&mut tokens, 0).unwrap(),
+    expected
+  );
+}

--- a/crates/rspack_dojang/src/exec.rs
+++ b/crates/rspack_dojang/src/exec.rs
@@ -1,0 +1,1041 @@
+use std::{
+  collections::{BTreeMap, HashMap},
+  sync::Mutex,
+};
+
+use html_escape::encode_safe;
+#[cfg(test)]
+use serde_json::{Value, json};
+
+use crate::{context::*, eval::*, expr::*};
+
+type JumpTable = HashMap<usize, usize>;
+type JumpTables = (JumpTable, JumpTable);
+
+// The executer that renders the template.
+#[derive(Debug)]
+pub struct Executer {
+  insts: Vec<Action<Eval>>,
+
+  // Tells where the instructor point to jump
+  // - For, If, While: Tells where to jump if the condition is false.
+  // - End, Break, Continue: Tells where to jump if hit.
+  jump_table: HashMap<usize, usize>,
+
+  // Mapping between index of "Break" and the corresponding For.
+  break_table: HashMap<usize, usize>,
+}
+
+impl Executer {
+  pub fn new(mut parser: Parser) -> Result<Self, String> {
+    let mut insts = Vec::new();
+
+    while let Some(expr) = parser.parse_tree.pop() {
+      insts.push(convert_expr_to_eval(expr)?)
+    }
+
+    insts.reverse();
+
+    let (jump_table, break_table) = Executer::compute_jump_table(&insts)?;
+    Ok(Executer {
+      jump_table,
+      break_table,
+      insts,
+    })
+  }
+
+  fn compute_jump_table(insts: &[Action<Eval>]) -> Result<JumpTables, String> {
+    let mut inst_index = 0;
+
+    let mut jump_table = HashMap::new();
+    let mut break_table = HashMap::new();
+
+    let mut if_matching_ends = BTreeMap::new();
+
+    // Every '{'.
+    let mut opened = Vec::new();
+
+    // Every '{' for loops (for, while). This will be used by break and continue.
+    let mut loop_opened = Vec::new();
+
+    // Mapping bewteen location of break/continue to the corresponding loop.
+    let mut break_and_continue_pos = HashMap::new();
+
+    while inst_index < insts.len() {
+      match &insts[inst_index] {
+        Action::If(_) => opened.push(inst_index),
+        Action::While(_) => {
+          opened.push(inst_index);
+          loop_opened.push(inst_index);
+        }
+        Action::For(_) => {
+          opened.push(inst_index);
+          loop_opened.push(inst_index);
+        }
+        Action::Else() => {
+          if let Some(Action::If(_)) = insts.get(inst_index + 1) {
+            inst_index += 1;
+            continue;
+          } else {
+            opened.push(inst_index)
+          }
+        }
+        Action::Do(eval) => {
+          if let Some(keyword) = eval.get_keyword()
+            && (keyword == Keyword::Break || keyword == Keyword::Continue)
+          {
+            if loop_opened.is_empty() {
+              return Err("Cannot break/continue within non-loop context.".to_string());
+            }
+
+            break_and_continue_pos.insert(inst_index, *loop_opened.last().unwrap());
+          }
+        }
+        Action::End() => {
+          if opened.is_empty() {
+            return Err(format!(
+              "Unmatched end found at {inst_index:?} for {insts:?}"
+            ));
+          }
+
+          let open_index = opened.pop().unwrap();
+          match &insts[open_index] {
+            Action::If(_) => {
+              if_matching_ends.insert(open_index, inst_index + 1);
+            }
+            Action::Else() => {
+              if_matching_ends.insert(open_index, inst_index + 1);
+            }
+            Action::For(_) => {
+              jump_table.insert(open_index, inst_index + 1);
+              jump_table.insert(inst_index, open_index);
+              loop_opened.pop();
+            }
+            Action::While(_) => {
+              jump_table.insert(open_index, inst_index + 1);
+              jump_table.insert(inst_index, open_index);
+              loop_opened.pop();
+            }
+            _ => {
+              return Err(format!("Unknown action {insts:?} with closing parentheses"));
+            }
+          }
+        }
+        _ => {}
+      }
+
+      inst_index += 1;
+    }
+
+    if !opened.is_empty() {
+      return Err(format!(
+        "No closing bracket found {}",
+        pretty_print_insts(insts)
+      ));
+    }
+
+    // Handle break and continue.
+    for (keyword_index, loop_index) in break_and_continue_pos {
+      if let Action::Do(eval) = &insts[keyword_index] {
+        let keyword = eval.get_keyword().unwrap();
+        if keyword == Keyword::Continue {
+          // For continue, then jump back to the start of the loop.
+          jump_table.insert(keyword_index, loop_index);
+        } else if keyword == Keyword::Break {
+          // For break, then jump back to the end of the loop.
+          jump_table.insert(keyword_index, jump_table[&loop_index]);
+          break_table.insert(keyword_index, loop_index);
+        }
+      }
+    }
+
+    // Now scan again to handle if-else.
+    while !if_matching_ends.is_empty() {
+      let (if_start, if_block_end) = if_matching_ends.iter().next().unwrap();
+      let if_start = *if_start;
+      let mut if_block_end = *if_block_end;
+
+      let mut if_else_block_starts = vec![if_start];
+
+      // Find the index of all "if"s in same if-else block.
+      while let Some(&Action::Else()) = insts.get(if_block_end) {
+        // If this is the if-else statement
+        if let Some(&Action::If(_)) = insts.get(if_block_end + 1) {
+          if_else_block_starts.push(if_block_end + 1);
+          if_block_end = if_matching_ends[&(if_block_end + 1)];
+        } else {
+          if_else_block_starts.push(if_block_end);
+
+          // Otherwise this is just else statement.
+          if_block_end = if_matching_ends[&if_block_end];
+          break;
+        }
+      }
+
+      // "End" of if statement should point to next of the End of the if-else block.
+      // "If" of the if statement should point to next of the End.
+      for if_start in if_else_block_starts {
+        let if_end = if_matching_ends[&if_start];
+
+        // This is the case when the condition is true.
+        jump_table.insert(if_end - 1, if_block_end);
+
+        // This is the case when the condition is false.
+        jump_table.insert(if_start, if_end);
+
+        if_matching_ends.remove(&if_start);
+      }
+    }
+
+    Ok((jump_table, break_table))
+  }
+
+  pub fn render(
+    &self,
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    template: &str,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<String, String> {
+    let mut rendered = String::new();
+    let mut for_index_counter = HashMap::new();
+
+    // Contains the range value of the for-loop.
+    let mut for_range_container = HashMap::new();
+
+    let mut inst_index = 0;
+    while inst_index < self.insts.len() {
+      match &self.insts[inst_index] {
+        Action::Show(show) => match show {
+          Show::Html { start, end } => {
+            rendered.push_str(&template[*start..*end]);
+          }
+          Show::ExprEscaped(eval) => {
+            rendered.push_str(&encode_safe(&Executer::run_eval(
+              context, templates, functions, eval, includes,
+            )?));
+          }
+          Show::ExprUnescaped(eval) => {
+            rendered.push_str(&Executer::run_eval(
+              context, templates, functions, eval, includes,
+            )?);
+          }
+        },
+        Action::If(eval) | Action::While(eval) => {
+          // Jump only if the condition is false. Otherwise just go to next instruction.
+          if !eval.run(context, templates, functions, includes)?.is_true() {
+            if let Some(next) = self.jump_table.get(&inst_index) {
+              inst_index = *next;
+              continue;
+            } else {
+              return Err(format!(
+                "Jump of the if statement is not set: {:?} index : {}",
+                self.insts, inst_index
+              ));
+            }
+          }
+        }
+        Action::For(eval) => {
+          let iter_index = match for_index_counter.get(&inst_index) {
+            Some(index) => *index,
+            None => 0usize,
+          };
+
+          // The for loop is first encountered. Compute the "range" part.
+          if iter_index == 0 {
+            for_range_container.insert(
+              inst_index,
+              eval.run_for_range(context, templates, functions, includes)?,
+            );
+          }
+
+          for_index_counter.insert(inst_index, iter_index + 1);
+
+          let range = &for_range_container[&inst_index];
+          if !eval.run_for_loop(context, range, iter_index)? {
+            if let Some(next) = self.jump_table.get(&inst_index) {
+              // Reset the index counter.
+              for_index_counter.insert(inst_index, 0);
+
+              inst_index = *next;
+
+              continue;
+            } else {
+              return Err(format!(
+                "Jump of the if statement is not set: {:?} index : {}",
+                self.insts, inst_index
+              ));
+            }
+          }
+        }
+        Action::End() => {
+          if let Some(next) = self.jump_table.get(&inst_index) {
+            inst_index = *next;
+            continue;
+          }
+        }
+        Action::Do(eval) => match eval.get_keyword() {
+          Some(Keyword::Break) => {
+            // Reset the iter counter of the loop that we escape.
+            for_index_counter.insert(self.break_table[&inst_index], 0);
+
+            inst_index = self.jump_table[&inst_index];
+            continue;
+          }
+          Some(Keyword::Continue) => {
+            inst_index = self.jump_table[&inst_index];
+            continue;
+          }
+          _ => {
+            Executer::run_eval(context, templates, functions, eval, includes)?;
+          }
+        },
+        Action::Else() => {}
+      }
+
+      inst_index += 1;
+    }
+
+    Ok(rendered)
+  }
+
+  // Runs Eval if it is not empty.
+  fn run_eval(
+    context: &mut Context,
+    templates: &HashMap<String, (Executer, String)>,
+    functions: &HashMap<String, FunctionContainer>,
+    eval: &Eval,
+    includes: &mut Mutex<HashMap<String, String>>,
+  ) -> Result<String, String> {
+    if eval.is_empty() {
+      return Ok(String::new());
+    }
+
+    Ok(eval.run(context, templates, functions, includes)?.to_str())
+  }
+}
+
+fn pretty_print_insts(insts: &[Action<Eval>]) -> String {
+  let mut result = String::new();
+
+  let mut padding = String::new();
+  for action in insts {
+    match action {
+      Action::If(_) | Action::While(_) | Action::For(_) => {
+        result.push_str(&format!("{padding}{action:?} \n"));
+        padding.push(' ');
+      }
+      Action::End() => {
+        padding.pop();
+        result.push_str(&format!("{padding}{action:?} \n"));
+      }
+      action => {
+        result.push_str(&format!("{padding}{action:?} \n"));
+      }
+    }
+  }
+
+  result
+}
+
+fn convert_expr_to_eval(action: Action<Tokens>) -> Result<Action<Eval>, String> {
+  match action {
+    Action::Show(show) => match show {
+      Show::Html { start, end } => Ok(Action::Show(Show::Html { start, end })),
+      Show::ExprEscaped(expr) => Ok(Action::Show(Show::ExprEscaped(Eval::new(expr)?))),
+      Show::ExprUnescaped(expr) => Ok(Action::Show(Show::ExprUnescaped(Eval::new(expr)?))),
+    },
+    Action::If(expr) => Ok(Action::If(Eval::new(expr)?)),
+    Action::While(expr) => Ok(Action::While(Eval::new(expr)?)),
+    Action::Do(expr) => Ok(Action::Do(Eval::new(expr)?)),
+    Action::For(expr) => Ok(Action::For(Eval::new(expr)?)),
+    Action::Else() => Ok(Action::Else()),
+    Action::End() => Ok(Action::End()),
+  }
+}
+
+#[test]
+fn test_if_jump_table() {
+  let executer = Executer::new(
+    Parser::parse(r#"<% if var1>=var2{ "b" } else if var1==3{"a"}else{"c"}%>"#).unwrap(),
+  )
+  .unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [(1, 4), (3, 11), (5, 8), (7, 11), (8, 11), (10, 11)]
+      .iter()
+      .copied()
+      .collect()
+  )
+}
+
+#[test]
+fn test_multiple_ifs() {
+  let executer =
+    Executer::new(Parser::parse(r#"<% if a >= b {} else if c >= a {} if a > b {} %>"#).unwrap())
+      .unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [(1, 4), (3, 8), (5, 8), (7, 8), (8, 11), (10, 11)]
+      .iter()
+      .copied()
+      .collect()
+  )
+}
+
+#[test]
+fn test_nested_ifs() {
+  let executer = Executer::new(
+    Parser::parse(r#"<% if a { if a {} else if b { if a {}} else {} if a {} } else { if a {}} %>"#)
+      .unwrap(),
+  )
+  .unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [
+      (1, 20),
+      (3, 6),
+      (5, 16),
+      (7, 13),
+      (9, 12),
+      (11, 12),
+      (12, 16),
+      (13, 16),
+      (15, 16),
+      (16, 19),
+      (18, 19),
+      (19, 26),
+      (20, 26),
+      (22, 25),
+      (24, 25),
+      (25, 26)
+    ]
+    .iter()
+    .copied()
+    .collect()
+  )
+}
+
+#[test]
+fn test_while_and_if() {
+  let executer =
+    Executer::new(Parser::parse(r#"<% while a < 3 { if a < 2 {} else {} } %>"#).unwrap()).unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [(1, 10), (3, 6), (5, 9), (6, 9), (8, 9), (9, 1)]
+      .iter()
+      .copied()
+      .collect()
+  )
+}
+
+#[test]
+fn test_for_and_if() {
+  let executer =
+    Executer::new(Parser::parse(r#"<% for a in v { if a < 2 {} else {} } %>"#).unwrap()).unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [(1, 10), (3, 6), (5, 9), (6, 9), (8, 9), (9, 1)]
+      .iter()
+      .copied()
+      .collect()
+  )
+}
+
+#[test]
+fn test_break_and_continue_jump_table() {
+  let executer = Executer::new(
+    Parser::parse(r#"<% for a in v { if a < 2 { break; } else { continue; } } %>"#).unwrap(),
+  )
+  .unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [
+      (1, 12),
+      (3, 7),
+      (4, 12),
+      (6, 11),
+      (7, 11),
+      (8, 1),
+      (10, 11),
+      (11, 1)
+    ]
+    .iter()
+    .copied()
+    .collect()
+  )
+}
+
+#[test]
+fn test_nested_continue_jump_table() {
+  let template = r#"<% for a in v { for b in v { if a == b { continue; } %><%= b %><% } if a == 2 { continue } } %>"#;
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  assert_eq!(
+    executer.jump_table,
+    [
+      (1, 16),
+      (3, 12),
+      (5, 9),
+      (6, 3),
+      (8, 9),
+      (11, 3),
+      (12, 15),
+      (13, 1),
+      (14, 15),
+      (15, 1)
+    ]
+    .iter()
+    .copied()
+    .collect()
+  )
+}
+#[test]
+fn test_arithmetic_exec() {
+  let context_json = r#"{"a": 1, "b":2, "c": 3, "d" : 2, "e" : 6, "f" : 2}"#;
+  let mut includes = Mutex::new(HashMap::new());
+
+  {
+    let context_value: Value = serde_json::from_str(context_json).unwrap();
+    let mut context = Context::new(context_value);
+
+    // b = a = (1 + 2 * 3 - 6 / 2) * 2  == 8
+    let template = r"<% b = a = (a + b * c - e / d) * f;e=a+b; if e == 16 { g = 5; h = 6} %>g=<%= g %> h=<%= h %>";
+    let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+    let result = executer
+      .render(
+        &mut context,
+        &HashMap::new(),
+        &HashMap::new(),
+        template,
+        &mut includes,
+      )
+      .unwrap();
+
+    assert_eq!(result, "g=5 h=6".to_string());
+  }
+}
+
+#[test]
+fn test_while_exec() {
+  let template =
+    r#"<% a = 0; while a < 3 { if a == 1 { %>One <% } else { %>a = <%= a %> <% } a = a + 1 } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let mut context = Context::new(Value::from(""));
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, "a = 0 One a = 2 ".to_string());
+}
+
+#[test]
+fn test_for_in_statement() {
+  let template = r#"<% for x in arr { %><%= x %> <% } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"arr" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, "1 2 3 4 5 ".to_string());
+}
+
+#[test]
+fn test_for_in_statement_with_index() {
+  let template = r#"<% for x in arr { %><%= index %> <%= x %>,<% } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"arr" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, "0 1,1 2,2 3,3 4,4 5,".to_string());
+}
+
+#[test]
+fn test_nested_for_in_statement() {
+  let template = r#"<% for x in arr { for y in arr2 { %><%= x %>*<%= y %>=<%= x * y %>,<% } } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"arr" : [1,2,3,4,5], "arr2" : [1,2]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(
+    result,
+    "1*1=1,1*2=2,2*1=2,2*2=4,3*1=3,3*2=6,4*1=4,4*2=8,5*1=5,5*2=10,".to_string()
+  );
+}
+
+#[test]
+fn test_break() {
+  let template = r#"<% for a in v { if a > b { break; } %><%= a %> <% } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"b" : 3, "v" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "1 2 3 ".to_string());
+}
+
+#[test]
+fn test_nested_break() {
+  let template =
+    r#"<% for a in v { for b in v { if a * b > 10 { break; } %><%= a * b %> <% } } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"v" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "1 2 3 4 5 2 4 6 8 10 3 6 9 4 8 5 10 ".to_string());
+}
+
+#[test]
+fn test_continue() {
+  let template = r#"<% for a in v { if a == b { continue; } %><%= a %> <% } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"b" : 3, "v" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "1 2 4 5 ".to_string());
+}
+
+#[test]
+fn test_nested_continue() {
+  let template = r#"<% for a in v { for b in v { if a == b { continue; } %><%= b %><% } if a == 2 { continue } } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"v" : [1,2,3,4,5]}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "23451345124512351234".to_string());
+}
+
+#[test]
+fn test_function() {
+  let template = r#"<%= func(a, b) %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : 10, "b" : 20}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let mut functions = HashMap::new();
+  functions.insert(
+    "func".to_string(),
+    FunctionContainer::F2(Box::new(|a: Operand, b: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      let b = match b {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      Operand::Value(Value::from(a + b))
+    })),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "30".to_string());
+}
+
+#[test]
+fn test_function_complex() {
+  // (12 + 10 * 20 - 2 + 1 + 3) * 2
+  let template = r#"<%= func(func(2, a), func(1+func2(a, b, 2), 3)) * 2 %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : 10, "b" : 20}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let mut functions = HashMap::new();
+  functions.insert(
+    "func".to_string(),
+    FunctionContainer::F2(Box::new(|a: Operand, b: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      let b = match b {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      Operand::Value(Value::from(a + b))
+    })),
+  );
+
+  functions.insert(
+    "func2".to_string(),
+    FunctionContainer::F3(Box::new(|a: Operand, b: Operand, c: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      let b = match b {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      let c = match c {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      Operand::Value(Value::from(a * b - c))
+    })),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "428".to_string());
+}
+
+#[test]
+fn test_function_with_statements() {
+  let template =
+    r#"<%= while func(a, b) < 10 { a = a + 1; %>(<%= a %>, <%= b %>) <% b = b + 1 } %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : 1, "b" : 2}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let mut functions = HashMap::new();
+  functions.insert(
+    "func".to_string(),
+    FunctionContainer::F2(Box::new(|a: Operand, b: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      let b = match b {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      Operand::Value(Value::from(a + b))
+    })),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "(2, 2) (3, 3) (4, 4) (5, 5) ".to_string());
+}
+
+#[test]
+fn test_function_taking_object() {
+  let template = r#"<%- func(a) %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_value: Value = json!({"a" : {"b" : 1, "c" : 2}});
+  let mut context = Context::new(context_value);
+
+  let mut functions = HashMap::new();
+  functions.insert(
+    "func".to_string(),
+    FunctionContainer::F1(Box::new(|a: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v,
+        _ => panic!(""),
+      };
+
+      Operand::Value(Value::String(a.to_string()))
+    })),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, r#"{"b":1,"c":2}"#.to_string());
+}
+
+#[test]
+fn test_predefined_include_function() {
+  let template = r#"<%- include(a) %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : "./tests/test_include.html"}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let functions = HashMap::new();
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, "<html>test include</html>\n".to_string());
+}
+
+#[test]
+fn test_predefined_include_template_function() {
+  let template = r#"<%- include_template(a) %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : "some_template", "title" : "TITLE"}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let functions = HashMap::new();
+  let mut templates = HashMap::new();
+
+  // Register "some_template". This will be loaded from include_template function.
+  let some_template = "<html><%= title %></html>".to_string();
+  templates.insert(
+    "some_template".to_string(),
+    (
+      Executer::new(Parser::parse(&some_template).unwrap()).unwrap(),
+      some_template,
+    ),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &templates,
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+
+  assert_eq!(result, "<html>TITLE</html>".to_string());
+}
+
+#[test]
+fn test_accessor() {
+  let template = r#"<%= 10000 + a[x][y + "c"][z] - 3%>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+  let context_json = r#"{"a" : { "b" : { "cc" : { "1" : 1234}}}, "x" : "b", "y" : "c", "z" : 1}"#;
+
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "11231".to_string());
+}
+
+#[test]
+fn test_accessor_and_function() {
+  let template = r#"<%= a[x][func2(y, "c")+"d"][func(z)] %>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+
+  let context_json = r#"{"a" : { "b" : { "ccd" : { "2" : 1234}}}, "x" : "b", "y" : "c", "z" : 1}"#;
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let mut functions = HashMap::new();
+  functions.insert(
+    "func2".to_string(),
+    FunctionContainer::F2(Box::new(|a: Operand, b: Operand| -> Operand {
+      let mut a = match a {
+        Operand::Value(v) => v.as_str().unwrap().to_string(),
+        _ => String::new(),
+      };
+
+      let b = match b {
+        Operand::Value(v) => v.as_str().unwrap().to_string(),
+        _ => String::new(),
+      };
+
+      a.push_str(&b);
+      Operand::Value(Value::from(a))
+    })),
+  );
+
+  functions.insert(
+    "func".to_string(),
+    FunctionContainer::F1(Box::new(|a: Operand| -> Operand {
+      let a = match a {
+        Operand::Value(v) => v.as_i64().unwrap(),
+        _ => 0,
+      };
+
+      Operand::Value(Value::from(a + 1))
+    })),
+  );
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &functions,
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "1234".to_string());
+}
+
+#[test]
+fn test_accessor_with_dot() {
+  let template = r#"<%= 10000 + a[x].cc[z] - 3%>"#;
+  let mut includes = Mutex::new(HashMap::new());
+  let executer = Executer::new(Parser::parse(template).unwrap()).unwrap();
+  let context_json = r#"{"a" : { "b" : { "cc" : { "1" : 1234}}}, "x" : "b", "y" : "c", "z" : 1}"#;
+
+  let context_value: Value = serde_json::from_str(context_json).unwrap();
+  let mut context = Context::new(context_value);
+
+  let result = executer
+    .render(
+      &mut context,
+      &HashMap::new(),
+      &HashMap::new(),
+      template,
+      &mut includes,
+    )
+    .unwrap();
+  assert_eq!(result, "11231".to_string());
+}

--- a/crates/rspack_dojang/src/exec.rs
+++ b/crates/rspack_dojang/src/exec.rs
@@ -58,7 +58,7 @@ impl Executer {
     // Every '{' for loops (for, while). This will be used by break and continue.
     let mut loop_opened = Vec::new();
 
-    // Mapping bewteen location of break/continue to the corresponding loop.
+    // Mapping between location of break/continue to the corresponding loop.
     let mut break_and_continue_pos = HashMap::new();
 
     while inst_index < insts.len() {

--- a/crates/rspack_dojang/src/expr.rs
+++ b/crates/rspack_dojang/src/expr.rs
@@ -1,0 +1,1150 @@
+use serde_json::Value;
+
+use crate::dojang::DojangOptions;
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Op {
+  Not,          // !
+  Or,           // ||
+  And,          // &&
+  ParenOpen,    // (
+  ParenClose,   // )
+  BracketOpen,  // [
+  BracketClose, // ]
+  Equal,        // ==
+  NotEqual,     // !=
+  Less,         // <
+  LessEq,       // <=
+  Greater,      // >
+  GreaterEq,    // >=,
+  Assign,       // =
+  Plus,         // +
+  Minus,        // -
+  Multiply,     // *
+  Divide,       // /
+  Comma,        // ,
+  Dot,          // .
+  Operand(Operand),
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Keyword {
+  In,
+  Continue,
+  Break,
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum Operand {
+  Value(Value),
+  Array(Vec<Operand>),
+  Object(Object),
+  Keyword(Keyword),
+  Function(String),
+}
+
+// Name that will be found in the execution context.
+#[derive(PartialEq, Debug, Clone)]
+pub struct Object {
+  pub name: String,
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Tokens {
+  pub ops: Vec<Op>,
+}
+
+#[derive(PartialEq, Debug)]
+pub enum Action<T> {
+  Show(Show<T>),
+  If(T),    // If condition
+  While(T), // Loop condition
+  For(T),   // For condition
+  Else(),   // Else
+  End(),    // Closing }
+  Do(T),
+}
+
+impl Action<Tokens> {
+  pub fn add_op(&mut self, op: Op) {
+    match self {
+      Action::Show(show) => match show {
+        Show::ExprEscaped(e) => e.ops.push(op),
+        Show::ExprUnescaped(e) => e.ops.push(op),
+        _ => panic!("Cannot add op to Show; op {op:?}"),
+      },
+      Action::If(expr) => {
+        expr.ops.push(op);
+      }
+      Action::While(expr) => {
+        expr.ops.push(op);
+      }
+      Action::For(expr) => {
+        expr.ops.push(op);
+      }
+      Action::Do(expr) => {
+        expr.ops.push(op);
+      }
+      _ => panic!("Cannot add op to {self:?}; op {op:?}"),
+    }
+  }
+}
+
+#[derive(PartialEq, Debug)]
+pub enum Show<T> {
+  Html { start: usize, end: usize }, // [start, end) of the original template.
+  ExprEscaped(T),
+  ExprUnescaped(T),
+}
+
+#[derive(PartialEq, Debug)]
+pub struct Parser {
+  pub parse_tree: Vec<Action<Tokens>>,
+}
+
+impl Parser {
+  pub fn parse(template: &str) -> Result<Self, String> {
+    Parser::parse_with_options(template, DojangOptions::default())
+  }
+  pub fn parse_with_options(mut template: &str, options: DojangOptions) -> Result<Self, String> {
+    let mut parse_tree = Vec::new();
+
+    let mut index_offset = 0;
+    while !template.is_empty() {
+      match template.find("<%") {
+        Some(tag_start) => {
+          let before_tag = &template[..tag_start];
+          if !before_tag.is_empty() {
+            parse_tree.push(Action::Show(Show::Html {
+              start: index_offset,
+              end: index_offset + tag_start,
+            }));
+          }
+
+          let after_tag = &template[tag_start + 2..];
+          index_offset += tag_start + 2;
+
+          match after_tag.find("%>") {
+            Some(tag_end) => {
+              //let escape = options.escape.as_str();
+              let escape = options.escape.as_str();
+              let unescape = options.unescape.as_str();
+
+              let tag_to_parse = match &template[tag_start + 2..tag_start + 3] {
+                str if str == escape => {
+                  parse_tree.push(Action::Show(Show::ExprEscaped(Tokens { ops: Vec::new() })));
+                  &after_tag[1..tag_end]
+                }
+                str if str == unescape => {
+                  parse_tree.push(Action::Show(Show::ExprUnescaped(Tokens {
+                    ops: Vec::new(),
+                  })));
+                  &after_tag[1..tag_end]
+                }
+                "#" => {
+                  // Ignore the comment.
+                  template = &after_tag[tag_end + 2..];
+                  index_offset += tag_end + 2;
+                  continue;
+                }
+                "%" => {
+                  // Show '%'.
+                  parse_tree.push(Action::Show(Show::Html {
+                    start: tag_start + 2,
+                    end: tag_start + 3,
+                  }));
+
+                  template = &after_tag[tag_end + 2..];
+                  index_offset += tag_end + 2;
+                  continue;
+                }
+                _ => {
+                  parse_tree.push(Action::Do(Tokens { ops: Vec::new() }));
+                  &after_tag[..tag_end]
+                }
+              };
+
+              Parser::parse_tag(tag_to_parse, &mut parse_tree)?;
+              template = &after_tag[tag_end + 2..];
+              index_offset += tag_end + 2;
+            }
+            _ => {
+              return Err("Unmatched %> tag found".to_string());
+            }
+          }
+        }
+        _ => {
+          parse_tree.push(Action::Show(Show::Html {
+            start: index_offset,
+            end: index_offset + template.len(),
+          }));
+          break;
+        }
+      }
+    }
+
+    Ok(Parser { parse_tree })
+  }
+
+  fn parse_tag(template: &str, parse_tree: &mut Vec<Action<Tokens>>) -> Result<(), String> {
+    let mut current = 0;
+    let mut token_begin = 0;
+
+    while current < template.len() {
+      let current_char = template.chars().nth(current).unwrap();
+
+      // Check string literal.
+      if current_char == '"' || current_char == '\'' {
+        match Parser::handle_string_literal(template, current, parse_tree) {
+          Ok(end_of_literal) => {
+            current = end_of_literal;
+            token_begin = current;
+            continue;
+          }
+          Err(e) => return Err(e),
+        }
+      }
+
+      // Handle Operators.
+      if template[current..current + 1]
+        .find(
+          &[
+            '&', '|', '(', ')', '!', '=', '<', '>', '+', '-', '*', '/', ',', '[', ']', '.',
+          ][..],
+        )
+        .is_some()
+      {
+        Parser::handle_operand(&template[token_begin..current], parse_tree);
+
+        match Parser::handle_operator(template, current, parse_tree.last_mut().unwrap()) {
+          Ok(end_of_op) => {
+            current = end_of_op;
+            token_begin = current;
+            continue;
+          }
+          Err(e) => return Err(e),
+        }
+      }
+
+      if current_char == ' ' {
+        let token = &template[token_begin..current];
+        Parser::handle_token(token, parse_tree);
+
+        token_begin = current + 1;
+      } else if current_char == '{' {
+        Parser::handle_token(&template[token_begin..current], parse_tree);
+        parse_tree.push(Action::Do(Tokens { ops: Vec::new() }));
+        token_begin = current + 1;
+      } else if current_char == '}' {
+        Parser::handle_token(&template[token_begin..current], parse_tree);
+        parse_tree.push(Action::End());
+        token_begin = current + 1;
+      } else if current_char == ';' {
+        Parser::handle_token(&template[token_begin..current], parse_tree);
+        match parse_tree.pop().unwrap() {
+          Action::Do(expr) => {
+            parse_tree.push(Action::Do(expr));
+            parse_tree.push(Action::Do(Tokens { ops: Vec::new() }));
+          }
+          Action::Show(show) => match show {
+            Show::Html { start: _, end: _ } => {
+              panic!("Show should not contain html");
+            }
+            Show::ExprUnescaped(expr) => {
+              // For <%= ... %> tags, only the last expression will be shown.
+              // In other words, <%= a; b %> is identical to <%= b %>
+              parse_tree.push(Action::Do(expr));
+              parse_tree.push(Action::Show(Show::ExprUnescaped(Tokens {
+                ops: Vec::new(),
+              })))
+            }
+            Show::ExprEscaped(expr) => {
+              parse_tree.push(Action::Do(expr));
+              parse_tree.push(Action::Show(Show::ExprEscaped(Tokens { ops: Vec::new() })))
+            }
+          },
+          _ => return Err(format!("Invalid position of ; at {template}")),
+        }
+        token_begin = current + 1;
+      }
+
+      current += 1;
+    }
+
+    Parser::handle_token(&template[token_begin..template.len()], parse_tree);
+    Ok(())
+  }
+
+  // Returns the next of the end of the string literal.
+  fn handle_string_literal(
+    template: &str,
+    start: usize,
+    parse_tree: &mut [Action<Tokens>],
+  ) -> Result<usize, String> {
+    let starting_quote = template.chars().nth(start).unwrap();
+    assert!(starting_quote == '"' || starting_quote == '\'');
+    let string_literal_end;
+
+    // Read until closing " is found.
+    let mut find_end_quote_start = start + 1;
+    loop {
+      match template[find_end_quote_start..].find(starting_quote) {
+        Some(end_quote_pos) => {
+          if end_quote_pos == 0
+            || template[find_end_quote_start..]
+              .chars()
+              .nth(end_quote_pos - 1)
+              .unwrap()
+              != '\\'
+          {
+            string_literal_end = find_end_quote_start + end_quote_pos;
+            break;
+          } else {
+            find_end_quote_start += end_quote_pos + 1;
+          }
+        }
+        _ => {
+          return Err(format!(
+            "template '{template}' does not have terminated {starting_quote} for string."
+          ));
+        }
+      }
+    }
+
+    parse_tree
+      .last_mut()
+      .unwrap()
+      .add_op(Op::Operand(Operand::Value(Value::from(
+        template[start + 1..string_literal_end].to_string(),
+      ))));
+
+    Ok(string_literal_end + 1)
+  }
+
+  fn handle_operator(
+    template: &str,
+    start: usize,
+    action: &mut Action<Tokens>,
+  ) -> Result<usize, String> {
+    // Check for the binary operators.
+    if template.len() >= start + 2
+      && let Some(op) = check_2_char_op(&template[start..start + 2])
+    {
+      action.add_op(op);
+      return Ok(start + 2);
+    }
+
+    // Check for the unary operators.
+    match template.chars().nth(start).unwrap() {
+      '!' => action.add_op(Op::Not),
+      '(' => action.add_op(Op::ParenOpen),
+      ')' => action.add_op(Op::ParenClose),
+      '[' => action.add_op(Op::BracketOpen),
+      ']' => action.add_op(Op::BracketClose),
+      '<' => action.add_op(Op::Less),
+      '>' => action.add_op(Op::Greater),
+      '=' => action.add_op(Op::Assign),
+      '+' => action.add_op(Op::Plus),
+      '-' => action.add_op(Op::Minus),
+      '*' => action.add_op(Op::Multiply),
+      '/' => action.add_op(Op::Divide),
+      ',' => action.add_op(Op::Comma),
+      '.' => action.add_op(Op::Dot),
+      c => {
+        return Err(format!("Unknown operator at '{template}', unknown : {c}"));
+      }
+    }
+
+    Ok(start + 1)
+  }
+
+  fn handle_token(token: &str, parse_tree: &mut Vec<Action<Tokens>>) {
+    if token == "if" {
+      parse_tree.push(Action::If(Tokens { ops: Vec::new() }));
+    } else if token == "while" {
+      parse_tree.push(Action::While(Tokens { ops: Vec::new() }));
+    } else if token == "for" {
+      parse_tree.push(Action::For(Tokens { ops: Vec::new() }));
+    } else if token == "else" {
+      parse_tree.push(Action::Else());
+    } else {
+      Parser::handle_operand(token, parse_tree);
+    }
+  }
+
+  fn handle_operand(mut operand: &str, parse_tree: &mut Vec<Action<Tokens>>) {
+    if operand.is_empty() {
+      return;
+    }
+
+    operand = operand.trim();
+
+    if let Action::End() = parse_tree.last().unwrap() {
+      parse_tree.push(Action::Do(Tokens { ops: Vec::new() }));
+    }
+
+    let action = parse_tree.last_mut().unwrap();
+
+    let first_char = operand.chars().nth(0).unwrap();
+    if first_char.is_ascii_digit() {
+      if operand.contains('.') {
+        action.add_op(Op::Operand(Operand::Value(Value::from(
+          operand.parse().unwrap_or(0.0),
+        ))));
+      } else {
+        action.add_op(Op::Operand(Operand::Value(Value::from(
+          operand.parse().unwrap_or(0),
+        ))));
+      }
+    } else {
+      match operand {
+        "in" => {
+          action.add_op(Op::Operand(Operand::Keyword(Keyword::In)));
+        }
+        "break" => {
+          action.add_op(Op::Operand(Operand::Keyword(Keyword::Break)));
+        }
+        "continue" => {
+          action.add_op(Op::Operand(Operand::Keyword(Keyword::Continue)));
+        }
+        _ => action.add_op(Op::Operand(Operand::Object(Object {
+          name: operand.to_string(),
+        }))),
+      }
+    }
+  }
+}
+
+fn check_2_char_op(s: &str) -> Option<Op> {
+  if s.len() != 2 {
+    return None;
+  }
+
+  if s == "&&" {
+    return Some(Op::And);
+  } else if s == "||" {
+    return Some(Op::Or);
+  } else if s == "==" {
+    return Some(Op::Equal);
+  } else if s == "!=" {
+    return Some(Op::NotEqual);
+  } else if s == "<=" {
+    return Some(Op::LessEq);
+  } else if s == ">=" {
+    return Some(Op::GreaterEq);
+  }
+
+  None
+}
+
+// Returns the operator priority; Lower number == Higher priority.
+// Used the precedance table at
+//   https://en.cppreference.com/w/c/language/operator_precedence.
+pub fn operator_priority(op: &Op) -> u32 {
+  match op {
+    Op::Not => 2,
+    Op::Multiply => 3,
+    Op::Divide => 3,
+    Op::Plus => 4,
+    Op::Minus => 4,
+    Op::Greater => 6,
+    Op::GreaterEq => 6,
+    Op::Less => 6,
+    Op::LessEq => 6,
+    Op::Equal => 7,
+    Op::NotEqual => 7,
+    Op::And => 11,
+    Op::Or => 12,
+    Op::Assign => 14,
+    Op::BracketOpen => 100,
+    Op::BracketClose => 100,
+    Op::ParenOpen => 100,
+    Op::ParenClose => 100,
+    _ => panic!("Oops {op:?}"),
+  }
+}
+
+pub fn operator_num_operands(op: &Op) -> usize {
+  match op {
+    Op::Not => 1,
+    _ => 2,
+  }
+}
+
+pub fn get_nth_element_from_operand(operand: &Operand, index: usize) -> Option<Value> {
+  match operand {
+    Operand::Value(value) => {
+      if value.is_array() {
+        let arr = value.as_array().unwrap();
+        if index >= arr.len() {
+          return None;
+        }
+
+        return Some(arr[index].clone());
+      } else if value.is_string() {
+        let s = value.as_str().unwrap();
+        if index >= s.len() {
+          return None;
+        }
+
+        return Some(Value::from(s.chars().nth(index).unwrap().to_string()));
+      }
+
+      return None;
+    }
+    Operand::Array(arr) => {
+      if index >= arr.len() {
+        return None;
+      }
+
+      match &arr[index] {
+        Operand::Value(value) => {
+          return Some(value.clone());
+        }
+        _ => {
+          return None;
+        }
+      }
+    }
+    _ => {}
+  }
+
+  None
+}
+
+pub fn convert_value_to_operand(value: Value) -> Operand {
+  match value {
+    Value::Object(obj) => Operand::Value(Value::Object(obj)),
+    Value::Array(arr) => {
+      let mut vec = Vec::new();
+      for elem in arr {
+        vec.push(Operand::Value(elem));
+      }
+      Operand::Array(vec)
+    }
+    v => Operand::Value(v),
+  }
+}
+
+pub fn convert_operand_to_value(operand: Operand) -> Value {
+  match operand {
+    Operand::Value(v) => v,
+    Operand::Array(arr) => {
+      let mut vec = Vec::new();
+      for elem in arr {
+        vec.push(convert_operand_to_value(elem));
+      }
+      Value::from(vec)
+    }
+    _ => {
+      panic!("Unable to convert object to value.")
+    }
+  }
+}
+
+#[test]
+fn parse_simple_expr_with_binary() {
+  let result = Parser::parse("<% some == 3 %>");
+
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "some".to_string(),
+        })),
+        Op::Equal,
+        Op::Operand(Operand::Value(Value::from(3))),
+      ],
+    })],
+  };
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_simple_expr_with_unary() {
+  let result = Parser::parse("<% !some_value %>");
+
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Not,
+        Op::Operand(Operand::Object(Object {
+          name: "some_value".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_complex_binary_and_unary() {
+  let result = Parser::parse("<% (a + b * c - e / d) * f %>");
+
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::ParenOpen,
+        Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        })),
+        Op::Plus,
+        Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        })),
+        Op::Multiply,
+        Op::Operand(Operand::Object(Object {
+          name: "c".to_string(),
+        })),
+        Op::Minus,
+        Op::Operand(Operand::Object(Object {
+          name: "e".to_string(),
+        })),
+        Op::Divide,
+        Op::Operand(Operand::Object(Object {
+          name: "d".to_string(),
+        })),
+        Op::ParenClose,
+        Op::Multiply,
+        Op::Operand(Operand::Object(Object {
+          name: "f".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_simple_literal() {
+  let result = Parser::parse(r#"<% some_value == "abc" %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "some_value".to_string(),
+        })),
+        Op::Equal,
+        Op::Operand(Operand::Value(Value::from("abc".to_string()))),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_simple_literal_single_quote() {
+  let result = Parser::parse(r#"<% some_value == 'a"bc' %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "some_value".to_string(),
+        })),
+        Op::Equal,
+        Op::Operand(Operand::Value(Value::from("a\"bc".to_string()))),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+#[test]
+fn parse_literal_with_escape() {
+  let result = Parser::parse(r#"<% some_value == "a\"bc" abc %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "some_value".to_string(),
+        })),
+        Op::Equal,
+        Op::Operand(Operand::Value(Value::from("a\\\"bc".to_string()))),
+        Op::Operand(Operand::Object(Object {
+          name: "abc".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_complex_expr() {
+  let result = Parser::parse("<% !some_value && ((var1 != var2) || some <= val) %>");
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Not,
+        Op::Operand(Operand::Object(Object {
+          name: "some_value".to_string(),
+        })),
+        Op::And,
+        Op::ParenOpen,
+        Op::ParenOpen,
+        Op::Operand(Operand::Object(Object {
+          name: "var1".to_string(),
+        })),
+        Op::NotEqual,
+        Op::Operand(Operand::Object(Object {
+          name: "var2".to_string(),
+        })),
+        Op::ParenClose,
+        Op::Or,
+        Op::Operand(Operand::Object(Object {
+          name: "some".to_string(),
+        })),
+        Op::LessEq,
+        Op::Operand(Operand::Object(Object {
+          name: "val".to_string(),
+        })),
+        Op::ParenClose,
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_complex_expr2() {
+  let result = Parser::parse(r"<% var1 >= var2 && var2 <= var3 || !var3  %>");
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "var1".to_string(),
+        })),
+        Op::GreaterEq,
+        Op::Operand(Operand::Object(Object {
+          name: "var2".to_string(),
+        })),
+        Op::And,
+        Op::Operand(Operand::Object(Object {
+          name: "var2".to_string(),
+        })),
+        Op::LessEq,
+        Op::Operand(Operand::Object(Object {
+          name: "var3".to_string(),
+        })),
+        Op::Or,
+        Op::Not,
+        Op::Operand(Operand::Object(Object {
+          name: "var3".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_if_statement() {
+  let result = Parser::parse(r#"<% if var1 >= var2 && var3 < "}" { "hello" } %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+          Op::GreaterEq,
+          Op::Operand(Operand::Object(Object {
+            name: "var2".to_string(),
+          })),
+          Op::And,
+          Op::Operand(Operand::Object(Object {
+            name: "var3".to_string(),
+          })),
+          Op::Less,
+          Op::Operand(Operand::Value(Value::from("}".to_string()))),
+        ],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from(
+          "hello".to_string(),
+        )))],
+      }),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_multiple_if_statement() {
+  let result = Parser::parse(r#"<% if var1>=var2{if var2>var3{} if !var1 {}} %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+          Op::GreaterEq,
+          Op::Operand(Operand::Object(Object {
+            name: "var2".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var2".to_string(),
+          })),
+          Op::Greater,
+          Op::Operand(Operand::Object(Object {
+            name: "var3".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::End(),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Not,
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::End(),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_if_else_statement() {
+  let result = Parser::parse(r#"<% if var1>=var2{ "b" } else if var1==3{"a"}else{"c"}%>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+          Op::GreaterEq,
+          Op::Operand(Operand::Object(Object {
+            name: "var2".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from("b".to_string())))],
+      }),
+      Action::End(),
+      Action::Else(),
+      Action::If(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+          Op::Equal,
+          Op::Operand(Operand::Value(Value::from(3))),
+        ],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from("a".to_string())))],
+      }),
+      Action::End(),
+      Action::Else(),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from("c".to_string())))],
+      }),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_while_statement() {
+  let result = Parser::parse(r#"<% while var1 >= var2{ "hello"} %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Do(Tokens { ops: vec![] }),
+      Action::While(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "var1".to_string(),
+          })),
+          Op::GreaterEq,
+          Op::Operand(Operand::Object(Object {
+            name: "var2".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from(
+          "hello".to_string(),
+        )))],
+      }),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_for_statement() {
+  let result = Parser::parse(r#"<% for a in vec{ "hello"} %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Do(Tokens { ops: vec![] }),
+      Action::For(Tokens {
+        ops: vec![
+          Op::Operand(Operand::Object(Object {
+            name: "a".to_string(),
+          })),
+          Op::Operand(Operand::Keyword(Keyword::In)),
+          Op::Operand(Operand::Object(Object {
+            name: "vec".to_string(),
+          })),
+        ],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Value(Value::from(
+          "hello".to_string(),
+        )))],
+      }),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_function() {
+  let result = Parser::parse(r#"<% func(1+1, a, b) + x %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "func".to_string(),
+        })),
+        Op::ParenOpen,
+        Op::Operand(Operand::Value(Value::from(1))),
+        Op::Plus,
+        Op::Operand(Operand::Value(Value::from(1))),
+        Op::Comma,
+        Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        })),
+        Op::Comma,
+        Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        })),
+        Op::ParenClose,
+        Op::Plus,
+        Op::Operand(Operand::Object(Object {
+          name: "x".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_braket() {
+  let result = Parser::parse(r#"<% func(a[1][2]) + x %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Object(Object {
+          name: "func".to_string(),
+        })),
+        Op::ParenOpen,
+        Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        })),
+        Op::BracketOpen,
+        Op::Operand(Operand::Value(Value::from(1))),
+        Op::BracketClose,
+        Op::BracketOpen,
+        Op::Operand(Operand::Value(Value::from(2))),
+        Op::BracketClose,
+        Op::ParenClose,
+        Op::Plus,
+        Op::Operand(Operand::Object(Object {
+          name: "x".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_property_accessor() {
+  let result = Parser::parse(r#"<% 1 + a.b[123].c %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![Action::Do(Tokens {
+      ops: vec![
+        Op::Operand(Operand::Value(Value::from(1))),
+        Op::Plus,
+        Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        })),
+        Op::Dot,
+        Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        })),
+        Op::BracketOpen,
+        Op::Operand(Operand::Value(Value::from(123))),
+        Op::BracketClose,
+        Op::Dot,
+        Op::Operand(Operand::Object(Object {
+          name: "c".to_string(),
+        })),
+      ],
+    })],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_tags_simple() {
+  let template = r#"<html><% if a { %>some tag<% } %><body></body></html>"#;
+  let result = Parser::parse(template);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Show(Show::Html { start: 0, end: 6 }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        }))],
+      }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::Show(Show::Html { start: 18, end: 26 }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::End(),
+      Action::Show(Show::Html { start: 33, end: 53 }),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+  assert_eq!(&template[18..26], "some tag");
+  assert_eq!(&template[33..53], "<body></body></html>");
+}
+
+#[test]
+fn parse_tags_escaped() {
+  let result = Parser::parse(r#"<html><% if a { %><%= data %><% } %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Show(Show::Html { start: 0, end: 6 }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::If(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        }))],
+      }),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::Show(Show::ExprEscaped(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "data".to_string(),
+        }))],
+      })),
+      Action::Do(Tokens { ops: vec![] }),
+      Action::End(),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_multipe_expressions() {
+  let result = Parser::parse(r#"<html><% a; b; c %><%= a; b %><%- a; b  %>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Show(Show::Html { start: 0, end: 6 }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        }))],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        }))],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "c".to_string(),
+        }))],
+      }),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        }))],
+      }),
+      Action::Show(Show::ExprEscaped(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        }))],
+      })),
+      Action::Do(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "a".to_string(),
+        }))],
+      }),
+      Action::Show(Show::ExprUnescaped(Tokens {
+        ops: vec![Op::Operand(Operand::Object(Object {
+          name: "b".to_string(),
+        }))],
+      })),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_ignore_comment() {
+  let result = Parser::parse(r#"<html><%# some comment %></html>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Show(Show::Html { start: 0, end: 6 }),
+      Action::Show(Show::Html { start: 25, end: 32 }),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}
+
+#[test]
+fn parse_percent_tag() {
+  let result = Parser::parse(r#"<html><%% %></html>"#);
+  let expected_expr = Parser {
+    parse_tree: vec![
+      Action::Show(Show::Html { start: 0, end: 6 }),
+      Action::Show(Show::Html { start: 8, end: 9 }),
+      Action::Show(Show::Html { start: 12, end: 19 }),
+    ],
+  };
+
+  assert_eq!(result.unwrap(), expected_expr);
+}

--- a/crates/rspack_dojang/src/expr.rs
+++ b/crates/rspack_dojang/src/expr.rs
@@ -438,7 +438,7 @@ fn check_2_char_op(s: &str) -> Option<Op> {
 }
 
 // Returns the operator priority; Lower number == Higher priority.
-// Used the precedance table at
+// Used the precedence table at
 //   https://en.cppreference.com/w/c/language/operator_precedence.
 pub fn operator_priority(op: &Op) -> u32 {
   match op {
@@ -964,7 +964,7 @@ fn parse_function() {
 }
 
 #[test]
-fn parse_braket() {
+fn parse_bracket() {
   let result = Parser::parse(r#"<% func(a[1][2]) + x %>"#);
   let expected_expr = Parser {
     parse_tree: vec![Action::Do(Tokens {
@@ -1076,7 +1076,7 @@ fn parse_tags_escaped() {
 }
 
 #[test]
-fn parse_multipe_expressions() {
+fn parse_multiple_expressions() {
   let result = Parser::parse(r#"<html><% a; b; c %><%= a; b %><%- a; b  %>"#);
   let expected_expr = Parser {
     parse_tree: vec![

--- a/crates/rspack_dojang/src/func_helper.rs
+++ b/crates/rspack_dojang/src/func_helper.rs
@@ -1,0 +1,89 @@
+// List of traits needed for wrapping regular functions to FunctionContainer.
+
+use serde_json::Value;
+
+use crate::expr::*;
+
+impl From<Operand> for bool {
+  fn from(op: Operand) -> Self {
+    if let Operand::Value(val) = op
+      && val.is_boolean()
+    {
+      return val.as_bool().unwrap();
+    }
+    false
+  }
+}
+
+impl From<bool> for Operand {
+  fn from(b: bool) -> Self {
+    Operand::Value(Value::from(b))
+  }
+}
+
+impl From<Operand> for i64 {
+  fn from(op: Operand) -> Self {
+    if let Operand::Value(val) = op
+      && val.is_i64()
+    {
+      return val.as_i64().unwrap();
+    }
+    0
+  }
+}
+
+impl From<i64> for Operand {
+  fn from(n: i64) -> Self {
+    Operand::Value(Value::from(n))
+  }
+}
+
+impl From<Operand> for f64 {
+  fn from(op: Operand) -> Self {
+    if let Operand::Value(val) = op
+      && val.is_f64()
+    {
+      return val.as_f64().unwrap();
+    }
+    0.
+  }
+}
+
+impl From<f64> for Operand {
+  fn from(n: f64) -> Self {
+    Operand::Value(Value::from(n))
+  }
+}
+
+impl From<Operand> for String {
+  fn from(op: Operand) -> Self {
+    if let Operand::Value(val) = op
+      && val.is_string()
+    {
+      return val.as_str().unwrap().to_string();
+    }
+    String::new()
+  }
+}
+
+impl From<String> for Operand {
+  fn from(s: String) -> Self {
+    Operand::Value(Value::from(s))
+  }
+}
+
+impl From<Operand> for Value {
+  fn from(op: Operand) -> Self {
+    if let Operand::Value(val) = op {
+      val
+    } else {
+      Value::Bool(false)
+    }
+  }
+}
+
+impl From<Value> for Operand {
+  fn from(val: Value) -> Self {
+    Operand::Value(val)
+  }
+}

--- a/crates/rspack_dojang/src/lib.rs
+++ b/crates/rspack_dojang/src/lib.rs
@@ -38,7 +38,7 @@
 //! ```
 //!
 //! Those template can be rendered by the either the name of the template file (when registered by
-//! `load`) or the name provided (when reigstered by `add`).
+//! `load`) or the name provided (when registered by `add`).
 //!
 //! To render the template, use `render` method of Dojang. You should provide the name of the
 //! template to render and the context to render. Context is simply a json data. Use serde_json to
@@ -78,7 +78,7 @@
 //! ```
 //!
 //! You have to choose add_function_* based on the number of parameters that the function has. We
-//! provde add_function_1 to add_function_4.
+//! provide add_function_1 to add_function_4.
 //!
 //! Also, the type of the function parameter must be non-reference, and should be one of i64, f64,
 //! u64, String, bool.

--- a/crates/rspack_dojang/src/lib.rs
+++ b/crates/rspack_dojang/src/lib.rs
@@ -1,0 +1,133 @@
+// Author Jaebum Lee (https://modoocode.com)
+//
+// Licensed under MIT license.
+
+// The parser and evaluator validate their internal stacks before accessing them.
+#![allow(clippy::unwrap_used)]
+
+//! Dojang, a EJS inspired HTML template engine.
+//!
+//! Dojang is a html template engine, which aims to be an drop-in replacement for the EJS html
+//! template engine. It follows the syntax of the EJS and follows the javascript syntax within the
+//! template. Dojang also provides the strong integration with Rust.
+//!
+//! Dojang is pronounced as doe-jang, and it means a "stamp" in Korean (도장).
+//!
+//! # Quick Start
+//!
+//! Every template files are parsed once during the construction of the `Dojang` object. `Dojang`
+//! owns and manages every template file provided. To provide the template files to `Dojang`, you
+//! can either specify the directory of the template files using `load` or you can
+//! manually provide the template as string using `add` method.
+//!
+//! ```
+//! use rspack_dojang::dojang::Dojang;
+//!
+//! fn main() {
+//!   let mut dj = Dojang::new();
+//!
+//!   // Load files as template under /template/files/path.
+//!   dj.load("/template/files/path");
+//!
+//!   // Register "template_file.html" which have "<%= data %>" as a template.
+//!   dj.add("template_file.html".to_string(), "<%= data %>".to_string());
+//!
+//!   // "hello" will be rendered.
+//!   assert_eq!(dj.render("template_file.html", serde_json::json!({"data" : "hello"})).unwrap(), "hello");
+//! }
+//! ```
+//!
+//! Those template can be rendered by the either the name of the template file (when registered by
+//! `load`) or the name provided (when reigstered by `add`).
+//!
+//! To render the template, use `render` method of Dojang. You should provide the name of the
+//! template to render and the context to render. Context is simply a json data. Use serde_json to
+//! either construct json data or parse the json string. You can even provide your custom struct if
+//! you define `Serialize` trait of serde.
+//!
+//! # Use Custom Functions
+//!
+//! One powerful feature is that you can use Rust functions inside of the template file. For
+//! example,
+//!
+//! ```
+//! use rspack_dojang::dojang::Dojang;
+//!
+//! fn add(a: i64, b: i64) -> i64 {
+//!   a + b
+//! }
+//!
+//! fn main() {
+//!   let mut dj = Dojang::new();
+//!
+//!   // Register our add function as "add_func". You can call add_func inside of the template now.
+//!   dj.add_function_2("add_func".to_string(), add);
+//!
+//!   dj.add(
+//!     "template_file.html".to_string(),
+//!     "<%= add_func(1, 2) %>".to_string(),
+//!   );
+//!
+//!   // "3" will be rendered.
+//!   assert_eq!(
+//!     dj.render("template_file.html", serde_json::json!({}))
+//!       .unwrap(),
+//!     "3"
+//!   );
+//! }
+//! ```
+//!
+//! You have to choose add_function_* based on the number of parameters that the function has. We
+//! provde add_function_1 to add_function_4.
+//!
+//! Also, the type of the function parameter must be non-reference, and should be one of i64, f64,
+//! u64, String, bool.
+//!
+//! # Supported Javascript syntax.
+//!
+//! Most of the basic Javascript syntax is supported. Still, any complex javascript usage is not
+//! recommended.
+//!
+//! * `if`, `else`, `for .. in`, `else` is supported.
+//!
+//! ```ejs
+//! <% for i in vec1 { %>
+//! <%   if i == 1 { %>
+//!   <p>i is one</p>
+//! <%   } else { <%>
+//!   <p><%= i + 3 %></p>
+//! <%   } %>
+//! <% } %>
+//! ```
+//!
+//! If `vec1` is provided as `[1,2,3]`, then the above will render
+//!
+//! ```html
+//! <p>i is one</p>
+//! <p>5</p>
+//! <p>6</p>
+//! ```
+//!
+//! * `break` and `continue` keywords are supported.
+//! * Property accessing using `.` and `[..]` are supported
+//! * Calling registered function is supported.
+//! * Local variables can be introduced but it does not have a scope (every introduced local
+//!   variables are global). It should be used with care. For example,
+//!
+//! ```ejs
+//! <%# Sets the value of a as 3. %>
+//! <%= a = 3 %>
+//! <% a %><%# This will print 3 %>
+//! ```
+mod context;
+mod default_functions;
+pub mod dojang;
+mod eval;
+mod exec;
+mod expr;
+pub mod func_helper;
+pub use crate::{
+  context::{Context, FunctionContainer},
+  dojang::Dojang,
+  expr::Operand,
+};

--- a/crates/rspack_dojang/tests/test.html
+++ b/crates/rspack_dojang/tests/test.html
@@ -1,0 +1,6 @@
+<html>
+  <%= test.title %>
+  <body>
+    <p>some content</p><% x = 0; while x < 10 { %><p>x is<%= x %></p><% x = x + 1 %><% } %>
+  </body>
+</html>

--- a/crates/rspack_dojang/tests/test_include.html
+++ b/crates/rspack_dojang/tests/test_include.html
@@ -1,0 +1,1 @@
+<html>test include</html>


### PR DESCRIPTION
## Summary

- migrate `rspack_dojang` from `rstackjs/rspack-dojang@5b1b5e7c` into `crates/rspack_dojang`
- align the crate metadata, edition, dependencies, formatting, and lints with the Rspack workspace
- replace the crates.io dependency with the in-workspace path dependency and update `Cargo.lock`
- preserve the original tests, fixtures, documentation, and source attribution

Keeping the template engine next to its two consumers (`rspack_core` and `rspack_plugin_html`) makes fixes and releases easier to coordinate. This migration is not intended to change rendering behavior.

### Validation

- `cargo test -p rspack_dojang --locked` (74 passed)
- `cargo clippy -p rspack_dojang --all-targets --locked -- --deny warnings`
- `cargo check -p rspack_core -p rspack_plugin_html --locked`
- `cargo package -p rspack_dojang --allow-dirty --no-verify --locked`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "builtinCases/plugin-html"` (13 passed)

## Related links

- https://github.com/rstackjs/rspack-dojang
- https://github.com/rstackjs/rspack-dojang/commit/5b1b5e7c8dcd3f78fc36cd24001bafa8722b7e1c

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
