### PR TITLE
fix(lazy-compilation): keep activated modules across rebuilds

### DIFF
--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -129,6 +129,10 @@ impl LazyCompilationProxyModule {
   pub fn invalid(&mut self) {
     self.need_build = true;
   }
+
+  pub fn is_active(&self) -> bool {
+    self.active
+  }
 }
 
 impl_empty_diagnosable_trait!(LazyCompilationProxyModule);

--- a/crates/rspack_plugin_lazy_compilation/src/plugin.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/plugin.rs
@@ -255,12 +255,9 @@ async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
       let Some(active_module) = module_graph.module_by_identifier(module_id) else {
         continue;
       };
-      if active_module
-        .downcast_ref::<LazyCompilationProxyModule>()
-        .is_none()
-      {
+      let Some(proxy) = active_module.downcast_ref::<LazyCompilationProxyModule>() else {
         continue;
-      }
+      };
 
       // Drop the proxy only when its sole incoming edge is an entry dep
       // that no longer belongs to any current entry. Any other shape
@@ -283,7 +280,13 @@ async fn compiler_make(&self, compilation: &mut Compilation) -> Result<()> {
         continue;
       }
 
-      to_invalidate.insert(*module_id);
+      // The backend reports every module the client currently keeps alive, so a
+      // proxy that already carries its lazy block needs no rebuild. Rebuilding it
+      // would emit a hot update, which makes the client re-activate and request
+      // another rebuild — an endless loop.
+      if !proxy.is_active() {
+        to_invalidate.insert(*module_id);
+      }
     }
   }
 

--- a/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
+++ b/packages/rspack/src/builtin-plugin/lazy-compilation/middleware.ts
@@ -119,11 +119,10 @@ function applyPlugin(
   activeModules: Set<string>,
 ) {
   const plugin = new BuiltinLazyCompilationPlugin(
-    () => {
-      const res = new Set(activeModules);
-      activeModules.clear();
-      return res;
-    },
+    // Keep the set across compilations. The client re-sends its whole active set
+    // after every HMR apply, so forgetting it here would make each re-send look
+    // like a fresh activation and trigger another rebuild.
+    () => new Set(activeModules),
     options.entries ?? true,
     options.imports ?? true,
     `${options.client || getDefaultClient(compiler)}?${encodeURIComponent(getFullServerUrl(options))}`,

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/index.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@/fixtures';
+
+// Editing any file used to drop the activated state of every lazy proxy, which
+// made the client re-activate them and ask for yet another rebuild.
+// https://github.com/web-infra-dev/rspack/issues/15062
+test('editing an unrelated file must not rebuild activated lazy proxies', async ({
+  page,
+  rspack,
+  fileAction,
+}) => {
+  await page.waitForFunction(
+    () => document.body.dataset.lazy === 'a,b,c,d',
+    null,
+    { timeout: 30000 },
+  );
+  await new Promise((r) => setTimeout(r, 3000));
+
+  let builds = 0;
+  rspack.compiler.hooks.done.tap('e2e-build-counter', () => {
+    builds++;
+  });
+
+  fileAction.updateFile('src/sibling.js', (content) =>
+    content.replace('v1', 'v2'),
+  );
+  await rspack.waitingForBuild();
+  await page.waitForFunction(
+    () => document.body.dataset.sibling === 'v2',
+    null,
+    { timeout: 30000 },
+  );
+
+  const modules: any[] =
+    rspack.compiler._lastCompilation?.getStats().toJson({
+      all: false,
+      modules: true,
+      cachedModules: true,
+    }).modules ?? [];
+  const proxies = modules.filter((m) =>
+    m.identifier?.includes('lazy-compilation-proxy'),
+  );
+
+  expect(proxies.length).toBeGreaterThan(0);
+  expect(proxies.filter((m) => m.built)).toEqual([]);
+
+  await new Promise((r) => setTimeout(r, 3000));
+  expect(builds).toBe(1);
+});

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/rspack.config.js
@@ -1,0 +1,20 @@
+const { rspack } = require('@rspack/core');
+
+/** @type { import('@rspack/core').RspackOptions } */
+module.exports = {
+  context: __dirname,
+  entry: {
+    main: './src/index.js',
+  },
+  mode: 'development',
+  stats: 'none',
+  devtool: false,
+  plugins: [new rspack.HtmlRspackPlugin()],
+  lazyCompilation: {
+    entries: false,
+    imports: true,
+  },
+  devServer: {
+    hot: true,
+  },
+};

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/index.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/index.js
@@ -1,0 +1,12 @@
+import { name } from './sibling.js';
+
+document.body.dataset.sibling = name;
+
+Promise.all([
+  import('./lazy-a.js'),
+  import('./lazy-b.js'),
+  import('./lazy-c.js'),
+  import('./lazy-d.js'),
+]).then((all) => {
+  document.body.dataset.lazy = all.map((m) => m.text).join(',');
+});

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-a.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-a.js
@@ -1,0 +1,1 @@
+export const text = 'a';

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-b.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-b.js
@@ -1,0 +1,1 @@
+export const text = 'b';

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-c.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-c.js
@@ -1,0 +1,1 @@
+export const text = 'c';

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-d.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/lazy-d.js
@@ -1,0 +1,1 @@
+export const text = 'd';

--- a/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/sibling.js
+++ b/tests/e2e/cases/lazy-compilation/hmr-keeps-proxy-active/src/sibling.js
@@ -1,0 +1,1 @@
+export const name = 'v1';

--- a/tests/rspack-test/compilerCases/lazy-compilation-reactivate.js
+++ b/tests/rspack-test/compilerCases/lazy-compilation-reactivate.js
@@ -1,0 +1,130 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { lazyCompilationMiddleware } = require("@rspack/core");
+
+// After an HMR apply the client re-sends its whole active set. Re-reporting a
+// module that is already active must not schedule another rebuild, otherwise
+// activation and HMR keep triggering each other.
+// https://github.com/web-infra-dev/rspack/issues/15062
+
+const SETTLE = 1000;
+
+let root;
+let middleware;
+
+function write(filename, content) {
+	const file = path.join(root, filename);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+function post(moduleId) {
+	return new Promise((resolve, reject) => {
+		middleware(
+			{ body: [moduleId], method: "POST", url: "/_rspack/lazy/trigger" },
+			{
+				end: resolve,
+				write() {},
+				writeHead(status) {
+					expect(status).toBe(200);
+				}
+			},
+			reject
+		).catch(reject);
+	});
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+	{
+		description:
+			"should not rebuild when an already activated module is reported again",
+		options() {
+			root = fs.mkdtempSync(path.join(os.tmpdir(), "rspack-lazy-reactivate-"));
+			write("src/main.js", "import('./dyn.js');\n");
+			write("src/dyn.js", "globalThis.dyn = 'DYN_PAYLOAD';\n");
+
+			return {
+				context: root,
+				mode: "development",
+				target: "web",
+				devtool: false,
+				entry: { main: "./src/main.js" },
+				lazyCompilation: { entries: false, imports: true },
+				output: { filename: "main.js", chunkFilename: "[name].js" },
+				optimization: { minimize: false, moduleIds: "named", chunkIds: "named" }
+			};
+		},
+		compiler(_context, compiler) {
+			middleware = lazyCompilationMiddleware(compiler);
+		},
+		async build(_context, compiler) {
+			const builds = [];
+			const waiters = [];
+			const nextBuild = () =>
+				builds.length > 0
+					? Promise.resolve(builds.shift())
+					: new Promise((resolve, reject) => {
+							const timeout = setTimeout(
+								() => reject(new Error("Timed out waiting for a rebuild")),
+								10000
+							);
+							waiters.push(value => {
+								clearTimeout(timeout);
+								resolve(value);
+							});
+						});
+
+			const watching = compiler.watch({}, (error, stats) => {
+				const value = {
+					error:
+						error ??
+						(stats?.hasErrors()
+							? new Error(stats.toString({ all: false, errors: true }))
+							: undefined),
+					stats
+				};
+				(waiters.shift() ?? (build => builds.push(build)))(value);
+			});
+
+			try {
+				const initial = await nextBuild();
+				expect(initial.error).toBeUndefined();
+
+				const moduleId = [...initial.stats.compilation.modules]
+					.map(module => module.identifier())
+					.find(identifier => identifier.includes("lazy-compilation-proxy"));
+				expect(moduleId).toBeDefined();
+
+				// First activation compiles the module behind the proxy.
+				await post(moduleId);
+				const activated = await nextBuild();
+				expect(activated.error).toBeUndefined();
+				const { compilation } = activated.stats;
+				expect(
+					Object.keys(compilation.assets).some(name =>
+						compilation
+							.getAsset(name)
+							.source.source()
+							.toString()
+							.includes("DYN_PAYLOAD")
+					)
+				).toBe(true);
+
+				// Re-reporting the same module must be a no-op.
+				await post(moduleId);
+				const settled = await Promise.race([
+					nextBuild().then(() => "rebuilt"),
+					new Promise(resolve => setTimeout(() => resolve("idle"), SETTLE))
+				]);
+				expect(settled).toBe("idle");
+			} finally {
+				await new Promise((resolve, reject) =>
+					watching.close(error => (error ? reject(error) : resolve()))
+				);
+				fs.rmSync(root, { force: true, recursive: true });
+			}
+		}
+	}
+];


### PR DESCRIPTION
Closes #15062

## Why

`activeModules` is the server-side record of which lazy proxies the client keeps alive, but it was wiped on every compilation, so the record could never outlive a single rebuild.

The client posts its **whole** active set (not a delta) and re-posts it after each HMR apply, since applying an update disposes the old proxy module and runs the new one. With the set already cleared, every re-post looked like a first-time activation and called `invalidate()` again.

The native side compounded it: `compiler_make` marked **every** reported proxy `need_build`, so already-active proxies were revoked and rebuilt on each compilation, emitting a hot update that pushed the client into re-activating — feeding the next round.

Together they form the `invalidate → rebuild → HMR → re-activate → invalidate` loop reported in the issue, and they also explain the milder symptom without HMR: any ordinary edit produced an empty snapshot, which reset `active_modules` and silently demoted every activated proxy back to inactive.

Before / after, editing one unrelated file with four lazy modules already activated:

| | proxies rebuilt | rebuilds |
| --- | --- | --- |
| before | 4 (all of them) | extra round-trips |
| after | 0 | 1 |

## What

- `middleware.ts` — the snapshot callback no longer clears `activeModules`. The middleware only ever adds to this set, so it is the union of everything the client has activated; keeping it makes a repeated report a no-op instead of a fresh activation.
- `plugin.rs` — only invalidate a reported proxy when it is not active yet. An already-active proxy carries its lazy block and needs no rebuild.

## Tests

- `compilerCases/lazy-compilation-reactivate.js` — posts the same module id twice through the real middleware; the second post must not schedule a rebuild. Fails on `main` with `expected 'rebuilt' to be 'idle'`.
- `e2e/cases/lazy-compilation/hmr-keeps-proxy-active` — with four activated lazy modules, editing an unrelated file must rebuild no proxy and trigger exactly one rebuild. Fails when only the middleware half of the fix is applied.

Verified locally: e2e `lazy-compilation` (24), `Compiler`, `HotWeb`, `HotNode`, `HotSnapshot`, `MultiCompiler`, `Cache`, `Watch`, `Example`, `Incremental-web`, `Builtin`, plus `cargo fmt`/`clippy`.