### PR TITLE
docs: align stats hooks docs with implementation

### DIFF
--- a/packages/rspack/src/stats/StatsFactory.ts
+++ b/packages/rspack/src/stats/StatsFactory.ts
@@ -61,7 +61,7 @@ type Hooks = Readonly<{
       undefined
     >
   >;
-  result: HookMap<SyncWaterfallHook<[any[], StatsFactoryContext]>>;
+  result: HookMap<SyncWaterfallHook<[any, StatsFactoryContext]>>;
   merge: HookMap<SyncBailHook<[any[], StatsFactoryContext], undefined>>;
   getItemName: HookMap<
     SyncBailHook<[any, StatsFactoryContext], string | undefined>
@@ -148,7 +148,7 @@ export class StatsFactory {
       ),
       result: new HookMap(
         () =>
-          new SyncWaterfallHook<[any[], StatsFactoryContext]>([
+          new SyncWaterfallHook<[any, StatsFactoryContext]>([
             'result',
             'context',
           ]),

--- a/website/docs/en/api/plugin-api/stats-hooks.mdx
+++ b/website/docs/en/api/plugin-api/stats-hooks.mdx
@@ -8,21 +8,21 @@ description: 'A HookMap, called when generating the specified stats item'
 
 ### StatsFactory.hooks.extract
 
-A HookMap, called when generating the specified stats item.
+A HookMap that is called when generating the specified stats item.
 
 - **Type:** `HookMap<SyncBailHook<[Object, any, StatsFactoryContext], undefined>>`
 - **Arguments:**
-  - `Object`: result stats item object which properties should be added.
-  - `Class`: the original data of the stats item
+  - `object`: result stats item object to which properties should be added
+  - `data`: original data of the stats item
   - `StatsFactoryContext`: generating context
 
 ```ts
+// Only common context fields are listed here. Different stats item types may provide additional fields.
 type StatsFactoryContext = {
   type: string;
-  makePathsRelative?: ((arg0: string) => string) | undefined;
-  compilation?: Compilation | undefined;
-  cachedGetErrors?: ((arg0: Compilation) => JsStatsError[]) | undefined;
-  cachedGetWarnings?: ((arg0: Compilation) => JsStatsWarning[]) | undefined;
+  compilation: Compilation;
+  makePathsRelative?: (value: string) => string;
+  [key: string]: any;
 };
 ```
 
@@ -40,27 +40,26 @@ compilation.hooks.statsFactory.tap('MyPlugin', (statsFactory, options) => {
 
 ### StatsFactory.hooks.result
 
-A HookMap, called after generating the specified stats item.
+A HookMap that is called after generating the specified stats item.
 
-- **Type:** `HookMap<SyncWaterfallHook<[any[], StatsFactoryContext], undefined>>`
+- **Type:** `HookMap<SyncWaterfallHook<[any, StatsFactoryContext]>>`
 - **Arguments:**
-  - `any[]`: generated stats item result
+  - `any`: generated stats item result
   - `StatsFactoryContext`: generating context
 
 ## StatsPrinter
 
 ### StatsPrinter.hooks.print
 
-A HookMap, called
-
-为一个 HookMap, called when generating the printed string of the specified stats item.
+A HookMap that is called when generating the printed string of the specified stats item.
 
 - **Type:** `HookMap<SyncBailHook<[{}, StatsPrinterContext], string>>`
 - **Arguments:**
-  - `Object`: stats item object
+  - `object`: stats item object
   - `StatsPrinterContext`: printing context
 
 ```ts
+// Only common context fields are listed here. Different stats item types may provide additional fields.
 type StatsPrinterContext = {
   type?: string;
   compilation?: StatsCompilation;
@@ -85,14 +84,15 @@ type StatsPrinterContext = {
   formatFlag?: (flag: string) => string;
   formatTime?: (time: number, boldQuantity?: boolean) => string;
   chunkGroupKind?: string;
+  [key: string]: any;
 };
 ```
 
 ### StatsPrinter.hooks.result
 
-A HookMap, called after generating the printed string of the specified stats item.
+A HookMap that is called after generating the printed string of the specified stats item.
 
-- **Type:** `HookMap<SyncBailHook<[{}, StatsPrinterContext], string>>`
+- **Type:** `HookMap<SyncWaterfallHook<[string, StatsPrinterContext]>>`
 - **Arguments:**
-  - `String`: printed string of the stats item
+  - `string`: printed string of the stats item
   - `StatsPrinterContext`: printing context

--- a/website/docs/zh/api/plugin-api/stats-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/stats-hooks.mdx
@@ -12,17 +12,17 @@ description: 'StatsFactory.hooks.extract 是一个 HookMap，在生成指定的 
 
 - **类型：** `HookMap<SyncBailHook<[Object, any, StatsFactoryContext], undefined>>`
 - **参数：**
-  - `Object`：该 stats 项目的结果对象，将属性添加于此对象
-  - `Class`：该 stats 项目对应的原始数据
+  - `object`：该 stats 项目的结果对象，生成的属性会添加到此对象
+  - `data`：该 stats 项目对应的原始数据
   - `StatsFactoryContext`：生成上下文
 
 ```ts
+// 以下仅列出通用的上下文字段；不同类型的 stats 项目可能提供额外字段
 type StatsFactoryContext = {
   type: string;
-  makePathsRelative?: ((arg0: string) => string) | undefined;
-  compilation?: Compilation | undefined;
-  cachedGetErrors?: ((arg0: Compilation) => JsStatsError[]) | undefined;
-  cachedGetWarnings?: ((arg0: Compilation) => JsStatsWarning[]) | undefined;
+  compilation: Compilation;
+  makePathsRelative?: (value: string) => string;
+  [key: string]: any;
 };
 ```
 
@@ -42,9 +42,9 @@ compilation.hooks.statsFactory.tap('MyPlugin', (statsFactory, options) => {
 
 `StatsFactory.hooks.result` 是一个 HookMap，在生成指定 stats 项目后触发。
 
-- **类型：** `HookMap<SyncWaterfallHook<[any[], StatsFactoryContext], undefined>>`
+- **类型：** `HookMap<SyncWaterfallHook<[any, StatsFactoryContext]>>`
 - **参数：**
-  - `any[]`：该 stats 项目的生成结果
+  - `any`：该 stats 项目的生成结果
   - `StatsFactoryContext`：生成上下文
 
 ## StatsPrinter
@@ -55,10 +55,11 @@ compilation.hooks.statsFactory.tap('MyPlugin', (statsFactory, options) => {
 
 - **类型：** `HookMap<SyncBailHook<[{}, StatsPrinterContext], string>>`
 - **参数：**
-  - `Object`：该 stats 项目
+  - `object`：该 stats 项目
   - `StatsPrinterContext`：打印上下文
 
 ```ts
+// 以下仅列出通用的上下文字段；不同类型的 stats 项目可能提供额外字段
 type StatsPrinterContext = {
   type?: string;
   compilation?: StatsCompilation;
@@ -83,6 +84,7 @@ type StatsPrinterContext = {
   formatFlag?: (flag: string) => string;
   formatTime?: (time: number, boldQuantity?: boolean) => string;
   chunkGroupKind?: string;
+  [key: string]: any;
 };
 ```
 
@@ -90,7 +92,7 @@ type StatsPrinterContext = {
 
 `StatsPrinter.hooks.result` 是一个 HookMap，在生成指定的 stats 项目的打印字符串后触发。
 
-- **类型：** `HookMap<SyncBailHook<[{}, StatsPrinterContext], string>>`
+- **类型：** `HookMap<SyncWaterfallHook<[string, StatsPrinterContext]>>`
 - **参数：**
-  - `String`：该 stats 项目打印字符串
+  - `string`：该 stats 项目打印字符串
   - `StatsPrinterContext`：打印上下文


### PR DESCRIPTION
## Summary

This PR corrects the documented `StatsFactory` and `StatsPrinter` hook signatures and context shapes so plugin authors see the values exposed at runtime. It also clarifies hook arguments, removes stray mixed-language text, and keeps the English and Chinese references aligned.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).