### PR TITLE
fix(cli): restore config key completions in defineConfig

### DIFF
--- a/packages/rspack-cli/src/cli.ts
+++ b/packages/rspack-cli/src/cli.ts
@@ -396,15 +396,19 @@ export type RspackConfigExport =
  */
 export function defineConfig<
   const Config extends RspackOptions | MultiRspackOptions,
->(config: (...args: Parameters<RspackConfigFn>) => Config): RspackConfigFn;
-export function defineConfig<
-  const Config extends RspackOptions | MultiRspackOptions,
+  const Definition extends
+    | Config
+    | ((...args: Parameters<RspackConfigFn>) => Config)
+    | ((...args: Parameters<RspackConfigFn>) => Promise<Config>),
 >(
-  config: (...args: Parameters<RspackConfigFn>) => Promise<Config>,
-): RspackConfigAsyncFn;
-export function defineConfig(config: RspackOptions): RspackOptions;
-export function defineConfig(config: MultiRspackOptions): MultiRspackOptions;
-export function defineConfig(config: RspackConfigExport): RspackConfigExport;
+  config: Definition,
+): Definition extends (...args: Parameters<RspackConfigFn>) => Promise<unknown>
+  ? RspackConfigAsyncFn
+  : Definition extends (...args: Parameters<RspackConfigFn>) => unknown
+    ? RspackConfigFn
+    : Definition extends readonly unknown[]
+      ? MultiRspackOptions
+      : RspackOptions;
 export function defineConfig(config: RspackConfigExport) {
   return config;
 }

--- a/tests/type-tests/resolution-bundler/defineConfig.ts
+++ b/tests/type-tests/resolution-bundler/defineConfig.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rspack/cli';
+import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
 
 defineConfig({
   mode: 'development',
@@ -44,8 +45,8 @@ defineConfig(async () => [
   },
 ]);
 
-// @ts-expect-error invalid mode
 defineConfig({
+  // @ts-expect-error invalid mode
   mode: 'invalid',
 });
 
@@ -58,3 +59,28 @@ defineConfig(() => ({
 defineConfig(async () => ({
   mode: 'invalid',
 }));
+
+const single: RspackOptions = defineConfig({
+  mode: 'development',
+});
+
+const multi: MultiRspackOptions = defineConfig([
+  {
+    mode: 'development',
+  },
+]);
+
+const syncResult: RspackOptions | MultiRspackOptions = defineConfig(() => ({
+  mode: 'development',
+}))({}, {});
+
+const asyncResult: Promise<RspackOptions | MultiRspackOptions> = defineConfig(
+  async () => ({
+    mode: 'development',
+  }),
+)({}, {});
+
+declare const dynamicConfig: RspackOptions | MultiRspackOptions;
+defineConfig(dynamicConfig);
+
+export { single, multi, syncResult, asyncResult };

--- a/tests/type-tests/resolution-nodenext/defineConfig.ts
+++ b/tests/type-tests/resolution-nodenext/defineConfig.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@rspack/cli';
+import type { MultiRspackOptions, RspackOptions } from '@rspack/core';
 
 defineConfig({
   mode: 'development',
@@ -44,8 +45,8 @@ defineConfig(async () => [
   },
 ]);
 
-// @ts-expect-error invalid mode
 defineConfig({
+  // @ts-expect-error invalid mode
   mode: 'invalid',
 });
 
@@ -58,3 +59,28 @@ defineConfig(() => ({
 defineConfig(async () => ({
   mode: 'invalid',
 }));
+
+const single: RspackOptions = defineConfig({
+  mode: 'development',
+});
+
+const multi: MultiRspackOptions = defineConfig([
+  {
+    mode: 'development',
+  },
+]);
+
+const syncResult: RspackOptions | MultiRspackOptions = defineConfig(() => ({
+  mode: 'development',
+}))({}, {});
+
+const asyncResult: Promise<RspackOptions | MultiRspackOptions> = defineConfig(
+  async () => ({
+    mode: 'development',
+  }),
+)({}, {});
+
+declare const dynamicConfig: RspackOptions | MultiRspackOptions;
+defineConfig(dynamicConfig);
+
+export { single, multi, syncResult, asyncResult };


### PR DESCRIPTION
## Summary

Same issue as web-infra-dev/rsbuild#8248, which was just fixed. Typing a config key inside `defineConfig({ ... })` stops suggesting config keys and suggests `Function.prototype` members instead.

```ts
export default defineConfig({
  mode: 'development',
  o // suggests `apply`, `bind`, `call`, `caller`, `prototype`, `toString`
});
```

Completions are correct on an empty line and break as soon as the first character is typed, because the const-generic callback overloads are declared before the object overloads. While a key is being typed it is not yet a valid `RspackOptions` property, so overload resolution falls back to the first matching signature — the callback one — and the contextual type becomes a function.

Verified against this repo's build output:

| `packages/rspack-cli` | completions after typing `o` |
| - | - |
| before | 9 `Function.prototype` members |
| after | 31 config keys |

Reordering the overloads is not an option: putting the object overloads first reintroduces the literal widening that the const-generic overloads were added to fix. So this merges them into a single const-generic signature with a conditional return type, preserving all four previous return types:

- async callback → `RspackConfigAsyncFn`
- sync callback → `RspackConfigFn`
- array → `MultiRspackOptions`
- object → `RspackOptions`

## Test Plan

- `tests/type-tests` keeps all existing cases and adds return type assertions for the four forms above, plus a non-literal `RspackOptions | MultiRspackOptions` value covering the `RspackConfigExport` overload this PR removes.
- One `@ts-expect-error` had to move onto the offending property:

  ```ts
  defineConfig({
    // @ts-expect-error invalid mode
    mode: 'invalid',
  });
  ```

  Previously the error was reported on the call itself (`TS2769 No overload matches this call`). Without overloads the checker reports `TS2322` directly on `mode`, which is a more precise diagnostic but a different line. The other two `@ts-expect-error` cases are unaffected.
- Completions were verified manually through the TypeScript language service against the built `packages/rspack-cli` output, before and after the change (numbers in the table above). That check is not automated here.

## Related Links

- web-infra-dev/rsbuild#8248
