### PR TITLE
fix(binding): avoid panic when module chunks are unavailable

### DIFF
--- a/crates/rspack_binding_api/src/chunk_graph.rs
+++ b/crates/rspack_binding_api/src/chunk_graph.rs
@@ -165,11 +165,16 @@ impl ChunkGraph {
   #[napi(ts_args_type = "module: Module", ts_return_type = "Chunk[]")]
   pub fn get_module_chunks(&self, module: ModuleObjectRef) -> Result<Vec<ChunkWrapper>> {
     self.with_compilation(|compilation| {
+      let Some(chunks) = compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .try_get_module_chunks(&module.identifier)
+      else {
+        return Ok(vec![]);
+      };
+
       Ok(
-        compilation
-          .build_chunk_graph_artifact
-          .chunk_graph
-          .get_module_chunks(module.identifier)
+        chunks
           .iter()
           .map(|chunk| ChunkWrapper::new(*chunk, compilation))
           .collect(),

--- a/tests/rspack-test/configCases/chunk-graph/issue-15136/index.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15136/index.js
@@ -1,0 +1,5 @@
+import startsWith from "lodash-es/startsWith.js";
+
+it("should bundle lodash-es through swc-loader", () => {
+	expect(startsWith("rspack", "rsp")).toBe(true);
+});

--- a/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
@@ -1,0 +1,37 @@
+class ReadChunkGraphDuringFinishModulesPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      'ReadChunkGraphDuringFinishModulesPlugin',
+      (compilation) => {
+        compilation.hooks.finishModules.tap(
+          'ReadChunkGraphDuringFinishModulesPlugin',
+          () => {
+            const module = [...compilation.modules].find((module) =>
+              module.identifier().includes('lodash-es/startsWith.js'),
+            );
+            expect(module).toBeDefined();
+            expect(compilation.chunkGraph.getModuleChunks(module)).toEqual([]);
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /lodash-es[\\/].*\.js$/,
+        loader: 'builtin:swc-loader',
+        type: 'javascript/esm',
+      },
+    ],
+  },
+  optimization: {
+    minimize: false,
+  },
+  plugins: [new ReadChunkGraphDuringFinishModulesPlugin()],
+};


### PR DESCRIPTION
## Summary

- avoid panicking when the JavaScript `ChunkGraph.getModuleChunks` API is queried before a module has been added to the chunk graph
- return an empty chunk list for that early compilation state while keeping the strict core accessor unchanged
- add a regression case that reads the chunk graph during `finishModules` while bundling `lodash-es` through `builtin:swc-loader`

## Related links

Fixes #15136

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

## Testing

- `pnpm run build:cli:dev`
- `cargo check -p rspack_binding_api --all-targets --locked`
- `pnpm run test -t 'configCases/chunk-graph/issue-15136'`
