### PR TITLE
chore: upgrade rspack-resolver to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5229,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.9.4"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adde60ec77d32748df78a55b3ac103d98c1f08c038cc0b3df8020243bda46117"
+checksum = "60c709ac5c0661a75c1b266887256710e05edef31971c806206f1f886afe01e3"
 dependencies = [
  "arc-swap",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ rayon               = { version = "1.12.0", default-features = false }
 regex               = { version = "1.12.4", default-features = false, features = ["perf"] }
 regex-syntax        = { version = "0.8.11", default-features = false, features = ["std"] }
 regress             = { version = "0.11.1", default-features = false, features = ["pattern"] }
-rspack_resolver     = { version = "=0.9.4", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
+rspack_resolver     = { version = "=0.10.0", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
 rustc-hash          = { version = "2.1.2", default-features = false }
 ryu-js              = { version = "1.0.2", default-features = false }
 scopeguard          = { version = "1.2.0", default-features = false }


### PR DESCRIPTION
## Summary

Bump `rspack_resolver` from `0.9.4` to `0.10.0`.

The main motivation is [rspack-resolver#291](https://github.com/web-infra-dev/rspack-resolver/pull/291): the resolver used to report every tsconfig in a project-references graph as a file dependency, and rspack keeps that set **per module**. In a monorepo this costs `module count × tsconfig count` and bursts memory. The resolver now stops reporting them.

Trade-off to be aware of: editing a tsconfig no longer invalidates a watch build.

Also picks up [rspack-resolver#288](https://github.com/web-infra-dev/rspack-resolver/pull/288) — `resolve.restrictions` paths are now normalized and compared by path components instead of by raw string prefix, so a restriction like `/a/b` no longer matches `/a/bc`.

No API change; `cargo check --workspace --all-targets` passes untouched.

## Related links

- https://github.com/web-infra-dev/rspack-resolver/releases/tag/v0.10.0
- workaround https://github.com/web-infra-dev/rspack/issues/15021
- close https://github.com/web-infra-dev/rspack/issues/14952


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
