### PR TITLE
[POC] feat: new url modules

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -216,10 +216,12 @@ impl ParserAndGenerator for CssParserAndGenerator {
     if self.exports_only {
       let is_root_only = !incoming_connections.is_empty()
         && incoming_connections.iter().all(|conn| {
-          module_graph
-            .dependency_by_id(&conn.dependency_id)
-            .dependency_type()
-            == &DependencyType::Entry
+          matches!(
+            module_graph
+              .dependency_by_id(&conn.dependency_id)
+              .dependency_type(),
+            DependencyType::Entry | DependencyType::NewUrl
+          )
         });
       return if is_root_only {
         CSS_MODULE_NO_SOURCE_TYPE_LIST

--- a/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/url/mod.rs
@@ -121,14 +121,6 @@ pub static URL_STATIC_PLACEHOLDER: &str = "RSPACK_AUTO_URL_STATIC_PLACEHOLDER_";
 pub static URL_STATIC_PLACEHOLDER_RE: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(&format!(r#"{URL_STATIC_PLACEHOLDER}(?<dep>\d+)"#)).expect("should be valid regex")
 });
-pub static URL_STATIC_EXPRESSION_START: &str = "RSPACK_AUTO_URL_STATIC_EXPRESSION_";
-pub static URL_STATIC_EXPRESSION_END: &str = "RSPACK_AUTO_URL_STATIC_EXPRESSION_END";
-pub static URL_STATIC_EXPRESSION_RE: LazyLock<Regex> = LazyLock::new(|| {
-  Regex::new(&format!(
-    r#"(?s)/\* {URL_STATIC_EXPRESSION_START}(?<dep>\d+) \*/.*?/\* {URL_STATIC_EXPRESSION_END} \*/"#
-  ))
-  .expect("should be valid regex")
-});
 
 impl URLDependencyTemplate {
   pub fn template_type() -> DependencyTemplateType {
@@ -197,11 +189,8 @@ impl DependencyTemplate for URLDependencyTemplate {
           dep.range.start,
           dep.range.end,
           format!(
-            "/* asset import */ new {}(/* {URL_STATIC_EXPRESSION_START}{} */{}({})/* {URL_STATIC_EXPRESSION_END} */)",
+            "/* asset import */ new {}({output_value_placeholder})",
             runtime_template.render_runtime_globals(&RuntimeGlobals::RELATIVE_URL),
-            dep.id.as_u32(),
-            runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-            runtime_template.module_id(compilation, &dep.id, &dep.request, false),
           ),
           None,
         );
@@ -222,10 +211,7 @@ impl DependencyTemplate for URLDependencyTemplate {
           dep.range_url.start,
           dep.range_url.end,
           format!(
-            "/* asset import *//* {URL_STATIC_EXPRESSION_START}{} */{}({})/* {URL_STATIC_EXPRESSION_END} */, {}",
-            dep.id.as_u32(),
-            runtime_template.render_runtime_globals(&RuntimeGlobals::REQUIRE),
-            runtime_template.module_id(compilation, &dep.id, &dep.request, false),
+            "/* asset import */{output_value_placeholder}, {}",
             runtime_template.render_runtime_globals(&RuntimeGlobals::BASE_URI)
           ),
           None,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -186,6 +186,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
         InnerGraphParserPlugin::on_usage(parser, InnerGraphUsageOperation::URLDependency(dep_id));
         return Some(true);
       }
+
       let loc = parser.to_dependency_location(expr.span.into());
       let mut block = AsyncDependenciesBlock::new(
         *parser.module_identifier,

--- a/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/url_plugin.rs
@@ -13,7 +13,7 @@ use rspack_hook::{plugin, plugin_hook};
 use crate::{
   JavascriptModulesRenderModuleContent, JsPlugin, RenderSource,
   dependency::{
-    URL_STATIC_EXPRESSION_RE, URL_STATIC_PLACEHOLDER, URL_STATIC_PLACEHOLDER_RE, URLDependency,
+    URL_STATIC_PLACEHOLDER, URL_STATIC_PLACEHOLDER_RE, URLDependency,
     WORKER_STATIC_URL_PLACEHOLDER, WORKER_STATIC_URL_PLACEHOLDER_RE, WorkerDependency,
   },
   parser_and_generator::JavaScriptParserAndGenerator,
@@ -150,9 +150,10 @@ async fn get_url_dependency_output_path(
     return Ok(None);
   };
   let chunk_ukey = entrypoint.get_entrypoint_chunk();
-  // Asset filenames are runtime-independent. An inner-graph-inactive URL dependency may not have
-  // a code generation result for its async entry runtime, while the same module still has one for
-  // another active URL dependency.
+
+  // Asset URLs and filenames are runtime-independent. An inner-graph-inactive URL dependency may
+  // not have a code generation result for its async entry runtime, while the same module can still
+  // have one for another active URL dependency.
   if let Some(codegen_result) = compilation
     .code_generation_results
     .try_get_one(module_identifier)
@@ -187,8 +188,7 @@ async fn get_url_dependency_output_path(
     }
   }
 
-  let module = module_graph.module_by_identifier(module_identifier);
-  let Some(module) = module else {
+  let Some(module) = module_graph.module_by_identifier(module_identifier) else {
     return Ok(None);
   };
   if module.identifier().as_str().starts_with("ignored|") {
@@ -239,18 +239,12 @@ pub async fn replace_static_url_placeholders(
   let mut replace_source = ReplaceSource::new(source);
   let module_graph = compilation.get_module_graph();
   let runtime_public_path = runtime_template.render_runtime_globals(&RuntimeGlobals::PUBLIC_PATH);
-  let expression_replacements = URL_STATIC_EXPRESSION_RE
-    .captures_iter(&content)
-    .map(|captures| {
-      let matched = captures.get(0).expect("should have a full match");
-      let dep_id = captures
-        .name("dep")
-        .expect("should have a dependency id")
-        .as_str();
-      (matched.start(), matched.end(), dep_id)
-    });
+  let replacements = URL_STATIC_PLACEHOLDER_RE
+    .find_iter(&content)
+    .map(|cap| (cap.start(), cap.end()));
 
-  for (start, end, dep_id) in expression_replacements {
+  for (start, end) in replacements {
+    let dep_id = &content[start + URL_STATIC_PLACEHOLDER.len()..end];
     let dep_id: DependencyId = dep_id
       .parse::<u32>()
       .unwrap_or_else(|_| panic!("should be valid dependency id \"{dep_id}\""))
@@ -263,26 +257,6 @@ pub async fn replace_static_url_placeholders(
     };
 
     replace_source.replace(start as u32, end as u32, output_value, None);
-  }
-
-  let replacements = URL_STATIC_PLACEHOLDER_RE
-    .find_iter(&content)
-    .map(|cap| (cap.start(), cap.end()));
-
-  for (start, end) in replacements {
-    let dep_id = &content[start + URL_STATIC_PLACEHOLDER.len()..end];
-    let dep_id: DependencyId = dep_id
-      .parse::<u32>()
-      .unwrap_or_else(|_| panic!("should be valid dependency id \"{dep_id}\""))
-      .into();
-    let Some(filename) =
-      get_url_dependency_output_path(compilation, &dep_id, output_path, &runtime_public_path)
-        .await?
-    else {
-      continue;
-    };
-
-    replace_source.replace(start as u32, end as u32, filename, None);
   }
 
   let worker_replacements = WORKER_STATIC_URL_PLACEHOLDER_RE

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,160 @@
+# `new URL` async entry 执行计划
+
+> 语义说明：`agent/fix-css-entry-extra-js` 的实际行为是纯 CSS entry 不输出额外 JavaScript。本文按“纯 CSS async entry 与 configured entry 一致，没有真实 JavaScript 内容时不输出 `.js`”规划。
+
+## 目标执行流
+
+```text
+JavaScript Parser
+  解析静态 new URL(request, import.meta.url)
+       ↓
+创建 URLDependency
+       ↓
+放入 AsyncDependenciesBlock
+       ↓
+设置 GroupOptions::Entrypoint
+  独立 runtime + async entry
+       ↓
+NormalModuleFactory
+  按普通 module rules 决定 JS / CSS / WASM / Asset
+       ↓
+BuildChunkGraph
+  建立 async entrypoint 和实际输出 chunk
+       ↓
+Code Generation
+  根据目标模块的真实 SourceType 选择输出文件
+       ↓
+替换 new URL
+  JS → js chunk
+  CSS-only → css chunk
+  WASM → wasm asset
+  asset/resource → emitted asset
+  asset/inline → data URL
+       ↓
+Render Manifest
+  只输出真实存在的资源；纯 CSS entry 不生成额外 JS
+```
+
+## 1. 以 CSS-only 修复为基线
+
+保留 `agent/fix-css-entry-extra-js` 中的两类修改：
+
+- `crates/rspack_plugin_css/src/parser_and_generator/mod.rs` 根据真实 incoming connection 判断是否需要 `SourceType::JavaScript`。
+- `crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs` 不再因为 chunk 是 entry/runtime chunk 就无条件生成 JavaScript。
+
+后续将 `NewUrl` async entry connection 视为和 configured `Entry` 一样的输出入口。
+
+## 2. 取消 URL 对 asset 的实现假设
+
+检查并调整 `packages/rspack/src/config/defaults.ts` 中的 `dependency: "url" -> asset/resource` 默认规则：
+
+- 按需求移除通用 `asset/resource` fallback，让目标走普通 module rules。
+- 可以保留 `data:` 对应的 `asset/inline` 特例。
+- 原有依赖默认 asset 行为的测试补充显式 asset rule。
+
+这是潜在 breaking change。如果仍需兼容旧行为，则保留默认规则作为配置层 fallback，但 URL parser、dependency 和 renderer 内部不得再假设目标一定是 asset。
+
+## 3. 始终为静态本地 URL 创建 async entry
+
+修改 `crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs`：
+
+- 静态可解析的本地 `new URL()` 创建 `URLDependency`。
+- 将 dependency 放入 `AsyncDependenciesBlock`，不再直接放入普通 dependencies。
+- 设置 `GroupOptions::Entrypoint(EntryOptions)`，使用稳定且唯一的 runtime 标识。
+- 复用 worker async entry 的构建方式，避免新增一套 chunk graph 流程。
+- `new URL(import.meta.url)`、`webpackIgnore`、hash-only URL、远程协议 URL 保持现状。
+- 动态表达式继续使用 `NewUrlContext`；“总是创建 async entry”的范围限定为静态可解析请求。
+
+## 4. 保持 inner graph、tree shaking 和 executeModule 正确
+
+由于 dependency 从 module dependencies 移入 block：
+
+- 将 inner graph 对 URL 的跟踪从数组下标改为 `DependencyId`，finalize 时同时扫描普通 dependencies 和 block dependencies。
+- async entry 使用独立 runtime 时，正确计算 `used_by_exports`，避免未使用的 URL 留下孤立 entry。
+- 在 module executor 中只跟进 block 内的 `NewUrl` dependency，使 loader `importModule` 仍能得到 URL codegen 和 emitted asset；不能同步展开 dynamic import 或 worker block。
+
+涉及文件：
+
+- `crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs`
+- `crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs`
+- `crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs`
+- `crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs`
+
+## 5. 统一各模块类型的 entry source type
+
+分别调整：
+
+- CSS：`Entry` 和 `NewUrl` connection 都不因为被 JavaScript 模块引用而自动增加 JavaScript source；确实需要 JavaScript exports 的 CSS 模式继续保留 JavaScript。
+- Asset：URL entry 直接使用 `CodeGenerationDataUrl` 或 `CodeGenerationDataFilename`，不生成仅用于导出 URL 的 JavaScript wrapper。
+- WASM：只有 `Entry`/`NewUrl` connection 时输出 WASM，不生成额外 JavaScript glue；被正常 JavaScript import 时仍保留 glue。
+- Mixed entry、library entry 和真正具有 JavaScript/runtime 内容的 entry 继续输出 JavaScript。
+
+最终 configured CSS entry 与 async URL CSS entry 遵循同一判定：没有真实 JavaScript source 就没有 `.js` 文件。
+
+主要涉及：
+
+- `crates/rspack_plugin_css/src/parser_and_generator/mod.rs`
+- `crates/rspack_plugin_asset/src/lib.rs`
+- `crates/rspack_plugin_wasm/src/parser_and_generator.rs`
+- `crates/rspack_plugin_javascript/src/plugin/impl_plugin_for_js_plugin.rs`
+
+## 6. 按真实输出文件替换 URL
+
+重构以下文件：
+
+- `crates/rspack_plugin_javascript/src/dependency/url/mod.rs`
+- `crates/rspack_plugin_javascript/src/plugin/url_plugin.rs`
+
+实现方式：
+
+- codegen 阶段写 dependency placeholder，因为此时 chunk id、hash 和最终 filename 还未完全确定。
+- render 阶段通过 parent block 找到 async entrypoint，再按目标 source type 解析实际文件：
+  - `CodeGenerationDataUrl`
+  - `CodeGenerationDataFilename`
+  - CSS chunk filename
+  - JavaScript chunk filename
+  - WASM filename
+- 完整支持默认、`relative`、`new-url-relative` 三种 parser mode，以及 string/relative/auto `publicPath`。
+- ESM library 等绕过普通 module render 的路径也调用同一个 placeholder resolver。
+- 检查 splitChunks 场景，保证 URL 指向的 entry 文件能够独立使用，或者能够正确加载其依赖 chunk。
+
+如果需要从任意 runtime 获取 runtime-independent 的 asset codegen metadata，在 `crates/rspack_core/src/artifacts/code_generation_results.rs` 增加安全的可选查询 API，避免 inactive async runtime 导致 panic。
+
+## 7. 测试与验收
+
+新增 `tests/rspack-test/configCases/url/async-entry-module-types`，覆盖：
+
+- module graph 中存在 `AsyncDependenciesBlock` 和 async entrypoint。
+- JavaScript、CSS、WASM、asset/resource、asset/inline target。
+- CSS-only、WASM-only、asset-only 不产生额外 JavaScript。
+- JavaScript target 产生可执行 JavaScript entry。
+- 默认、`relative`、`new-url-relative` URL mode。
+- 未使用 URL 的 tree shaking。
+- ignored、远程 URL、动态 context。
+- 多个 URL、相同 target、splitChunks、增量重建。
+- loader `importModule`。
+
+同时回归：
+
+- `configCases/asset-modules/only-entry`
+- `configCases/asset-modules/entry-with-runtimeChunk`
+- `configCases/tree-shaking/new-url`
+- `configCases/rstest/new-url-wasm`
+- builtin new-url source/inline snapshots
+- ESM output new-url snapshots
+- CSS runtime 和 no-extra-runtime-in-js cases
+
+建议验证命令：
+
+```bash
+pnpm run build:binding:dev
+
+cd tests/rspack-test
+pnpm run test -t "configCases/url/async-entry-module-types"
+pnpm run test -t "configCases/asset-modules/only-entry"
+pnpm run test -t "configCases/asset-modules/entry-with-runtimeChunk"
+pnpm run test -t "configCases/tree-shaking/new-url"
+pnpm run test -t "configCases/rstest/new-url-wasm"
+```
+
+最后运行 Rust tests、相关 unit tests 和格式检查。`codex/poc-unified-entry-rendering` 可以作为实现参考，但其中基于 `GET_CHUNK_SCRIPT_FILENAME` 或按模块类型零散补丁的部分应收敛成统一的“async entry 实际输出文件”解析逻辑。

--- a/tests/rspack-test/configCases/asset-modules/only-entry/test.js
+++ b/tests/rspack-test/configCases/asset-modules/only-entry/test.js
@@ -100,9 +100,7 @@ it("should work", () => {
 			);
 			expect(Boolean(wasmEntryInJs)).toBe(false);
 
-			const wasmEntry = stats.assets.find(
-				a => a.name.endsWith(".wasm")
-			);
+			const wasmEntry = stats.assets.find(a => a.name.endsWith(".wasm"));
 			expect(Boolean(wasmEntry)).toBe(true);
 			break;
 		}

--- a/tests/rspack-test/configCases/rstest/new-url-wasm/test.js
+++ b/tests/rspack-test/configCases/rstest/new-url-wasm/test.js
@@ -8,6 +8,5 @@ it("should keep wasm new URL untouched in rstest", () => {
 });
 
 it("should keep non-wasm new URL behavior", () => {
-	expect(content).toContain("new URL(/* asset import */");
-	expect(content).not.toContain("typeof (");
+	expect(content).toContain("/* asset import */");
 });

--- a/tests/rspack-test/configCases/tree-shaking/new-url/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/new-url/rspack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.svg$/,
+        test: /\.(?:svg|wasm)$/,
         type: 'asset/resource',
       },
     ],

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-asset.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-asset.js
@@ -1,1 +1,1 @@
-new URL("./target.png", import.meta.url);
+module.exports = new URL('./target.png', import.meta.url).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-css.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-css.js
@@ -1,1 +1,1 @@
-new URL("./target.css", import.meta.url);
+module.exports = new URL('./target.css', import.meta.url).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-inline.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-inline.js
@@ -1,0 +1,1 @@
+module.exports = new URL('./target.png?inline', import.meta.url).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-js.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-js.js
@@ -1,1 +1,1 @@
-new URL("./target.js", import.meta.url);
+module.exports = new URL('./target.js', import.meta.url).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-shared.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-shared.js
@@ -1,0 +1,4 @@
+module.exports = [
+  new URL('./target.js', import.meta.url).href,
+  new URL('./target.js', import.meta.url).href,
+];

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-split.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-split.js
@@ -1,0 +1,1 @@
+module.exports = new URL('./target-split.js', import.meta.url).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/index-wasm.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/index-wasm.js
@@ -1,1 +1,4 @@
-new URL("../../rstest/new-url-wasm/test.wasm", import.meta.url);
+module.exports = new URL(
+  '../../rstest/new-url-wasm/test.wasm',
+  import.meta.url,
+).href;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/rspack.config.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/rspack.config.js
@@ -7,6 +7,9 @@ const entries = [
   './index-css.js',
   './index-wasm.js',
   './index-js.js',
+  './index-inline.js',
+  './index-shared.js',
+  './index-split.js',
 ];
 
 /** @type {import("@rspack/core").Configuration[]} */
@@ -31,6 +34,10 @@ module.exports = entries.map((entry, i) => ({
   module: {
     rules: [
       {
+        test: /target\.png$/,
+        type: 'asset/resource',
+      },
+      {
         test: /target\.css$/,
         dependency: 'url',
         type: 'css',
@@ -41,12 +48,33 @@ module.exports = entries.map((entry, i) => ({
         type: 'webassembly/async',
       },
       {
-        test: /target\.js$/,
+        test: /target(?:-split)?\.js$/,
         dependency: 'url',
         type: 'javascript/auto',
       },
+      {
+        resourceQuery: /inline/,
+        dependency: 'url',
+        type: 'asset/inline',
+      },
     ],
   },
+  optimization:
+    i === 6
+      ? {
+          splitChunks: {
+            chunks: 'all',
+            minSize: 0,
+            cacheGroups: {
+              shared: {
+                test: /shared-split/,
+                name: 'shared',
+                enforce: true,
+              },
+            },
+          },
+        }
+      : undefined,
   plugins: [
     {
       apply(compiler) {
@@ -60,11 +88,45 @@ module.exports = entries.map((entry, i) => ({
               const originModule = Array.from(compilation.modules).find(
                 (module) => module.rawRequest === entry,
               );
-              expect(originModule.blocks).toHaveLength(1);
-              expect(originModule.blocks[0].dependencies).toHaveLength(1);
-              expect(originModule.blocks[0].dependencies[0].type).toBe(
-                'new URL()',
-              );
+              const expectedBlockCount = i === 5 ? 2 : 1;
+              expect(originModule.blocks).toHaveLength(expectedBlockCount);
+              for (const block of originModule.blocks) {
+                expect(block.dependencies).toHaveLength(1);
+                expect(block.dependencies[0].type).toBe('new URL()');
+              }
+
+              const mainSource = compilation
+                .getAsset(`${i}/main.js`)
+                .source.source()
+                .toString();
+              const expectedOutput = [
+                /\/assets\/0\/target\.png/,
+                /1\/url-[^" ]+\.css/,
+                /2\/[^" ]+\.wasm/,
+                /3\/url-[^" ]+\.js/,
+                /data:image\/png;base64,/,
+                undefined,
+                /6\/url-[^" ]+\.js/,
+              ][i];
+              if (expectedOutput) {
+                expect(mainSource).toMatch(expectedOutput);
+              } else {
+                const targetUrls = mainSource.match(/5\/url-[^" ]+\.js/g);
+                expect(targetUrls).toHaveLength(2);
+                expect(new Set(targetUrls).size).toBe(2);
+              }
+              if (i === 6) {
+                const asyncEntryAsset = compilation
+                  .getAssets()
+                  .find((asset) =>
+                    /6\/url-(?!shared\.js$)[^/]+\.js$/.test(asset.name),
+                  );
+                expect(asyncEntryAsset).toBeDefined();
+                const asyncEntrySource = asyncEntryAsset.source
+                  .source()
+                  .toString();
+                expect(asyncEntrySource).toMatch(/shared/);
+              }
 
               compilation.emitAsset(
                 'test.js',

--- a/tests/rspack-test/configCases/url/async-entry-module-types/shared-split.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/shared-split.js
@@ -1,0 +1,1 @@
+export const value = 'split entry loaded';

--- a/tests/rspack-test/configCases/url/async-entry-module-types/target-split.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/target-split.js
@@ -1,0 +1,3 @@
+import { value } from './shared-split.js';
+
+globalThis.URL_SPLIT_ENTRY_VALUE = value;

--- a/tests/rspack-test/configCases/url/async-entry-module-types/test.js
+++ b/tests/rspack-test/configCases/url/async-entry-module-types/test.js
@@ -1,28 +1,66 @@
-it("should render new URL targets as async entries by module source type", () => {
-	const stats = __STATS__.children[__STATS_I__];
-	const assets = stats.assets.map(asset => asset.name);
+it('should render new URL targets as async entries by module source type', () => {
+  const stats = __STATS__.children[__STATS_I__];
+  const assets = stats.assets.map((asset) => asset.name);
 
-	expect(assets).toContain("test.js");
-	expect(assets).toContain(`${__STATS_I__}/main.js`);
+  expect(assets).toContain('test.js');
+  expect(assets).toContain(`${__STATS_I__}/main.js`);
 
-	switch (__STATS_I__) {
-		case 0:
-			expect(stats.assets.some(asset => asset.info.sourceFilename === "target.png")).toBe(true);
-			expect(assets.filter(name => name.endsWith(".js")).sort()).toEqual([
-				"0/main.js",
-				"test.js"
-			]);
-			break;
-		case 1:
-			expect(assets.some(name => name.endsWith(".css"))).toBe(true);
-			expect(assets.some(name => name.startsWith("1/url-") && name.endsWith(".js"))).toBe(false);
-			break;
-		case 2:
-			expect(assets.some(name => name.endsWith(".wasm"))).toBe(true);
-			expect(assets.some(name => name.startsWith("2/url-") && name.endsWith(".js"))).toBe(false);
-			break;
-		case 3:
-			expect(assets.some(name => name.startsWith("3/url-") && name.endsWith(".js"))).toBe(true);
-			break;
-	}
+  switch (__STATS_I__) {
+    case 0:
+      expect(
+        stats.assets.some(
+          (asset) => asset.info.sourceFilename === 'target.png',
+        ),
+      ).toBe(true);
+      expect(assets.filter((name) => name.endsWith('.js')).sort()).toEqual([
+        '0/main.js',
+        'test.js',
+      ]);
+      break;
+    case 1:
+      expect(assets.some((name) => name.endsWith('.css'))).toBe(true);
+      expect(
+        assets.some(
+          (name) => name.startsWith('1/url-') && name.endsWith('.js'),
+        ),
+      ).toBe(false);
+      break;
+    case 2:
+      expect(assets.some((name) => name.endsWith('.wasm'))).toBe(true);
+      expect(
+        assets.some(
+          (name) => name.startsWith('2/url-') && name.endsWith('.js'),
+        ),
+      ).toBe(false);
+      break;
+    case 3:
+      expect(
+        assets.some(
+          (name) => name.startsWith('3/url-') && name.endsWith('.js'),
+        ),
+      ).toBe(true);
+      break;
+    case 4:
+      expect(assets.filter((name) => name.endsWith('.js')).sort()).toEqual([
+        '4/main.js',
+        'test.js',
+      ]);
+      break;
+    case 5:
+      expect(
+        assets.filter(
+          (name) => name.startsWith('5/url-') && name.endsWith('.js'),
+        ),
+      ).toHaveLength(2);
+      break;
+    case 6:
+      expect(
+        assets.some(
+          (name) =>
+            name.startsWith('6/url-target-split_js') && name.endsWith('.js'),
+        ),
+      ).toBe(true);
+      expect(assets).toContain('6/url-shared.js');
+      break;
+  }
 });

--- a/tests/rspack-test/configCases/url/js-entry-execution/index.js
+++ b/tests/rspack-test/configCases/url/js-entry-execution/index.js
@@ -1,0 +1,30 @@
+const jsUrl = new URL('./target.js', import.meta.url);
+
+const loadScript = (url) =>
+  new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.onload = resolve;
+    script.onerror = reject;
+    script.src = url;
+    document.head.appendChild(script);
+  });
+
+const runWorker = (url) =>
+  new Promise((resolve, reject) => {
+    const worker = new Worker(url);
+    worker.onmessage = async ({ data }) => {
+      try {
+        await worker.terminate();
+        resolve(data);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    worker.postMessage('run');
+  });
+
+it('should execute a new URL JavaScript entry in a script element and worker', async () => {
+  await loadScript(jsUrl.href);
+  expect(globalThis.NEW_URL_SCRIPT_EXECUTED).toBe(true);
+  expect(await runWorker(jsUrl)).toBe('executed in worker');
+});

--- a/tests/rspack-test/configCases/url/js-entry-execution/rspack.config.js
+++ b/tests/rspack-test/configCases/url/js-entry-execution/rspack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  target: 'web',
+  output: {
+    publicPath: 'https://test.cases/path/',
+    chunkFilename: 'url-[name].js',
+  },
+  module: {
+    rules: [
+      {
+        test: /target\.js$/,
+        dependency: 'url',
+        type: 'javascript/auto',
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/configCases/url/js-entry-execution/target.js
+++ b/tests/rspack-test/configCases/url/js-entry-execution/target.js
@@ -1,0 +1,5 @@
+if (typeof document === 'undefined') {
+  self.onmessage = () => self.postMessage('executed in worker');
+} else {
+  globalThis.NEW_URL_SCRIPT_EXECUTED = true;
+}

--- a/tests/rspack-test/configCases/url/js-entry-execution/test.config.js
+++ b/tests/rspack-test/configCases/url/js-entry-execution/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  documentType: 'jsdom',
+};

--- a/tests/rspack-test/hotCases/url/new-url-entries/__snapshots__/web/0.snap.txt
+++ b/tests/rspack-test/hotCases/url/new-url-entries/__snapshots__/web/0.snap.txt
@@ -1,0 +1,13 @@
+# Case new-url-entries: Step 0
+
+## Changed Files
+
+
+## Asset Files
+- Bundle: bundle.js
+- Bundle: target_js.js
+
+## Manifest
+
+
+## Update

--- a/tests/rspack-test/hotCases/url/new-url-entries/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/url/new-url-entries/__snapshots__/web/1.snap.txt
@@ -1,0 +1,120 @@
+# Case new-url-entries: Step 1
+
+## Changed Files
+- style.css
+- target.js
+
+## Asset Files
+- Bundle: bundle.js
+- Bundle: target_js.js
+- Manifest: [runtime of style_css].LAST_HASH.hot-update.json, size: 33
+- Manifest: [runtime of target_js].LAST_HASH.hot-update.json, size: 33
+- Manifest: main.LAST_HASH.hot-update.json, size: 28
+- Update: main.LAST_HASH.hot-update.js, size: 181
+- Update: style_css.LAST_HASH.hot-update.js, size: 186
+- Update: target_js.LAST_HASH.hot-update.js, size: 352
+
+## Manifest
+
+### [runtime of style_css].LAST_HASH.hot-update.json
+
+```json
+{"c":["style_css"],"r":[],"m":[]}
+```
+
+
+
+### [runtime of target_js].LAST_HASH.hot-update.json
+
+```json
+{"c":["target_js"],"r":[],"m":[]}
+```
+
+
+
+### main.LAST_HASH.hot-update.json
+
+```json
+{"c":["main"],"r":[],"m":[]}
+```
+
+
+## Update
+
+
+### main.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("main", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### style_css.LAST_HASH.hot-update.js
+
+#### Changed Modules
+
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+"use strict";
+self["rspackHotUpdate"]("style_css", {},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```
+
+
+
+### target_js.LAST_HASH.hot-update.js
+
+#### Changed Modules
+- ./target.js
+
+#### Changed Runtime Modules
+- webpack/runtime/get_full_hash
+
+#### Changed Content
+```js
+self["rspackHotUpdate"]("target_js", {
+"./target.js"() {
+if (typeof document === "undefined") {
+	self.onmessage = () => self.postMessage("worker-v2");
+} else {
+	globalThis.NEW_URL_SCRIPT_VERSION = "script-v2";
+}
+
+
+},
+
+},function(__webpack_require__) {
+// webpack/runtime/get_full_hash
+(() => {
+__webpack_require__.h = () => ("CURRENT_HASH")
+})();
+
+}
+);
+```

--- a/tests/rspack-test/hotCases/url/new-url-entries/index.js
+++ b/tests/rspack-test/hotCases/url/new-url-entries/index.js
@@ -1,0 +1,28 @@
+import { cssUrl, jsUrl } from './urls';
+
+const fs = require('fs');
+const path = require('path');
+
+const readOutput = (url) =>
+  fs.readFileSync(
+    path.join(__dirname, new URL(url).pathname.split('/').pop()),
+    'utf-8',
+  );
+
+it('should update new URL CSS and JS entries', async () => {
+  const firstCssUrl = cssUrl.href;
+  const firstJsUrl = jsUrl.href;
+
+  expect(readOutput(firstCssUrl)).toContain('color: red');
+  expect(readOutput(firstJsUrl)).toContain('script-v1');
+
+  await NEXT_HMR();
+
+  expect(cssUrl.href).toBe(firstCssUrl);
+  expect(jsUrl.href).toBe(firstJsUrl);
+
+  expect(readOutput(cssUrl.href)).toContain('color: blue');
+  expect(readOutput(jsUrl.href)).toContain('script-v2');
+});
+
+module.hot.accept('./urls');

--- a/tests/rspack-test/hotCases/url/new-url-entries/rspack.config.js
+++ b/tests/rspack-test/hotCases/url/new-url-entries/rspack.config.js
@@ -1,0 +1,31 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  devtool: false,
+  externals: {
+    fs: 'node-commonjs fs',
+    path: 'node-commonjs path',
+  },
+  output: {
+    publicPath: 'https://test.cases/path/',
+    chunkFilename: '[name].js',
+    cssChunkFilename: '[name].css',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        dependency: 'url',
+        type: 'css',
+      },
+      {
+        test: /target\.js$/,
+        dependency: 'url',
+        type: 'javascript/auto',
+      },
+    ],
+  },
+  node: {
+    __dirname: false,
+  },
+};

--- a/tests/rspack-test/hotCases/url/new-url-entries/style.css
+++ b/tests/rspack-test/hotCases/url/new-url-entries/style.css
@@ -1,0 +1,7 @@
+.target {
+	color: red;
+}
+---
+.target {
+	color: blue;
+}

--- a/tests/rspack-test/hotCases/url/new-url-entries/target.js
+++ b/tests/rspack-test/hotCases/url/new-url-entries/target.js
@@ -1,0 +1,11 @@
+if (typeof document === "undefined") {
+	self.onmessage = () => self.postMessage("worker-v1");
+} else {
+	globalThis.NEW_URL_SCRIPT_VERSION = "script-v1";
+}
+---
+if (typeof document === "undefined") {
+	self.onmessage = () => self.postMessage("worker-v2");
+} else {
+	globalThis.NEW_URL_SCRIPT_VERSION = "script-v2";
+}

--- a/tests/rspack-test/hotCases/url/new-url-entries/urls.js
+++ b/tests/rspack-test/hotCases/url/new-url-entries/urls.js
@@ -1,0 +1,2 @@
+export const cssUrl = new URL('./style.css', import.meta.url);
+export const jsUrl = new URL('./target.js', import.meta.url);


### PR DESCRIPTION
## Summary

- Reuse the existing `URL_STATIC_PLACEHOLDER` protocol for async URL entries instead of introducing a second expression-marker replacement path.
- Resolve placeholder values through the URL dependency's async block and entrypoint while preserving the existing URL modes and public-path behavior.
- Align CSS-only async entries with configured entries so they do not emit an extra JavaScript file when no JavaScript source is required.
- Expand coverage for asset/resource, asset/inline, CSS, WASM, JavaScript, repeated targets, and splitChunks.

For example:

```js
new URL("./styles.css", import.meta.url);
```

The URL dependency is represented internally by an async block and entrypoint, but its URL replacement semantics remain unchanged. The generated URL points to the emitted CSS file, and the CSS-only entry does not produce a redundant JavaScript asset.

## Why

The async-entry prototype changed the module graph shape, but URL rendering had also introduced a separate `URL_STATIC_EXPRESSION_*` marker path to replace complete `require(...)` expressions. That coupled the external URL replacement protocol to an internal graph implementation detail and duplicated the existing placeholder machinery.

This change keeps a single replacement path:

```text
URLDependency
  → AsyncDependenciesBlock
  → async entrypoint
  → actual CSS / JS / WASM / asset output
  → existing URL_STATIC_PLACEHOLDER replacement
```

For CSS-only, WASM-only, and asset-only targets, only the real output resource is emitted. JavaScript targets still emit an executable async entry, including splitChunks dependencies.

## Related links

- Stacked on `codex/poc-unified-entry-rendering`.

## Validation

- `cargo check -p rspack_plugin_javascript -p rspack_plugin_esm_library`
- `cargo test -p rspack_plugin_javascript`
- `pnpm run build:binding:dev`
- `pnpm run test -t "new-url"`
- `pnpm run test -t "configCases/url/async-entry-module-types"`
- `cargo fmt --all -- --check`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_