### PR TITLE
[POC] feat: add loader chain caching

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -959,6 +959,12 @@ export interface JsLoaderContext {
   buildDependencies: Array<string>
   loaderItems: Array<JsLoaderItem>
   loaderIndex: number
+  /**
+   * Inclusive start and exclusive end of the current JavaScript execution
+   * span inside the loader chain.
+   */
+  loaderChainStart: number
+  loaderChainEnd: number
   loaderState: Readonly<JsLoaderState>
   __internal__error?: RspackError
   /**
@@ -2736,6 +2742,8 @@ export interface RawModuleRule {
 export interface RawModuleRuleUse {
   loader: string
   options?: string
+  cache: boolean
+  cacheKey: string
 }
 
 export interface RawNodeOption {

--- a/crates/rspack/tests/loader.rs
+++ b/crates/rspack/tests/loader.rs
@@ -28,6 +28,8 @@ async fn lightningcss() {
           options: Some(json!({
             "include": 1 // lower nesting syntax
           }).to_string()),
+          cache: false,
+          cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -79,6 +81,8 @@ async fn swc() {
               }
             }
           }).to_string()),
+          cache: false,
+          cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -114,7 +118,9 @@ async fn react_refresh() {
           r#use: ModuleRuleUse::Array(vec![
           ModuleRuleUseLoader {
             loader: "builtin:react-refresh-loader".to_string(),
-            options: None
+            options: None,
+            cache: false,
+            cache_key: String::new(),
           },
           ModuleRuleUseLoader {
           loader: "builtin:swc-loader".to_string(),
@@ -135,6 +141,8 @@ async fn react_refresh() {
               }
             }
           }).to_string()),
+          cache: false,
+          cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -171,7 +179,9 @@ async fn preact_refresh() {
           r#use: ModuleRuleUse::Array(vec![
           ModuleRuleUseLoader {
             loader: "builtin:preact-refresh-loader".to_string(),
-            options: None
+            options: None,
+            cache: false,
+            cache_key: String::new(),
           },
           ModuleRuleUseLoader {
           loader: "builtin:swc-loader".to_string(),
@@ -192,6 +202,8 @@ async fn preact_refresh() {
               }
             }
           }).to_string()),
+          cache: false,
+          cache_key: String::new(),
         }]),
           ..Default::default()
         },

--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -110,6 +110,10 @@ pub struct JsLoaderContext {
 
   pub loader_items: Vec<JsLoaderItem>,
   pub loader_index: i32,
+  /// Inclusive start and exclusive end of the current JavaScript execution
+  /// span inside the loader chain.
+  pub loader_chain_start: i32,
+  pub loader_chain_end: i32,
   #[napi(ts_type = "Readonly<JsLoaderState>")]
   pub loader_state: JsLoaderState,
   #[napi(js_name = "__internal__error")]
@@ -129,11 +133,14 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
   ) -> std::result::Result<Self, Self::Error> {
     let module = &cx.context.module;
 
-    #[allow(clippy::unwrap_used)]
+    let execution_span = cx
+      .current_execution_span()
+      .expect("yielding requires a current loader-chain span");
     Ok(JsLoaderContext {
       resource: cx.resource_data.resource().to_owned(),
       module: ModuleObject::with_ptr(
-        NonNull::new(module.as_ref() as *const dyn Module as *mut dyn Module).unwrap(),
+        NonNull::new(module.as_ref() as *const dyn Module as *mut dyn Module)
+          .expect("module reference should always produce a non-null pointer"),
         cx.context.compiler_id,
       ),
       hot: cx.hot,
@@ -176,6 +183,8 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
 
       loader_items: cx.loader_items.iter().map(Into::into).collect(),
       loader_index: cx.loader_index,
+      loader_chain_start: execution_span.start as i32,
+      loader_chain_end: execution_span.end as i32,
       loader_state: cx.state().into(),
       error: None,
       utf8_hint: None,

--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -26,15 +26,18 @@ pub struct JsLoaderItem {
   pub no_pitch: bool,
 }
 
-impl From<&rspack_loader_runner::LoaderItem<RunnerContext>> for JsLoaderItem {
-  fn from(value: &rspack_loader_runner::LoaderItem<RunnerContext>) -> Self {
+impl JsLoaderItem {
+  fn from_parts(
+    value: &rspack_loader_runner::LoaderItem<RunnerContext>,
+    state: &rspack_loader_runner::LoaderItemState,
+  ) -> Self {
     JsLoaderItem {
       loader: value.request().to_string(),
       r#type: value.r#type().to_string(),
 
-      data: value.data().clone(),
-      normal_executed: value.normal_executed(),
-      pitch_executed: value.pitch_executed(),
+      data: state.data().clone(),
+      normal_executed: state.normal_executed(),
+      pitch_executed: state.pitch_executed(),
 
       no_pitch: false,
     }
@@ -134,8 +137,9 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
     let module = &cx.context.module;
 
     let execution_span = cx
-      .current_execution_span()
-      .expect("yielding requires a current loader-chain span");
+      .current_execution_chain()
+      .expect("yielding requires a current execution chain")
+      .range();
     Ok(JsLoaderContext {
       resource: cx.resource_data.resource().to_owned(),
       module: ModuleObject::with_ptr(
@@ -181,7 +185,12 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
         .map(|i| i.to_string_lossy().to_string())
         .collect(),
 
-      loader_items: cx.loader_items.iter().map(Into::into).collect(),
+      loader_items: cx
+        .loader_items
+        .iter()
+        .zip(cx.loader_item_states.iter())
+        .map(|(item, state)| JsLoaderItem::from_parts(item, state))
+        .collect(),
       loader_index: cx.loader_index,
       loader_chain_start: execution_span.start as i32,
       loader_chain_end: execution_span.end as i32,

--- a/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
@@ -6,8 +6,8 @@ use rspack_cacheable::{
 };
 use rspack_collections::Identifier;
 use rspack_core::{
-  BoxLoader, Context, Loader, ModuleRuleUseLoader, NormalModuleFactoryResolveLoader, ResolveResult,
-  Resolver, Resource, RunnerContext,
+  BoxLoader, Context, Loader, LoaderExecutionKind, ModuleRuleUseLoader,
+  NormalModuleFactoryResolveLoader, ResolveResult, Resolver, Resource, RunnerContext,
 };
 use rspack_error::Result;
 use rspack_hook::plugin_hook;
@@ -30,6 +30,10 @@ impl Loader<RunnerContext> for JsLoader {
 
   fn r#type(&self) -> Option<&str> {
     self.1.as_deref()
+  }
+
+  fn execution_kind(&self) -> LoaderExecutionKind {
+    LoaderExecutionKind::JavaScript
   }
 }
 

--- a/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
@@ -34,13 +34,18 @@ pub(crate) async fn loader_should_yield(
       } else {
         let loaders_without_pitch = self.loaders_without_pitch.read().await;
         let span = loader_context
-          .current_execution_span()
-          .expect("pitching requires a current loader-chain span");
+          .current_execution_chain()
+          .expect("pitching requires a current execution chain")
+          .range();
         let start = loader_context.loader_index as usize;
         let should_yield = loader_context.loader_items[start..span.end]
           .iter()
-          .any(|loader| {
-            !loader.pitch_executed() && !loaders_without_pitch.contains(loader.path().as_str())
+          .enumerate()
+          .any(|(offset, loader)| {
+            !loader_context
+              .loader_item_state(start + offset)
+              .pitch_executed()
+              && !loaders_without_pitch.contains(loader.path().as_str())
           });
         Ok(Some(should_yield))
       }
@@ -141,24 +146,21 @@ pub(crate) fn merge_loader_context(
   });
   to.__finish_with((content, source_map, additional_data));
 
-  // update loader status
-  to.loader_items = to
-    .loader_items
-    .drain(..)
-    .zip(from.loader_items.drain(..))
-    .map(|(mut to, from)| {
+  // update per-run loader status without mutating the shared loader metadata
+  for (index, from) in from.loader_items.drain(..).enumerate() {
+    if let Some(to) = to.loader_item_states.get_mut(index) {
       if from.normal_executed {
-        to.set_normal_executed()
+        to.set_normal_executed();
+        // A JavaScript normal loader that returned to Rust has completed even
+        // when it produced an empty result.
+        to.set_finish_called();
       }
       if from.pitch_executed {
         to.set_pitch_executed()
       }
       to.set_data(from.data);
-      // JS loader should always be considered as finished
-      to.set_finish_called();
-      to
-    })
-    .collect();
+    }
+  }
   to.loader_index = from.loader_index;
   to.parse_meta.extend(
     from

--- a/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
@@ -1,6 +1,6 @@
 use napi::{Either, bindgen_prelude::JsValuesTupleIntoVec};
 use rspack_core::{
-  AdditionalData, BUILTIN_LOADER_PREFIX, LoaderContext, NormalModuleLoaderShouldYield,
+  AdditionalData, LoaderContext, LoaderExecutionKind, NormalModuleLoaderShouldYield,
   NormalModuleLoaderStartYielding, RunnerContext,
 };
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -29,19 +29,24 @@ pub(crate) async fn loader_should_yield(
     }
     LoaderState::Pitching => {
       let current_loader = loader_context.current_loader();
-      if current_loader.request().starts_with(BUILTIN_LOADER_PREFIX) {
+      if current_loader.execution_kind() != LoaderExecutionKind::JavaScript {
         Ok(Some(false))
       } else {
         let loaders_without_pitch = self.loaders_without_pitch.read().await;
-        let should_yield = !loaders_without_pitch.contains(current_loader.path().as_str());
+        let span = loader_context
+          .current_execution_span()
+          .expect("pitching requires a current loader-chain span");
+        let start = loader_context.loader_index as usize;
+        let should_yield = loader_context.loader_items[start..span.end]
+          .iter()
+          .any(|loader| {
+            !loader.pitch_executed() && !loaders_without_pitch.contains(loader.path().as_str())
+          });
         Ok(Some(should_yield))
       }
     }
     LoaderState::Normal => Ok(Some(
-      !loader_context
-        .current_loader()
-        .request()
-        .starts_with(BUILTIN_LOADER_PREFIX),
+      loader_context.current_loader().execution_kind() == LoaderExecutionKind::JavaScript,
     )),
   }
 }

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -49,6 +49,8 @@ use crate::{
 pub struct RawModuleRuleUse {
   pub loader: String,
   pub options: Option<String>,
+  pub cache: bool,
+  pub cache_key: String,
 }
 
 #[rspack_napi_macros::tagged_union]
@@ -1021,6 +1023,8 @@ impl TryFrom<RawModuleRule> for ModuleRule {
           .map(|rule_use| ModuleRuleUseLoader {
             loader: rule_use.loader,
             options: rule_use.options,
+            cache: rule_use.cache,
+            cache_key: rule_use.cache_key,
           })
           .collect::<Vec<_>>();
         Ok::<ModuleRuleUse, rspack_error::Error>(ModuleRuleUse::Array(uses))
@@ -1035,6 +1039,8 @@ impl TryFrom<RawModuleRule> for ModuleRule {
                 .map(|rule_use| ModuleRuleUseLoader {
                   loader: rule_use.loader,
                   options: rule_use.options,
+                  cache: rule_use.cache,
+                  cache_key: rule_use.cache_key,
                 })
                 .collect::<Vec<_>>()
             })

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -151,9 +151,20 @@ impl Compiler {
 
     let options = Arc::new(options);
     let compilation_logging: CompilationLogging = Default::default();
-    let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
-    let buildtime_plugin_driver =
-      PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
+    let plugin_driver = PluginDriver::new(
+      &compiler_path,
+      options.clone(),
+      plugins,
+      resolver_factory.clone(),
+      intermediate_filesystem.clone(),
+    );
+    let buildtime_plugin_driver = PluginDriver::new(
+      &compiler_path,
+      options.clone(),
+      buildtime_plugins,
+      resolver_factory.clone(),
+      intermediate_filesystem.clone(),
+    );
     let cache = new_cache(
       &compiler_path,
       options.clone(),

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -1,0 +1,676 @@
+use std::{
+  hash::Hash,
+  path::PathBuf,
+  sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+  },
+  time::{SystemTime, UNIX_EPOCH},
+};
+
+use rspack_fs::IntermediateFileSystem;
+use rspack_hash::{HashFunction, RspackHasher};
+use rspack_loader_runner::{
+  AdditionalData, Content, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState,
+  LoaderContext,
+};
+use rspack_sources::SourceMap;
+use rspack_util::fx_hash::FxDashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+  CacheOptions, CompilationAsset, CompilerOptions, Module, RunnerContext,
+  cache::persistent::storage::StorageOptions,
+};
+
+const LOADER_CACHE_FORMAT_VERSION: u8 = 1;
+static TEMP_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct FileStamp {
+  path: PathBuf,
+  state: FileStampState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+enum FileStampState {
+  Missing,
+  Existing {
+    mtime_ms: u64,
+    ctime_ms: u64,
+    size: u64,
+    is_directory: bool,
+  },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+struct LoaderCacheKey {
+  compiler_scope: String,
+  static_fingerprint: String,
+  input_hash: u64,
+  loader_files: Vec<FileStamp>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct DependencyDelta {
+  added: FxHashSet<PathBuf>,
+  removed: FxHashSet<PathBuf>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct JsonObjectDelta {
+  upserted: serde_json::Map<String, serde_json::Value>,
+  removed: FxHashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct LoaderCacheEntry {
+  content: Option<Content>,
+  source_map: Option<String>,
+  additional_data: Option<AdditionalData>,
+  file_dependencies: DependencyDelta,
+  context_dependencies: DependencyDelta,
+  missing_dependencies: DependencyDelta,
+  build_dependencies: DependencyDelta,
+  dependency_stamps: Vec<FileStamp>,
+  parse_meta: rspack_loader_runner::ParseMeta,
+  assets: FxHashMap<String, CompilationAsset>,
+  build_info_extras: JsonObjectDelta,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum PersistedContent {
+  String(String),
+  Buffer(Vec<u8>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedLoaderCacheEntry {
+  key: LoaderCacheKey,
+  content: PersistedContent,
+  source_map: Option<String>,
+  file_dependencies: DependencyDelta,
+  context_dependencies: DependencyDelta,
+  missing_dependencies: DependencyDelta,
+  build_dependencies: DependencyDelta,
+  dependency_stamps: Vec<FileStamp>,
+  build_info_extras: JsonObjectDelta,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedLoaderCacheEnvelope {
+  format_version: u8,
+  written_at_ms: u64,
+  checksum: u64,
+  entry: PersistedLoaderCacheEntry,
+}
+
+impl PersistedLoaderCacheEntry {
+  fn from_memory(key: LoaderCacheKey, entry: &LoaderCacheEntry) -> Option<Self> {
+    if entry.additional_data.is_some() || !entry.parse_meta.is_empty() || !entry.assets.is_empty() {
+      return None;
+    }
+    let content = match entry.content.as_ref()? {
+      Content::String(content) => PersistedContent::String(content.clone()),
+      Content::Buffer(content) => PersistedContent::Buffer(content.clone()),
+    };
+    Some(Self {
+      key,
+      content,
+      source_map: entry.source_map.clone(),
+      file_dependencies: entry.file_dependencies.clone(),
+      context_dependencies: entry.context_dependencies.clone(),
+      missing_dependencies: entry.missing_dependencies.clone(),
+      build_dependencies: entry.build_dependencies.clone(),
+      dependency_stamps: entry.dependency_stamps.clone(),
+      build_info_extras: entry.build_info_extras.clone(),
+    })
+  }
+
+  fn into_memory(self, expected_key: &LoaderCacheKey) -> Option<LoaderCacheEntry> {
+    if &self.key != expected_key {
+      return None;
+    }
+    let content = match self.content {
+      PersistedContent::String(content) => Content::String(content),
+      PersistedContent::Buffer(content) => Content::Buffer(content),
+    };
+    Some(LoaderCacheEntry {
+      content: Some(content),
+      source_map: self.source_map,
+      additional_data: None,
+      file_dependencies: self.file_dependencies,
+      context_dependencies: self.context_dependencies,
+      missing_dependencies: self.missing_dependencies,
+      build_dependencies: self.build_dependencies,
+      dependency_stamps: self.dependency_stamps,
+      parse_meta: Default::default(),
+      assets: Default::default(),
+      build_info_extras: self.build_info_extras,
+    })
+  }
+}
+
+#[derive(Debug, Clone)]
+struct LoaderCacheFileStore {
+  root: rspack_paths::Utf8PathBuf,
+  readonly: bool,
+  max_age: u64,
+  fs: Arc<dyn IntermediateFileSystem>,
+}
+
+impl LoaderCacheFileStore {
+  fn now_ms() -> u64 {
+    SystemTime::now()
+      .duration_since(UNIX_EPOCH)
+      .unwrap_or_default()
+      .as_millis() as u64
+  }
+
+  fn checksum(bytes: &[u8]) -> u64 {
+    let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+    hasher.write(bytes);
+    hasher.finish()
+  }
+
+  fn digest(key: &LoaderCacheKey) -> String {
+    let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+    key.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+  }
+
+  fn path(&self, key: &LoaderCacheKey) -> rspack_paths::Utf8PathBuf {
+    self.root.join(format!("{}.json", Self::digest(key)))
+  }
+
+  async fn get(&self, key: &LoaderCacheKey) -> Option<LoaderCacheEntry> {
+    let path = self.path(key);
+    let bytes = self.fs.read_file(&path).await.ok()?;
+    let envelope = serde_json::from_slice::<PersistedLoaderCacheEnvelope>(&bytes).ok()?;
+    if envelope.format_version != LOADER_CACHE_FORMAT_VERSION {
+      return None;
+    }
+    if Self::now_ms().saturating_sub(envelope.written_at_ms) > self.max_age.saturating_mul(1000) {
+      if !self.readonly {
+        let _ = self.fs.remove_file(&path).await;
+      }
+      return None;
+    }
+    let entry_bytes = serde_json::to_vec(&envelope.entry).ok()?;
+    if Self::checksum(&entry_bytes) != envelope.checksum {
+      return None;
+    }
+    envelope.entry.into_memory(key)
+  }
+
+  async fn put(&self, key: LoaderCacheKey, entry: &LoaderCacheEntry) {
+    if self.readonly {
+      return;
+    }
+    let Some(entry) = PersistedLoaderCacheEntry::from_memory(key.clone(), entry) else {
+      // Never leave an older persistable result behind when the latest result
+      // is memory-only.
+      let _ = self.fs.remove_file(&self.path(&key)).await;
+      return;
+    };
+    let Ok(entry_bytes) = serde_json::to_vec(&entry) else {
+      return;
+    };
+    let envelope = PersistedLoaderCacheEnvelope {
+      format_version: LOADER_CACHE_FORMAT_VERSION,
+      written_at_ms: Self::now_ms(),
+      checksum: Self::checksum(&entry_bytes),
+      entry,
+    };
+    let Ok(bytes) = serde_json::to_vec(&envelope) else {
+      return;
+    };
+    let path = self.path(&key);
+    let Some(parent) = path.parent() else {
+      return;
+    };
+    if self.fs.create_dir_all(parent).await.is_err() {
+      return;
+    }
+    let temp_id = TEMP_FILE_ID.fetch_add(1, Ordering::Relaxed);
+    let temp = path.with_extension(format!("json.tmp.{}.{}", std::process::id(), temp_id));
+    if self.fs.write(&temp, &bytes).await.is_ok() && self.fs.rename(&temp, &path).await.is_err() {
+      let _ = self.fs.remove_file(&path).await;
+      let _ = self.fs.rename(&temp, &path).await;
+    }
+    let _ = self.fs.remove_file(&temp).await;
+  }
+}
+
+pub(crate) struct LoaderCacheMissState {
+  key: LoaderCacheKey,
+  diagnostics_len: usize,
+  file_dependencies: FxHashSet<PathBuf>,
+  context_dependencies: FxHashSet<PathBuf>,
+  missing_dependencies: FxHashSet<PathBuf>,
+  build_dependencies: FxHashSet<PathBuf>,
+  parse_meta_keys: FxHashSet<String>,
+  asset_keys: FxHashSet<String>,
+  build_info_extras: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoaderCacheService {
+  enabled: bool,
+  compiler_scope: String,
+  entries: FxDashMap<LoaderCacheKey, LoaderCacheEntry>,
+  file_store: Option<LoaderCacheFileStore>,
+}
+
+impl LoaderCacheService {
+  pub(crate) fn new(
+    compiler_path: &str,
+    options: &CompilerOptions,
+    intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
+  ) -> Self {
+    let (enabled, version, file_store) = match &options.cache {
+      CacheOptions::Disabled => (false, "", None),
+      CacheOptions::Memory { .. } => (true, "", None),
+      CacheOptions::Persistent(options) => {
+        let file_store = match &options.storage {
+          StorageOptions::FileSystem { directory } => Some(LoaderCacheFileStore {
+            root: directory.join("loader-chain-cache/v1"),
+            readonly: options.readonly,
+            max_age: options.max_age,
+            fs: intermediate_filesystem,
+          }),
+        };
+        (true, options.version.as_str(), file_store)
+      }
+    };
+    Self {
+      enabled,
+      compiler_scope: format!(
+        "{}\0{compiler_path}\0{}\0{:?}\0{}\0{version}",
+        rspack_workspace::rspack_pkg_version!(),
+        options.name.as_deref().unwrap_or_default(),
+        options.mode,
+        options.context,
+      ),
+      entries: Default::default(),
+      file_store,
+    }
+  }
+}
+
+fn dependency_delta(
+  baseline: &FxHashSet<PathBuf>,
+  current: &FxHashSet<PathBuf>,
+) -> DependencyDelta {
+  DependencyDelta {
+    added: current.difference(baseline).cloned().collect(),
+    removed: baseline.difference(current).cloned().collect(),
+  }
+}
+
+fn replay_dependency_delta(dependencies: &mut FxHashSet<PathBuf>, delta: &DependencyDelta) {
+  dependencies.retain(|dependency| !delta.removed.contains(dependency));
+  dependencies.extend(delta.added.iter().cloned());
+}
+
+fn json_object_delta(
+  baseline: &serde_json::Map<String, serde_json::Value>,
+  current: &serde_json::Map<String, serde_json::Value>,
+) -> JsonObjectDelta {
+  JsonObjectDelta {
+    upserted: current
+      .iter()
+      .filter(|(key, value)| baseline.get(*key) != Some(*value))
+      .map(|(key, value)| (key.clone(), value.clone()))
+      .collect(),
+    removed: baseline
+      .keys()
+      .filter(|key| !current.contains_key(*key))
+      .cloned()
+      .collect(),
+  }
+}
+
+fn replay_json_object_delta(
+  object: &mut serde_json::Map<String, serde_json::Value>,
+  delta: &JsonObjectDelta,
+) {
+  object.retain(|key, _| !delta.removed.contains(key));
+  object.extend(delta.upserted.clone());
+}
+
+async fn file_stamp(context: &RunnerContext, path: PathBuf) -> FileStamp {
+  let path_utf8 = rspack_paths::Utf8Path::from_path(&path);
+  let state = match path_utf8 {
+    Some(path) => match context.fs.metadata(path).await {
+      Ok(metadata) => FileStampState::Existing {
+        mtime_ms: metadata.mtime_ms,
+        ctime_ms: metadata.ctime_ms,
+        size: metadata.size,
+        is_directory: metadata.is_directory,
+      },
+      Err(_) => FileStampState::Missing,
+    },
+    None => FileStampState::Missing,
+  };
+  FileStamp { path, state }
+}
+
+async fn file_stamps(
+  context: &RunnerContext,
+  paths: impl IntoIterator<Item = PathBuf>,
+) -> Vec<FileStamp> {
+  let mut paths = paths.into_iter().collect::<Vec<_>>();
+  paths.sort();
+  paths.dedup();
+  let mut stamps = Vec::with_capacity(paths.len());
+  for path in paths {
+    stamps.push(file_stamp(context, path).await);
+  }
+  stamps
+}
+
+async fn context_dependency_stamps(
+  context: &RunnerContext,
+  roots: impl IntoIterator<Item = PathBuf>,
+) -> Vec<FileStamp> {
+  let mut pending = roots.into_iter().collect::<Vec<_>>();
+  let mut visited = FxHashSet::default();
+  let mut stamps = Vec::new();
+  while let Some(path) = pending.pop() {
+    if !visited.insert(path.clone()) {
+      continue;
+    }
+    let stamp = file_stamp(context, path.clone()).await;
+    if matches!(
+      stamp.state,
+      FileStampState::Existing {
+        is_directory: true,
+        ..
+      }
+    ) && let Some(path) = rspack_paths::Utf8Path::from_path(&path)
+      && let Ok(entries) = context.fs.read_dir(path).await
+    {
+      pending.extend(
+        entries
+          .into_iter()
+          .map(|entry| path.join(entry).into_std_path_buf()),
+      );
+    }
+    stamps.push(stamp);
+  }
+  stamps.sort_by(|left, right| left.path.cmp(&right.path));
+  stamps
+}
+
+async fn stamps_are_valid(context: &RunnerContext, stamps: &[FileStamp]) -> bool {
+  for stored in stamps {
+    if file_stamp(context, stored.path.clone()).await.state != stored.state {
+      return false;
+    }
+  }
+  true
+}
+
+fn input_hash(content: &Content) -> u64 {
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  hasher.write(if content.is_string() {
+    b"string"
+  } else {
+    b"buffer"
+  });
+  hasher.write(content.as_bytes());
+  hasher.finish()
+}
+
+impl LoaderCacheService {
+  async fn cache_key(
+    &self,
+    context: &mut LoaderContext<RunnerContext>,
+    chain: &LoaderChain,
+  ) -> Option<LoaderCacheKey> {
+    // Source maps and AdditionalData are also loader inputs. Until both have
+    // a stable input fingerprint, bypass instead of returning a partial hit.
+    if context.source_map().is_some() || context.additional_data().is_some() {
+      tracing::trace!(
+        target: "rspack::loader_cache",
+        reason = "unsupported-input-metadata",
+        chain_len = chain.len(),
+        "loader chain cache bypass"
+      );
+      return None;
+    }
+    let content = context.content()?;
+    tracing::trace!(
+      target: "rspack::loader_cache",
+      input_bytes = content.as_bytes().len(),
+      chain_len = chain.len(),
+      "loader chain cache key"
+    );
+    let input_hash = input_hash(content);
+    let loader_paths = context.loader_items[chain.range()]
+      .iter()
+      .filter(|loader| loader.path().is_absolute())
+      .map(|loader| loader.path().as_std_path().to_path_buf())
+      .collect::<Vec<_>>();
+    context
+      .build_dependencies
+      .extend(loader_paths.iter().cloned());
+    let loader_files = file_stamps(&context.context, loader_paths).await;
+    Some(LoaderCacheKey {
+      compiler_scope: self.compiler_scope.clone(),
+      static_fingerprint: chain.static_fingerprint().to_owned(),
+      input_hash,
+      loader_files,
+    })
+  }
+
+  pub(crate) async fn before_normal_chain(
+    &self,
+    context: &mut LoaderContext<RunnerContext>,
+    chain: &LoaderChain,
+  ) -> LoaderChainCacheAction {
+    if !self.enabled {
+      tracing::trace!(
+        target: "rspack::loader_cache",
+        reason = "compiler-cache-disabled",
+        chain_len = chain.len(),
+        "loader chain cache bypass"
+      );
+      return LoaderChainCacheAction::Disabled;
+    }
+    let Some(key) = self.cache_key(context, chain).await else {
+      return LoaderChainCacheAction::Disabled;
+    };
+
+    let entry = if let Some(entry) = self.entries.get(&key) {
+      Some(entry.value().clone())
+    } else if let Some(file_store) = &self.file_store {
+      let entry = file_store.get(&key).await;
+      if let Some(entry) = &entry {
+        self.entries.insert(key.clone(), entry.clone());
+      }
+      entry
+    } else {
+      None
+    };
+    if let Some(entry) = entry {
+      if !stamps_are_valid(&context.context, &entry.dependency_stamps).await {
+        tracing::trace!(
+          target: "rspack::loader_cache",
+          reason = "dependency-changed",
+          chain_len = chain.len(),
+          "loader chain cache stale"
+        );
+        self.entries.remove(&key);
+      } else {
+        let source_map = match entry.source_map {
+          Some(source_map) => match SourceMap::from_json(source_map) {
+            Ok(source_map) => Some(source_map),
+            Err(_) => {
+              self.entries.remove(&key);
+              return self.miss(context, key);
+            }
+          },
+          None => None,
+        };
+        replay_dependency_delta(&mut context.file_dependencies, &entry.file_dependencies);
+        replay_dependency_delta(
+          &mut context.context_dependencies,
+          &entry.context_dependencies,
+        );
+        replay_dependency_delta(
+          &mut context.missing_dependencies,
+          &entry.missing_dependencies,
+        );
+        replay_dependency_delta(&mut context.build_dependencies, &entry.build_dependencies);
+        context.parse_meta.extend(entry.parse_meta);
+        context
+          .context
+          .module
+          .build_info_mut()
+          .assets
+          .extend(entry.assets);
+        replay_json_object_delta(
+          &mut context.context.module.build_info_mut().extras,
+          &entry.build_info_extras,
+        );
+        context.__finish_with((entry.content, source_map, entry.additional_data));
+        tracing::trace!(
+          target: "rspack::loader_cache",
+          chain_len = chain.len(),
+          "loader chain cache hit"
+        );
+        return LoaderChainCacheAction::Hit;
+      }
+    }
+
+    tracing::trace!(
+      target: "rspack::loader_cache",
+      chain_len = chain.len(),
+      "loader chain cache miss"
+    );
+    self.miss(context, key)
+  }
+
+  fn miss(
+    &self,
+    context: &LoaderContext<RunnerContext>,
+    key: LoaderCacheKey,
+  ) -> LoaderChainCacheAction {
+    LoaderChainCacheAction::Miss(LoaderChainCacheState::new(LoaderCacheMissState {
+      key,
+      diagnostics_len: context.diagnostics.len(),
+      file_dependencies: context.file_dependencies.clone(),
+      context_dependencies: context.context_dependencies.clone(),
+      missing_dependencies: context.missing_dependencies.clone(),
+      build_dependencies: context.build_dependencies.clone(),
+      parse_meta_keys: context.parse_meta.keys().cloned().collect(),
+      asset_keys: context
+        .context
+        .module
+        .build_info()
+        .assets
+        .keys()
+        .cloned()
+        .collect(),
+      build_info_extras: context.context.module.build_info().extras.clone(),
+    }))
+  }
+
+  pub(crate) async fn after_normal_chain(
+    &self,
+    context: &mut LoaderContext<RunnerContext>,
+    state: LoaderCacheMissState,
+  ) {
+    if !context.cacheable || context.diagnostics.len() != state.diagnostics_len {
+      tracing::trace!(
+        target: "rspack::loader_cache",
+        reason = if !context.cacheable { "cacheable-false" } else { "diagnostics" },
+        "loader chain cache bypass"
+      );
+      return;
+    }
+
+    let file_dependencies = dependency_delta(&state.file_dependencies, &context.file_dependencies);
+    let context_dependencies =
+      dependency_delta(&state.context_dependencies, &context.context_dependencies);
+    let missing_dependencies =
+      dependency_delta(&state.missing_dependencies, &context.missing_dependencies);
+    let build_dependencies =
+      dependency_delta(&state.build_dependencies, &context.build_dependencies);
+    // Stamp the full post-chain dependency sets. A dependency may already have
+    // been registered by a loader to the right, so stamping only set deltas
+    // would miss a dependency that this chain also observes.
+    let dependency_paths = context
+      .file_dependencies
+      .iter()
+      .chain(&context.missing_dependencies)
+      .chain(&context.build_dependencies)
+      .cloned()
+      .collect::<Vec<_>>();
+    let mut dependency_stamps = file_stamps(&context.context, dependency_paths).await;
+    dependency_stamps.extend(
+      context_dependency_stamps(
+        &context.context,
+        context.context_dependencies.iter().cloned(),
+      )
+      .await,
+    );
+    dependency_stamps.sort_by(|left, right| left.path.cmp(&right.path));
+    dependency_stamps.dedup_by(|left, right| left.path == right.path);
+
+    // A dependency changing while the chain is running makes the candidate
+    // ambiguous. Do not publish it.
+    if !stamps_are_valid(&context.context, &dependency_stamps).await {
+      tracing::trace!(
+        target: "rspack::loader_cache",
+        reason = "dependency-changed-during-execution",
+        "loader chain cache bypass"
+      );
+      return;
+    }
+
+    let parse_meta = context
+      .parse_meta
+      .iter()
+      .filter(|(key, _)| !state.parse_meta_keys.contains(*key))
+      .map(|(key, value)| (key.clone(), value.clone()))
+      .collect();
+    let assets = context
+      .context
+      .module
+      .build_info()
+      .assets
+      .iter()
+      .filter(|(key, _)| !state.asset_keys.contains(*key))
+      .map(|(key, value)| (key.clone(), value.clone()))
+      .collect();
+    let build_info_extras = json_object_delta(
+      &state.build_info_extras,
+      &context.context.module.build_info().extras,
+    );
+
+    let entry = LoaderCacheEntry {
+      content: context.content().cloned(),
+      source_map: context.source_map().map(SourceMap::to_json),
+      additional_data: context.additional_data().cloned(),
+      file_dependencies,
+      context_dependencies,
+      missing_dependencies,
+      build_dependencies,
+      dependency_stamps,
+      parse_meta,
+      assets,
+      build_info_extras,
+    };
+    self.entries.insert(state.key.clone(), entry.clone());
+    tracing::trace!(target: "rspack::loader_cache", "loader chain cache store");
+    if let Some(file_store) = &self.file_store {
+      file_store.put(state.key, &entry).await;
+    }
+  }
+}
+
+pub(crate) type SharedLoaderCacheService = Arc<LoaderCacheService>;

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -460,7 +460,10 @@ impl LoaderCacheService {
     let loader_files = file_stamps(&context.context, loader_paths).await;
     Some(LoaderCacheKey {
       compiler_scope: self.compiler_scope.clone(),
-      static_fingerprint: chain.static_fingerprint().to_owned(),
+      static_fingerprint: chain
+        .static_fingerprint()
+        .expect("loader cache service only accepts CacheChain")
+        .to_owned(),
       input_hash,
       loader_files,
     })

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -1,6 +1,11 @@
 use std::sync::Arc;
 
-pub use rspack_loader_runner::{Content, Loader, LoaderContext, run_loaders};
+pub use rspack_loader_runner::{
+  Content, Loader, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState,
+  LoaderChainMergeReason, LoaderChainStrategy, LoaderContext, LoaderExecutionKind,
+  LoaderRunnerOptions, run_loaders, run_loaders_with_options,
+  run_loaders_with_options_and_strategy,
+};
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{CompilationId, CompilerId, CompilerOptions, NormalModule, ResolverFactory};
@@ -11,6 +16,7 @@ pub struct RunnerContext {
   pub compilation_id: CompilationId,
   pub options: Arc<CompilerOptions>,
   pub resolver_factory: Arc<ResolverFactory>,
+  pub fs: Arc<dyn rspack_fs::ReadableFileSystem>,
   pub module: Box<NormalModule>,
   pub source_map_kind: SourceMapKind,
 }

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
 pub use rspack_loader_runner::{
-  Content, Loader, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState,
-  LoaderChainMergeReason, LoaderChainStrategy, LoaderContext, LoaderExecutionKind,
-  LoaderRunnerOptions, run_loaders, run_loaders_with_options,
-  run_loaders_with_options_and_strategy,
+  Content, Loader, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderChainLocation,
+  LoaderChainStrategy, LoaderContext, LoaderExecutionKind, LoaderItem, LoaderItemState,
+  LoaderRunnerOptions, create_loader_items, plan_loader_chains, run_loaders,
+  run_loaders_with_options, run_loaders_with_options_and_strategy, run_loaders_with_preplanned,
 };
 use rspack_util::source_map::SourceMapKind;
 

--- a/crates/rspack_core/src/loader/loaders.rs
+++ b/crates/rspack_core/src/loader/loaders.rs
@@ -1,0 +1,93 @@
+use std::sync::{Arc, OnceLock, RwLock};
+
+use derive_more::Debug;
+use rspack_cacheable::{cacheable, with::Skip};
+
+use crate::{
+  BoxLoader, LoaderChain, LoaderChainLocation, LoaderChainStrategy, LoaderItem,
+  LoaderRunnerOptions, RunnerContext, SharedLoaderCacheService, create_loader_items,
+  plan_loader_chains,
+};
+
+type LoaderChains = (Arc<[LoaderChain]>, Arc<[LoaderChainLocation]>);
+
+/// Static loader metadata and its preassembled execution plan for one module.
+///
+/// The skipped fields are initialized by the module factory. When a module is
+/// restored from persistent cache, they are rebuilt once on first use because
+/// runtime loader metadata and the compiler-scoped cache service are not
+/// serializable.
+#[cacheable]
+#[derive(Debug)]
+pub struct Loaders {
+  #[debug(skip)]
+  loaders: Vec<BoxLoader>,
+  options: Vec<LoaderRunnerOptions>,
+  #[cacheable(with=Skip)]
+  loader_items: OnceLock<Arc<[LoaderItem<RunnerContext>]>>,
+  #[cacheable(with=Skip)]
+  loader_chains: OnceLock<LoaderChains>,
+  #[debug(skip)]
+  #[cacheable(with=Skip)]
+  cache_service: RwLock<Option<SharedLoaderCacheService>>,
+}
+
+impl Loaders {
+  pub(crate) fn new(
+    loaders: Vec<BoxLoader>,
+    options: Vec<LoaderRunnerOptions>,
+    cache_service: SharedLoaderCacheService,
+  ) -> Self {
+    let loader_items = Arc::from(create_loader_items(loaders.clone(), options.clone()));
+    let (loader_chains, loader_chain_locations) =
+      plan_loader_chains(&loader_items, LoaderChainStrategy::default());
+
+    Self {
+      loaders,
+      options,
+      loader_items: OnceLock::from(loader_items),
+      loader_chains: OnceLock::from((Arc::from(loader_chains), Arc::from(loader_chain_locations))),
+      cache_service: RwLock::new(Some(cache_service)),
+    }
+  }
+
+  pub fn loaders(&self) -> &[BoxLoader] {
+    &self.loaders
+  }
+
+  pub(crate) fn loader_items(&self) -> &Arc<[LoaderItem<RunnerContext>]> {
+    self.loader_items.get_or_init(|| {
+      Arc::from(create_loader_items(
+        self.loaders.clone(),
+        self.options.clone(),
+      ))
+    })
+  }
+
+  pub(crate) fn loader_chains(&self) -> &LoaderChains {
+    self.loader_chains.get_or_init(|| {
+      let (chains, locations) =
+        plan_loader_chains(self.loader_items(), LoaderChainStrategy::default());
+      (Arc::from(chains), Arc::from(locations))
+    })
+  }
+
+  pub(crate) fn bind_cache_service(&self, cache_service: SharedLoaderCacheService) {
+    let mut current = self
+      .cache_service
+      .write()
+      .expect("loader cache service lock should not be poisoned");
+    if current.is_none() {
+      *current = Some(cache_service);
+    }
+  }
+
+  pub(crate) fn cache_service(&self) -> SharedLoaderCacheService {
+    self
+      .cache_service
+      .read()
+      .expect("loader cache service lock should not be poisoned")
+      .clone()
+      .expect("loader cache service should be bound before running loaders")
+  }
+}

--- a/crates/rspack_core/src/loader/mod.rs
+++ b/crates/rspack_core/src/loader/mod.rs
@@ -1,5 +1,7 @@
 mod loader_runner;
 pub use loader_runner::*;
+mod loaders;
+pub use loaders::*;
 mod loader_cache;
 pub(crate) use loader_cache::*;
 mod rspack_loader;

--- a/crates/rspack_core/src/loader/mod.rs
+++ b/crates/rspack_core/src/loader/mod.rs
@@ -1,4 +1,6 @@
 mod loader_runner;
 pub use loader_runner::*;
+mod loader_cache;
+pub(crate) use loader_cache::*;
 mod rspack_loader;
 pub use rspack_loader::*;

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -9,10 +9,14 @@ use rspack_loader_runner::{
 use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::{LoaderCacheMissState, RunnerContext, SharedPluginDriver, utils::extract_source_map};
+use crate::{
+  LoaderCacheMissState, RunnerContext, SharedLoaderCacheService, SharedPluginDriver,
+  utils::extract_source_map,
+};
 
 pub struct RspackLoaderRunnerPlugin {
   pub plugin_driver: SharedPluginDriver,
+  pub(crate) loader_cache_service: SharedLoaderCacheService,
   pub extract_source_map: Option<bool>,
 }
 
@@ -132,7 +136,6 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
   ) -> Result<LoaderChainCacheAction> {
     Ok(
       self
-        .plugin_driver
         .loader_cache_service
         .before_normal_chain(context, chain)
         .await,
@@ -149,7 +152,6 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
       .downcast::<LoaderCacheMissState>()
       .expect("loader cache state should be created by LoaderCacheService");
     self
-      .plugin_driver
       .loader_cache_service
       .after_normal_chain(context, *state)
       .await;

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::ReadableFileSystem;
-use rspack_loader_runner::{Content, LoaderContext, LoaderRunnerPlugin, ResourceData};
+use rspack_loader_runner::{
+  Content, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderContext,
+  LoaderRunnerPlugin, ResourceData,
+};
 use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::{RunnerContext, SharedPluginDriver, utils::extract_source_map};
+use crate::{LoaderCacheMissState, RunnerContext, SharedPluginDriver, utils::extract_source_map};
 
 pub struct RspackLoaderRunnerPlugin {
   pub plugin_driver: SharedPluginDriver,
@@ -120,5 +123,36 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
       .loader_yield
       .call(context)
       .await
+  }
+
+  async fn before_normal_chain(
+    &self,
+    context: &mut LoaderContext<Self::Context>,
+    chain: &LoaderChain,
+  ) -> Result<LoaderChainCacheAction> {
+    Ok(
+      self
+        .plugin_driver
+        .loader_cache_service
+        .before_normal_chain(context, chain)
+        .await,
+    )
+  }
+
+  async fn after_normal_chain(
+    &self,
+    context: &mut LoaderContext<Self::Context>,
+    _chain: &LoaderChain,
+    state: LoaderChainCacheState,
+  ) -> Result<()> {
+    let state = state
+      .downcast::<LoaderCacheMissState>()
+      .expect("loader cache state should be created by LoaderCacheService");
+    self
+      .plugin_driver
+      .loader_cache_service
+      .after_normal_chain(context, *state)
+      .await;
+    Ok(())
   }
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -16,7 +16,9 @@ use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
-use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData, run_loaders};
+use rspack_loader_runner::{
+  AdditionalData, Content, LoaderContext, ResourceData, run_loaders_with_options,
+};
 use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
@@ -29,11 +31,12 @@ use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependencyTemplate, BoxLoader, BoxModule,
   BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph,
   CodeGenerationResult, Compilation, ConnectionState, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
-  ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
-  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
+  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions,
+  LoaderRunnerOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext,
+  ParseResult, ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions,
+  RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
+  SourceType, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
@@ -119,6 +122,7 @@ pub struct NormalModule {
   /// Loaders for the module
   #[debug(skip)]
   loaders: Vec<BoxLoader>,
+  loader_runner_options: Vec<LoaderRunnerOptions>,
 
   /// Built source of this module (passed with loaders)
   #[cacheable(with=AsOption<AsPreset>)]
@@ -187,6 +191,7 @@ impl NormalModule {
     resource_data: Arc<ResourceData>,
     resolve_options: Option<Arc<Resolve>>,
     loaders: Vec<BoxLoader>,
+    loader_runner_options: Vec<LoaderRunnerOptions>,
     context: Option<Context>,
     extract_source_map: Option<bool>,
     import_phase: ImportPhase,
@@ -213,6 +218,7 @@ impl NormalModule {
       resource_data,
       resolve_options,
       loaders,
+      loader_runner_options,
       source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,
@@ -412,8 +418,9 @@ impl Module for NormalModule {
     let compiler_options = build_context.compiler_options.clone();
     let resolver_factory = build_context.resolver_factory.clone();
     let fs = build_context.fs.clone();
-    let (mut loader_result, err) = run_loaders(
+    let (mut loader_result, err) = run_loaders_with_options(
       self.loaders.clone(),
+      self.loader_runner_options.clone(),
       self.resource_data.clone(),
       Some(plugin.clone()),
       RunnerContext {
@@ -421,6 +428,7 @@ impl Module for NormalModule {
         compilation_id,
         options: compiler_options,
         resolver_factory,
+        fs: fs.clone(),
         source_map_kind: self.source_map_kind,
         module: self,
       },

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -16,9 +16,7 @@ use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
-use rspack_loader_runner::{
-  AdditionalData, Content, LoaderContext, ResourceData, run_loaders_with_options,
-};
+use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData};
 use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
@@ -31,15 +29,14 @@ use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependencyTemplate, BoxLoader, BoxModule,
   BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph,
   CodeGenerationResult, Compilation, ConnectionState, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions,
-  LoaderRunnerOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext,
-  ParseResult, ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions,
-  RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
-  SourceType, contextify,
+  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions, Loaders, Module,
+  ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
+  ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
+  ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
+  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
-  module_update_hash,
+  module_update_hash, run_loaders_with_preplanned,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -121,8 +118,7 @@ pub struct NormalModule {
   resource_data: Arc<ResourceData>,
   /// Loaders for the module
   #[debug(skip)]
-  loaders: Vec<BoxLoader>,
-  loader_runner_options: Vec<LoaderRunnerOptions>,
+  loaders: Arc<Loaders>,
 
   /// Built source of this module (passed with loaders)
   #[cacheable(with=AsOption<AsPreset>)]
@@ -190,8 +186,7 @@ impl NormalModule {
     match_resource: Option<ResourceData>,
     resource_data: Arc<ResourceData>,
     resolve_options: Option<Arc<Resolve>>,
-    loaders: Vec<BoxLoader>,
-    loader_runner_options: Vec<LoaderRunnerOptions>,
+    loaders: Arc<Loaders>,
     context: Option<Context>,
     extract_source_map: Option<bool>,
     import_phase: ImportPhase,
@@ -218,7 +213,6 @@ impl NormalModule {
       resource_data,
       resolve_options,
       loaders,
-      loader_runner_options,
       source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,
@@ -268,7 +262,7 @@ impl NormalModule {
   }
 
   pub fn loaders(&self) -> &[BoxLoader] {
-    &self.loaders
+    self.loaders.loaders()
   }
 
   pub fn parser_and_generator(&self) -> &dyn ParserAndGenerator {
@@ -385,7 +379,7 @@ impl Module for NormalModule {
     perfetto.process_name = format!("Rspack Build Detail"),
     module.resource = self.resource_resolved_data().resource(),
     module.identifier = self.identifier().as_str(),
-    module.loaders = ?self.loaders.iter().map(|l| l.identifier().as_str()).collect::<Vec<_>>())
+    module.loaders = ?self.loaders.loaders().iter().map(|l| l.identifier().as_str()).collect::<Vec<_>>())
   )]
   async fn build(
     mut self: Box<Self>,
@@ -408,8 +402,18 @@ impl Module for NormalModule {
       .call(self.as_mut())
       .await?;
 
+    self
+      .loaders
+      .bind_cache_service(build_context.plugin_driver.loader_cache_service.clone());
+    let loader_cache_service = self.loaders.cache_service();
+    let loader_items = self.loaders.loader_items().clone();
+    let (loader_chains, loader_chain_locations) = {
+      let (chains, locations) = self.loaders.loader_chains();
+      (chains.clone(), locations.clone())
+    };
     let plugin = Arc::new(RspackLoaderRunnerPlugin {
       plugin_driver: build_context.plugin_driver.clone(),
+      loader_cache_service,
       extract_source_map: self.extract_source_map,
     });
 
@@ -418,9 +422,10 @@ impl Module for NormalModule {
     let compiler_options = build_context.compiler_options.clone();
     let resolver_factory = build_context.resolver_factory.clone();
     let fs = build_context.fs.clone();
-    let (mut loader_result, err) = run_loaders_with_options(
-      self.loaders.clone(),
-      self.loader_runner_options.clone(),
+    let (mut loader_result, err) = run_loaders_with_preplanned(
+      loader_items,
+      loader_chains,
+      loader_chain_locations,
       self.resource_data.clone(),
       Some(plugin.clone()),
       RunnerContext {
@@ -575,7 +580,7 @@ impl Module for NormalModule {
         module_user_request: &self.user_request,
         module_match_resource: self.match_resource.as_ref(),
         module_source_map_kind: self.source_map_kind,
-        loaders: &self.loaders,
+        loaders: self.loaders.loaders(),
         resource_data: &self.resource_data,
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -12,7 +12,7 @@ use crate::{
   AssetInlineGeneratorOptions, AssetResourceGeneratorOptions, BoxLoader, BoxModule,
   CompilerOptions, Context, CssAutoOrModuleParserOptions, CssModuleGeneratorOptions,
   CssModuleParserOptions, Dependency, DependencyCategory, DependencyType, FactoryMeta, FuncUseCtx,
-  GeneratorOptions, MatchContext, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
+  GeneratorOptions, Loaders, MatchContext, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
   ModuleFactoryResult, ModuleIdentifier, ModuleLayer, ModuleRuleEffect, ModuleRuleEnforce,
   ModuleRuleUse, ModuleRuleUseLoader, ModuleType, NormalModule, ParserAndGenerator, ParserOptions,
   ParserOptionsMap, RawModule, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
@@ -1107,6 +1107,11 @@ module.exports = "data:,";
       .into_iter()
       .map(|resolved| (resolved.loader, resolved.options))
       .unzip();
+    let loaders = Arc::new(Loaders::new(
+      loaders,
+      loader_runner_options,
+      self.plugin_driver.loader_cache_service.clone(),
+    ));
 
     let resolved_module_type = self.calculate_module_type(match_module_type, &matched_module_rules);
     let resolved_module_layer =
@@ -1188,7 +1193,6 @@ module.exports = "data:,";
         resource_resolve_data,
         resolved_resolve_options,
         loaders,
-        loader_runner_options,
         create_data.context.clone().map(|x| x.into()),
         resolved_extract_source_map,
         dependency_phase,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
-use rspack_loader_runner::{Loader, Scheme, get_scheme};
+use rspack_loader_runner::{Loader, LoaderRunnerOptions, Scheme, get_scheme};
 use rspack_paths::ArcResolverPathSet;
 use rspack_util::{MergeFrom, fx_hash::FxDashMap};
 use sugar_path::SugarPath;
@@ -853,6 +853,8 @@ impl NormalModuleFactory {
                 .get(ident)
                 .map(|object| object.to_string())
             }),
+            cache: false,
+            cache_key: String::new(),
           }
         }));
         scheme = get_scheme(unresolved_resource);
@@ -999,7 +1001,7 @@ module.exports = "data:,";
       }
     };
 
-    let loaders: Vec<BoxLoader> = {
+    let resolved_loaders: Vec<ResolvedLoader> = {
       let mut pre_loaders: Vec<ModuleRuleUseLoader> = vec![];
       let mut post_loaders: Vec<ModuleRuleUseLoader> = vec![];
       let mut normal_loaders: Vec<ModuleRuleUseLoader> = vec![];
@@ -1049,42 +1051,62 @@ module.exports = "data:,";
       );
 
       for l in post_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        all_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options.context, &loader_resolver, &l)
+            .await?,
+        )
       }
 
       let mut resolved_normal_loaders = vec![];
       for l in normal_loaders {
-        resolved_normal_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        resolved_normal_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options.context, &loader_resolver, &l)
+            .await?,
+        )
       }
 
       if match_resource_data.is_some() {
         all_loaders.extend(resolved_normal_loaders);
-        all_loaders.extend(resolved_inline_loaders);
+        all_loaders.extend(
+          resolved_inline_loaders
+            .iter()
+            .cloned()
+            .map(ResolvedLoader::uncached),
+        );
       } else {
-        all_loaders.extend(resolved_inline_loaders);
+        all_loaders.extend(
+          resolved_inline_loaders
+            .iter()
+            .cloned()
+            .map(ResolvedLoader::uncached),
+        );
         all_loaders.extend(resolved_normal_loaders);
       }
 
       for l in pre_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        all_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options.context, &loader_resolver, &l)
+            .await?,
+        )
       }
 
       all_loaders
     };
 
-    let request = if !loaders.is_empty() {
-      let s = loaders
+    let request = if !resolved_loaders.is_empty() {
+      let s = resolved_loaders
         .iter()
-        .map(|i| i.identifier().as_str())
+        .map(|i| i.loader.identifier().as_str())
         .collect::<Vec<_>>()
         .join("!");
       format!("{s}!{}", resource_data.resource())
     } else {
       resource_data.resource().to_owned()
     };
+    let (loaders, loader_runner_options): (Vec<_>, Vec<_>) = resolved_loaders
+      .into_iter()
+      .map(|resolved| (resolved.loader, resolved.options))
+      .unzip();
 
     let resolved_module_type = self.calculate_module_type(match_module_type, &matched_module_rules);
     let resolved_module_layer =
@@ -1166,6 +1188,7 @@ module.exports = "data:,";
         resource_resolve_data,
         resolved_resolve_options,
         loaders,
+        loader_runner_options,
         create_data.context.clone().map(|x| x.into()),
         resolved_extract_source_map,
         dependency_phase,
@@ -1350,6 +1373,35 @@ async fn resolve_each(
     .call(context, loader_resolver, l)
     .await?
     .ok_or_else(|| error!("Unable to resolve loader {}", l.loader))
+}
+
+struct ResolvedLoader {
+  loader: BoxLoader,
+  options: LoaderRunnerOptions,
+}
+
+impl ResolvedLoader {
+  fn uncached(loader: BoxLoader) -> Self {
+    Self {
+      loader,
+      options: LoaderRunnerOptions::default(),
+    }
+  }
+}
+
+async fn resolve_each_with_options(
+  plugin_driver: &SharedPluginDriver,
+  context: &Context,
+  loader_resolver: &Resolver,
+  loader: &ModuleRuleUseLoader,
+) -> Result<ResolvedLoader> {
+  Ok(ResolvedLoader {
+    loader: resolve_each(plugin_driver, context, loader_resolver, loader).await?,
+    options: LoaderRunnerOptions {
+      cache: loader.cache,
+      cache_key: loader.cache_key.clone(),
+    },
+  })
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -1693,6 +1693,11 @@ pub struct ModuleRuleUseLoader {
   /// Loader options
   /// This only exists if the loader is a built-in loader.
   pub options: Option<String>,
+  /// Cache the normal result of this loader.
+  pub cache: bool,
+  /// Stable serialization of the public loader options, used by loader-chain
+  /// cache key construction.
+  pub cache_key: String,
 }
 
 pub type FnUse =

--- a/crates/rspack_core/src/plugin/plugin_driver.rs
+++ b/crates/rspack_core/src/plugin/plugin_driver.rs
@@ -2,12 +2,13 @@ use std::sync::{Arc, Mutex};
 
 use derive_more::Debug;
 use rspack_error::Diagnostic;
+use rspack_fs::IntermediateFileSystem;
 use rspack_util::fx_hash::FxDashMap;
 
 use crate::{
   ApplyContext, BoxedParserAndGeneratorBuilder, CompilationHooks, CompilationId, CompilerHooks,
   CompilerOptions, ConcatenatedModuleHooks, ContextModuleFactoryHooks, ModuleType,
-  NormalModuleFactoryHooks, NormalModuleHooks, Plugin, ResolverFactory,
+  NormalModuleFactoryHooks, NormalModuleHooks, Plugin, ResolverFactory, SharedLoaderCacheService,
 };
 
 #[derive(Debug)]
@@ -15,6 +16,7 @@ pub struct PluginDriver {
   pub(crate) options: Arc<CompilerOptions>,
   pub plugins: Vec<Box<dyn Plugin>>,
   pub resolver_factory: Arc<ResolverFactory>,
+  pub(crate) loader_cache_service: SharedLoaderCacheService,
   #[debug(skip)]
   pub registered_parser_and_generator_builder:
     FxDashMap<ModuleType, BoxedParserAndGeneratorBuilder>,
@@ -30,9 +32,11 @@ pub struct PluginDriver {
 
 impl PluginDriver {
   pub fn new(
+    compiler_path: &str,
     options: Arc<CompilerOptions>,
     plugins: Vec<Box<dyn Plugin>>,
     resolver_factory: Arc<ResolverFactory>,
+    intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   ) -> Arc<Self> {
     let mut compiler_hooks = Default::default();
     let mut compilation_hooks = Default::default();
@@ -61,6 +65,11 @@ impl PluginDriver {
       options: options.clone(),
       plugins,
       resolver_factory,
+      loader_cache_service: Arc::new(crate::LoaderCacheService::new(
+        compiler_path,
+        &options,
+        intermediate_filesystem,
+      )),
       registered_parser_and_generator_builder,
       diagnostics: Arc::new(Mutex::new(vec![])),
       compiler_hooks,

--- a/crates/rspack_loader_runner/src/chain.rs
+++ b/crates/rspack_loader_runner/src/chain.rs
@@ -1,0 +1,201 @@
+use std::{any::Any, ops::Range};
+
+use rspack_cacheable::cacheable;
+
+use crate::LoaderItem;
+
+#[cacheable]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LoaderRunnerOptions {
+  pub cache: bool,
+  pub cache_key: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoaderExecutionKind {
+  Native,
+  JavaScript,
+  Mixed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LoaderChainMergeReason {
+  Singleton,
+  Cache,
+  JavaScript,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum LoaderChainStrategy {
+  None,
+  CacheOnly,
+  JavaScriptOnly,
+  #[default]
+  CacheAndJavaScript,
+}
+
+impl LoaderChainStrategy {
+  fn merge_cache(self) -> bool {
+    matches!(self, Self::CacheOnly | Self::CacheAndJavaScript)
+  }
+
+  fn merge_javascript(self) -> bool {
+    matches!(self, Self::JavaScriptOnly | Self::CacheAndJavaScript)
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoaderChain {
+  range: Range<usize>,
+  cache: bool,
+  execution_kind: LoaderExecutionKind,
+  merge_reason: LoaderChainMergeReason,
+  static_fingerprint: String,
+}
+
+pub struct LoaderChainCacheState(Box<dyn Any + Send>);
+
+impl std::fmt::Debug for LoaderChainCacheState {
+  fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    formatter.write_str("LoaderChainCacheState(..)")
+  }
+}
+
+impl LoaderChainCacheState {
+  pub fn new(value: impl Any + Send) -> Self {
+    Self(Box::new(value))
+  }
+
+  pub fn downcast<T: Any + Send>(self) -> std::result::Result<Box<T>, Self> {
+    match self.0.downcast::<T>() {
+      Ok(value) => Ok(value),
+      Err(value) => Err(Self(value)),
+    }
+  }
+}
+
+pub enum LoaderChainCacheAction {
+  Disabled,
+  Hit,
+  Miss(LoaderChainCacheState),
+}
+
+impl LoaderChain {
+  pub fn range(&self) -> Range<usize> {
+    self.range.clone()
+  }
+
+  pub fn start(&self) -> usize {
+    self.range.start
+  }
+
+  pub fn end(&self) -> usize {
+    self.range.end
+  }
+
+  pub fn len(&self) -> usize {
+    self.range.len()
+  }
+
+  pub fn is_empty(&self) -> bool {
+    self.range.is_empty()
+  }
+
+  pub fn cache(&self) -> bool {
+    self.cache
+  }
+
+  pub fn execution_kind(&self) -> LoaderExecutionKind {
+    self.execution_kind
+  }
+
+  pub fn merge_reason(&self) -> LoaderChainMergeReason {
+    self.merge_reason
+  }
+
+  pub fn static_fingerprint(&self) -> &str {
+    &self.static_fingerprint
+  }
+
+  pub fn contains(&self, loader_index: usize) -> bool {
+    self.range.contains(&loader_index)
+  }
+}
+
+pub fn plan_loader_chains<Context: Send>(
+  loaders: &[LoaderItem<Context>],
+  strategy: LoaderChainStrategy,
+) -> Vec<LoaderChain> {
+  let mut chains = Vec::new();
+  let mut index = 0;
+
+  while index < loaders.len() {
+    let first = &loaders[index];
+    let mut end = index + 1;
+    let mut merge_reason = LoaderChainMergeReason::Singleton;
+
+    if strategy.merge_cache() && first.cache() {
+      while end < loaders.len() && loaders[end].cache() {
+        end += 1;
+      }
+      merge_reason = LoaderChainMergeReason::Cache;
+    } else if strategy.merge_javascript()
+      && first.execution_kind() == LoaderExecutionKind::JavaScript
+      && !first.cache()
+    {
+      // A cache boundary is a semantic boundary. JavaScript loaders on both
+      // sides may still be yielded together by a higher-level dispatcher in
+      // the future, but they cannot become one cache unit.
+      while end < loaders.len()
+        && loaders[end].execution_kind() == LoaderExecutionKind::JavaScript
+        && !loaders[end].cache()
+      {
+        end += 1;
+      }
+      if end > index + 1 {
+        merge_reason = LoaderChainMergeReason::JavaScript;
+      }
+    }
+
+    let execution_kind = loaders[index..end]
+      .iter()
+      .map(LoaderItem::execution_kind)
+      .reduce(|left, right| {
+        if left == right {
+          left
+        } else {
+          LoaderExecutionKind::Mixed
+        }
+      })
+      .unwrap_or(LoaderExecutionKind::Native);
+    let cache = loaders[index..end].iter().all(LoaderItem::cache);
+    let mut static_fingerprint = String::new();
+    for loader in loaders[index..end].iter().rev() {
+      // `request` contains path, query and fragment. The explicit loader type
+      // is appended because it changes raw/string conversion semantics.
+      let request = loader.request();
+      let identity = request.as_str();
+      let options = loader.cache_key();
+      static_fingerprint.push_str(&identity.len().to_string());
+      static_fingerprint.push(':');
+      static_fingerprint.push_str(identity);
+      static_fingerprint.push_str(&loader.r#type().len().to_string());
+      static_fingerprint.push(':');
+      static_fingerprint.push_str(loader.r#type());
+      static_fingerprint.push_str(&options.len().to_string());
+      static_fingerprint.push(':');
+      static_fingerprint.push_str(options);
+    }
+
+    chains.push(LoaderChain {
+      range: index..end,
+      cache,
+      execution_kind,
+      merge_reason,
+      static_fingerprint,
+    });
+    index = end;
+  }
+
+  chains
+}

--- a/crates/rspack_loader_runner/src/chain.rs
+++ b/crates/rspack_loader_runner/src/chain.rs
@@ -15,14 +15,6 @@ pub struct LoaderRunnerOptions {
 pub enum LoaderExecutionKind {
   Native,
   JavaScript,
-  Mixed,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum LoaderChainMergeReason {
-  Singleton,
-  Cache,
-  JavaScript,
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -45,15 +37,37 @@ impl LoaderChainStrategy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LoaderChain {
-  range: Range<usize>,
-  cache: bool,
-  execution_kind: LoaderExecutionKind,
-  merge_reason: LoaderChainMergeReason,
-  static_fingerprint: String,
+pub enum LoaderChain {
+  CacheChain {
+    range: Range<usize>,
+    static_fingerprint: String,
+    children: Vec<LoaderChain>,
+  },
+  JsExecutionChain {
+    range: Range<usize>,
+  },
+  NativeExecutionChain {
+    range: Range<usize>,
+  },
 }
 
-pub struct LoaderChainCacheState(Box<dyn Any + Send>);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoaderChainLocation {
+  root_index: usize,
+  child_index: Option<usize>,
+}
+
+impl LoaderChainLocation {
+  pub fn root_index(&self) -> usize {
+    self.root_index
+  }
+
+  pub fn child_index(&self) -> Option<usize> {
+    self.child_index
+  }
+}
+
+pub struct LoaderChainCacheState(Box<dyn Any + Send + Sync>);
 
 impl std::fmt::Debug for LoaderChainCacheState {
   fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -62,11 +76,11 @@ impl std::fmt::Debug for LoaderChainCacheState {
 }
 
 impl LoaderChainCacheState {
-  pub fn new(value: impl Any + Send) -> Self {
+  pub fn new(value: impl Any + Send + Sync) -> Self {
     Self(Box::new(value))
   }
 
-  pub fn downcast<T: Any + Send>(self) -> std::result::Result<Box<T>, Self> {
+  pub fn downcast<T: Any + Send + Sync>(self) -> std::result::Result<Box<T>, Self> {
     match self.0.downcast::<T>() {
       Ok(value) => Ok(value),
       Err(value) => Err(Self(value)),
@@ -80,122 +94,267 @@ pub enum LoaderChainCacheAction {
   Miss(LoaderChainCacheState),
 }
 
+#[derive(Debug)]
+pub enum CacheChainState {
+  Pending,
+  Bypassed,
+  Hit,
+  Miss(LoaderChainCacheState),
+  Completed,
+}
+
 impl LoaderChain {
   pub fn range(&self) -> Range<usize> {
-    self.range.clone()
+    match self {
+      Self::CacheChain { range, .. }
+      | Self::JsExecutionChain { range }
+      | Self::NativeExecutionChain { range } => range.clone(),
+    }
   }
 
   pub fn start(&self) -> usize {
-    self.range.start
+    self.range().start
   }
 
   pub fn end(&self) -> usize {
-    self.range.end
+    self.range().end
   }
 
   pub fn len(&self) -> usize {
-    self.range.len()
+    self.range().len()
   }
 
   pub fn is_empty(&self) -> bool {
-    self.range.is_empty()
+    self.range().is_empty()
   }
 
-  pub fn cache(&self) -> bool {
-    self.cache
+  pub fn is_cache(&self) -> bool {
+    matches!(self, Self::CacheChain { .. })
   }
 
-  pub fn execution_kind(&self) -> LoaderExecutionKind {
-    self.execution_kind
+  pub fn execution_kind(&self) -> Option<LoaderExecutionKind> {
+    match self {
+      Self::CacheChain { .. } => None,
+      Self::JsExecutionChain { .. } => Some(LoaderExecutionKind::JavaScript),
+      Self::NativeExecutionChain { .. } => Some(LoaderExecutionKind::Native),
+    }
   }
 
-  pub fn merge_reason(&self) -> LoaderChainMergeReason {
-    self.merge_reason
+  pub fn children(&self) -> &[LoaderChain] {
+    match self {
+      Self::CacheChain { children, .. } => children,
+      Self::JsExecutionChain { .. } | Self::NativeExecutionChain { .. } => &[],
+    }
   }
 
-  pub fn static_fingerprint(&self) -> &str {
-    &self.static_fingerprint
+  pub fn static_fingerprint(&self) -> Option<&str> {
+    match self {
+      Self::CacheChain {
+        static_fingerprint, ..
+      } => Some(static_fingerprint),
+      Self::JsExecutionChain { .. } | Self::NativeExecutionChain { .. } => None,
+    }
   }
 
   pub fn contains(&self, loader_index: usize) -> bool {
-    self.range.contains(&loader_index)
+    self.range().contains(&loader_index)
   }
+}
+
+fn execution_chain(range: Range<usize>, kind: LoaderExecutionKind) -> LoaderChain {
+  match kind {
+    LoaderExecutionKind::Native => LoaderChain::NativeExecutionChain { range },
+    LoaderExecutionKind::JavaScript => LoaderChain::JsExecutionChain { range },
+  }
+}
+
+fn plan_execution_chains<Context: Send>(
+  loaders: &[LoaderItem<Context>],
+  range: Range<usize>,
+  merge_javascript: bool,
+) -> Vec<LoaderChain> {
+  let mut chains = Vec::new();
+  let mut index = range.start;
+  while index < range.end {
+    let kind = loaders[index].execution_kind();
+    let mut end = index + 1;
+    if merge_javascript && kind == LoaderExecutionKind::JavaScript {
+      while end < range.end && loaders[end].execution_kind() == LoaderExecutionKind::JavaScript {
+        end += 1;
+      }
+    }
+    chains.push(execution_chain(index..end, kind));
+    index = end;
+  }
+  chains
+}
+
+fn static_fingerprint<Context: Send>(
+  loaders: &[LoaderItem<Context>],
+  range: Range<usize>,
+) -> String {
+  let mut fingerprint = String::new();
+  for loader in loaders[range].iter().rev() {
+    // `request` contains path, query and fragment. The explicit loader type
+    // is appended because it changes raw/string conversion semantics.
+    let request = loader.request();
+    let identity = request.as_str();
+    let options = loader.cache_key();
+    fingerprint.push_str(&identity.len().to_string());
+    fingerprint.push(':');
+    fingerprint.push_str(identity);
+    fingerprint.push_str(&loader.r#type().len().to_string());
+    fingerprint.push(':');
+    fingerprint.push_str(loader.r#type());
+    fingerprint.push_str(&options.len().to_string());
+    fingerprint.push(':');
+    fingerprint.push_str(options);
+  }
+  fingerprint
 }
 
 pub fn plan_loader_chains<Context: Send>(
   loaders: &[LoaderItem<Context>],
   strategy: LoaderChainStrategy,
-) -> Vec<LoaderChain> {
-  let mut chains = Vec::new();
+) -> (Vec<LoaderChain>, Vec<LoaderChainLocation>) {
+  let mut roots = Vec::new();
+  let mut locations = vec![
+    LoaderChainLocation {
+      root_index: 0,
+      child_index: None,
+    };
+    loaders.len()
+  ];
   let mut index = 0;
 
   while index < loaders.len() {
-    let first = &loaders[index];
-    let mut end = index + 1;
-    let mut merge_reason = LoaderChainMergeReason::Singleton;
-
-    if strategy.merge_cache() && first.cache() {
-      while end < loaders.len() && loaders[end].cache() {
-        end += 1;
+    let root_index = roots.len();
+    if loaders[index].cache() {
+      let mut end = index + 1;
+      if strategy.merge_cache() {
+        while end < loaders.len() && loaders[end].cache() {
+          end += 1;
+        }
       }
-      merge_reason = LoaderChainMergeReason::Cache;
-    } else if strategy.merge_javascript()
-      && first.execution_kind() == LoaderExecutionKind::JavaScript
-      && !first.cache()
-    {
-      // A cache boundary is a semantic boundary. JavaScript loaders on both
-      // sides may still be yielded together by a higher-level dispatcher in
-      // the future, but they cannot become one cache unit.
+      let range = index..end;
+      let children = plan_execution_chains(loaders, range.clone(), strategy.merge_javascript());
+      for (child_index, child) in children.iter().enumerate() {
+        for loader_index in child.range() {
+          locations[loader_index] = LoaderChainLocation {
+            root_index,
+            child_index: Some(child_index),
+          };
+        }
+      }
+      roots.push(LoaderChain::CacheChain {
+        static_fingerprint: static_fingerprint(loaders, range.clone()),
+        range,
+        children,
+      });
+      index = end;
+      continue;
+    }
+
+    let kind = loaders[index].execution_kind();
+    let mut end = index + 1;
+    if strategy.merge_javascript() && kind == LoaderExecutionKind::JavaScript {
       while end < loaders.len()
-        && loaders[end].execution_kind() == LoaderExecutionKind::JavaScript
         && !loaders[end].cache()
+        && loaders[end].execution_kind() == LoaderExecutionKind::JavaScript
       {
         end += 1;
       }
-      if end > index + 1 {
-        merge_reason = LoaderChainMergeReason::JavaScript;
-      }
     }
-
-    let execution_kind = loaders[index..end]
-      .iter()
-      .map(LoaderItem::execution_kind)
-      .reduce(|left, right| {
-        if left == right {
-          left
-        } else {
-          LoaderExecutionKind::Mixed
-        }
-      })
-      .unwrap_or(LoaderExecutionKind::Native);
-    let cache = loaders[index..end].iter().all(LoaderItem::cache);
-    let mut static_fingerprint = String::new();
-    for loader in loaders[index..end].iter().rev() {
-      // `request` contains path, query and fragment. The explicit loader type
-      // is appended because it changes raw/string conversion semantics.
-      let request = loader.request();
-      let identity = request.as_str();
-      let options = loader.cache_key();
-      static_fingerprint.push_str(&identity.len().to_string());
-      static_fingerprint.push(':');
-      static_fingerprint.push_str(identity);
-      static_fingerprint.push_str(&loader.r#type().len().to_string());
-      static_fingerprint.push(':');
-      static_fingerprint.push_str(loader.r#type());
-      static_fingerprint.push_str(&options.len().to_string());
-      static_fingerprint.push(':');
-      static_fingerprint.push_str(options);
+    for location in &mut locations[index..end] {
+      *location = LoaderChainLocation {
+        root_index,
+        child_index: None,
+      };
     }
-
-    chains.push(LoaderChain {
-      range: index..end,
-      cache,
-      execution_kind,
-      merge_reason,
-      static_fingerprint,
-    });
+    roots.push(execution_chain(index..end, kind));
     index = end;
   }
 
-  chains
+  debug_assert_eq!(locations.len(), loaders.len());
+  #[cfg(debug_assertions)]
+  validate_loader_chain_plan(loaders, &roots, &locations);
+  (roots, locations)
+}
+
+#[cfg(debug_assertions)]
+fn validate_loader_chain_plan<Context: Send>(
+  loaders: &[LoaderItem<Context>],
+  roots: &[LoaderChain],
+  locations: &[LoaderChainLocation],
+) {
+  assert_eq!(locations.len(), loaders.len());
+  let mut next_root_start = 0;
+
+  for (root_index, root) in roots.iter().enumerate() {
+    let root_range = root.range();
+    assert_eq!(root_range.start, next_root_start);
+    assert!(root_range.start < root_range.end);
+    assert!(root_range.end <= loaders.len());
+    next_root_start = root_range.end;
+
+    match root {
+      LoaderChain::CacheChain { children, .. } => {
+        assert!(loaders[root_range.clone()].iter().all(LoaderItem::cache));
+        assert!(!children.is_empty());
+        let mut next_child_start = root_range.start;
+        for (child_index, child) in children.iter().enumerate() {
+          assert!(!child.is_cache());
+          let child_range = child.range();
+          assert_eq!(child_range.start, next_child_start);
+          assert!(child_range.start < child_range.end);
+          assert!(child_range.end <= root_range.end);
+          next_child_start = child_range.end;
+          let kind = child
+            .execution_kind()
+            .expect("cache children must be execution chains");
+          assert!(
+            loaders[child_range.clone()]
+              .iter()
+              .all(|loader| loader.execution_kind() == kind)
+          );
+          for loader_index in child_range {
+            assert_eq!(
+              locations[loader_index],
+              LoaderChainLocation {
+                root_index,
+                child_index: Some(child_index),
+              }
+            );
+          }
+        }
+        assert_eq!(next_child_start, root_range.end);
+      }
+      LoaderChain::JsExecutionChain { .. } | LoaderChain::NativeExecutionChain { .. } => {
+        assert!(
+          loaders[root_range.clone()]
+            .iter()
+            .all(|loader| !loader.cache())
+        );
+        let kind = root
+          .execution_kind()
+          .expect("execution root must have an execution kind");
+        assert!(
+          loaders[root_range.clone()]
+            .iter()
+            .all(|loader| loader.execution_kind() == kind)
+        );
+        for loader_index in root_range {
+          assert_eq!(
+            locations[loader_index],
+            LoaderChainLocation {
+              root_index,
+              child_index: None,
+            }
+          );
+        }
+      }
+    }
+  }
+
+  assert_eq!(next_root_start, loaders.len());
 }

--- a/crates/rspack_loader_runner/src/context.rs
+++ b/crates/rspack_loader_runner/src/context.rs
@@ -1,4 +1,4 @@
-use std::{ops::Range, path::PathBuf, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use derive_more::Debug;
 use rspack_error::Diagnostic;
@@ -7,8 +7,8 @@ use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  AdditionalData, Content, LoaderChain, LoaderItem, LoaderRunnerPlugin, ParseMeta, ResourceData,
-  loader::LoaderItemList,
+  AdditionalData, CacheChainState, Content, LoaderChain, LoaderChainLocation, LoaderItem,
+  LoaderItemState, LoaderRunnerPlugin, ParseMeta, ResourceData, loader::LoaderItemList,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -56,8 +56,11 @@ pub struct LoaderContext<Context: Send> {
   /// Loader States
   pub(crate) state: State,
   pub loader_index: i32,
-  pub loader_items: Vec<LoaderItem<Context>>,
-  pub(crate) loader_chains: Vec<LoaderChain>,
+  pub loader_items: Arc<[LoaderItem<Context>]>,
+  pub loader_item_states: Vec<LoaderItemState>,
+  pub(crate) loader_chains: Arc<[LoaderChain]>,
+  pub(crate) loader_chain_locations: Arc<[LoaderChainLocation]>,
+  pub(crate) cache_chain_states: Vec<Option<CacheChainState>>,
   #[debug(skip)]
   pub plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
 }
@@ -87,6 +90,34 @@ impl<Context: Send> LoaderContext<Context> {
     &self.loader_items[self.loader_index as usize]
   }
 
+  pub fn loader_item_state(&self, index: usize) -> &LoaderItemState {
+    &self.loader_item_states[index]
+  }
+
+  pub fn loader_item_state_mut(&mut self, index: usize) -> &mut LoaderItemState {
+    &mut self.loader_item_states[index]
+  }
+
+  pub fn current_loader_state(&self) -> &LoaderItemState {
+    self.loader_item_state(self.loader_index as usize)
+  }
+
+  pub fn current_loader_state_mut(&mut self) -> &mut LoaderItemState {
+    self.loader_item_state_mut(self.loader_index as usize)
+  }
+
+  pub fn set_current_loader_pitch_executed(&mut self) {
+    self.current_loader_state_mut().set_pitch_executed();
+  }
+
+  pub fn set_current_loader_normal_executed(&mut self) {
+    self.current_loader_state_mut().set_normal_executed();
+  }
+
+  pub fn set_current_loader_finish_called(&mut self) {
+    self.current_loader_state_mut().set_finish_called();
+  }
+
   pub fn loader_chains(&self) -> &[LoaderChain] {
     &self.loader_chains
   }
@@ -94,9 +125,9 @@ impl<Context: Send> LoaderContext<Context> {
   pub fn current_chain_index(&self) -> Option<usize> {
     let loader_index = usize::try_from(self.loader_index).ok()?;
     self
-      .loader_chains
-      .iter()
-      .position(|chain| chain.contains(loader_index))
+      .loader_chain_locations
+      .get(loader_index)
+      .map(LoaderChainLocation::root_index)
   }
 
   pub fn current_chain(&self) -> Option<&LoaderChain> {
@@ -105,21 +136,14 @@ impl<Context: Send> LoaderContext<Context> {
       .and_then(|index| self.loader_chains.get(index))
   }
 
-  /// Returns the maximal contiguous execution-runtime span around the current
-  /// loader, bounded by the current loader chain.
-  pub fn current_execution_span(&self) -> Option<Range<usize>> {
+  pub fn current_execution_chain(&self) -> Option<&LoaderChain> {
     let loader_index = usize::try_from(self.loader_index).ok()?;
-    let chain = self.current_chain()?;
-    let kind = self.loader_items.get(loader_index)?.execution_kind();
-    let mut start = loader_index;
-    let mut end = loader_index + 1;
-    while start > chain.start() && self.loader_items[start - 1].execution_kind() == kind {
-      start -= 1;
+    let location = self.loader_chain_locations.get(loader_index)?;
+    let root = self.loader_chains.get(location.root_index())?;
+    match location.child_index() {
+      Some(child_index) => root.children().get(child_index),
+      None => Some(root),
     }
-    while end < chain.end() && self.loader_items[end].execution_kind() == kind {
-      end += 1;
-    }
-    Some(start..end)
   }
 
   /// Emit a diagnostic, it can be a `warning` or `error`.
@@ -195,14 +219,14 @@ impl<Context: Send> LoaderContext<Context> {
 
   pub fn finish_with(&mut self, patch: impl Into<LoaderPatch>) {
     self.__finish_with(patch);
-    self.current_loader().set_finish_called();
+    self.set_current_loader_finish_called();
   }
 
   pub fn finish_with_empty(&mut self) {
     self.content = None;
     self.source_map = None;
     self.additional_data = None;
-    self.current_loader().set_finish_called();
+    self.set_current_loader_finish_called();
   }
 
   #[inline]

--- a/crates/rspack_loader_runner/src/context.rs
+++ b/crates/rspack_loader_runner/src/context.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{ops::Range, path::PathBuf, sync::Arc};
 
 use derive_more::Debug;
 use rspack_error::Diagnostic;
@@ -7,7 +7,7 @@ use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  AdditionalData, Content, LoaderItem, LoaderRunnerPlugin, ParseMeta, ResourceData,
+  AdditionalData, Content, LoaderChain, LoaderItem, LoaderRunnerPlugin, ParseMeta, ResourceData,
   loader::LoaderItemList,
 };
 
@@ -57,6 +57,7 @@ pub struct LoaderContext<Context: Send> {
   pub(crate) state: State,
   pub loader_index: i32,
   pub loader_items: Vec<LoaderItem<Context>>,
+  pub(crate) loader_chains: Vec<LoaderChain>,
   #[debug(skip)]
   pub plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
 }
@@ -84,6 +85,41 @@ impl<Context: Send> LoaderContext<Context> {
   #[inline]
   pub fn current_loader(&self) -> &LoaderItem<Context> {
     &self.loader_items[self.loader_index as usize]
+  }
+
+  pub fn loader_chains(&self) -> &[LoaderChain] {
+    &self.loader_chains
+  }
+
+  pub fn current_chain_index(&self) -> Option<usize> {
+    let loader_index = usize::try_from(self.loader_index).ok()?;
+    self
+      .loader_chains
+      .iter()
+      .position(|chain| chain.contains(loader_index))
+  }
+
+  pub fn current_chain(&self) -> Option<&LoaderChain> {
+    self
+      .current_chain_index()
+      .and_then(|index| self.loader_chains.get(index))
+  }
+
+  /// Returns the maximal contiguous execution-runtime span around the current
+  /// loader, bounded by the current loader chain.
+  pub fn current_execution_span(&self) -> Option<Range<usize>> {
+    let loader_index = usize::try_from(self.loader_index).ok()?;
+    let chain = self.current_chain()?;
+    let kind = self.loader_items.get(loader_index)?.execution_kind();
+    let mut start = loader_index;
+    let mut end = loader_index + 1;
+    while start > chain.start() && self.loader_items[start - 1].execution_kind() == kind {
+      start -= 1;
+    }
+    while end < chain.end() && self.loader_items[end].execution_kind() == kind {
+      end += 1;
+    }
+    Some(start..end)
   }
 
   /// Emit a diagnostic, it can be a `warning` or `error`.

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(string_from_utf8_lossy_owned)]
 
+mod chain;
 mod content;
 mod context;
 mod loader;
@@ -7,12 +8,18 @@ mod plugin;
 mod runner;
 mod scheme;
 
+pub use chain::{
+  LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderChainMergeReason,
+  LoaderChainStrategy, LoaderExecutionKind, LoaderRunnerOptions, plan_loader_chains,
+};
 pub use content::{AdditionalData, Content, DescriptionData, ParseMeta, ResourceData};
 pub use context::{LoaderContext, State};
 pub use loader::{DisplayWithSuffix, Loader, LoaderItem, ResourceParsedData, parse_resource};
 pub use plugin::LoaderRunnerPlugin;
 pub use rspack_collections::{Identifiable, Identifier};
-pub use runner::{LoaderResult, run_loaders};
+pub use runner::{
+  LoaderResult, run_loaders, run_loaders_with_options, run_loaders_with_options_and_strategy,
+};
 pub use scheme::{Scheme, get_scheme};
 
 pub const BUILTIN_LOADER_PREFIX: &str = "builtin:";

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -9,16 +9,19 @@ mod runner;
 mod scheme;
 
 pub use chain::{
-  LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderChainMergeReason,
+  CacheChainState, LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderChainLocation,
   LoaderChainStrategy, LoaderExecutionKind, LoaderRunnerOptions, plan_loader_chains,
 };
 pub use content::{AdditionalData, Content, DescriptionData, ParseMeta, ResourceData};
 pub use context::{LoaderContext, State};
-pub use loader::{DisplayWithSuffix, Loader, LoaderItem, ResourceParsedData, parse_resource};
+pub use loader::{
+  DisplayWithSuffix, Loader, LoaderItem, LoaderItemState, ResourceParsedData, parse_resource,
+};
 pub use plugin::LoaderRunnerPlugin;
 pub use rspack_collections::{Identifiable, Identifier};
 pub use runner::{
-  LoaderResult, run_loaders, run_loaders_with_options, run_loaders_with_options_and_strategy,
+  LoaderResult, create_loader_items, run_loaders, run_loaders_with_options,
+  run_loaders_with_options_and_strategy, run_loaders_with_preplanned,
 };
 pub use scheme::{Scheme, get_scheme};
 

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -15,7 +15,7 @@ use rspack_error::Result;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::identifier::strip_zero_width_space_for_fragment;
 
-use super::LoaderContext;
+use super::{LoaderContext, LoaderExecutionKind, LoaderRunnerOptions};
 
 #[derive(Debug)]
 pub struct LoaderItem<Context: Send> {
@@ -48,11 +48,29 @@ pub struct LoaderItem<Context: Send> {
   /// This flag is used to align with webpack's behavior:
   /// If nothing is modified in the loader, the loader will reset the content, source map, and additional data.
   finish_called: AtomicBool,
+  cache: bool,
+  cache_key: String,
+  execution_kind: LoaderExecutionKind,
 }
 
 impl<C: Send> LoaderItem<C> {
   pub fn loader(&self) -> &Arc<dyn Loader<C>> {
     &self.loader
+  }
+
+  #[inline]
+  pub fn cache(&self) -> bool {
+    self.cache
+  }
+
+  #[inline]
+  pub fn cache_key(&self) -> &str {
+    &self.cache_key
+  }
+
+  #[inline]
+  pub fn execution_kind(&self) -> LoaderExecutionKind {
+    self.execution_kind
   }
 
   #[inline]
@@ -201,11 +219,23 @@ where
   fn r#type(&self) -> Option<&str> {
     None
   }
+
+  /// Selects the runtime responsible for executing this loader.
+  fn execution_kind(&self) -> LoaderExecutionKind {
+    LoaderExecutionKind::Native
+  }
 }
 
 impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
   fn from(loader: Arc<dyn Loader<C>>) -> Self {
+    Self::new(loader, LoaderRunnerOptions::default())
+  }
+}
+
+impl<C: Send> LoaderItem<C> {
+  pub(crate) fn new(loader: Arc<dyn Loader<C>>, options: LoaderRunnerOptions) -> Self {
     let ident = &**loader.identifier();
+    let execution_kind = loader.execution_kind();
     if let Some(r#type) = loader.r#type() {
       let ResourceParsedData {
         path,
@@ -224,6 +254,9 @@ impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
         pitch_executed: AtomicBool::new(false),
         normal_executed: AtomicBool::new(false),
         finish_called: AtomicBool::new(false),
+        cache: options.cache,
+        cache_key: options.cache_key,
+        execution_kind,
       };
     }
     let ident = loader.identifier();
@@ -243,6 +276,9 @@ impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
       pitch_executed: AtomicBool::new(false),
       normal_executed: AtomicBool::new(false),
       finish_called: AtomicBool::new(false),
+      cache: options.cache,
+      cache_key: options.cache_key,
+      execution_kind,
     }
   }
 }

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -1,11 +1,4 @@
-use std::{
-  fmt::Display,
-  ops::Deref,
-  sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-  },
-};
+use std::{fmt::Display, ops::Deref, sync::Arc};
 
 use async_trait::async_trait;
 use derive_more::Debug;
@@ -35,22 +28,20 @@ pub struct LoaderItem<Context: Send> {
   /// Fragment of a loader, starts with `#`.
   #[allow(dead_code)]
   fragment: Option<String>,
-  /// Data shared between pitching and normal
-  data: serde_json::Value,
   r#type: String,
-  pitch_executed: AtomicBool,
-  normal_executed: AtomicBool,
-  /// Whether loader was called with [LoaderContext::finish_with].
-  ///
-  /// Indicates that the loader has finished its work,
-  /// otherwise loader runner will reset [`LoaderContext::content`], [`LoaderContext::source_map`], [`LoaderContext::additional_data`].
-  ///
-  /// This flag is used to align with webpack's behavior:
-  /// If nothing is modified in the loader, the loader will reset the content, source map, and additional data.
-  finish_called: AtomicBool,
   cache: bool,
   cache_key: String,
   execution_kind: LoaderExecutionKind,
+}
+
+#[derive(Debug, Default)]
+pub struct LoaderItemState {
+  /// Data shared between pitching and normal.
+  data: serde_json::Value,
+  pitch_executed: bool,
+  normal_executed: bool,
+  /// Whether loader was called with [LoaderContext::finish_with].
+  finish_called: bool,
 }
 
 impl<C: Send> LoaderItem<C> {
@@ -97,51 +88,39 @@ impl<C: Send> LoaderItem<C> {
   pub fn r#type(&self) -> &str {
     &self.r#type
   }
+}
 
-  #[inline]
+impl LoaderItemState {
   pub fn data(&self) -> &serde_json::Value {
     &self.data
   }
 
-  #[inline]
-  #[doc(hidden)]
   pub fn set_data(&mut self, data: serde_json::Value) {
     self.data = data;
   }
 
-  #[inline]
-  #[doc(hidden)]
   pub fn pitch_executed(&self) -> bool {
-    self.pitch_executed.load(Ordering::Relaxed)
+    self.pitch_executed
   }
 
-  #[inline]
   pub fn normal_executed(&self) -> bool {
-    self.normal_executed.load(Ordering::Relaxed)
+    self.normal_executed
   }
 
-  #[inline]
-  #[doc(hidden)]
   pub fn finish_called(&self) -> bool {
-    self.finish_called.load(Ordering::Relaxed)
+    self.finish_called
   }
 
-  #[inline]
-  #[doc(hidden)]
-  pub fn set_pitch_executed(&self) {
-    self.pitch_executed.store(true, Ordering::Relaxed)
+  pub fn set_pitch_executed(&mut self) {
+    self.pitch_executed = true;
   }
 
-  #[inline]
-  #[doc(hidden)]
-  pub fn set_normal_executed(&self) {
-    self.normal_executed.store(true, Ordering::Relaxed)
+  pub fn set_normal_executed(&mut self) {
+    self.normal_executed = true;
   }
 
-  #[inline]
-  #[doc(hidden)]
-  pub fn set_finish_called(&self) {
-    self.finish_called.store(true, Ordering::Relaxed)
+  pub fn set_finish_called(&mut self) {
+    self.finish_called = true;
   }
 }
 
@@ -205,7 +184,7 @@ where
   async fn run(&self, loader_context: &mut LoaderContext<Context>) -> Result<()> {
     // If loader does not implement normal stage,
     // it should inherit the result from the previous loader.
-    loader_context.current_loader().set_finish_called();
+    loader_context.set_current_loader_finish_called();
     Ok(())
   }
 
@@ -233,7 +212,7 @@ impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
 }
 
 impl<C: Send> LoaderItem<C> {
-  pub(crate) fn new(loader: Arc<dyn Loader<C>>, options: LoaderRunnerOptions) -> Self {
+  pub fn new(loader: Arc<dyn Loader<C>>, options: LoaderRunnerOptions) -> Self {
     let ident = &**loader.identifier();
     let execution_kind = loader.execution_kind();
     if let Some(r#type) = loader.r#type() {
@@ -249,11 +228,7 @@ impl<C: Send> LoaderItem<C> {
         path,
         query,
         fragment,
-        data: serde_json::Value::Null,
         r#type: ty,
-        pitch_executed: AtomicBool::new(false),
-        normal_executed: AtomicBool::new(false),
-        finish_called: AtomicBool::new(false),
         cache: options.cache,
         cache_key: options.cache_key,
         execution_kind,
@@ -271,11 +246,7 @@ impl<C: Send> LoaderItem<C> {
       path,
       query,
       fragment,
-      data: serde_json::Value::Null,
       r#type: String::default(),
-      pitch_executed: AtomicBool::new(false),
-      normal_executed: AtomicBool::new(false),
-      finish_called: AtomicBool::new(false),
       cache: options.cache,
       cache_key: options.cache_key,
       execution_kind,

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -6,7 +6,7 @@ use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  LoaderContext,
+  LoaderChain, LoaderChainCacheAction, LoaderChainCacheState, LoaderContext,
   content::{Content, ResourceData},
 };
 
@@ -27,6 +27,23 @@ pub trait LoaderRunnerPlugin: Send + Sync {
   }
 
   async fn start_yielding(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    Ok(())
+  }
+
+  async fn before_normal_chain(
+    &self,
+    _context: &mut LoaderContext<Self::Context>,
+    _chain: &LoaderChain,
+  ) -> Result<LoaderChainCacheAction> {
+    Ok(LoaderChainCacheAction::Disabled)
+  }
+
+  async fn after_normal_chain(
+    &self,
+    _context: &mut LoaderContext<Self::Context>,
+    _chain: &LoaderChain,
+    _state: LoaderChainCacheState,
+  ) -> Result<()> {
     Ok(())
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -8,10 +8,11 @@ use rustc_hash::FxHashSet as HashSet;
 use tracing::{Instrument, info_span};
 
 use crate::{
-  LoaderChainCacheAction, LoaderChainStrategy, LoaderRunnerOptions, ParseMeta,
+  CacheChainState, LoaderChainCacheAction, LoaderChainLocation, LoaderChainStrategy,
+  LoaderRunnerOptions, ParseMeta,
   content::{AdditionalData, Content, ResourceData},
   context::{LoaderContext, State},
-  loader::{Loader, LoaderItem},
+  loader::{Loader, LoaderItem, LoaderItemState},
   plan_loader_chains,
   plugin::LoaderRunnerPlugin,
 };
@@ -33,7 +34,7 @@ async fn run_pitch_chain<Context: Send>(
   resource: &str,
 ) -> Result<()> {
   let chain = cx
-    .current_chain()
+    .current_execution_chain()
     .cloned()
     .expect("pitching requires a current loader chain");
   let chain_end = chain.end() as i32;
@@ -43,8 +44,6 @@ async fn run_pitch_chain<Context: Send>(
     chain_len = chain.len(),
     chain_start = chain.start(),
     chain_end = chain.end(),
-    cache = chain.cache(),
-    merge_reason = ?chain.merge_reason(),
     execution_kind = ?chain.execution_kind(),
   );
 
@@ -58,12 +57,12 @@ async fn run_pitch_chain<Context: Send>(
         continue;
       }
 
-      if cx.current_loader().pitch_executed() {
+      if cx.current_loader_state().pitch_executed() {
         cx.loader_index += 1;
         continue;
       }
 
-      cx.current_loader().set_pitch_executed();
+      cx.set_current_loader_pitch_executed();
       let loader = cx.current_loader().loader().clone();
       let loader_span = info_span!("run_loader:pitch", resource);
       loader.pitch(cx).instrument(loader_span).await?;
@@ -92,15 +91,16 @@ async fn run_normal_chain<Context: Send>(
     chain_len = chain.len(),
     chain_start = chain.start(),
     chain_end = chain.end(),
-    cache = chain.cache(),
-    merge_reason = ?chain.merge_reason(),
     execution_kind = ?chain.execution_kind(),
   );
 
   // A pitch short-circuit may start the normal phase in the middle of a chain.
   // Such an execution does not represent the full chain and must not be cached.
   let executes_full_chain = cx.loader_index == chain.end() as i32 - 1;
-  let cache_action = if chain.cache()
+  let root_index = cx
+    .current_chain_index()
+    .expect("normal execution requires a current loader chain index");
+  let cache_action = if chain.is_cache()
     && executes_full_chain
     && let Some(plugin) = cx.plugin.clone()
   {
@@ -109,11 +109,24 @@ async fn run_normal_chain<Context: Send>(
     LoaderChainCacheAction::Disabled
   };
 
-  if matches!(cache_action, LoaderChainCacheAction::Hit) {
-    for loader in &cx.loader_items[chain.range()] {
-      loader.set_normal_executed();
-      loader.set_finish_called();
+  if chain.is_cache() {
+    cx.cache_chain_states[root_index] = Some(match cache_action {
+      LoaderChainCacheAction::Disabled => CacheChainState::Bypassed,
+      LoaderChainCacheAction::Hit => CacheChainState::Hit,
+      LoaderChainCacheAction::Miss(state) => CacheChainState::Miss(state),
+    });
+  }
+
+  if matches!(
+    cx.cache_chain_states[root_index],
+    Some(CacheChainState::Hit)
+  ) {
+    for loader_index in chain.range() {
+      let state = cx.loader_item_state_mut(loader_index);
+      state.set_normal_executed();
+      state.set_finish_called();
     }
+    cx.cache_chain_states[root_index] = Some(CacheChainState::Completed);
     cx.loader_index = chain_start - 1;
     return Ok(());
   }
@@ -125,16 +138,16 @@ async fn run_normal_chain<Context: Send>(
         continue;
       }
 
-      if cx.current_loader().normal_executed() {
+      if cx.current_loader_state().normal_executed() {
         cx.loader_index -= 1;
         continue;
       }
 
-      cx.current_loader().set_normal_executed();
+      cx.set_current_loader_normal_executed();
       let loader = cx.current_loader().loader().clone();
       let loader_span = info_span!("run_loader:normal", resource);
       loader.run(cx).instrument(loader_span).await?;
-      if !cx.current_loader().finish_called() {
+      if !cx.current_loader_state().finish_called() {
         // If nothing is returned from this loader, set every output to None to
         // match webpack loader-runner behavior.
         cx.finish_with_empty();
@@ -146,10 +159,17 @@ async fn run_normal_chain<Context: Send>(
   .await;
 
   result?;
-  if let LoaderChainCacheAction::Miss(state) = cache_action
-    && let Some(plugin) = cx.plugin.clone()
-  {
-    plugin.after_normal_chain(cx, &chain, state).await?;
+  match cx.cache_chain_states[root_index].take() {
+    Some(CacheChainState::Miss(state)) => {
+      if let Some(plugin) = cx.plugin.clone() {
+        plugin.after_normal_chain(cx, &chain, state).await?;
+      }
+      cx.cache_chain_states[root_index] = Some(CacheChainState::Completed);
+    }
+    Some(CacheChainState::Bypassed) => {
+      cx.cache_chain_states[root_index] = Some(CacheChainState::Completed);
+    }
+    state => cx.cache_chain_states[root_index] = state,
   }
   Ok(())
 }
@@ -189,8 +209,9 @@ You may need an additional plugin to handle "{scheme}:" URIs."#
 }
 
 fn create_loader_context<Context: Send>(
-  loader_items: Vec<LoaderItem<Context>>,
-  chain_strategy: LoaderChainStrategy,
+  loader_items: Arc<[LoaderItem<Context>]>,
+  loader_chains: Arc<[crate::LoaderChain]>,
+  loader_chain_locations: Arc<[LoaderChainLocation]>,
   resource_data: Arc<ResourceData>,
   plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
@@ -202,7 +223,14 @@ fn create_loader_context<Context: Send>(
     file_dependencies.insert(resource_path.to_owned().into_std_path_buf());
   }
 
-  let loader_chains = plan_loader_chains(&loader_items, chain_strategy);
+  assert_eq!(loader_items.len(), loader_chain_locations.len());
+  let loader_item_states = (0..loader_items.len())
+    .map(|_| LoaderItemState::default())
+    .collect();
+  let cache_chain_states = loader_chains
+    .iter()
+    .map(|chain| chain.is_cache().then_some(CacheChainState::Pending))
+    .collect();
   LoaderContext {
     hot: false,
     cacheable: true,
@@ -218,11 +246,30 @@ fn create_loader_context<Context: Send>(
     state: State::Init,
     loader_index: 0,
     loader_items,
+    loader_item_states,
     loader_chains,
+    loader_chain_locations,
+    cache_chain_states,
     plugin,
     resource_data,
     diagnostics: vec![],
   }
+}
+
+pub fn create_loader_items<Context: Send>(
+  loaders: Vec<Arc<dyn Loader<Context>>>,
+  loader_options: Vec<LoaderRunnerOptions>,
+) -> Vec<LoaderItem<Context>> {
+  assert_eq!(
+    loaders.len(),
+    loader_options.len(),
+    "loader options must stay aligned with loaders"
+  );
+  loaders
+    .into_iter()
+    .zip(loader_options)
+    .map(|(loader, options)| LoaderItem::new(loader, options))
+    .collect()
 }
 
 #[tracing::instrument("LoaderRunner:run_loaders", skip_all, level = "trace")]
@@ -269,17 +316,37 @@ pub async fn run_loaders_with_options_and_strategy<Context: Send>(
   context: Context,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> (LoaderResult<Context>, Option<Error>) {
-  assert_eq!(
-    loaders.len(),
-    loader_options.len(),
-    "loader options must stay aligned with loaders"
+  let loader_items = Arc::from(create_loader_items(loaders, loader_options));
+  let (loader_chains, loader_chain_locations) = plan_loader_chains(&loader_items, chain_strategy);
+  run_loaders_with_preplanned(
+    loader_items,
+    Arc::from(loader_chains),
+    Arc::from(loader_chain_locations),
+    resource_data,
+    plugin,
+    context,
+    fs,
+  )
+  .await
+}
+
+pub async fn run_loaders_with_preplanned<Context: Send>(
+  loader_items: Arc<[LoaderItem<Context>]>,
+  loader_chains: Arc<[crate::LoaderChain]>,
+  loader_chain_locations: Arc<[LoaderChainLocation]>,
+  resource_data: Arc<ResourceData>,
+  plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
+  context: Context,
+  fs: Arc<dyn ReadableFileSystem>,
+) -> (LoaderResult<Context>, Option<Error>) {
+  let mut cx = create_loader_context(
+    loader_items,
+    loader_chains,
+    loader_chain_locations,
+    resource_data,
+    plugin,
+    context,
   );
-  let loaders = loaders
-    .into_iter()
-    .zip(loader_options)
-    .map(|(loader, options)| LoaderItem::new(loader, options))
-    .collect::<Vec<LoaderItem<Context>>>();
-  let mut cx = create_loader_context(loaders, chain_strategy, resource_data, plugin, context);
   let result = run_loaders_impl(&mut cx, fs).await;
   (LoaderResult::new(cx), result.err())
 }

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -8,10 +8,11 @@ use rustc_hash::FxHashSet as HashSet;
 use tracing::{Instrument, info_span};
 
 use crate::{
-  ParseMeta,
+  LoaderChainCacheAction, LoaderChainStrategy, LoaderRunnerOptions, ParseMeta,
   content::{AdditionalData, Content, ResourceData},
   context::{LoaderContext, State},
   loader::{Loader, LoaderItem},
+  plan_loader_chains,
   plugin::LoaderRunnerPlugin,
 };
 
@@ -25,6 +26,132 @@ impl<Context: Send> LoaderContext<Context> {
     }
     Ok(false)
   }
+}
+
+async fn run_pitch_chain<Context: Send>(
+  cx: &mut LoaderContext<Context>,
+  resource: &str,
+) -> Result<()> {
+  let chain = cx
+    .current_chain()
+    .cloned()
+    .expect("pitching requires a current loader chain");
+  let chain_end = chain.end() as i32;
+  let span = info_span!(
+    "run_loader_chain:pitch",
+    resource,
+    chain_len = chain.len(),
+    chain_start = chain.start(),
+    chain_end = chain.end(),
+    cache = chain.cache(),
+    merge_reason = ?chain.merge_reason(),
+    execution_kind = ?chain.execution_kind(),
+  );
+
+  async {
+    while cx.loader_index < chain_end {
+      let yield_span = info_span!("run_loader:pitch:yield_to_js", resource);
+      if cx.start_yielding().instrument(yield_span).await? {
+        if cx.content.is_some() {
+          break;
+        }
+        continue;
+      }
+
+      if cx.current_loader().pitch_executed() {
+        cx.loader_index += 1;
+        continue;
+      }
+
+      cx.current_loader().set_pitch_executed();
+      let loader = cx.current_loader().loader().clone();
+      let loader_span = info_span!("run_loader:pitch", resource);
+      loader.pitch(cx).instrument(loader_span).await?;
+      if cx.content.is_some() {
+        break;
+      }
+    }
+    Ok(())
+  }
+  .instrument(span)
+  .await
+}
+
+async fn run_normal_chain<Context: Send>(
+  cx: &mut LoaderContext<Context>,
+  resource: &str,
+) -> Result<()> {
+  let chain = cx
+    .current_chain()
+    .cloned()
+    .expect("normal execution requires a current loader chain");
+  let chain_start = chain.start() as i32;
+  let span = info_span!(
+    "run_loader_chain:normal",
+    resource,
+    chain_len = chain.len(),
+    chain_start = chain.start(),
+    chain_end = chain.end(),
+    cache = chain.cache(),
+    merge_reason = ?chain.merge_reason(),
+    execution_kind = ?chain.execution_kind(),
+  );
+
+  // A pitch short-circuit may start the normal phase in the middle of a chain.
+  // Such an execution does not represent the full chain and must not be cached.
+  let executes_full_chain = cx.loader_index == chain.end() as i32 - 1;
+  let cache_action = if chain.cache()
+    && executes_full_chain
+    && let Some(plugin) = cx.plugin.clone()
+  {
+    plugin.before_normal_chain(cx, &chain).await?
+  } else {
+    LoaderChainCacheAction::Disabled
+  };
+
+  if matches!(cache_action, LoaderChainCacheAction::Hit) {
+    for loader in &cx.loader_items[chain.range()] {
+      loader.set_normal_executed();
+      loader.set_finish_called();
+    }
+    cx.loader_index = chain_start - 1;
+    return Ok(());
+  }
+
+  let result: Result<()> = async {
+    while cx.loader_index >= chain_start {
+      let yield_span = info_span!("run_loader:yield_to_js", resource);
+      if cx.start_yielding().instrument(yield_span).await? {
+        continue;
+      }
+
+      if cx.current_loader().normal_executed() {
+        cx.loader_index -= 1;
+        continue;
+      }
+
+      cx.current_loader().set_normal_executed();
+      let loader = cx.current_loader().loader().clone();
+      let loader_span = info_span!("run_loader:normal", resource);
+      loader.run(cx).instrument(loader_span).await?;
+      if !cx.current_loader().finish_called() {
+        // If nothing is returned from this loader, set every output to None to
+        // match webpack loader-runner behavior.
+        cx.finish_with_empty();
+      }
+    }
+    Ok(())
+  }
+  .instrument(span)
+  .await;
+
+  result?;
+  if let LoaderChainCacheAction::Miss(state) = cache_action
+    && let Some(plugin) = cx.plugin.clone()
+  {
+    plugin.after_normal_chain(cx, &chain, state).await?;
+  }
+  Ok(())
 }
 
 #[tracing::instrument("LoaderRunner:process_resource",
@@ -63,6 +190,7 @@ You may need an additional plugin to handle "{scheme}:" URIs."#
 
 fn create_loader_context<Context: Send>(
   loader_items: Vec<LoaderItem<Context>>,
+  chain_strategy: LoaderChainStrategy,
   resource_data: Arc<ResourceData>,
   plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
@@ -74,6 +202,7 @@ fn create_loader_context<Context: Send>(
     file_dependencies.insert(resource_path.to_owned().into_std_path_buf());
   }
 
+  let loader_chains = plan_loader_chains(&loader_items, chain_strategy);
   LoaderContext {
     hot: false,
     cacheable: true,
@@ -89,6 +218,7 @@ fn create_loader_context<Context: Send>(
     state: State::Init,
     loader_index: 0,
     loader_items,
+    loader_chains,
     plugin,
     resource_data,
     diagnostics: vec![],
@@ -103,11 +233,53 @@ pub async fn run_loaders<Context: Send>(
   context: Context,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> (LoaderResult<Context>, Option<Error>) {
+  let loader_options = vec![LoaderRunnerOptions::default(); loaders.len()];
+  run_loaders_with_options(loaders, loader_options, resource_data, plugin, context, fs).await
+}
+
+pub async fn run_loaders_with_options<Context: Send>(
+  loaders: Vec<Arc<dyn Loader<Context>>>,
+  loader_options: Vec<LoaderRunnerOptions>,
+  resource_data: Arc<ResourceData>,
+  plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
+  context: Context,
+  fs: Arc<dyn ReadableFileSystem>,
+) -> (LoaderResult<Context>, Option<Error>) {
+  run_loaders_with_options_and_strategy(
+    loaders,
+    loader_options,
+    LoaderChainStrategy::default(),
+    resource_data,
+    plugin,
+    context,
+    fs,
+  )
+  .await
+}
+
+/// Runs loaders with an explicit chain planning strategy. This is intended for
+/// tests and benchmarks that compare chain merging without changing executor
+/// semantics.
+pub async fn run_loaders_with_options_and_strategy<Context: Send>(
+  loaders: Vec<Arc<dyn Loader<Context>>>,
+  loader_options: Vec<LoaderRunnerOptions>,
+  chain_strategy: LoaderChainStrategy,
+  resource_data: Arc<ResourceData>,
+  plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
+  context: Context,
+  fs: Arc<dyn ReadableFileSystem>,
+) -> (LoaderResult<Context>, Option<Error>) {
+  assert_eq!(
+    loaders.len(),
+    loader_options.len(),
+    "loader options must stay aligned with loaders"
+  );
   let loaders = loaders
     .into_iter()
-    .map(|i| i.into())
+    .zip(loader_options)
+    .map(|(loader, options)| LoaderItem::new(loader, options))
     .collect::<Vec<LoaderItem<Context>>>();
-  let mut cx = create_loader_context(loaders, resource_data, plugin, context);
+  let mut cx = create_loader_context(loaders, chain_strategy, resource_data, plugin, context);
   let result = run_loaders_impl(&mut cx, fs).await;
   (LoaderResult::new(cx), result.err())
 }
@@ -131,24 +303,7 @@ async fn run_loaders_impl<Context: Send>(
           cx.state.transition(State::ProcessResource);
           continue;
         }
-        let span = info_span!("run_loader:pitch:yield_to_js", resource);
-        if cx.start_yielding().instrument(span).await? {
-          if cx.content.is_some() {
-            cx.state.transition(State::Normal);
-            cx.loader_index -= 1;
-          }
-          continue;
-        }
-
-        if cx.current_loader().pitch_executed() {
-          cx.loader_index += 1;
-          continue;
-        }
-
-        cx.current_loader().set_pitch_executed();
-        let loader = cx.current_loader().loader().clone();
-        let span = info_span!("run_loader:pitch", resource);
-        loader.pitch(cx).instrument(span).await?;
+        run_pitch_chain(cx, resource).await?;
         if cx.content.is_some() {
           cx.state.transition(State::Normal);
           cx.loader_index -= 1;
@@ -166,31 +321,7 @@ async fn run_loaders_impl<Context: Send>(
           continue;
         }
 
-        if cx.loader_index == 0 && cx.current_loader().normal_executed() {
-          cx.state.transition(State::Finished);
-          continue;
-        }
-        let span = info_span!("run_loader:yield_to_js", resource);
-        if cx.start_yielding().instrument(span).await? {
-          continue;
-        }
-
-        if cx.current_loader().normal_executed() {
-          cx.loader_index -= 1;
-          continue;
-        }
-
-        cx.current_loader().set_normal_executed();
-        let loader = cx.current_loader().loader().clone();
-
-        let span = info_span!("run_loader:normal", resource);
-        loader.run(cx).instrument(span).await?;
-        if !cx.current_loader().finish_called() {
-          // If nothing is returned from this loader,
-          // we set everything to [None] and move to the next loader.
-          // This mocks the behavior of webpack loader-runner.
-          cx.finish_with_empty();
-        }
+        run_normal_chain(cx, resource).await?;
       }
       State::Finished => break,
     }

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -535,9 +535,11 @@ function createRawModuleRuleUsesImpl(
 
   return uses.filter(Boolean).map((use, index) => {
     let o: string | undefined;
+    let fingerprintOptions = use.options;
     let isBuiltin = false;
     if (use.loader.startsWith(BUILTIN_LOADER_PREFIX)) {
       const temp = getBuiltinLoaderOptions(use.loader, use.options, options);
+      fingerprintOptions = temp;
       // keep json with indent so miette can show pretty error
       o = isNil(temp)
         ? undefined
@@ -555,8 +557,134 @@ function createRawModuleRuleUsesImpl(
         isBuiltin,
       ),
       options: o,
+      cache: use.cache ?? false,
+      cacheKey: use.cache
+        ? stableSerializeLoaderOptions(
+            fingerprintOptions,
+            `${path}[${index}].options`,
+          )
+        : '',
     };
   });
+}
+
+function stableSerializeLoaderOptions(value: unknown, path: string): string {
+  const seen = new Set<object>();
+
+  const serialize = (current: unknown, currentPath: string): string => {
+    if (current === undefined) return 'undefined';
+    if (current === null) return 'null';
+
+    switch (typeof current) {
+      case 'string':
+        return `string:${JSON.stringify(current)}`;
+      case 'boolean':
+        return `boolean:${current}`;
+      case 'number':
+        return `number:${Object.is(current, -0) ? '-0' : String(current)}`;
+      case 'bigint':
+        return `bigint:${current.toString()}`;
+      case 'function':
+      case 'symbol':
+        throw new Error(
+          `\`Rule.use.cache\` requires stably serializable loader options. ` +
+            `The value at \`${currentPath}\` has unsupported type \`${typeof current}\`.`,
+        );
+      case 'object':
+        break;
+      default:
+        return `${typeof current}:${String(current)}`;
+    }
+
+    const object = current as object;
+    if (seen.has(object)) {
+      throw new Error(
+        `\`Rule.use.cache\` requires stably serializable loader options. ` +
+          `The value at \`${currentPath}\` contains a circular reference.`,
+      );
+    }
+    seen.add(object);
+
+    let result: string;
+    if (Array.isArray(object)) {
+      const extraKeys = Object.keys(object).filter(
+        (key) => !/^\d+$/.test(key) || Number(key) >= object.length,
+      );
+      if (
+        extraKeys.length > 0 ||
+        Object.getOwnPropertySymbols(object).length > 0
+      ) {
+        throw new Error(
+          `\`Rule.use.cache\` requires stably serializable loader options. ` +
+            `The array at \`${currentPath}\` contains custom properties.`,
+        );
+      }
+      const items = Array.from({ length: object.length }, (_, index) =>
+        index in object
+          ? serialize(object[index], `${currentPath}[${index}]`)
+          : 'hole',
+      );
+      result = `array:[${items.join(',')}]`;
+    } else if (object instanceof RegExp) {
+      result = `regexp:${object.source}/${object.flags}/${object.lastIndex}`;
+    } else if (object instanceof Date) {
+      result = `date:${object.toISOString()}`;
+    } else if (object instanceof URL) {
+      result = `url:${object.toString()}`;
+    } else if (object instanceof Map) {
+      const entries = [...object.entries()].map(([key, item], index) => [
+        serialize(key, `${currentPath}.<key:${index}>`),
+        serialize(item, `${currentPath}.<value:${index}>`),
+      ]);
+      result = `map:{${entries.map(([key, item]) => `${key}:${item}`).join(',')}}`;
+    } else if (object instanceof Set) {
+      const entries = [...object.values()].map((item, index) =>
+        serialize(item, `${currentPath}.<set:${index}>`),
+      );
+      result = `set:{${entries.join(',')}}`;
+    } else {
+      const prototype = Object.getPrototypeOf(object);
+      if (prototype !== Object.prototype && prototype !== null) {
+        throw new Error(
+          `\`Rule.use.cache\` requires stably serializable loader options. ` +
+            `The value at \`${currentPath}\` is an unsupported \`${object.constructor?.name ?? 'object'}\` instance.`,
+        );
+      }
+      if (Object.getOwnPropertySymbols(object).length > 0) {
+        throw new Error(
+          `\`Rule.use.cache\` requires stably serializable loader options. ` +
+            `The value at \`${currentPath}\` contains symbol keys.`,
+        );
+      }
+      const keys = Object.keys(object).sort();
+      if (Object.getOwnPropertyNames(object).length !== keys.length) {
+        throw new Error(
+          `\`Rule.use.cache\` requires stably serializable loader options. ` +
+            `The value at \`${currentPath}\` contains non-enumerable properties.`,
+        );
+      }
+      result = `object:{${keys
+        .map((key) => {
+          const descriptor = Object.getOwnPropertyDescriptor(object, key);
+          if (descriptor?.get || descriptor?.set) {
+            throw new Error(
+              `\`Rule.use.cache\` requires stably serializable loader options. ` +
+                `The value at \`${currentPath}.${key}\` is an accessor property.`,
+            );
+          }
+          return `${JSON.stringify(key)}:${serialize(
+            (object as Record<string, unknown>)[key],
+            `${currentPath}.${key}`,
+          )}`;
+        })
+        .join(',')}}`;
+    }
+
+    seen.delete(object);
+    return result;
+  };
+
+  return serialize(value, path);
 }
 
 function resolveStringifyLoaders(

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -875,6 +875,17 @@ export type RuleSetLoaderWithOptions = {
    */
   parallel?: boolean | { maxWorkers?: number };
 
+  /**
+   * Cache the normal result of this loader. Consecutive cacheable loaders are
+   * executed and cached as one loader chain.
+   *
+   * A cached loader must produce its result only from the input source and its
+   * options. Loaders depending on implicit state such as time, environment
+   * variables or resourcePath should not enable this option.
+   * @default false
+   */
+  cache?: boolean;
+
   options?: RuleSetLoaderOptions;
 };
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -173,10 +173,6 @@ export class LoaderObject {
     this.loaderItem.noPitch = true;
   }
 
-  shouldYield() {
-    return this.request.startsWith(BUILTIN_LOADER_PREFIX);
-  }
-
   static __from_binding(
     loaderItem: JsLoaderItem,
     compiler: Compiler,
@@ -232,6 +228,8 @@ export async function runLoaders(
   context: JsLoaderContext,
 ): Promise<JsLoaderContext> {
   const loaderState = context.loaderState;
+  const loaderChainStart = context.loaderChainStart;
+  const loaderChainEnd = context.loaderChainEnd;
   const pitch = loaderState === JsLoaderState.Pitching;
 
   const { resource } = context;
@@ -749,6 +747,8 @@ export async function runLoaders(
       sourceMap: loaderContext.sourceMap,
       rootContext: loaderContext.rootContext,
       loaderIndex: loaderContext.loaderIndex,
+      loaderChainStart: context.loaderChainStart,
+      loaderChainEnd: context.loaderChainEnd,
       loaders: loaderContext.loaders.map((item) => {
         let options = item.options;
         // Do not pass options into worker, if it's not prepared to be executed
@@ -1011,12 +1011,11 @@ export async function runLoaders(
   try {
     switch (loaderState) {
       case JsLoaderState.Pitching: {
-        while (loaderContext.loaderIndex < loaderContext.loaders.length) {
+        while (loaderContext.loaderIndex < loaderChainEnd) {
           const currentLoaderObject =
             loaderContext.loaders[loaderContext.loaderIndex];
           const parallelism = enableParallelism(currentLoaderObject);
 
-          if (currentLoaderObject.shouldYield()) break;
           if (currentLoaderObject.pitchExecuted) {
             loaderContext.loaderIndex += 1;
             continue;
@@ -1057,12 +1056,11 @@ export async function runLoaders(
         let sourceMapParsed = false;
         let additionalData = context.additionalData;
 
-        while (loaderContext.loaderIndex >= 0) {
+        while (loaderContext.loaderIndex >= loaderChainStart) {
           const currentLoaderObject =
             loaderContext.loaders[loaderContext.loaderIndex];
           const parallelism = enableParallelism(currentLoaderObject);
 
-          if (currentLoaderObject.shouldYield()) break;
           if (currentLoaderObject.normalExecuted) {
             loaderContext.loaderIndex--;
             continue;

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -26,7 +26,6 @@ import { commitCustomFieldsToRust } from '../BuildInfo';
 import type { Compilation } from '../Compilation';
 import type { Compiler } from '../Compiler';
 import {
-  BUILTIN_LOADER_PREFIX,
   type Diagnostic,
   isUseSimpleSourceMap,
   isUseSourceMap,
@@ -755,7 +754,7 @@ export async function runLoaders(
         // in the worker thread.
         //
         // Aligns yielding strategy within the worker.
-        if (!item.parallel || item.request.startsWith(BUILTIN_LOADER_PREFIX)) {
+        if (!item.parallel) {
           options = undefined;
         }
         return {

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -28,8 +28,6 @@ import {
 } from './service';
 import { convertArgs, runSyncOrAsync } from './utils';
 
-const BUILTIN_LOADER_PREFIX = 'builtin:';
-
 interface WorkerOptions {
   loaderContext: LoaderContext & {
     loaderChainStart: number;
@@ -456,15 +454,13 @@ async function loaderImpl(
     if (!currentLoaderObject?.parallel) {
       return true;
     }
-    if (currentLoaderObject?.request.startsWith(BUILTIN_LOADER_PREFIX)) {
-      return true;
-    }
     return false;
   };
 
   // Execute loader list until the current loader object is to yield to the main
-  // thread.  This happens if the loader is marked as non-parallel or if it is a
-  // builtin loader which belongs to the rust side.
+  // thread. This happens when the loader is marked as non-parallel. The
+  // factory-prepared execution chain guarantees that this range contains only
+  // JavaScript loaders.
   switch (loaderState) {
     case JsLoaderState.Pitching: {
       while (loaderContext.loaderIndex < loaderContext.loaderChainEnd) {

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -31,7 +31,10 @@ import { convertArgs, runSyncOrAsync } from './utils';
 const BUILTIN_LOADER_PREFIX = 'builtin:';
 
 interface WorkerOptions {
-  loaderContext: LoaderContext;
+  loaderContext: LoaderContext & {
+    loaderChainStart: number;
+    loaderChainEnd: number;
+  };
   loaderState: JsLoaderState;
   args: any[];
 
@@ -464,7 +467,7 @@ async function loaderImpl(
   // builtin loader which belongs to the rust side.
   switch (loaderState) {
     case JsLoaderState.Pitching: {
-      while (loaderContext.loaderIndex < loaderContext.loaders.length) {
+      while (loaderContext.loaderIndex < loaderContext.loaderChainEnd) {
         const currentLoaderObject =
           loaderContext.loaders[loaderContext.loaderIndex];
         if (shouldYieldToMainThread(currentLoaderObject)) break;
@@ -493,7 +496,7 @@ async function loaderImpl(
       break;
     }
     case JsLoaderState.Normal: {
-      while (loaderContext.loaderIndex >= 0) {
+      while (loaderContext.loaderIndex >= loaderContext.loaderChainStart) {
         const currentLoaderObject =
           loaderContext.loaders[loaderContext.loaderIndex];
 

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,313 @@
+# Loader Chain 与 Loader Result Cache 执行计划
+
+## 1. 目标
+
+本次改造包含三个相互关联的目标：
+
+1. 在 loader runner 中引入 `LoaderChain`，一个 chain 包含一个或多个按原顺序排列的 loader，并成为 runner 外层状态机的基本执行单元。
+2. 在 `Rule.use` 的 loader 配置中，在 `options`、`parallel` 同一层增加 `cache?: boolean`。`cache: true` 表示该 loader 的 normal 阶段结果可以按“输入代码哈希 + loader options”复用。
+3. 将连续的可缓存 loader 合并到同一个 chain，一次计算输入代码哈希并缓存整个转换区间；同时将连续的 JS loader 合并，令 Rust/JS yield 的边界直接由 chain 描述，而不是由 Rust、JS 主线程和 worker 各自扫描 loader 列表推断。
+
+本次不改变 webpack 可观察到的 loader 顺序、pitch/normal 方向、`loaderContext.loaderIndex`、`remainingRequest`、`previousRequest`、`data` 和 raw/string 转换语义。
+
+## 2. 当前执行流与主要问题
+
+当前配置和执行路径为：
+
+```text
+Rule.use { loader, options, parallel }
+  packages/rspack/src/config/types.ts
+       ↓
+createRawModuleRuleUses / ident references
+  packages/rspack/src/config/adapterRuleUse.ts
+       ↓
+RawModuleRuleUse -> ModuleRuleUseLoader
+  crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+  crates/rspack_core/src/options/module.rs
+       ↓
+逐个 resolve 为 BoxLoader
+  crates/rspack_core/src/normal_module_factory.rs
+       ↓
+run_loaders(Vec<BoxLoader>)
+  crates/rspack_loader_runner/src/runner.rs
+       ↓
+以 loader_index 为游标逐个 pitch / normal
+       ↓
+遇到 JS loader 时 should_yield / loader_yield
+  crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
+       ↓
+JS 主线程和 worker 再次向前/向后扫描连续 loader
+  packages/rspack/src/loader-runner/index.ts
+  packages/rspack/src/loader-runner/worker.ts
+```
+
+主要问题：
+
+- runner 的调度单元、JS yield 单元和未来缓存单元不是同一个概念，边界判断分散在 Rust、JS 主线程和 worker 中。
+- 如果用“每个 loader 外包一层 cache loader”的方式实现缓存，连续 loader 会对同一份中间代码重复计算哈希。
+- `parallel` 目前通过 ident reference 旁路传递；新增缓存信息如果继续只留在 JS 侧，Rust runner 无法在执行前建立 chain。
+- loader 的输出不只有代码，还包括 source map、additional data、依赖集合以及 module/loader context 副作用；只缓存 content 会造成行为不一致。
+
+仓库历史中的 loader cache 原型可以复用其依赖增量回放、loader 文件失效、内存/持久化分层等经验，但不继续采用插入 `builtin:cache-loader` 的结构；缓存应直接成为 `LoaderChain` normal 执行的一部分。
+
+## 3. 目标模型
+
+### 3.1 配置与 resolved loader
+
+公共类型增加：
+
+```ts
+type RuleSetLoaderWithOptions = {
+  loader: string;
+  options?: string | Record<string, any>;
+  parallel?: boolean | { maxWorkers?: number };
+  cache?: boolean;
+  ident?: string;
+};
+```
+
+绑定和 core 不再只传 `BoxLoader`，而是保留执行规划所需的元信息：
+
+```text
+ResolvedLoader
+  loader: BoxLoader
+  cache: bool
+  options_fingerprint: stable bytes/hash
+  execution_kind: Native | JavaScript
+```
+
+`cache` 默认值为 `false`。inline loader 和字符串形式 loader 没有显式标记时保持不缓存。`execution_kind` 应由 loader/resolver 明确提供，避免长期依赖 `builtin:` 前缀猜测执行域；JS loader 返回 `JavaScript`，native/builtin loader 默认为 `Native`。
+
+JS object options 需要在配置适配阶段生成稳定 fingerprint，再通过 `RawModuleRuleUse` 和 `ModuleRuleUseLoader` 传到 Rust。不能把 `ident` 本身当作 options 内容，也不能直接依赖对象属性插入顺序。第一版仅接受可稳定序列化的 cache options；遇到 function、symbol、循环引用等不稳定值时，在对应 option path 给出明确配置错误，避免产生表面命中但结果错误的缓存。
+
+### 3.2 LoaderChain
+
+在 `crates/rspack_loader_runner/src/chain.rs` 新增结构化模型，chain 持有 loader 在扁平列表中的范围，而不使用 `$` 等字符串分隔符编码：
+
+```text
+LoaderChain
+  range: [start, end)
+  cache_mode: Disabled | WholeChain
+  execution_kind: Native | JavaScript | Mixed
+  merge_reason: Singleton | Cache | JavaScript
+  static_fingerprint: ordered(loader identity + options fingerprint)
+```
+
+`LoaderContext` 继续保存扁平 `loader_items` 和全局 `loader_index`，新增内部 `loader_chains`、`chain_index` 和 chain 内部进度。这样 loader 看到的 `loaders`、`loaderIndex` 和各类 request 字符串不发生变化；chain 只是 runner 的内部调度视图。
+
+pitch 阶段按 chain、chain 内按 loader 从左向右执行；normal 阶段按 chain、chain 内按 loader 从右向左执行。pitch 返回内容时仍跳转到当前 loader 左侧的 normal 流程。
+
+### 3.3 独立的 chain 规划/合并逻辑
+
+合并逻辑必须与执行器分离，建议提供以下纯函数：
+
+```text
+create_singleton_chains(loaders)
+merge_cacheable_chains(chains)
+merge_javascript_chains(chains)
+plan_loader_chains(loaders, strategy)
+```
+
+`strategy` 至少支持内部 A/B 组合：
+
+- `None`：每个 loader 一个 chain，作为功能和性能基线。
+- `CacheOnly`：只合并连续 `cache: true` loader。
+- `JavaScriptOnly`：只合并连续 JS loader。
+- `CacheAndJavaScript`：生产路径，同时应用两类合并。
+
+合并规则：
+
+1. 先把连续 `cache: true` loader 合并为最大区间，允许区间内同时存在 native 和 JS loader；这是一次 cache lookup/store 的语义边界。
+2. 再合并其余连续 JS loader。JS 合并不能跨越已有的缓存边界，否则会把 `cache: false` loader 纳入缓存结果，或拆掉连续 cache loader 的单次哈希边界。
+3. 未合并的 native loader 保持单元素 chain。
+4. 合并只能改变分组，不能改变 loader 顺序和 request 字符串。
+
+对于 mixed cache chain，外层仍把整个区间视为一个缓存单元；chain 内执行器根据连续的 native/JS span 调度。这样可以满足“连续 cache loader 只算一次 key”，同时不要求 Rust loader 在 JS worker 中运行。
+
+## 4. 缓存语义
+
+### 4.1 Key
+
+按需求，动态 key 的核心为：
+
+```text
+input_hash = hash(input content bytes)
+options_hash = hash(按 chain normal 执行顺序排列的每个 loader options fingerprint)
+cache_key = versioned namespace(chain loader identities) + input_hash + options_hash
+```
+
+- loader identity 放在 cache namespace/静态 fingerprint 中，防止两个不同 loader 使用相同 options 和输入时冲突。
+- `input_hash` 在进入一个 cache chain 时只计算一次；chain 中有多少个 loader 都不重复计算。
+- `options_hash` 和 loader identity 尽量在 chain 构造时预计算，每个模块执行时只组合 input hash。
+- cache 格式包含 Rspack 版本和格式版本；loader 实现文件加入 build dependencies，并通过 snapshot/内容时间戳使 loader 代码变化后失效。
+- 按需求不默认加入 `resourcePath`，因此 `cache: true` 同时是一项纯度声明：normal 输出应只由输入代码和 options 决定。文档中必须明确依赖 `resourcePath`、环境变量、时间或外部隐式状态的 loader 不应开启该选项；显式注册的依赖仍参与 entry 有效性检查。
+
+source map 和 opaque additional data 也可能影响后续 loader。第一版采用保守策略：输入存在无法稳定 fingerprint 的 source map/additional data 时跳过该 chain 的缓存，而不是生成不完整 key；后续可以在不改变 chain API 的前提下扩展稳定序列化。
+
+### 4.2 Lookup、执行和 store
+
+缓存只作用于 normal 阶段；所有 pitch 函数始终执行，以保留短路、`data` 初始化和 pitch 副作用语义。
+
+```text
+进入 cache chain 的 normal 阶段
+  取得当前 content
+       ↓
+计算一次 input_hash + 组合静态 fingerprint
+       ↓
+cache hit? ── yes ──> 回放结果/依赖/副作用，标记 chain 内 normal_executed
+    │ no
+    ↓
+按原顺序执行 chain（必要时在 native/JS span 间 yield）
+    ↓
+chain 完成且允许缓存?
+    ├─ no: 直接进入前一个 chain
+    └─ yes: 捕获输出与增量，写入 cache，再进入前一个 chain
+```
+
+以下情况不写入 entry：执行报错、任一 loader 调用 `cacheable(false)`、出现无法安全保存/回放的上下文副作用、输入或输出 additional data 无法由当前 backend 表示、执行期间依赖快照发生变化。失败和 cache I/O 只表现为 miss，不应让 compilation 失败。
+
+### 4.3 Cache entry
+
+entry 至少保存并在 hit 时回放：
+
+- content（保留 string/buffer 类型）和 source map；
+- backend 支持时的 additional data；不支持时该次不落盘，且不能返回缺失数据的 hit；
+- file/context/missing/build dependency 相对 chain 执行前的增删 delta；
+- parse meta、`cacheable` 状态以及 chain 执行产生的可缓存 diagnostics；
+- loader/module context 上可观察的产物，例如 emitted assets/build info delta；若某种副作用暂时无法完整捕获，则该次执行 bypass cache；
+- 完整 cache identity、格式版本、写入时间和依赖快照，用于校验碰撞、损坏和失效。
+
+不要缓存 error，也不要在 hit 时重新触发 loader 日志。normal 执行完成后才原子发布 entry，避免并发读取半成品。
+
+### 4.4 Backend 与生命周期
+
+在 `crates/rspack_core/src/loader/loader_cache.rs` 提供 compiler-scoped `LoaderCacheService`：
+
+- L1 使用并发内存 map，支持同一 compiler 内不同模块复用。
+- compiler 配置为 persistent cache 时接入现有 persistent storage/snapshot 生命周期，使用独立 versioned scope；memory cache 时只保留 L1。
+- 全局 cache disabled 时 `cache: true` 仍保留 chain 规划，但 lookup/store 退化为关闭状态，便于保持单一执行路径。
+- 同 key 并发 miss 可选用 single-flight，避免多个模块同时执行同一昂贵 chain；第一阶段先保证原子写和正确性，再单独评估 single-flight 是否值得加入。
+
+## 5. 分阶段实施
+
+### 阶段 A：配置与元信息贯通
+
+1. 在 `packages/rspack/src/config/types.ts` 增加 `cache?: boolean` 和纯度/默认值说明。
+2. 修改 `packages/rspack/src/config/adapterRuleUse.ts`：设置默认值、生成稳定 options fingerprint，并把 cache 元信息直接写入 `RawModuleRuleUse`；不要仅放进 JS ident reference。
+3. 修改 `crates/rspack_binding_api/src/raw_options/raw_module/mod.rs`、生成的 binding 类型和 `crates/rspack_core/src/options/module.rs`，让静态数组和 function-form `use` 都保留 `cache` 与 fingerprint。
+4. 修改 `crates/rspack_core/src/normal_module_factory.rs` 的 resolve 结果，使用 `ResolvedLoader` 保存 loader、cache、fingerprint 和执行域；inline/pre/normal/post loader 拼接后仍保持当前最终顺序。
+5. 更新所有手工构造 `ModuleRuleUseLoader` 的 Rust 调用点，默认 `cache: false`。
+
+阶段验收：不开启 `cache` 时生成的 request、loader 顺序和现有用例结果完全不变；类型测试能识别 `cache: true`。
+
+### 阶段 B：引入 chain，但先保持 singleton 行为
+
+1. 在 `rspack_loader_runner` 增加 `LoaderChain`、chain 游标和扁平 loader 兼容访问器。
+2. 将 `run_loaders` 外层状态机改成按 chain 推进，但先固定使用 `strategy = None`，确保每个 chain 只有一个 loader。
+3. 把 pitch/normal 的 loader 级循环移动到 chain executor；保持 `finish_called`、空返回值、pitch 短路和错误定位行为。
+4. tracing 从只记录 loader 增加 chain span，并保留具体 loader 子 span，字段包括 chain 长度、range、execution kind、merge reason。
+
+阶段验收：关闭合并时，现有 loader runner、builtin loader、JS loader 和错误快照无变化；这是之后所有优化的稳定基线。
+
+### 阶段 C：独立实现并启用 JS chain 合并
+
+1. 实现 `merge_javascript_chains`，先在测试/benchmark 中对比 `None` 与 `JavaScriptOnly`。
+2. 修改 `crates/rspack_binding_api/src/plugins/js_loader/context.rs`，向 JS 传递结构化 chain range/chain index，同时继续传完整扁平 loader items。
+3. 修改 `crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs`：`should_yield` 只判断当前 chain/span，不再通过当前 loader 前缀重复推断整个连续区间；`no_pitch` 信息按 chain 成员更新。
+4. 修改 `packages/rspack/src/loader-runner/index.ts`：JS runner 严格在 Rust 提供的 chain range 内 pitch/normal，删除“扫描到下一个 builtin loader”为止的隐式边界。
+5. 修改 `packages/rspack/src/loader-runner/worker.ts`：worker 同样消费明确 range；parallel 与 `maxWorkers` 仍按成员配置执行，不能因 chain 合并把 non-parallel loader 发送到 worker。
+6. 命中 JS chain 边界后一次 Rust→JS→Rust round-trip 完成该范围，返回每个成员的 executed/data 状态和最终全局 loader index。
+
+阶段验收：相同 loader 列表下 JS yield 次数等于 JS chain 数，而不是 JS loader 数；pitching、mixed builtin/JS、parallel mixed、raw loader 和无 pitch loader 均保持现有行为。
+
+### 阶段 D：cache chain 与内存缓存
+
+1. 实现 `merge_cacheable_chains`，并在生产 planner 中使用 `CacheAndJavaScript`；cache 合并先于 JS 合并。
+2. 在 chain normal executor 前后加入 lookup/store 状态，确保 mixed chain 跨 JS yield 后仍能继续同一个 miss 执行并在左边界只 store 一次。
+3. 实现静态 fingerprint 预计算和单次 input content hash；tracing/计数器分别记录 key 计算次数、hit/miss/store/bypass 原因。
+4. 实现 compiler-scoped 内存 `LoaderCacheService`，完整捕获并回放 entry 中的输出和 context delta。
+5. 尊重 `cacheable(false)`、错误、diagnostics、dependency 与副作用的 bypass 规则。
+
+阶段验收：连续 N 个 cache loader 在一次 normal 流程中只计算一次 input hash、一次 lookup、一次 store；相同输入和 options 的下一次执行跳过全部 N 个 normal loader。
+
+### 阶段 E：持久化与失效
+
+1. 将 loader cache scope 接入现有 persistent cache 生命周期，复用现有 cache directory、readonly、版本和 snapshot 约束，避免创建另一个用户配置入口。
+2. entry 落盘采用 versioned envelope、完整 identity 校验、校验和与原子写；损坏或 I/O 错误降级为 miss。
+3. 保存 loader 实现文件及显式依赖快照；资源输入通过 input content hash 失效，依赖和 loader 文件通过 snapshot 失效。
+4. additional data 或 context 副作用无法稳定持久化的 entry 仅允许停留在 L1，且旧的同 key 磁盘 entry 必须失效，防止错误回退。
+5. compiler close 时等待 pending writes，readonly 模式只读不写。
+
+阶段验收：第二个 compiler/process 能命中有效 entry；修改输入、options、loader 文件或依赖后 miss；损坏 entry、并发 writer 和 readonly 不影响构建正确性。
+
+### 阶段 F：默认启用、清理旧判断与文档
+
+1. 所有回归和性能数据通过后启用 `CacheAndJavaScript`，保留 `None`/分项 strategy 仅供测试和 benchmark 调用，不暴露临时环境变量作为正式 API。
+2. 删除 Rust/JS/worker 中已经由 chain range 取代的重复连续 loader 扫描和 `$` composed-loader 遗留注释。
+3. 更新 loader 配置文档和类型说明，给出适合缓存的纯 loader 示例与不应缓存的 `resourcePath`/时间/隐式外部状态示例。
+4. 在 release note 中说明 `cache` 是 opt-in、默认 false、normal-only，且 `cacheable(false)` 会阻止写入。
+
+## 6. 测试矩阵
+
+遵循项目测试约束，优先在现有 runner 下增加 case，不新增顶层 `test.js`，也不添加 crate 内联 Rust unit test。
+
+### 配置和 chain 规划
+
+- `cache` 缺省/false/true，object、string 和 function-form `use`。
+- 不稳定 options 给出包含配置路径的错误。
+- singleton、连续 cache、由 non-cache 分隔、连续 JS、mixed native/JS 的 chain shape 通过 tracing/test-only inspection 验证。
+- `None` 与 `CacheAndJavaScript` 对同一 fixture 产生相同输出、request 和 loader context 观察值。
+
+### 缓存 key 和结果
+
+- 相同代码 + 相同 options 命中；代码变化 miss；options 变化 miss；不同 loader identity 不冲突。
+- 两个或更多连续 cache loader 只执行一次 chain lookup，并全部在 hit 时跳过。
+- 相同内容的不同资源可以共享 entry；依赖 `resourcePath` 的反例在文档中明确为不满足 cache contract。
+- string/buffer、source map、可支持的 additional data、空返回 loader。
+- `cacheable(false)`、throw/callback error、diagnostic、无法回放的 emit/side effect 均不写入错误 entry。
+
+### pitch、JS yield 和 parallel
+
+- 有/无 pitch、pitch 返回 content、pitch data 传到 normal、pitch 短路跨 chain。
+- 连续 JS loader 一次 yield；JS/native/JS 形成明确边界；cache mixed chain 可在内部 yield 后完成同一个 store。
+- parallel true/false 混合、不同 `maxWorkers`、worker loader context、raw buffer、source map 和 additional data。
+- 复跑现有 `tests/rspack-test/configCases/loader-parallel*`，确保 worker 行为没有退化。
+
+### watch/persistent invalidation
+
+- 仅修改 resource code、loader options、loader 文件、file/context/missing/build dependency。
+- cache hit 时依赖增删 delta 被正确回放，watch 下一轮仍能收到失效信号。
+- 第二 compiler 命中、格式版本变化 miss、损坏 entry miss、并发写原子性、readonly。
+
+本地 sandbox 中按项目约束跳过 storage 和 native watcher 容易卡住的测试；对应场景交给非 sandbox CI。JS+Rust 修改完成后先执行 `pnpm run build:cli:dev`，再运行新增的过滤 case、`pnpm run test:unit`、`pnpm run test:rs` 和 `cargo lint`。
+
+## 7. 性能对比与可观测性
+
+为独立比较合并收益，使用相同 executor，只替换 planner strategy，采集：
+
+- chain 数、平均/最大 chain 长度；
+- Rust→JS yield/round-trip 次数；
+- worker dispatch 次数；
+- input hash 计算次数和总字节数；
+- cache lookup/hit/miss/store/bypass 数；
+- loader normal 实际执行次数；
+- 冷构建、同 compiler 重复构建、watch rebuild、第二 process persistent warm build 耗时。
+
+至少对以下四组结果做对比：`None`、`JavaScriptOnly`、`CacheOnly`、`CacheAndJavaScript`。性能 fixture 应包含大量小 JS loader、多个连续昂贵 cache loader、cache/native/JS 混排以及低命中场景，防止只优化理想高命中路径。
+
+验收标准：
+
+- 未标记 cache 的项目输出和行为零变化；JS chain 合并只减少调度开销。
+- 连续 cache loader 的 input hash 次数从 loader 数降为 chain 数。
+- warm hit 路径不执行 chain 内 normal loader，并正确回放所有可观察结果。
+- miss 路径的额外 fingerprint/hash/快照成本可量化，且 `CacheAndJavaScript` 相对 singleton 基线有稳定收益或至少无显著回退。
+
+## 8. 主要风险与处理
+
+- **错误共享跨资源结果**：严格文档化 input/options 纯度契约；loader identity 隔离 namespace；显式依赖参与失效。
+- **options fingerprint 不稳定**：配置阶段 canonicalize；不支持的值直接报错，不静默退化为 ident 或 `[object Object]`。
+- **source map/additional data 不完整**：无法稳定 fingerprint/保存时 bypass，不产生部分 entry。
+- **pitch 与 normal 状态错位**：pitch 不缓存；保留扁平 loader 状态和全局 index；先以 singleton chain 完成等价重构。
+- **JS/worker 边界改变 parallel 语义**：chain 只确定可执行范围，worker eligibility 和 pool options 仍逐成员检查。
+- **副作用丢失**：以 chain 前后 delta 捕获并回放；暂不支持的副作用使 entry 不可缓存。
+- **合并优化难以归因**：planner 独立、strategy 可注入、统一 tracing 指标，确保可以单独关闭 cache merge 或 JS merge 做对比。

--- a/plan.md
+++ b/plan.md
@@ -1,313 +1,713 @@
-# Loader Chain 与 Loader Result Cache 执行计划
+# 嵌套 Loader Chain 重构实施计划
 
-## 1. 目标
+## 1. 背景与结论
 
-本次改造包含三个相互关联的目标：
-
-1. 在 loader runner 中引入 `LoaderChain`，一个 chain 包含一个或多个按原顺序排列的 loader，并成为 runner 外层状态机的基本执行单元。
-2. 在 `Rule.use` 的 loader 配置中，在 `options`、`parallel` 同一层增加 `cache?: boolean`。`cache: true` 表示该 loader 的 normal 阶段结果可以按“输入代码哈希 + loader options”复用。
-3. 将连续的可缓存 loader 合并到同一个 chain，一次计算输入代码哈希并缓存整个转换区间；同时将连续的 JS loader 合并，令 Rust/JS yield 的边界直接由 chain 描述，而不是由 Rust、JS 主线程和 worker 各自扫描 loader 列表推断。
-
-本次不改变 webpack 可观察到的 loader 顺序、pitch/normal 方向、`loaderContext.loaderIndex`、`remainingRequest`、`previousRequest`、`data` 和 raw/string 转换语义。
-
-## 2. 当前执行流与主要问题
-
-当前配置和执行路径为：
-
-```text
-Rule.use { loader, options, parallel }
-  packages/rspack/src/config/types.ts
-       ↓
-createRawModuleRuleUses / ident references
-  packages/rspack/src/config/adapterRuleUse.ts
-       ↓
-RawModuleRuleUse -> ModuleRuleUseLoader
-  crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
-  crates/rspack_core/src/options/module.rs
-       ↓
-逐个 resolve 为 BoxLoader
-  crates/rspack_core/src/normal_module_factory.rs
-       ↓
-run_loaders(Vec<BoxLoader>)
-  crates/rspack_loader_runner/src/runner.rs
-       ↓
-以 loader_index 为游标逐个 pitch / normal
-       ↓
-遇到 JS loader 时 should_yield / loader_yield
-  crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs
-       ↓
-JS 主线程和 worker 再次向前/向后扫描连续 loader
-  packages/rspack/src/loader-runner/index.ts
-  packages/rspack/src/loader-runner/worker.ts
-```
-
-主要问题：
-
-- runner 的调度单元、JS yield 单元和未来缓存单元不是同一个概念，边界判断分散在 Rust、JS 主线程和 worker 中。
-- 如果用“每个 loader 外包一层 cache loader”的方式实现缓存，连续 loader 会对同一份中间代码重复计算哈希。
-- `parallel` 目前通过 ident reference 旁路传递；新增缓存信息如果继续只留在 JS 侧，Rust runner 无法在执行前建立 chain。
-- loader 的输出不只有代码，还包括 source map、additional data、依赖集合以及 module/loader context 副作用；只缓存 content 会造成行为不一致。
-
-仓库历史中的 loader cache 原型可以复用其依赖增量回放、loader 文件失效、内存/持久化分层等经验，但不继续采用插入 `builtin:cache-loader` 的结构；缓存应直接成为 `LoaderChain` normal 执行的一部分。
-
-## 3. 目标模型
-
-### 3.1 配置与 resolved loader
-
-公共类型增加：
-
-```ts
-type RuleSetLoaderWithOptions = {
-  loader: string;
-  options?: string | Record<string, any>;
-  parallel?: boolean | { maxWorkers?: number };
-  cache?: boolean;
-  ident?: string;
-};
-```
-
-绑定和 core 不再只传 `BoxLoader`，而是保留执行规划所需的元信息：
-
-```text
-ResolvedLoader
-  loader: BoxLoader
-  cache: bool
-  options_fingerprint: stable bytes/hash
-  execution_kind: Native | JavaScript
-```
-
-`cache` 默认值为 `false`。inline loader 和字符串形式 loader 没有显式标记时保持不缓存。`execution_kind` 应由 loader/resolver 明确提供，避免长期依赖 `builtin:` 前缀猜测执行域；JS loader 返回 `JavaScript`，native/builtin loader 默认为 `Native`。
-
-JS object options 需要在配置适配阶段生成稳定 fingerprint，再通过 `RawModuleRuleUse` 和 `ModuleRuleUseLoader` 传到 Rust。不能把 `ident` 本身当作 options 内容，也不能直接依赖对象属性插入顺序。第一版仅接受可稳定序列化的 cache options；遇到 function、symbol、循环引用等不稳定值时，在对应 option path 给出明确配置错误，避免产生表面命中但结果错误的缓存。
-
-### 3.2 LoaderChain
-
-在 `crates/rspack_loader_runner/src/chain.rs` 新增结构化模型，chain 持有 loader 在扁平列表中的范围，而不使用 `$` 等字符串分隔符编码：
+当前实现已经能够把连续 `cache: true` loader 合并为一个缓存区间，也能在 mixed cache chain 中运行 JS loader 和 builtin loader。但当前模型只有一个扁平 `LoaderChain`：
 
 ```text
 LoaderChain
-  range: [start, end)
-  cache_mode: Disabled | WholeChain
+  range
+  cache
   execution_kind: Native | JavaScript | Mixed
-  merge_reason: Singleton | Cache | JavaScript
-  static_fingerprint: ordered(loader identity + options fingerprint)
 ```
 
-`LoaderContext` 继续保存扁平 `loader_items` 和全局 `loader_index`，新增内部 `loader_chains`、`chain_index` 和 chain 内部进度。这样 loader 看到的 `loaders`、`loaderIndex` 和各类 request 字符串不发生变化；chain 只是 runner 的内部调度视图。
+当一个 cache chain 同时包含 JS 和 builtin loader 时，runner 通过 `current_execution_span()` 在运行时重新扫描相邻 loader，临时计算 JS/native 执行区间。这能保证当前执行结果正确，但没有把“缓存边界”和“执行边界”显式组合起来，导致：
 
-pitch 阶段按 chain、chain 内按 loader 从左向右执行；normal 阶段按 chain、chain 内按 loader 从右向左执行。pitch 返回内容时仍跳转到当前 loader 左侧的 normal 流程。
+- cache chain 内部的 JS 合并没有出现在 planner 结果中；
+- `merge_reason` 只能记录 cache 或 JavaScript，不能同时表达两层原因；
+- `CacheOnly` 仍可能在运行时隐式合并连续 JS loader，无法独立比较优化；
+- 每次 yield 都重新扫描 execution span；
+- tracing、测试和 benchmark 无法观察 cache chain 内部的 JS/native 子链。
 
-### 3.3 独立的 chain 规划/合并逻辑
+本次重构将 `LoaderChain` 改为递归 enum，由 `CacheChain` 包含一个或多个显式执行链：
 
-合并逻辑必须与执行器分离，建议提供以下纯函数：
-
-```text
-create_singleton_chains(loaders)
-merge_cacheable_chains(chains)
-merge_javascript_chains(chains)
-plan_loader_chains(loaders, strategy)
+```rust
+pub enum LoaderChain {
+  CacheChain {
+    range: Range<usize>,
+    static_fingerprint: String,
+    children: Vec<LoaderChain>,
+  },
+  JsExecutionChain {
+    range: Range<usize>,
+  },
+  NativeExecutionChain {
+    range: Range<usize>,
+  },
+}
 ```
 
-`strategy` 至少支持内部 A/B 组合：
+这里使用递归 enum 表达组合关系，但生产 planner 只生成固定的两层结构：
 
-- `None`：每个 loader 一个 chain，作为功能和性能基线。
-- `CacheOnly`：只合并连续 `cache: true` loader。
-- `JavaScriptOnly`：只合并连续 JS loader。
-- `CacheAndJavaScript`：生产路径，同时应用两类合并。
+- `CacheChain` 只能出现在 root；
+- `CacheChain.children` 只能包含 `JsExecutionChain` 或 `NativeExecutionChain`；
+- `JsExecutionChain` 和 `NativeExecutionChain` 都是叶子；
+- 禁止 `CacheChain` 嵌套 `CacheChain`，避免没有语义的任意递归。
 
-合并规则：
+## 2. 目标结构
 
-1. 先把连续 `cache: true` loader 合并为最大区间，允许区间内同时存在 native 和 JS loader；这是一次 cache lookup/store 的语义边界。
-2. 再合并其余连续 JS loader。JS 合并不能跨越已有的缓存边界，否则会把 `cache: false` loader 纳入缓存结果，或拆掉连续 cache loader 的单次哈希边界。
-3. 未合并的 native loader 保持单元素 chain。
-4. 合并只能改变分组，不能改变 loader 顺序和 request 字符串。
-
-对于 mixed cache chain，外层仍把整个区间视为一个缓存单元；chain 内执行器根据连续的 native/JS span 调度。这样可以满足“连续 cache loader 只算一次 key”，同时不要求 Rust loader 在 JS worker 中运行。
-
-## 4. 缓存语义
-
-### 4.1 Key
-
-按需求，动态 key 的核心为：
+例如 loader 列表为：
 
 ```text
-input_hash = hash(input content bytes)
-options_hash = hash(按 chain normal 执行顺序排列的每个 loader options fingerprint)
-cache_key = versioned namespace(chain loader identities) + input_hash + options_hash
+0  js-a       cache=true
+1  js-b       cache=true
+2  builtin-c  cache=true
+3  js-d       cache=true
+4  js-e       cache=false
+5  js-f       cache=false
+6  builtin-g  cache=false
 ```
 
-- loader identity 放在 cache namespace/静态 fingerprint 中，防止两个不同 loader 使用相同 options 和输入时冲突。
-- `input_hash` 在进入一个 cache chain 时只计算一次；chain 中有多少个 loader 都不重复计算。
-- `options_hash` 和 loader identity 尽量在 chain 构造时预计算，每个模块执行时只组合 input hash。
-- cache 格式包含 Rspack 版本和格式版本；loader 实现文件加入 build dependencies，并通过 snapshot/内容时间戳使 loader 代码变化后失效。
-- 按需求不默认加入 `resourcePath`，因此 `cache: true` 同时是一项纯度声明：normal 输出应只由输入代码和 options 决定。文档中必须明确依赖 `resourcePath`、环境变量、时间或外部隐式状态的 loader 不应开启该选项；显式注册的依赖仍参与 entry 有效性检查。
-
-source map 和 opaque additional data 也可能影响后续 loader。第一版采用保守策略：输入存在无法稳定 fingerprint 的 source map/additional data 时跳过该 chain 的缓存，而不是生成不完整 key；后续可以在不改变 chain API 的前提下扩展稳定序列化。
-
-### 4.2 Lookup、执行和 store
-
-缓存只作用于 normal 阶段；所有 pitch 函数始终执行，以保留短路、`data` 初始化和 pitch 副作用语义。
+生产策略应生成：
 
 ```text
-进入 cache chain 的 normal 阶段
-  取得当前 content
+Loaders
+│
+├─ CacheChain [0..4]
+│  ├─ JsExecutionChain     [0..2]
+│  ├─ NativeExecutionChain [2..3]
+│  └─ JsExecutionChain     [3..4]
+│
+├─ JsExecutionChain       [4..6]
+│
+└─ NativeExecutionChain   [6..7]
+```
+
+职责严格分离：
+
+```text
+CacheChain
+  cache key / lookup / hit replay / miss store
        ↓
-计算一次 input_hash + 组合静态 fingerprint
+ExecutionChain children
+  JS chain     -> 一次 Rust → JS → Rust yield
+  Native chain -> Rust 内执行
        ↓
-cache hit? ── yes ──> 回放结果/依赖/副作用，标记 chain 内 normal_executed
-    │ no
-    ↓
-按原顺序执行 chain（必要时在 native/JS span 间 yield）
-    ↓
-chain 完成且允许缓存?
-    ├─ no: 直接进入前一个 chain
-    └─ yes: 捕获输出与增量，写入 cache，再进入前一个 chain
+扁平 loader_items
+  保留全局 loader_index、request、data 和执行状态
 ```
 
-以下情况不写入 entry：执行报错、任一 loader 调用 `cacheable(false)`、出现无法安全保存/回放的上下文副作用、输入或输出 additional data 无法由当前 backend 表示、执行期间依赖快照发生变化。失败和 cache I/O 只表现为 miss，不应让 compilation 失败。
+`LoaderContext.loader_items` 与本轮 `loader_item_states` 通过相同 index 组合成完整 loader 视图。chain tree 只保存 index range 和缓存静态信息，不复制 loader，也不改变 webpack 可观察的 loader 顺序。
 
-### 4.3 Cache entry
+## 3. 数据模型与不变量
 
-entry 至少保存并在 hit 时回放：
+### 3.1 LoaderChain API
 
-- content（保留 string/buffer 类型）和 source map；
-- backend 支持时的 additional data；不支持时该次不落盘，且不能返回缺失数据的 hit；
-- file/context/missing/build dependency 相对 chain 执行前的增删 delta；
-- parse meta、`cacheable` 状态以及 chain 执行产生的可缓存 diagnostics；
-- loader/module context 上可观察的产物，例如 emitted assets/build info delta；若某种副作用暂时无法完整捕获，则该次执行 bypass cache；
-- 完整 cache identity、格式版本、写入时间和依赖快照，用于校验碰撞、损坏和失效。
+在 `crates/rspack_loader_runner/src/chain.rs` 将当前 struct 替换为 enum，并提供统一访问器：
 
-不要缓存 error，也不要在 hit 时重新触发 loader 日志。normal 执行完成后才原子发布 entry，避免并发读取半成品。
+```rust
+impl LoaderChain {
+  pub fn range(&self) -> Range<usize>;
+  pub fn start(&self) -> usize;
+  pub fn end(&self) -> usize;
+  pub fn len(&self) -> usize;
+  pub fn is_cache(&self) -> bool;
+  pub fn execution_kind(&self) -> Option<LoaderExecutionKind>;
+  pub fn children(&self) -> &[LoaderChain];
+}
+```
 
-### 4.4 Backend 与生命周期
+调整类型：
 
-在 `crates/rspack_core/src/loader/loader_cache.rs` 提供 compiler-scoped `LoaderCacheService`：
+- `LoaderExecutionKind` 只保留 `Native | JavaScript`，删除 `Mixed`；mixed 是 `CacheChain` 包含不同叶子链的结构属性，不再是某个执行链的类型。
+- 删除 `LoaderChainMergeReason`，variant 本身表达 chain 角色；需要 tracing 时记录 `chain_kind=cache|javascript|native`。
+- `static_fingerprint` 只属于 `CacheChain`。
+- cache lookup/store hook 只接收 `CacheChain`，执行 hook 只接收叶子 execution chain。
 
-- L1 使用并发内存 map，支持同一 compiler 内不同模块复用。
-- compiler 配置为 persistent cache 时接入现有 persistent storage/snapshot 生命周期，使用独立 versioned scope；memory cache 时只保留 L1。
-- 全局 cache disabled 时 `cache: true` 仍保留 chain 规划，但 lookup/store 退化为关闭状态，便于保持单一执行路径。
-- 同 key 并发 miss 可选用 single-flight，避免多个模块同时执行同一昂贵 chain；第一阶段先保证原子写和正确性，再单独评估 single-flight 是否值得加入。
+### 3.2 结构不变量
 
-## 5. 分阶段实施
+planner 构造完成后统一校验以下不变量：
 
-### 阶段 A：配置与元信息贯通
+1. root chains 按 range 连续覆盖全部 loader，不重叠、不留空洞。
+2. 每个 `CacheChain` 至少包含一个 child。
+3. `CacheChain.children` 连续覆盖外层完整 range。
+4. child 不允许是 `CacheChain`。
+5. `JsExecutionChain` 中所有 loader 的 execution kind 都是 JavaScript。
+6. `NativeExecutionChain` 中所有 loader 的 execution kind 都是 Native。
+7. `CacheChain` 范围内所有 loader 都是 `cache=true`。
+8. 未开启 cache 的 loader 不能被放入 `CacheChain`。
 
-1. 在 `packages/rspack/src/config/types.ts` 增加 `cache?: boolean` 和纯度/默认值说明。
-2. 修改 `packages/rspack/src/config/adapterRuleUse.ts`：设置默认值、生成稳定 options fingerprint，并把 cache 元信息直接写入 `RawModuleRuleUse`；不要仅放进 JS ident reference。
-3. 修改 `crates/rspack_binding_api/src/raw_options/raw_module/mod.rs`、生成的 binding 类型和 `crates/rspack_core/src/options/module.rs`，让静态数组和 function-form `use` 都保留 `cache` 与 fingerprint。
-4. 修改 `crates/rspack_core/src/normal_module_factory.rs` 的 resolve 结果，使用 `ResolvedLoader` 保存 loader、cache、fingerprint 和执行域；inline/pre/normal/post loader 拼接后仍保持当前最终顺序。
-5. 更新所有手工构造 `ModuleRuleUseLoader` 的 Rust 调用点，默认 `cache: false`。
+校验放在 planner 边界，debug/test 构建中强校验；executor 不重复推断这些事实。
 
-阶段验收：不开启 `cache` 时生成的 request、loader 顺序和现有用例结果完全不变；类型测试能识别 `cache: true`。
+### 3.3 O(1) chain 定位
 
-### 阶段 B：引入 chain，但先保持 singleton 行为
+不要在每次 pitch/normal/yield 时递归扫描 tree。chain 和定位索引直接保存在 `Loaders`：
 
-1. 在 `rspack_loader_runner` 增加 `LoaderChain`、chain 游标和扁平 loader 兼容访问器。
-2. 将 `run_loaders` 外层状态机改成按 chain 推进，但先固定使用 `strategy = None`，确保每个 chain 只有一个 loader。
-3. 把 pitch/normal 的 loader 级循环移动到 chain executor；保持 `finish_called`、空返回值、pitch 短路和错误定位行为。
-4. tracing 从只记录 loader 增加 chain span，并保留具体 loader 子 span，字段包括 chain 长度、range、execution kind、merge reason。
+```rust
+pub struct LoaderChainLocation {
+  root_index: usize,
+  child_index: Option<usize>,
+}
+```
 
-阶段验收：关闭合并时，现有 loader runner、builtin loader、JS loader 和错误快照无变化；这是之后所有优化的稳定基线。
+`locations[loader_index]` 直接定位：
 
-### 阶段 C：独立实现并启用 JS chain 合并
+- 当前 root cache/execution chain；
+- 当前叶子 execution chain；
+- JS bridge 应接收的明确 range。
 
-1. 实现 `merge_javascript_chains`，先在测试/benchmark 中对比 `None` 与 `JavaScriptOnly`。
-2. 修改 `crates/rspack_binding_api/src/plugins/js_loader/context.rs`，向 JS 传递结构化 chain range/chain index，同时继续传完整扁平 loader items。
-3. 修改 `crates/rspack_binding_api/src/plugins/js_loader/scheduler.rs`：`should_yield` 只判断当前 chain/span，不再通过当前 loader 前缀重复推断整个连续区间；`no_pitch` 信息按 chain 成员更新。
-4. 修改 `packages/rspack/src/loader-runner/index.ts`：JS runner 严格在 Rust 提供的 chain range 内 pitch/normal，删除“扫描到下一个 builtin loader”为止的隐式边界。
-5. 修改 `packages/rspack/src/loader-runner/worker.ts`：worker 同样消费明确 range；parallel 与 `maxWorkers` 仍按成员配置执行，不能因 chain 合并把 non-parallel loader 发送到 worker。
-6. 命中 JS chain 边界后一次 Rust→JS→Rust round-trip 完成该范围，返回每个成员的 executed/data 状态和最终全局 loader index。
+由此删除 `LoaderContext::current_execution_span()` 及其运行时左右扫描。
 
-阶段验收：相同 loader 列表下 JS yield 次数等于 JS chain 数，而不是 JS loader 数；pitching、mixed builtin/JS、parallel mixed、raw loader 和无 pitch loader 均保持现有行为。
+### 3.4 在 Module 上保存预组装的 `Arc<Loaders>`
 
-### 阶段 D：cache chain 与内存缓存
+chain tree 不应等到 `NormalModule::build()` 才重新构造。新增不可变的 `Loaders`，在 `NormalModuleFactory` 完成 loader resolve、排序和配置合并后一次性创建，并通过 `Arc` 保存到 `NormalModule`：
 
-1. 实现 `merge_cacheable_chains`，并在生产 planner 中使用 `CacheAndJavaScript`；cache 合并先于 JS 合并。
-2. 在 chain normal executor 前后加入 lookup/store 状态，确保 mixed chain 跨 JS yield 后仍能继续同一个 miss 执行并在左边界只 store 一次。
-3. 实现静态 fingerprint 预计算和单次 input content hash；tracing/计数器分别记录 key 计算次数、hit/miss/store/bypass 原因。
-4. 实现 compiler-scoped 内存 `LoaderCacheService`，完整捕获并回放 entry 中的输出和 context delta。
-5. 尊重 `cacheable(false)`、错误、diagnostics、dependency 与副作用的 bypass 规则。
+```rust
+pub struct Loaders {
+  loaders: Vec<BoxLoader>,
+  options: Vec<LoaderRunnerOptions>,
+  loader_items: OnceLock<Arc<[LoaderItem<RunnerContext>]>>,
+  loader_chains: OnceLock<(
+    Arc<[LoaderChain]>,
+    Arc<[LoaderChainLocation]>,
+  )>,
+  cache_service: RwLock<Option<Arc<LoaderCacheService>>>,
+}
+```
 
-阶段验收：连续 N 个 cache loader 在一次 normal 流程中只计算一次 input hash、一次 lookup、一次 store；相同输入和 options 的下一次执行跳过全部 N 个 normal loader。
+`Loaders` 包含每个 module 预组装好的 loader 执行描述，以及指向 compiler-scoped cache service 的共享句柄：
 
-### 阶段 E：持久化与失效
+- resolved loader 实例；
+- request/path/query/fragment/type 等一次解析结果；
+- `cache` 和 options fingerprint；
+- 预计算的 cache static fingerprint；
+- 完整 chain tree 和 location index。
+- `Arc<LoaderCacheService>`；每个 module 持有一个 clone，但底层 L1/persistent backend 仍由同一个 compiler service 共享。
 
-1. 将 loader cache scope 接入现有 persistent cache 生命周期，复用现有 cache directory、readonly、版本和 snapshot 约束，避免创建另一个用户配置入口。
-2. entry 落盘采用 versioned envelope、完整 identity 校验、校验和与原子写；损坏或 I/O 错误降级为 miss。
-3. 保存 loader 实现文件及显式依赖快照；资源输入通过 input content hash 失效，依赖和 loader 文件通过 snapshot 失效。
-4. additional data 或 context 副作用无法稳定持久化的 entry 仅允许停留在 L1，且旧的同 key 磁盘 entry 必须失效，防止错误回退。
-5. compiler close 时等待 pending writes，readonly 模式只读不写。
+这里的“缓存状态”需要区分静态和动态两部分：
 
-阶段验收：第二个 compiler/process 能命中有效 entry；修改输入、options、loader 文件或依赖后 miss；损坏 entry、并发 writer 和 readonly 不影响构建正确性。
+- 静态缓存状态放进 `Loaders`：`cache` 开关、options fingerprint、loader identity、`CacheChain` 结构和 static fingerprint。
+- cache service 句柄放进 `Loaders`，service 内部可以通过 interior mutability 保存 compiler 级 L1 entry 和 persistent backend。
+- 本轮执行状态不直接保存在共享 `Loaders` 字段上：input hash、active hit/miss、miss snapshot 和正在执行的 cache action 依赖当前 build，应保存在本轮 runner state；最终 entry 写入 `Loaders.cache_service` 指向的共享 service。
 
-### 阶段 F：默认启用、清理旧判断与文档
+因此 `Loaders` 是每个 module 自己的完整预组装执行对象，但其中的 cache service 是 compiler 级共享服务，不是为每个 module 单独创建一份 backend。
 
-1. 所有回归和性能数据通过后启用 `CacheAndJavaScript`，保留 `None`/分项 strategy 仅供测试和 benchmark 调用，不暴露临时环境变量作为正式 API。
-2. 删除 Rust/JS/worker 中已经由 chain range 取代的重复连续 loader 扫描和 `$` composed-loader 遗留注释。
-3. 更新 loader 配置文档和类型说明，给出适合缓存的纯 loader 示例与不应缓存的 `resourcePath`/时间/隐式外部状态示例。
-4. 在 release note 中说明 `cache` 是 opt-in、默认 false、normal-only，且 `cacheable(false)` 会阻止写入。
+`NormalModule` 从：
 
-## 6. 测试矩阵
+```rust
+loaders: Vec<BoxLoader>,
+loader_runner_options: Vec<LoaderRunnerOptions>,
+```
 
-遵循项目测试约束，优先在现有 runner 下增加 case，不新增顶层 `test.js`，也不添加 crate 内联 Rust unit test。
+改为：
 
-### 配置和 chain 规划
+```rust
+loaders: Arc<Loaders>,
+```
 
-- `cache` 缺省/false/true，object、string 和 function-form `use`。
-- 不稳定 options 给出包含配置路径的错误。
-- singleton、连续 cache、由 non-cache 分隔、连续 JS、mixed native/JS 的 chain shape 通过 tracing/test-only inspection 验证。
-- `None` 与 `CacheAndJavaScript` 对同一 fixture 产生相同输出、request 和 loader context 观察值。
+`resource_data: Arc<ResourceData>` 保持 `NormalModule` 上的原字段，不放入 `Loaders`；本次只把原 loader 数组和这个分支新增的 loader/cache/chain 字段收拢进 `Loaders`。
 
-### 缓存 key 和结果
+factory 与运行时执行流变为：
 
-- 相同代码 + 相同 options 命中；代码变化 miss；options 变化 miss；不同 loader identity 不冲突。
-- 两个或更多连续 cache loader 只执行一次 chain lookup，并全部在 hit 时跳过。
-- 相同内容的不同资源可以共享 entry；依赖 `resourcePath` 的反例在文档中明确为不满足 cache contract。
-- string/buffer、source map、可支持的 additional data、空返回 loader。
-- `cacheable(false)`、throw/callback error、diagnostic、无法回放的 emit/side effect 均不写入错误 entry。
+```text
+NormalModuleFactory
+  resolve post / inline / normal / pre loaders
+       ↓
+确定最终扁平顺序和 runner options
+       ↓
+Loaders::new(..., strategy)
+  解析 loader descriptor
+  生成 LoaderChain tree
+  计算 location index/static fingerprint
+  clone compiler LoaderCacheService handle
+       ↓
+Arc<Loaders> 保存到 NormalModule
+       ↓
+NormalModule::build / rebuild
+  Arc::clone（不重新解析、不重新规划）
+       ↓
+只创建本次运行的 LoaderItemState / CacheChainState
+       ↓
+run_loaders_with_preplanned(Loaders 中的共享 items/chains/locations, ...)
+  按预组装 plan 一次性运行
+```
 
-### pitch、JS yield 和 parallel
+这可以避免每次 build 重复执行：
 
-- 有/无 pitch、pitch 返回 content、pitch data 传到 normal、pitch 短路跨 chain。
-- 连续 JS loader 一次 yield；JS/native/JS 形成明确边界；cache mixed chain 可在内部 yield 后完成同一个 store。
-- parallel true/false 混合、不同 `maxWorkers`、worker loader context、raw buffer、source map 和 additional data。
-- 复跑现有 `tests/rspack-test/configCases/loader-parallel*`，确保 worker 行为没有退化。
+- clone 两个平行 Vec 并重新 zip；
+- 对每个 loader 重新解析 identifier/query/fragment/type；
+- 重新读取 execution kind；
+- 重新计算静态 fingerprint；
+- 重新规划 chain tree 和 location index。
 
-### watch/persistent invalidation
+#### 重构 `LoaderItem`：静态定义与运行时状态分离
 
-- 仅修改 resource code、loader options、loader 文件、file/context/missing/build dependency。
-- cache hit 时依赖增删 delta 被正确回放，watch 下一轮仍能收到失效信号。
-- 第二 compiler 命中、格式版本变化 miss、损坏 entry miss、并发写原子性、readonly。
+当前分支的 `LoaderItem` 同时保存固定定义和可变执行状态。重构后，存放在 `Arc<Loaders>` 中的 `LoaderItem` 只保留 factory 阶段已经确定、后续 build 不会变化的字段：
 
-本地 sandbox 中按项目约束跳过 storage 和 native watcher 容易卡住的测试；对应场景交给非 sandbox CI。JS+Rust 修改完成后先执行 `pnpm run build:cli:dev`，再运行新增的过滤 case、`pnpm run test:unit`、`pnpm run test:rs` 和 `cargo lint`。
+```rust
+pub struct LoaderItem<Context: Send> {
+  loader: Arc<dyn Loader<Context>>,
+  request: Identifier,
+  path: Utf8PathBuf,
+  query: Option<String>,
+  fragment: Option<String>,
+  loader_type: String,
+  execution_kind: LoaderExecutionKind,
+  cache: bool,
+  cache_key: String,
+}
+```
 
-## 7. 性能对比与可观测性
+以下字段从 `LoaderItem` 移除：
 
-为独立比较合并收益，使用相同 executor，只替换 planner strategy，采集：
+- `data`；
+- `pitch_executed`；
+- `normal_executed`；
+- `finish_called`。
 
-- chain 数、平均/最大 chain 长度；
-- Rust→JS yield/round-trip 次数；
-- worker dispatch 次数；
-- input hash 计算次数和总字节数；
-- cache lookup/hit/miss/store/bypass 数；
-- loader normal 实际执行次数；
-- 冷构建、同 compiler 重复构建、watch rebuild、第二 process persistent warm build 耗时。
+它们组成每次 run 新建的 `LoaderItemState`，不再需要 `AtomicBool`：
 
-至少对以下四组结果做对比：`None`、`JavaScriptOnly`、`CacheOnly`、`CacheAndJavaScript`。性能 fixture 应包含大量小 JS loader、多个连续昂贵 cache loader、cache/native/JS 混排以及低命中场景，防止只优化理想高命中路径。
+```rust
+#[derive(Default)]
+pub struct LoaderItemState {
+  data: serde_json::Value,
+  pitch_executed: bool,
+  normal_executed: bool,
+  finish_called: bool,
+}
 
-验收标准：
+pub enum CacheChainState {
+  Pending,
+  Bypassed,
+  Hit,
+  Miss(LoaderChainCacheState),
+  Completed,
+}
 
-- 未标记 cache 的项目输出和行为零变化；JS chain 合并只减少调度开销。
-- 连续 cache loader 的 input hash 次数从 loader 数降为 chain 数。
-- warm hit 路径不执行 chain 内 normal loader，并正确回放所有可观察结果。
-- miss 路径的额外 fingerprint/hash/快照成本可量化，且 `CacheAndJavaScript` 相对 singleton 基线有稳定收益或至少无显著回退。
+pub struct LoaderContext<Context: Send> {
+  loaders: Arc<Loaders>,
+  item_states: Box<[LoaderItemState]>,
+  cache_chain_states: Box<[CacheChainState]>,
+  loader_index: i32,
+  // content/dependencies/context 等本轮状态
+}
+```
 
-## 8. 主要风险与处理
+loader 访问器通过相同 index 组合 `Loaders.items` 与 `LoaderContext.item_states`。JS bridge 返回时只更新 `LoaderItemState`，不替换或重建 `Loaders.items/chains/locations`。
 
-- **错误共享跨资源结果**：严格文档化 input/options 纯度契约；loader identity 隔离 namespace；显式依赖参与失效。
-- **options fingerprint 不稳定**：配置阶段 canonicalize；不支持的值直接报错，不静默退化为 ident 或 `[object Object]`。
-- **source map/additional data 不完整**：无法稳定 fingerprint/保存时 bypass，不产生部分 entry。
-- **pitch 与 normal 状态错位**：pitch 不缓存；保留扁平 loader 状态和全局 index；先以 singleton chain 完成等价重构。
-- **JS/worker 边界改变 parallel 语义**：chain 只确定可执行范围，worker eligibility 和 pool options 仍逐成员检查。
-- **副作用丢失**：以 chain 前后 delta 捕获并回放；暂不支持的副作用使 entry 不可缓存。
-- **合并优化难以归因**：planner 独立、strategy 可注入、统一 tracing 指标，确保可以单独关闭 cache merge 或 JS merge 做对比。
+#### 由 `CacheChain` 控制动态 normal 状态
+
+静态 `CacheChain` 不直接保存可变字段，而是通过 root index 控制本轮对应的 `CacheChainState` 和范围内的 `LoaderItemState`：
+
+```text
+CacheChain::enter_normal
+  Pending
+     ├─ 不满足缓存条件 ──> Bypassed
+     ├─ cache hit ──────> Hit
+     │                    标记 range 内 normal_executed/finish_called
+     │                    回放 content/dependencies/build effects
+     └─ cache miss ─────> Miss(snapshot)
+                          执行 children
+                               ↓
+CacheChain::finish_normal
+  Miss(snapshot) ──> store ──> Completed
+  Bypassed       ────────────> Completed
+```
+
+状态所有权约束：
+
+- pitch 始终执行，因此 `pitch_executed` 和 pitch 写入的 `data` 由叶子 execution chain 按 loader 更新，不能从 cache entry 回放；
+- cache miss 时，JS/native execution chain 逐个更新 `normal_executed` 和 `finish_called`；
+- cache hit 时，由外层 `CacheChain` 一次性更新整个 range 的 normal/finish 状态并移动全局 `loader_index`；
+- `cacheable(false)`、pitch short-circuit、错误或不可缓存副作用把当前 root 的 `CacheChainState` 转为 `Bypassed`；
+- `LoaderChainCacheState` 只属于当前 run，不能放进 module-owned `Loaders` 或复用于下一次 rebuild；
+- 下一次 build 为所有 items/cache roots 重新创建默认 state，但复用同一个静态 `Arc<Loaders>`。
+
+core 生产路径最终收敛为从 `Loaders` 取出预组装结果，再调用 loader-runner crate 的通用入口：
+
+```rust
+run_loaders_with_preplanned(
+  loader_items: Arc<[LoaderItem<RunnerContext>]>,
+  loader_chains: Arc<[LoaderChain]>,
+  loader_chain_locations: Arc<[LoaderChainLocation]>,
+  resource_data,
+  plugin,
+  context,
+  fs,
+)
+```
+
+删除生产路径中的平行参数 `Vec<BoxLoader> + Vec<LoaderRunnerOptions>`，也不再在 `run_loaders` 内调用 `LoaderItem::new` 或 `plan_loader_chains`。
+
+cache lookup/store 直接从 `Loaders.cache_service()` 取得服务，不需要再给 `NormalModule` 增加独立的 `loader_cache_service` 字段。
+
+#### 组装时机和 late mutation
+
+`Loaders::new` 必须发生在以下操作全部完成之后：
+
+1. module rules/function-form `use` 已求值；
+2. post/inline/normal/pre loader 已 resolve；
+3. `matchResource` 和 inline loader 顺序已经确定；
+4. 所有能够改变最终 loader 列表的 factory hook 已结束。
+
+当前 `before_loaders` hook 接收 `&mut NormalModule`，但没有公开的 loader mutation API。此次改造应明确 `Loaders` 在 module 创建后默认不可变。如果未来或内部 hook 需要替换 loader，必须调用统一入口：
+
+```rust
+NormalModule::replace_loaders(resolved_loaders)
+  -> Arc::new(Loaders::new(...))
+```
+
+禁止直接修改 items 而不重建 chains/locations。不要对已经共享的 `Arc<Loaders>` 原地写入，也不要只更新 loader items 而保留旧 chain tree。
+
+#### Cacheable/持久化模块缓存
+
+`NormalModule` 当前参与 cacheable 序列化。`Arc<Loaders>` 接入时需要明确区分可序列化的 loader/chain 字段和不可序列化的 compiler service：
+
+- `Loaders.items` 中的 loader trait object 沿用现有 `cacheable_dyn` 能力；
+- chains 和 locations 只包含 range、variant、fingerprint 和 index，可安全序列化；
+- `LoaderCacheService` 包含当前 compiler 的内存表、文件系统和 persistent 配置，不能作为 module cache payload 序列化，也不能从旧 compiler 恢复到新 compiler；
+- `Loaders.cache_service` 必须采用 skip/rebind 语义：新 module 在 factory 中绑定，反序列化 module 在进入当前 compilation 后绑定当前 compiler 的 service；
+- rebind 只能替换 service handle，不能重算 items/chains/locations；
+- 反序列化后校验 chain 不变量；
+- 调整 cache schema/version，避免旧 `Vec<BoxLoader> + Vec<LoaderRunnerOptions>` 与新布局混用。
+
+不引入第二个中间容器类型。`Loaders` 序列化原始 loader trait objects 与 options，并跳过 `OnceLock` 中的运行时 items/plan 以及 cache service。正常 factory 路径会预填两个 `OnceLock`；持久化恢复的 module 因为不再经过 factory，会在第一次 build 时重建一次 items/plan 并绑定当前 compiler service，后续 rebuild 继续复用。这样不会在每次 build 重算，也不会把旧 compiler service 恢复到新 compiler。
+
+```text
+NormalModule
+  loaders: Arc<Loaders>
+             ├─ items
+             ├─ chains
+             ├─ locations
+             └─ Arc<LoaderCacheService>
+```
+
+#### Strategy 与 benchmark
+
+生产 `NormalModule` 保存一个按默认 strategy 生成的 `Arc<Loaders>`。测试和 benchmark 需要对比 strategy 时，在计时区间外分别构造多个 `Loaders::new_with_strategy(...)`；不要在 runner 热路径临时重新规划，否则会把 planner 成本混入 executor 对比，也违背预组装目标。
+
+#### 方案边界
+
+这个方案总体可行，但需要接受两个边界：
+
+1. `Arc` 只能消除同一 module 多次 build/rebuild 的重复规划；不同 module 即使 loader 列表相同，仍各自持有一个 `Loaders`。跨 module 去重需要额外的 factory-level interner，不属于本次改造。
+2. loader 数通常较少，规划本身是 O(N)；性能收益必须通过 rebuild/大规模模块 benchmark 验证。该结构的首要收益是让 chain 成为稳定的 module 元数据，并简化 runner，而不是预设规划成本一定显著。
+
+## 4. 独立 planner
+
+planner 继续与 executor 分离，并拆成可以单独测试和 benchmark 的纯步骤：
+
+```text
+create_loader_groups(loaders, strategy)
+       ↓
+生成 root cache boundaries
+       ↓
+partition_execution_chains(root range, strategy)
+       ↓
+生成 CacheChain children 或 root execution chain
+       ↓
+build_location_index + validate
+       ↓
+Loaders.chains + Loaders.locations
+```
+
+建议接口：
+
+```rust
+pub fn plan_loader_chains<Context: Send>(
+  loaders: &[LoaderItem<Context>],
+  strategy: LoaderChainStrategy,
+) -> (Box<[LoaderChain]>, Box<[LoaderChainLocation]>);
+
+fn plan_root_ranges(...);
+fn plan_execution_children(...);
+fn build_location_index(...);
+fn validate_plan(...);
+```
+
+### 4.1 策略语义
+
+保留四种内部策略，但让两类优化真正独立：
+
+| Strategy | cache=true loader | 连续 JS loader |
+| --- | --- | --- |
+| `None` | 每个 loader 是 singleton `CacheChain` | 每个叶子是 singleton |
+| `CacheOnly` | 连续 cache loader 合并为一个 `CacheChain` | children 保持 singleton |
+| `JavaScriptOnly` | cache loader 保持 singleton `CacheChain` | 只合并同一 cache boundary 内或连续 uncached JS |
+| `CacheAndJavaScript` | 合并连续 cache loader | 每个 root 内再合并连续 JS loader |
+
+即使关闭 cache merge，`cache=true` 的 loader 仍必须有 singleton `CacheChain`，继续保留缓存功能；strategy 只控制是否把多个缓存 loader 合为一次 key/lookup，而不是控制 cache 功能开关。
+
+JS merge 不得跨越两个 cache root，否则会破坏独立 cache lookup/store 的语义边界。
+
+### 4.2 NativeExecutionChain 规则
+
+- `None`、`CacheOnly` 基线中 native loader 保持 singleton，方便严格对比。
+- `JavaScriptOnly` 不额外合并 native loader。
+- `CacheAndJavaScript` 中 cache root 内相邻 native loader 可以归入同一个 `NativeExecutionChain`，但第一版也可以保持 singleton；是否合并 native 不得影响 yield 次数或 cache key 次数。
+- 计划和 executor 均允许 `NativeExecutionChain` 包含一个或多个 loader，为后续 native batch/tracing 留出空间。
+
+## 5. Runner 执行模型
+
+### 5.1 Pitch
+
+pitch 不参与缓存，但按 plan 的叶子 execution chain 调度：
+
+```text
+root 从左到右
+  execution child 从左到右
+    loader 从左到右 pitch
+```
+
+- 进入 `JsExecutionChain` 时一次 yield 给 JS。
+- 进入 `NativeExecutionChain` 时在 Rust 中运行完整 range。
+- pitch 返回 content 后，仍按全局 `loader_index - 1` 进入 normal。
+- pitch short-circuit 发生在 `CacheChain` 内部时，只运行当前 loader 左侧部分；该 cache root 本轮 normal 必须 bypass lookup/store，因为不是完整 chain 输入输出。
+
+### 5.2 Normal
+
+normal 按 root 和 child 逆序执行：
+
+```text
+root 从右到左
+  CacheChain before_normal_chain
+    hit  -> 回放并跳过全部 children
+    miss -> children 从右到左
+              loader 从右到左 normal
+            完成后 after_normal_chain/store 一次
+```
+
+以 mixed cache chain 为例：
+
+```text
+CacheChain [0..4]
+  normal order:
+    JsExecutionChain [3..4]
+      ↓
+    NativeExecutionChain [2..3]
+      ↓
+    JsExecutionChain [0..2]，内部顺序 1 → 0
+      ↓
+    store CacheChain [0..4]
+```
+
+Cache miss 状态保存在当前 run 对应 root index 的 `CacheChainState::Miss` 中，跨多个 child yield 保持到 root 左边界，不能放到某个 JS/native child 或静态 `LoaderItem` 中。这样 cache hook 的调用次数始终是每个 outer cache chain 一次，而不是每个 child 一次。
+
+### 5.3 状态兼容
+
+必须继续保持：
+
+- `loader_index` 是扁平列表中的全局 index；
+- `pitch_executed`、`normal_executed`、`finish_called` 仍属于单个 loader 的本轮 `LoaderItemState`；
+- `remainingRequest`、`currentRequest`、`previousRequest` 基于完整扁平 loader list；
+- raw/string 转换发生在相邻 loader 之间，不因 chain 边界改变；
+- cache hit 标记 outer chain 内全部 normal loader 为 executed/finished；
+- error 仍定位到具体 loader，而不是只显示 outer cache chain。
+
+## 6. JS 主线程与 worker 调度
+
+### 6.1 Rust → JS bridge
+
+`JsLoaderContext` 不再接收动态 `current_execution_span()`，直接读取 plan 中的 `JsExecutionChain.range`。
+
+内部字段建议从：
+
+```text
+loaderChainStart / loaderChainEnd
+```
+
+重命名为：
+
+```text
+executionChainStart / executionChainEnd
+```
+
+避免 JS 侧把它误认为包含 cache root 的完整 range。若 binding 兼容成本较高，可以先保留字段名，但注释必须明确它始终表示叶子 `JsExecutionChain`。
+
+### 6.2 JS runner
+
+`packages/rspack/src/loader-runner/index.ts`：
+
+- pitching 只执行 `[executionChainStart, executionChainEnd)`；
+- normal 只逆序执行同一范围；
+- JS runner 不再判断相邻 loader 是否 builtin；planner 已保证范围内全部是 JS loader；
+- 一次 yield 可以完成整个 JS child，并返回最终 `loader_index` 和每个成员状态。
+
+### 6.3 Worker
+
+`packages/rspack/src/loader-runner/worker.ts`：
+
+- worker 仍只执行逐成员满足 `parallel` 的 JS loader；
+- non-parallel loader 仍回到 JS 主线程；
+- 删除用于识别 Rust builtin 的 `BUILTIN_LOADER_PREFIX` 分支，因为 builtin 不可能出现在 `JsExecutionChain`；
+- `maxWorkers`、raw/source map/additional data 和同步请求行为保持逐 loader 语义。
+
+## 7. Cache service 适配
+
+缓存 key 和 entry 格式不需要重新设计。core runner 从 `Arc<Loaders>` 取得其 compiler-scoped service handle，再让 cache API 只接受 `CacheChain`：
+
+```rust
+before_normal_chain(context, cache_chain)
+after_normal_chain(context, cache_chain, state)
+```
+
+调整点：
+
+1. `static_fingerprint` 从 enum 的 `CacheChain` variant 读取。
+2. input content 只在进入 outer cache chain 时 hash 一次。
+3. cache hit 一次标记并跳过 outer range 内全部 child/loader。
+4. cache miss 在执行完全部 child 后 store 一次。
+5. dependency、parse meta、assets、build info 和 additional data delta 仍以 outer range 的执行前后状态捕获。
+6. pitch short-circuit 进入 outer range 中部时 bypass 整个 cache chain，不能对子链产生部分 entry。
+7. global cache disabled 时保留 tree 规划，只让 cache action 返回 `Disabled`。
+
+缓存 identity 继续按 outer cache chain 的 normal 顺序包含所有 loader identity、type 和 options fingerprint。children 的划分不得进入 cache key，否则仅切换 JS merge strategy 会造成无意义的缓存失效。
+
+## 8. 分阶段实施
+
+### 阶段 A：在 factory 引入预组装 `Loaders` 和 enum plan
+
+1. 将 `LoaderChain` struct 改成 enum，并增加 location index 和结构校验。
+2. 新增单一的 `Loaders` struct，收拢当前 module 上的 loader 数组、runner options、本分支新增的静态字段、chains、locations 和 cache service。
+3. 在 `NormalModuleFactory` 得到 post/inline/normal/pre 的最终顺序后调用一次 `Loaders::new`，并绑定 compiler 的 `Arc<LoaderCacheService>`。
+4. `NormalModule` 改为只保存 `Arc<Loaders>`，删除平行的 `loaders` 与 `loader_runner_options` 字段。
+5. 重写 `plan_loader_chains`，为四种 strategy 生成完整 tree，并在 factory 组装阶段调用。
+6. 保留当前 executor，通过临时适配器读取 `Loaders` 中的定义和 tree，先保证代码可编译。
+7. 在 tracing/test-only 输出中打印 root 与 children，确认 mixed cache chain 的 shape。
+
+验收：factory 对每个 module 只组装一次 `Loaders`；同一 module rebuild 不再解析 loader 或调用 planner；同一 loader list 在四种 strategy 下得到预期 tree。
+
+### 阶段 B：执行器切换到显式 leaf chain
+
+1. runner 入口和 `LoaderContext` 直接接收 `Arc<Loaders>`，通过其 items/chains/locations 增加 `current_root_chain()`、`current_execution_chain()` 和 O(1) location 查询。
+2. pitch/normal runner 以 root + leaf range 推进。
+3. 将 `LoaderItem` 拆成 `Loaders.items` 中的静态部分和每次 run 的 `LoaderItemState`，删除静态 item 上的 `AtomicBool`/`data`。
+4. 为每个 cache root 创建 `CacheChainState`，把 lookup/hit/miss/bypass/store 生命周期固定在 outer cache root。
+5. JS bridge 只回写 `LoaderItemState`，禁止修改共享 items/chains/locations；cache hit 由 `CacheChain` 批量更新其 range。
+6. 删除生产路径的 loader/options clone+zip、`LoaderItem::new` 和 `plan_loader_chains` 调用。
+7. 删除 `Mixed`、`merge_reason` 和旧 chain range 分支。
+8. 保留完整扁平 loader 观察语义并验证 pitch short-circuit。
+
+验收：使用 `strategy=None` 时与当前逐 loader 行为完全一致；mixed cache chain 的 hit/miss 各只触发一次 cache hook。
+
+### 阶段 C：JS bridge 消费显式 JsExecutionChain
+
+1. Rust scheduler 只在当前叶子是 `JsExecutionChain` 时 yield。
+2. binding 传递叶子的明确 range，不再调用 `current_execution_span()`。
+3. JS 主线程和 worker 严格消费该 range。
+4. 删除 Rust 和 worker 中的相邻 execution-kind/builtin 扫描。
+5. 更新生成的 N-API 类型。
+
+验收：一次 `JsExecutionChain` 只产生一次 Rust/JS round-trip；builtin 永远不会进入 JS range。
+
+### 阶段 D：缓存、测试和可观测性收尾
+
+1. factory 创建 `Loaders` 时 clone compiler-scoped `LoaderCacheService` handle；确认所有 module 共享同一底层 service，而不是各自创建 backend。
+2. cache service API 限定为 `CacheChain`，确认 fingerprint 不包含 child shape。
+3. 实现 module cache 反序列化后的 service rebind；不能恢复旧 compiler service，允许在首次 build 惰性重建一次被跳过的 items/chains/locations。
+4. tracing 分别记录 outer cache chain 和 leaf execution chain。
+5. 增加 strategy A/B 指标：factory plan 次数、rebuild replan 次数、root 数、child 数、JS yield 数、cache hash/lookup/store 数。
+6. 更新内部文档和 `plan.md` 对应实现状态。
+7. 运行构建、lint 和回归测试。
+
+验收：`CacheOnly` 与 `CacheAndJavaScript` 的 cache 次数相同、JS yield 次数不同；`JavaScriptOnly` 与 `None` 的 cache boundary 相同、JS yield 次数不同。
+
+## 9. 测试矩阵
+
+遵循项目约束，不新增 crate-local inline Rust `#[test]`；优先使用现有 JS case runner，确需直接验证 planner shape 时放入合适的专用测试 crate/integration harness。
+
+### 9.1 Planner shape
+
+- 全 JS、全 native、JS/native/JS 混合。
+- 连续 cache、cache/non-cache/cache、单个 cache loader。
+- mixed cache root 的 children 为 JS/Native/JS。
+- root 和 children range 连续、无重叠、无空洞。
+- children 中不存在 `CacheChain`。
+- 四种 strategy 对同一 loader list 生成预期不同的 tree。
+
+重点 fixture：
+
+```text
+cache JS A
+cache JS B
+cache builtin C
+cache JS D
+uncached JS E
+uncached JS F
+uncached builtin G
+```
+
+`CacheAndJavaScript` 期望：
+
+```text
+Cache[0..4](JS[0..2], Native[2..3], JS[3..4])
+JS[4..6]
+Native[6..7]
+```
+
+### 9.2 执行顺序
+
+- pitch 按 0 → N，normal 按 N → 0。
+- JS child 内多个 loader 一次 yield，但保持逐 loader raw/string 转换。
+- JS/native/JS mixed cache miss 的输出与 singleton baseline 相同。
+- mixed cache hit 跳过全部 JS/native normal loader。
+- pitch 在 cache root 中间短路时不 lookup/store 部分 cache entry。
+- error、empty return、`cacheable(false)` 和 diagnostics 行为不变。
+
+### 9.3 Strategy 独立性
+
+- `None`：每个执行 leaf singleton，每个 cache loader singleton cache root。
+- `CacheOnly`：连续 cache 合并，但内部连续 JS 仍是 singleton children。
+- `JavaScriptOnly`：cache boundary 不合并，允许每个 boundary 内 JS 合并。
+- `CacheAndJavaScript`：外层 cache 和内层 JS 都合并。
+- 四种策略输出、dependency、source map 和 additional data 完全一致。
+
+### 9.4 JS/worker
+
+- 连续 JS child 的主线程执行。
+- parallel true/false 在同一 JS child 中切换。
+- worker 不再需要 builtin 前缀判断。
+- `maxWorkers`、无 pitch loader、raw buffer、source map、additional data。
+- 复跑现有 loader-parallel cases。
+
+### 9.5 Cache invalidation
+
+- mixed chain memory hit 和 persistent hit。
+- 修改输入、任一 child loader options、任一 loader 文件或显式依赖后 miss。
+- child 划分策略改变但 outer loader identity/input/options 不变时 cache key 保持一致。
+- cache hit 后依赖和 build side effects 正确回放。
+
+### 9.6 `Loaders` 生命周期
+
+- factory 为一个 module 只调用一次 `Loaders::new` 和 planner。
+- 同一 module 的 watch rebuild 复用同一个 `Loaders` 和 chain 结果，但所有 `LoaderItemState`/`CacheChainState` 都重新创建。
+- cache hit 由 `CacheChain` 一次性标记范围内的 normal/finish 状态；pitch/data 保持本轮执行结果。
+- 两个 module 分别拥有自己的 `Arc<Loaders>`，但其 `cache_service` 指向同一个 compiler-scoped service。
+- 相同 cache key 可以跨 module 命中，证明没有误建 module-local backend。
+- module cache 序列化不包含 compiler service；反序列化后绑定当前 compiler service。
+- 反序列化后的首次 build 最多重新解析/规划一次，之后的 rebuild 必须复用同一 plan。
+- late loader replacement 只能通过统一 API 完成，并生成新的 `Arc<Loaders>` 和 plan。
+
+## 10. 验证命令
+
+JS 和 Rust 都会修改，完成后依次执行：
+
+```text
+pnpm run build:cli:dev
+pnpm run test:rs
+pnpm run test:unit
+cargo lint
+```
+
+另外单独运行：
+
+- loader-chain watch cases；
+- loader-chain persistent cache case；
+- loader-parallel config/runtime cases；
+- planner strategy 对比用例。
+
+按仓库约束，在 sandbox 中跳过 storage 和 native watcher 会卡住的测试；对应部分交给非 sandbox CI。
+
+## 11. 完成标准
+
+- `LoaderChain` 已改为 `CacheChain | JsExecutionChain | NativeExecutionChain` enum。
+- `NormalModule` 只保存一个 factory 预组装的 `Arc<Loaders>`，不再分别保存 loader 数组和 runner options。
+- `Loaders` 包含 loader items、chains、locations 和 compiler-scoped cache service handle；不同 module 不共享组装结果，但共享底层 cache service。
+- `LoaderItem` 的固定定义与 `LoaderItemState` 已分离，module-owned items 不包含 `data` 或 executed/finish 状态。
+- module rebuild 不重新解析 loader、不重新计算 static fingerprint，也不重新规划 chain；只初始化本轮 `LoaderItemState` 和 `CacheChainState`。
+- mixed cache chain 显式包含 JS/native children，不再用 `execution_kind=Mixed` 表示。
+- runner、JS bridge 和 worker 不再动态扫描 execution span。
+- cache lookup/store 只发生在 outer `CacheChain`，JS yield 只发生在 `JsExecutionChain`。
+- 四种 strategy 能独立启停 cache 合并和 JS 合并，并可用指标验证。
+- pitch/normal 顺序、loader context、parallel、缓存结果和失效行为与 singleton baseline 一致。
+- 所有新增与相关回归测试通过，文档与生成 binding 类型同步更新。

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-0.txt
@@ -1,0 +1,17 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-1.txt
@@ -1,0 +1,20 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (1 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> snapshot restored with detected changed dependencies:
+<i> modified paths (1):
+<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/loader-chain-persistent/trigger.js
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/__snapshots__/stats-2.txt
@@ -1,0 +1,12 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<w> persistent cache invalidated because build dependencies changed:
+<w> modified paths (1):
+<w>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/loader-chain-persistent/loader.js
+<t> validate build dependencies: xx ms
+<t> write make to persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/index.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/index.js
@@ -1,0 +1,11 @@
+const value = require('./value');
+
+it('should reuse a loader chain across compilers', async () => {
+  expect(value).toBe(COMPILER_INDEX < 2 ? 1 : 2);
+  if (COMPILER_INDEX === 0) {
+    await NEXT_START();
+  }
+  if (COMPILER_INDEX === 1) {
+    await NEXT_START();
+  }
+});

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/left-loader.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/left-loader.js
@@ -1,0 +1,4 @@
+module.exports = function (source) {
+  this.addDependency(`${this.rootContext}/trigger.js`);
+  return source;
+};

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/loader.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/loader.js
@@ -1,0 +1,24 @@
+const loaderRuns = Symbol.for('rspack.test.loaderChainPersistentRuns');
+globalThis[loaderRuns] = globalThis[loaderRuns] || 0;
+
+module.exports = function (source) {
+  globalThis[loaderRuns]++;
+  return source.replace('__RUNS__', globalThis[loaderRuns]);
+};
+---
+const loaderRuns = Symbol.for('rspack.test.loaderChainPersistentRuns');
+globalThis[loaderRuns] = globalThis[loaderRuns] || 0;
+
+module.exports = function (source) {
+  globalThis[loaderRuns]++;
+  return source.replace('__RUNS__', globalThis[loaderRuns]);
+};
+---
+const loaderRuns = Symbol.for('rspack.test.loaderChainPersistentRuns');
+globalThis[loaderRuns] = globalThis[loaderRuns] || 0;
+
+// Changing the loader implementation must invalidate its cached chain.
+module.exports = function (source) {
+  globalThis[loaderRuns]++;
+  return source.replace('__RUNS__', globalThis[loaderRuns]);
+};

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/rspack.config.js
@@ -1,0 +1,23 @@
+const path = require('path');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  context: __dirname,
+  cache: {
+    type: 'persistent',
+  },
+  module: {
+    rules: [
+      {
+        test: /value\.js$/,
+        use: [
+          path.resolve(__dirname, 'left-loader.js'),
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/trigger.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/trigger.js
@@ -1,0 +1,3 @@
+module.exports = 0;
+---
+module.exports = 1;

--- a/tests/rspack-test/cacheCases/common/loader-chain-persistent/value.js
+++ b/tests/rspack-test/cacheCases/common/loader-chain-persistent/value.js
@@ -1,0 +1,1 @@
+module.exports = __RUNS__;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/index.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/index.js
@@ -1,0 +1,5 @@
+const value = require('./value');
+
+it('should not store a loader chain when cacheable(false) is called', () => {
+  expect(value).toBe(+WATCH_STEP + 1);
+});

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 0;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/0/value.js
@@ -1,0 +1,1 @@
+module.exports = __RUNS__;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/1/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/1/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/2/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/2/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/loader.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/loader.js
@@ -1,0 +1,8 @@
+let loaderRuns = 0;
+
+module.exports = function (source) {
+  this.addDependency(`${this.rootContext}/trigger.js`);
+  this.cacheable(false);
+  loaderRuns++;
+  return source.replace('__RUNS__', loaderRuns);
+};

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache-disabled/rspack.config.js
@@ -1,0 +1,19 @@
+const path = require('path');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  cache: true,
+  module: {
+    rules: [
+      {
+        test: /value\.js$/,
+        use: () => [
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/dep.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/dep.js
@@ -1,0 +1,1 @@
+module.exports = 'initial';

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/index.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/index.js
@@ -1,0 +1,32 @@
+const value = require('./value');
+
+it('should cache a consecutive loader chain until its input changes', () => {
+  if (+WATCH_STEP < 3) {
+    expect(value).toEqual({
+      value: 'initial',
+      leftRuns: +WATCH_STEP + 1,
+      markedRuns: 1,
+      rightRuns: 1,
+      sourceMap: true,
+      additionalData: true,
+    });
+  } else if (+WATCH_STEP === 3) {
+    expect(value).toEqual({
+      value: 'initial',
+      leftRuns: 4,
+      markedRuns: 2,
+      rightRuns: 2,
+      sourceMap: true,
+      additionalData: true,
+    });
+  } else {
+    expect(value).toEqual({
+      value: 'changed',
+      leftRuns: 5,
+      markedRuns: 3,
+      rightRuns: 3,
+      sourceMap: true,
+      additionalData: true,
+    });
+  }
+});

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 0;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/0/value.js
@@ -1,0 +1,8 @@
+module.exports = {
+  value: 'initial',
+  leftRuns: __LEFT__,
+  markedRuns: __MARKED__,
+  rightRuns: __RIGHT__,
+  sourceMap: __SOURCE_MAP__,
+  additionalData: __ADDITIONAL_DATA__,
+};

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/1/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/1/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 1;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/2/trigger.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/2/trigger.js
@@ -1,0 +1,1 @@
+module.exports = 2;

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/3/dep.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/3/dep.js
@@ -1,0 +1,1 @@
+module.exports = 'changed';

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/4/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/4/value.js
@@ -1,0 +1,8 @@
+module.exports = {
+  value: 'changed',
+  leftRuns: __LEFT__,
+  markedRuns: __MARKED__,
+  rightRuns: __RIGHT__,
+  sourceMap: __SOURCE_MAP__,
+  additionalData: __ADDITIONAL_DATA__,
+};

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/loader.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/loader.js
@@ -1,0 +1,44 @@
+const loaderRuns = {
+  left: 0,
+  marked: 0,
+  right: 0,
+};
+
+module.exports = function (source, sourceMap, additionalData) {
+  const { name } = this.getOptions();
+  if (name === 'left') {
+    this.addDependency(`${this.rootContext}/trigger.js`);
+  }
+  loaderRuns[name]++;
+  source = source.replace(`__${name.toUpperCase()}__`, loaderRuns[name]);
+
+  if (name === 'right') {
+    this.addDependency(`${this.rootContext}/dep.js`);
+    this.callback(
+      null,
+      source,
+      {
+        version: 3,
+        sources: ['value.js'],
+        names: [],
+        mappings: '',
+      },
+      { right: true },
+    );
+    return;
+  }
+  if (name === 'marked') {
+    this.callback(null, source, sourceMap, {
+      ...additionalData,
+      marked: true,
+    });
+    return;
+  }
+
+  return source
+    .replace('__SOURCE_MAP__', sourceMap?.version === 3)
+    .replace(
+      '__ADDITIONAL_DATA__',
+      additionalData?.right === true && additionalData?.marked === true,
+    );
+};

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/rspack.config.js
@@ -19,6 +19,10 @@ module.exports = {
             cache: true,
           },
           {
+            loader: 'builtin:test-passthrough-loader',
+            cache: true,
+          },
+          {
             loader: path.resolve(__dirname, 'loader.js'),
             options: { name: 'right' },
             parallel: { maxWorkers: 1 },

--- a/tests/rspack-test/watchCases/loaders/loader-chain-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-chain-cache/rspack.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  cache: true,
+  module: {
+    rules: [
+      {
+        test: /value\.js$/,
+        use: [
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'left' },
+          },
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'marked' },
+            parallel: { maxWorkers: 1 },
+            cache: true,
+          },
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'right' },
+            parallel: { maxWorkers: 1 },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -755,6 +755,7 @@ type RuleSetLoaderWithOptions = {
   loader: string;
   options?: string | Record<string, any>;
   parallel?: boolean | { maxWorkers?: number };
+  cache?: boolean;
 };
 ```
 
@@ -837,6 +838,39 @@ export default {
   },
 };
 ```
+
+## rules[].use.cache
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Caches the normal-phase result of a loader when the compiler [cache](/config/cache) is enabled. Consecutive loaders with `cache: true` are executed and cached as one loader chain, so Rspack hashes the chain input only once. Pitch functions still run on every compilation.
+
+The cache key is based on the input source, the ordered loader identities, and canonicalized loader options. Loader files and dependencies registered through the loader context participate in invalidation. Calling `this.cacheable(false)` prevents the current result from being stored.
+
+```js title="rspack.config.mjs"
+export default {
+  cache: true,
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'expensive-transform-loader',
+            options: { target: 'es2022' },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+`cache: true` is a purity declaration. Enable it only when the loader output is determined by its input source and options. A loader that depends on `resourcePath`, environment variables, time, or other implicit state must not enable it. Explicit dependencies should be registered with methods such as `this.addDependency()`.
+
+Options must be stably serializable. Functions, symbols, circular references, symbol keys, and unsupported class instances produce a configuration error. When a chain receives source-map or additional-data input that cannot be fingerprinted safely, Rspack conservatively bypasses its result cache.
 
 ## rules[].use.parallel
 

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -754,6 +754,7 @@ type RuleSetLoaderWithOptions = {
   loader: string;
   options?: string | Record<string, any>;
   parallel?: boolean | { maxWorkers?: number };
+  cache?: boolean;
 };
 ```
 
@@ -835,6 +836,39 @@ export default {
   },
 };
 ```
+
+## rules[].use.cache
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+当编译器[缓存](/config/cache)开启时，缓存 loader normal 阶段的执行结果。连续配置了 `cache: true` 的 loader 会作为一条 loader chain 执行和缓存，因此 Rspack 只需对 chain 的输入计算一次哈希。pitch 函数仍会在每次编译时执行。
+
+缓存 key 由输入源码、按顺序排列的 loader 标识以及规范化后的 loader options 组成。loader 文件和通过 loader context 注册的依赖都会参与失效判断。调用 `this.cacheable(false)` 会阻止本次结果写入缓存。
+
+```js title="rspack.config.mjs"
+export default {
+  cache: true,
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: 'expensive-transform-loader',
+            options: { target: 'es2022' },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+`cache: true` 同时是一项纯度声明。只有当 loader 的输出完全由输入源码和 options 决定时才应启用它。依赖 `resourcePath`、环境变量、时间或其他隐式状态的 loader 不应启用此选项；显式依赖应通过 `this.addDependency()` 等方法注册。
+
+Options 必须能够稳定序列化。函数、symbol、循环引用、symbol key 和不支持的 class 实例会产生配置错误。当 chain 的输入包含无法安全生成 fingerprint 的 source map 或 additional data 时，Rspack 会保守地跳过该次结果缓存。
 
 ## rules[].use.parallel
 

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -342,6 +342,8 @@ fn configure_swc_loader(builder: &mut CompilerBuilder) {
             })
             .to_string(),
           ),
+          cache: false,
+          cache_key: String::new(),
         }]),
         ..Default::default()
       },

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -77,6 +77,8 @@ pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
               })
               .to_string(),
             ),
+            cache: false,
+            cache_key: String::new(),
           }]),
           ..Default::default()
         },


### PR DESCRIPTION
## Summary

Introduce loader chains as the loader runner's execution unit and add opt-in per-loader caching through a new `cache` option alongside `parallel`.

Consecutive cacheable loaders are merged into one loader chain so they share a single input hash calculation and cache lookup. Consecutive JavaScript loaders are also merged, keeping JS yielding and worker scheduling scoped to the chain. The chain planning strategy is isolated from execution so the optimization can be benchmarked or disabled independently.

The cache key includes the loader input, loader requests, loader types, and stable serialized loader options. Cached results replay dependencies and supported build side effects, while loader implementation or dependency changes invalidate the entry. Both memory and persistent compiler caches are supported.

### Example

```js
module.exports = {
  module: {
    rules: [
      {
        test: /\.js$/,
        use: [
          {
            loader: "first-loader",
            options: { target: "modern" },
            cache: true
          },
          {
            loader: "second-loader",
            cache: true,
            parallel: true
          }
        ]
      }
    ]
  }
};
```

In this example, the two consecutive cached loaders execute as one loader chain. Rspack hashes the chain input once and reuses the complete chain result on subsequent compilations when the input, loader implementations, options, and tracked dependencies are unchanged.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:rs`
- `cargo lint`
- Loader-chain planner Rust tests: 10 passed
- New watch, `cacheable(false)`, persistent-cache, and loader-parallel cases passed
- Main unit suite: 9061 passed; three browserslist cases hit an existing shared temporary-file cleanup race under parallel execution, and the affected 11 cases passed when rerun in isolation

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_