### PR TITLE
refactor: use trait objects for scoped tasks

### DIFF
--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -170,61 +170,63 @@ pub(crate) async fn code_generation_modules(
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((compilation_ref, &module_graph, cache_counter, job)) };
 
-      s.spawn(|(this, module_graph, cache_counter, job)| async move {
-        let options = &this.options;
+      s.spawn(Box::new(|(this, module_graph, cache_counter, job)| {
+        Box::pin(async move {
+          let options = &this.options;
 
-        let module = module_graph
-          .module_by_identifier(&job.module)
-          .expect("should have module");
-        let (codegen_res, from_cache) = this
-          .code_generate_cache_artifact
-          .use_cache(&job, || async {
-            let mut runtime_template = this.runtime_template.create_module_code_template();
-            let mut code_generation_context = ModuleCodeGenerationContext {
-              compilation: this,
-              runtime: Some(&job.runtime),
-              concatenation_scope: job.scope.clone(),
-              runtime_template: &mut runtime_template,
-            };
+          let module = module_graph
+            .module_by_identifier(&job.module)
+            .expect("should have module");
+          let (codegen_res, from_cache) = this
+            .code_generate_cache_artifact
+            .use_cache(&job, || async {
+              let mut runtime_template = this.runtime_template.create_module_code_template();
+              let mut code_generation_context = ModuleCodeGenerationContext {
+                compilation: this,
+                runtime: Some(&job.runtime),
+                concatenation_scope: job.scope.clone(),
+                runtime_template: &mut runtime_template,
+              };
 
-            module
-              .code_generation(&mut code_generation_context)
-              .await
-              .map(|mut codegen_res| {
-                codegen_res
-                  .runtime_requirements
-                  .extend(*runtime_template.runtime_requirements());
-                if module.as_concatenated_module().is_some() {
-                  // Concatenated modules are special here: `job.hash` already
-                  // fingerprints the generated module bodies, so we only need
-                  // to fold in the remaining codegen metadata.
-                  codegen_res.set_hash_for_concatenated_module(
-                    &job.hash,
-                    &options.output.hash_function,
-                    &options.output.hash_digest,
-                    &options.output.hash_salt,
-                  );
-                } else {
-                  codegen_res.set_hash(
-                    &options.output.hash_function,
-                    &options.output.hash_digest,
-                    &options.output.hash_salt,
-                  );
-                }
-                codegen_res
-              })
-          })
-          .await;
-        if let Some(counter) = cache_counter {
-          if from_cache {
-            counter.hit();
-          } else {
-            counter.miss();
+              module
+                .code_generation(&mut code_generation_context)
+                .await
+                .map(|mut codegen_res| {
+                  codegen_res
+                    .runtime_requirements
+                    .extend(*runtime_template.runtime_requirements());
+                  if module.as_concatenated_module().is_some() {
+                    // Concatenated modules are special here: `job.hash` already
+                    // fingerprints the generated module bodies, so we only need
+                    // to fold in the remaining codegen metadata.
+                    codegen_res.set_hash_for_concatenated_module(
+                      &job.hash,
+                      &options.output.hash_function,
+                      &options.output.hash_digest,
+                      &options.output.hash_salt,
+                    );
+                  } else {
+                    codegen_res.set_hash(
+                      &options.output.hash_function,
+                      &options.output.hash_digest,
+                      &options.output.hash_salt,
+                    );
+                  }
+                  codegen_res
+                })
+            })
+            .await;
+          if let Some(counter) = cache_counter {
+            if from_cache {
+              counter.hit();
+            } else {
+              counter.miss();
+            }
           }
-        }
 
-        (job.module, job.runtimes, codegen_res.map(Box::new))
-      })
+          (job.module, job.runtimes, codegen_res.map(Box::new))
+        })
+      }))
     })
   })
   .await;

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -170,7 +170,7 @@ pub(crate) async fn code_generation_modules(
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((compilation_ref, &module_graph, cache_counter, job)) };
 
-      s.spawn(Box::new(|(this, module_graph, cache_counter, job)| {
+      s.spawn(|(this, module_graph, cache_counter, job)| {
         Box::pin(async move {
           let options = &this.options;
 
@@ -226,7 +226,7 @@ pub(crate) async fn code_generation_modules(
 
           (job.module, job.runtimes, codegen_res.map(Box::new))
         })
-      }))
+      })
     })
   })
   .await;

--- a/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
@@ -122,23 +122,25 @@ pub async fn create_chunk_assets(
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((compilation_ref, &plugin_driver, chunk)) };
 
-      s.spawn(|(this, plugin_driver, chunk)| async {
-        let mut manifests = Vec::new();
-        let mut diagnostics = Vec::new();
-        plugin_driver
-          .compilation_hooks
-          .render_manifest
-          .call(this, chunk, &mut manifests, &mut diagnostics)
-          .await?;
+      s.spawn(Box::new(|(this, plugin_driver, chunk)| {
+        Box::pin(async {
+          let mut manifests = Vec::new();
+          let mut diagnostics = Vec::new();
+          plugin_driver
+            .compilation_hooks
+            .render_manifest
+            .call(this, chunk, &mut manifests, &mut diagnostics)
+            .await?;
 
-        rspack_error::Result::Ok((
-          *chunk,
-          ChunkRenderResult {
-            manifests,
-            diagnostics,
-          },
-        ))
-      });
+          rspack_error::Result::Ok((
+            *chunk,
+            ChunkRenderResult {
+              manifests,
+              diagnostics,
+            },
+          ))
+        })
+      }));
     })
   })
   .await;

--- a/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_chunk_assets/mod.rs
@@ -122,7 +122,7 @@ pub async fn create_chunk_assets(
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((compilation_ref, &plugin_driver, chunk)) };
 
-      s.spawn(Box::new(|(this, plugin_driver, chunk)| {
+      s.spawn(|(this, plugin_driver, chunk)| {
         Box::pin(async {
           let mut manifests = Vec::new();
           let mut diagnostics = Vec::new();
@@ -140,7 +140,7 @@ pub async fn create_chunk_assets(
             },
           ))
         })
-      }));
+      });
     })
   })
   .await;

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -175,13 +175,13 @@ pub async fn create_hash(
       })
       .for_each(|runtime_module_identifier| {
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-        s.spawn(Box::new(|(compilation, runtime_module_identifier)| {
+        s.spawn(|(compilation, runtime_module_identifier)| {
           Box::pin(async {
             let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
             let digest = runtime_module.get_runtime_hash(compilation, None).await?;
             Ok((*runtime_module_identifier, digest))
           })
-        }));
+        });
       })
   })
   .await
@@ -201,12 +201,12 @@ pub async fn create_hash(
   let other_chunks_hash_results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for chunk in other_chunks {
       let s = unsafe { token.used((compilation_ref, chunk, plugin_driver.clone())) };
-      s.spawn(Box::new(|(compilation, chunk, plugin_driver)| {
+      s.spawn(|(compilation, chunk, plugin_driver)| {
         Box::pin(async move {
           let hash_result = process_chunk_hash(compilation, *chunk, &plugin_driver).await?;
           Ok((*chunk, hash_result))
         })
-      }));
+      });
     }
   })
   .await
@@ -354,13 +354,13 @@ pub async fn create_hash(
         .get_chunk_runtime_modules_iterable(&runtime_chunk_ukey)
         .for_each(|runtime_module_identifier| {
           let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-          s.spawn(Box::new(|(compilation, runtime_module_identifier)| {
+          s.spawn(|(compilation, runtime_module_identifier)| {
             Box::pin(async {
               let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
               let digest = runtime_module.get_runtime_hash(compilation, None).await?;
               Ok((*runtime_module_identifier, digest))
             })
-          }));
+          });
         })
     })
     .await
@@ -493,26 +493,24 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
       .iter()
       .for_each(|(runtime_module_identifier, runtime_module)| {
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier, runtime_module)) };
-        s.spawn(Box::new(
-          |(compilation, runtime_module_identifier, runtime_module)| {
-            Box::pin(async {
-              let mut runtime_template = compilation.runtime_template.create_module_code_template();
-              let mut code_generation_context = ModuleCodeGenerationContext {
-                compilation,
-                runtime: None,
-                concatenation_scope: None,
-                runtime_template: &mut runtime_template,
-              };
-              let result = runtime_module
-                .code_generation(&mut code_generation_context)
-                .await?;
-              let source = result
-                .get(&SourceType::Runtime)
-                .expect("should have source");
-              Ok((*runtime_module_identifier, source.clone()))
-            })
-          },
-        ))
+        s.spawn(|(compilation, runtime_module_identifier, runtime_module)| {
+          Box::pin(async {
+            let mut runtime_template = compilation.runtime_template.create_module_code_template();
+            let mut code_generation_context = ModuleCodeGenerationContext {
+              compilation,
+              runtime: None,
+              concatenation_scope: None,
+              runtime_template: &mut runtime_template,
+            };
+            let result = runtime_module
+              .code_generation(&mut code_generation_context)
+              .await?;
+            let source = result
+              .get(&SourceType::Runtime)
+              .expect("should have source");
+            Ok((*runtime_module_identifier, source.clone()))
+          })
+        })
       })
   })
   .await

--- a/crates/rspack_core/src/compilation/create_hash/mod.rs
+++ b/crates/rspack_core/src/compilation/create_hash/mod.rs
@@ -175,11 +175,13 @@ pub async fn create_hash(
       })
       .for_each(|runtime_module_identifier| {
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-        s.spawn(|(compilation, runtime_module_identifier)| async {
-          let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-          let digest = runtime_module.get_runtime_hash(compilation, None).await?;
-          Ok((*runtime_module_identifier, digest))
-        });
+        s.spawn(Box::new(|(compilation, runtime_module_identifier)| {
+          Box::pin(async {
+            let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
+            let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+            Ok((*runtime_module_identifier, digest))
+          })
+        }));
       })
   })
   .await
@@ -199,10 +201,12 @@ pub async fn create_hash(
   let other_chunks_hash_results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for chunk in other_chunks {
       let s = unsafe { token.used((compilation_ref, chunk, plugin_driver.clone())) };
-      s.spawn(|(compilation, chunk, plugin_driver)| async move {
-        let hash_result = process_chunk_hash(compilation, *chunk, &plugin_driver).await?;
-        Ok((*chunk, hash_result))
-      });
+      s.spawn(Box::new(|(compilation, chunk, plugin_driver)| {
+        Box::pin(async move {
+          let hash_result = process_chunk_hash(compilation, *chunk, &plugin_driver).await?;
+          Ok((*chunk, hash_result))
+        })
+      }));
     }
   })
   .await
@@ -350,11 +354,13 @@ pub async fn create_hash(
         .get_chunk_runtime_modules_iterable(&runtime_chunk_ukey)
         .for_each(|runtime_module_identifier| {
           let s = unsafe { token.used((compilation_ref, runtime_module_identifier)) };
-          s.spawn(|(compilation, runtime_module_identifier)| async {
-            let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
-            let digest = runtime_module.get_runtime_hash(compilation, None).await?;
-            Ok((*runtime_module_identifier, digest))
-          });
+          s.spawn(Box::new(|(compilation, runtime_module_identifier)| {
+            Box::pin(async {
+              let runtime_module = &compilation.runtime_modules[runtime_module_identifier];
+              let digest = runtime_module.get_runtime_hash(compilation, None).await?;
+              Ok((*runtime_module_identifier, digest))
+            })
+          }));
         })
     })
     .await
@@ -487,24 +493,26 @@ pub async fn runtime_modules_code_generation(compilation: &mut Compilation) -> R
       .iter()
       .for_each(|(runtime_module_identifier, runtime_module)| {
         let s = unsafe { token.used((compilation_ref, runtime_module_identifier, runtime_module)) };
-        s.spawn(
-          |(compilation, runtime_module_identifier, runtime_module)| async {
-            let mut runtime_template = compilation.runtime_template.create_module_code_template();
-            let mut code_generation_context = ModuleCodeGenerationContext {
-              compilation,
-              runtime: None,
-              concatenation_scope: None,
-              runtime_template: &mut runtime_template,
-            };
-            let result = runtime_module
-              .code_generation(&mut code_generation_context)
-              .await?;
-            let source = result
-              .get(&SourceType::Runtime)
-              .expect("should have source");
-            Ok((*runtime_module_identifier, source.clone()))
+        s.spawn(Box::new(
+          |(compilation, runtime_module_identifier, runtime_module)| {
+            Box::pin(async {
+              let mut runtime_template = compilation.runtime_template.create_module_code_template();
+              let mut code_generation_context = ModuleCodeGenerationContext {
+                compilation,
+                runtime: None,
+                concatenation_scope: None,
+                runtime_template: &mut runtime_template,
+              };
+              let result = runtime_module
+                .code_generation(&mut code_generation_context)
+                .await?;
+              let source = result
+                .get(&SourceType::Runtime)
+                .expect("should have source");
+              Ok((*runtime_module_identifier, source.clone()))
+            })
           },
-        )
+        ))
       })
   })
   .await

--- a/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
@@ -132,21 +132,19 @@ pub async fn create_module_hashes(
   let results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for module_identifier in modules {
       let s = unsafe { token.used((compilation_ref, &mg, chunk_graph, chunk_by_ukey)) };
-      s.spawn(Box::new(
-        move |(compilation, mg, chunk_graph, chunk_by_ukey)| {
-          Box::pin(async move {
-            let mut hashes = RuntimeSpecMap::new();
-            let module = mg
-              .module_by_identifier(&module_identifier)
-              .expect("should have module");
-            for runtime in chunk_graph.get_module_runtimes_iter(module_identifier, chunk_by_ukey) {
-              let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
-              hashes.set(runtime.clone(), hash);
-            }
-            Ok((module_identifier, hashes))
-          })
-        },
-      ));
+      s.spawn(move |(compilation, mg, chunk_graph, chunk_by_ukey)| {
+        Box::pin(async move {
+          let mut hashes = RuntimeSpecMap::new();
+          let module = mg
+            .module_by_identifier(&module_identifier)
+            .expect("should have module");
+          for runtime in chunk_graph.get_module_runtimes_iter(module_identifier, chunk_by_ukey) {
+            let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
+            hashes.set(runtime.clone(), hash);
+          }
+          Ok((module_identifier, hashes))
+        })
+      });
     }
   })
   .await

--- a/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
@@ -132,19 +132,21 @@ pub async fn create_module_hashes(
   let results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for module_identifier in modules {
       let s = unsafe { token.used((compilation_ref, &mg, chunk_graph, chunk_by_ukey)) };
-      s.spawn(
-        move |(compilation, mg, chunk_graph, chunk_by_ukey)| async move {
-          let mut hashes = RuntimeSpecMap::new();
-          let module = mg
-            .module_by_identifier(&module_identifier)
-            .expect("should have module");
-          for runtime in chunk_graph.get_module_runtimes_iter(module_identifier, chunk_by_ukey) {
-            let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
-            hashes.set(runtime.clone(), hash);
-          }
-          Ok((module_identifier, hashes))
+      s.spawn(Box::new(
+        move |(compilation, mg, chunk_graph, chunk_by_ukey)| {
+          Box::pin(async move {
+            let mut hashes = RuntimeSpecMap::new();
+            let module = mg
+              .module_by_identifier(&module_identifier)
+              .expect("should have module");
+            for runtime in chunk_graph.get_module_runtimes_iter(module_identifier, chunk_by_ukey) {
+              let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
+              hashes.set(runtime.clone(), hash);
+            }
+            Ok((module_identifier, hashes))
+          })
         },
-      );
+      ));
     }
   })
   .await

--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -212,7 +212,7 @@ pub async fn process_modules_runtime_requirements(
       })
       .for_each(|module| {
         let s = unsafe { token.used((compilation_ref, &plugin_driver)) };
-        s.spawn(Box::new(move |(compilation, plugin_driver)| {
+        s.spawn(move |(compilation, plugin_driver)| {
           Box::pin(async move {
             let mut map = RuntimeSpecMap::new();
             let runtimes = compilation
@@ -285,7 +285,7 @@ pub async fn process_modules_runtime_requirements(
             }
             Ok((module, map))
           })
-        }));
+        });
       });
   })
   .await

--- a/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
+++ b/crates/rspack_core/src/compilation/runtime_requirements/mod.rs
@@ -212,78 +212,80 @@ pub async fn process_modules_runtime_requirements(
       })
       .for_each(|module| {
         let s = unsafe { token.used((compilation_ref, &plugin_driver)) };
-        s.spawn(move |(compilation, plugin_driver)| async move {
-          let mut map = RuntimeSpecMap::new();
-          let runtimes = compilation
-            .build_chunk_graph_artifact
-            .chunk_graph
-            .get_module_runtimes_iter(
-              module,
-              &compilation.build_chunk_graph_artifact.chunk_by_ukey,
-            );
-          for runtime in runtimes {
-            let runtime_requirements = compilation
-              .process_runtime_requirements_cache_artifact
-              .use_cache(module, runtime, compilation, || async {
-                let mut runtime_requirements = compilation
-                  .code_generation_results
-                  .get_runtime_requirements(&module, Some(runtime));
+        s.spawn(Box::new(move |(compilation, plugin_driver)| {
+          Box::pin(async move {
+            let mut map = RuntimeSpecMap::new();
+            let runtimes = compilation
+              .build_chunk_graph_artifact
+              .chunk_graph
+              .get_module_runtimes_iter(
+                module,
+                &compilation.build_chunk_graph_artifact.chunk_by_ukey,
+              );
+            for runtime in runtimes {
+              let runtime_requirements = compilation
+                .process_runtime_requirements_cache_artifact
+                .use_cache(module, runtime, compilation, || async {
+                  let mut runtime_requirements = compilation
+                    .code_generation_results
+                    .get_runtime_requirements(&module, Some(runtime));
 
-                plugin_driver
-                  .compilation_hooks
-                  .additional_module_runtime_requirements
-                  .call(compilation, &module, &mut runtime_requirements)
-                  .await
-                  .map_err(|e| {
-                    e.wrap_err(
+                  plugin_driver
+                    .compilation_hooks
+                    .additional_module_runtime_requirements
+                    .call(compilation, &module, &mut runtime_requirements)
+                    .await
+                    .map_err(|e| {
+                      e.wrap_err(
                       "caused by plugins in Compilation.hooks.additionalModuleRuntimeRequirements",
                     )
-                  })?;
+                    })?;
 
-                process_runtime_requirement_hook(
-                  compilation,
-                  &mut runtime_requirements,
-                  &mut (),
-                  {
-                    let plugin_driver = plugin_driver.clone();
-                    move |compilation,
-                          all_runtime_requirements,
-                          runtime_requirements,
-                          runtime_requirements_mut,
-                          _| {
-                      Box::pin({
-                        let plugin_driver = plugin_driver.clone();
-                        async move {
-                          plugin_driver
-                            .compilation_hooks
-                            .runtime_requirement_in_module
-                            .call(
-                              compilation,
-                              &module,
-                              all_runtime_requirements,
-                              runtime_requirements,
-                              runtime_requirements_mut,
-                            )
-                            .await
-                            .map_err(|e| {
-                              e.wrap_err(
+                  process_runtime_requirement_hook(
+                    compilation,
+                    &mut runtime_requirements,
+                    &mut (),
+                    {
+                      let plugin_driver = plugin_driver.clone();
+                      move |compilation,
+                            all_runtime_requirements,
+                            runtime_requirements,
+                            runtime_requirements_mut,
+                            _| {
+                        Box::pin({
+                          let plugin_driver = plugin_driver.clone();
+                          async move {
+                            plugin_driver
+                              .compilation_hooks
+                              .runtime_requirement_in_module
+                              .call(
+                                compilation,
+                                &module,
+                                all_runtime_requirements,
+                                runtime_requirements,
+                                runtime_requirements_mut,
+                              )
+                              .await
+                              .map_err(|e| {
+                                e.wrap_err(
                                 "caused by plugins in Compilation.hooks.runtimeRequirementInModule",
                               )
-                            })?;
-                          Ok(())
-                        }
-                      })
-                    }
-                  },
-                )
+                              })?;
+                            Ok(())
+                          }
+                        })
+                      }
+                    },
+                  )
+                  .await?;
+                  Ok(runtime_requirements)
+                })
                 .await?;
-                Ok(runtime_requirements)
-              })
-              .await?;
-            map.set(runtime.clone(), runtime_requirements);
-          }
-          Ok((module, map))
-        });
+              map.set(runtime.clone(), runtime_requirements);
+            }
+            Ok((module, map))
+          })
+        }));
       });
   })
   .await

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -404,9 +404,9 @@ impl Compiler {
           // SAFETY: await immediately and trust caller to poll future entirely
           let s = unsafe { token.used((&self, filename, asset, output_path)) };
 
-          s.spawn(Box::new(|(this, filename, asset, output_path)| {
+          s.spawn(|(this, filename, asset, output_path)| {
             Box::pin(this.emit_asset(output_path, filename, asset))
-          }));
+          });
         })
     })
     .await;

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -404,9 +404,9 @@ impl Compiler {
           // SAFETY: await immediately and trust caller to poll future entirely
           let s = unsafe { token.used((&self, filename, asset, output_path)) };
 
-          s.spawn(|(this, filename, asset, output_path)| {
-            this.emit_asset(output_path, filename, asset)
-          });
+          s.spawn(Box::new(|(this, filename, asset, output_path)| {
+            Box::pin(this.emit_asset(output_path, filename, asset))
+          }));
         })
     })
     .await;

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1033,26 +1033,28 @@ impl Module for ConcatenatedModule {
         let module_to_info_map =
           matches!(info, ModuleInfo::Concatenated(_)).then(|| arc_map.clone());
         let s = unsafe { token.used((&self, &compilation, runtime, id, info)) };
-        s.spawn(|(module, compilation, runtime, id, info)| async move {
-          let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
-            let info = info.as_ref();
-            Some(ConcatenationScope::new(
-              module.id,
-              module_to_info_map.expect("should have module_to_info_map for concatenated module"),
-              ConcatenatedModuleInfo {
-                index: info.index,
-                module: info.module,
-                ..Default::default()
-              },
-            ))
-          } else {
-            None
-          };
-          let updated_module_info = module
-            .analyze_module(compilation, info, runtime, concatenation_scope)
-            .await?;
-          Ok((*id, Box::new(updated_module_info)))
-        });
+        s.spawn(Box::new(|(module, compilation, runtime, id, info)| {
+          Box::pin(async move {
+            let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
+              let info = info.as_ref();
+              Some(ConcatenationScope::new(
+                module.id,
+                module_to_info_map.expect("should have module_to_info_map for concatenated module"),
+                ConcatenatedModuleInfo {
+                  index: info.index,
+                  module: info.module,
+                  ..Default::default()
+                },
+              ))
+            } else {
+              None
+            };
+            let updated_module_info = module
+              .analyze_module(compilation, info, runtime, concatenation_scope)
+              .await?;
+            Ok((*id, Box::new(updated_module_info)))
+          })
+        }));
       })
     })
     .await
@@ -2068,26 +2070,28 @@ impl Module for ConcatenatedModule {
       concatenation_entries.into_iter().for_each(|job| {
         let s = unsafe { token.used((job, compilation, generation_runtime)) };
 
-        s.spawn(|(job, compilation, generation_runtime)| async move {
-          match job {
-            ConcatenationEntry::Concatenated(e) => {
-              let digest = compilation
-                .get_module_graph()
-                .module_by_identifier(&e.module)
-                .expect("should have module")
-                .get_runtime_hash(compilation, generation_runtime)
-                .await?;
-              Ok(Some(digest.encoded().to_string()))
+        s.spawn(Box::new(|(job, compilation, generation_runtime)| {
+          Box::pin(async move {
+            match job {
+              ConcatenationEntry::Concatenated(e) => {
+                let digest = compilation
+                  .get_module_graph()
+                  .module_by_identifier(&e.module)
+                  .expect("should have module")
+                  .get_runtime_hash(compilation, generation_runtime)
+                  .await?;
+                Ok(Some(digest.encoded().to_string()))
+              }
+              ConcatenationEntry::External(e) => Ok(
+                ChunkGraph::get_module_id(
+                  &compilation.module_ids_artifact,
+                  e.module(compilation.get_module_graph()),
+                )
+                .map(|id| id.to_string()),
+              ),
             }
-            ConcatenationEntry::External(e) => Ok(
-              ChunkGraph::get_module_id(
-                &compilation.module_ids_artifact,
-                e.module(compilation.get_module_graph()),
-              )
-              .map(|id| id.to_string()),
-            ),
-          }
-        })
+          })
+        }))
       })
     })
     .await

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1033,7 +1033,7 @@ impl Module for ConcatenatedModule {
         let module_to_info_map =
           matches!(info, ModuleInfo::Concatenated(_)).then(|| arc_map.clone());
         let s = unsafe { token.used((&self, &compilation, runtime, id, info)) };
-        s.spawn(Box::new(|(module, compilation, runtime, id, info)| {
+        s.spawn(|(module, compilation, runtime, id, info)| {
           Box::pin(async move {
             let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
               let info = info.as_ref();
@@ -1054,7 +1054,7 @@ impl Module for ConcatenatedModule {
               .await?;
             Ok((*id, Box::new(updated_module_info)))
           })
-        }));
+        });
       })
     })
     .await
@@ -2070,7 +2070,7 @@ impl Module for ConcatenatedModule {
       concatenation_entries.into_iter().for_each(|job| {
         let s = unsafe { token.used((job, compilation, generation_runtime)) };
 
-        s.spawn(Box::new(|(job, compilation, generation_runtime)| {
+        s.spawn(|(job, compilation, generation_runtime)| {
           Box::pin(async move {
             match job {
               ConcatenationEntry::Concatenated(e) => {
@@ -2091,7 +2091,7 @@ impl Module for ConcatenatedModule {
               ),
             }
           })
-        }))
+        })
       })
     })
     .await

--- a/crates/rspack_parallel/src/scope.rs
+++ b/crates/rspack_parallel/src/scope.rs
@@ -2,6 +2,9 @@ use std::{cell::RefCell, future::Future, marker::PhantomData, pin::Pin};
 
 use tokio::task::{JoinError, JoinHandle};
 
+pub type ScopedFuture<'scope, O> = Pin<Box<dyn Future<Output = O> + Send + 'scope>>;
+pub type ScopedTask<'scope, T, O> = Box<dyn FnOnce(T) -> ScopedFuture<'scope, O> + Send + 'scope>;
+
 /// Scope Token
 pub struct Token<'scope, 'spawner, O> {
   list: &'spawner RefCell<Vec<JoinHandle<O>>>,
@@ -42,9 +45,11 @@ pub struct Spawner<'scope, 'spawner, T, O> {
 ///   for i in 0..list.len() {
 ///     let s = unsafe { token.used(&list) };
 ///
-///     s.spawn(move |list| async move {
-///       &list[i];
-///     });
+///     s.spawn(Box::new(move |list| {
+///       Box::pin(async move {
+///         &list[i];
+///       })
+///     }));
 ///   }
 /// })
 /// .await;
@@ -61,9 +66,11 @@ pub struct Spawner<'scope, 'spawner, T, O> {
 ///   for i in 0..list.len() {
 ///     let s = unsafe { token.used(&list) };
 ///
-///     s.spawn(move |list| async move {
-///       &list[i];
-///     });
+///     s.spawn(Box::new(move |list| {
+///       Box::pin(async move {
+///         &list[i];
+///       })
+///     }));
 ///   }
 /// })
 /// .await;
@@ -133,23 +140,18 @@ impl<'scope, 'spawner, O> Token<'scope, 'spawner, O> {
 
 impl<'scope, T, O> Spawner<'scope, '_, T, O> {
   /// Spawn task from used reference
-  pub fn spawn<F, Fut>(self, f: F)
+  pub fn spawn(self, f: ScopedTask<'scope, T, O>)
   where
-    // TODO Use AsyncFnOnce
-    F: FnOnce(T) -> Fut + 'static,
-    Fut: Future<Output = O> + Send + 'scope,
     T: Send + Sync + 'scope,
     O: Send + 'static,
   {
     let fut = f(self.used);
-    let fut: Pin<Box<dyn Future<Output = O> + Send + 'scope>> = Box::pin(fut);
 
     // # Safety
     //
     // The safety guarantee here comes from `Token::used`.
     // The user needs to ensure that the task will done within used reference lifetime.
-    let fut: Pin<Box<dyn Future<Output = O> + Send + 'static>> =
-      unsafe { std::mem::transmute(fut) };
+    let fut: ScopedFuture<'static, O> = unsafe { std::mem::transmute(fut) };
 
     let j = rspack_tasks::spawn_in_compiler_context(fut);
     self.list.borrow_mut().push(j);

--- a/crates/rspack_parallel/src/scope.rs
+++ b/crates/rspack_parallel/src/scope.rs
@@ -3,7 +3,6 @@ use std::{cell::RefCell, future::Future, marker::PhantomData, pin::Pin};
 use tokio::task::{JoinError, JoinHandle};
 
 pub type ScopedFuture<'scope, O> = Pin<Box<dyn Future<Output = O> + Send + 'scope>>;
-pub type ScopedTask<'scope, T, O> = Box<dyn FnOnce(T) -> ScopedFuture<'scope, O> + Send + 'scope>;
 
 /// Scope Token
 pub struct Token<'scope, 'spawner, O> {
@@ -45,11 +44,11 @@ pub struct Spawner<'scope, 'spawner, T, O> {
 ///   for i in 0..list.len() {
 ///     let s = unsafe { token.used(&list) };
 ///
-///     s.spawn(Box::new(move |list| {
+///     s.spawn(move |list| {
 ///       Box::pin(async move {
 ///         &list[i];
 ///       })
-///     }));
+///     });
 ///   }
 /// })
 /// .await;
@@ -66,11 +65,11 @@ pub struct Spawner<'scope, 'spawner, T, O> {
 ///   for i in 0..list.len() {
 ///     let s = unsafe { token.used(&list) };
 ///
-///     s.spawn(Box::new(move |list| {
+///     s.spawn(move |list| {
 ///       Box::pin(async move {
 ///         &list[i];
 ///       })
-///     }));
+///     });
 ///   }
 /// })
 /// .await;
@@ -140,7 +139,7 @@ impl<'scope, 'spawner, O> Token<'scope, 'spawner, O> {
 
 impl<'scope, T, O> Spawner<'scope, '_, T, O> {
   /// Spawn task from used reference
-  pub fn spawn(self, f: ScopedTask<'scope, T, O>)
+  pub fn spawn(self, f: impl FnOnce(T) -> ScopedFuture<'scope, O>)
   where
     T: Send + Sync + 'scope,
     O: Send + 'static,

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -565,7 +565,7 @@ impl CopyRspackPlugin {
                 logger,
               ))
             };
-            s.spawn(
+            s.spawn(Box::new(
               move |(
                 pattern,
                 context,
@@ -574,22 +574,24 @@ impl CopyRspackPlugin {
                 diagnostics,
                 compilation,
                 logger,
-              )| async move {
-                Self::analyze_every_entry(
-                  entry,
-                  pattern,
-                  context,
-                  output_path,
-                  from_type,
-                  file_dependencies,
-                  diagnostics,
-                  compilation,
-                  logger,
-                  index,
-                )
-                .await
+              )| {
+                Box::pin(async move {
+                  Self::analyze_every_entry(
+                    entry,
+                    pattern,
+                    context,
+                    output_path,
+                    from_type,
+                    file_dependencies,
+                    diagnostics,
+                    compilation,
+                    logger,
+                    index,
+                  )
+                  .await
+                })
               },
-            );
+            ));
           });
         })
         .await

--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -565,7 +565,7 @@ impl CopyRspackPlugin {
                 logger,
               ))
             };
-            s.spawn(Box::new(
+            s.spawn(
               move |(
                 pattern,
                 context,
@@ -591,7 +591,7 @@ impl CopyRspackPlugin {
                   .await
                 })
               },
-            ));
+            );
           });
         })
         .await

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -195,40 +195,42 @@ impl CssPlugin {
               hooks,
             ))
           };
-          s.spawn(
-            |(compilation, chunk, module, cur_source, render_conditions, hooks)| async move {
-              let mut post_module_container = {
-                let mut builder = CssSourceBuilder::new(false, true, Default::default());
-                if builder.push_css_source(
-                  cur_source.clone(),
-                  &render_conditions,
-                  css_module_has_charset(module),
-                ) {
-                  builder.push_line();
-                }
-                CssModulesRenderSource {
-                  source: builder.into_source(),
-                }
-              };
+          s.spawn(Box::new(
+            |(compilation, chunk, module, cur_source, render_conditions, hooks)| {
+              Box::pin(async move {
+                let mut post_module_container = {
+                  let mut builder = CssSourceBuilder::new(false, true, Default::default());
+                  if builder.push_css_source(
+                    cur_source.clone(),
+                    &render_conditions,
+                    css_module_has_charset(module),
+                  ) {
+                    builder.push_line();
+                  }
+                  CssModulesRenderSource {
+                    source: builder.into_source(),
+                  }
+                };
 
-              let chunk_ukey = chunk.as_u32().into();
-              // Module package hooks may add module-specific decorations such as pathinfo.
-              // Deduplicate the undecorated source but emit the rendered source.
-              let source_before_hooks = post_module_container.source.clone();
-              hooks
-                .render_module_package
-                .call(compilation, &chunk_ukey, module, &mut post_module_container)
-                .await?;
+                let chunk_ukey = chunk.as_u32().into();
+                // Module package hooks may add module-specific decorations such as pathinfo.
+                // Deduplicate the undecorated source but emit the rendered source.
+                let source_before_hooks = post_module_container.source.clone();
+                hooks
+                  .render_module_package
+                  .call(compilation, &chunk_ukey, module, &mut post_module_container)
+                  .await?;
 
-              Ok((
-                module.identifier(),
-                CssModuleRenderSources {
-                  source_before_hooks,
-                  rendered_source: post_module_container.source,
-                },
-              ))
+                Ok((
+                  module.identifier(),
+                  CssModuleRenderSources {
+                    source_before_hooks,
+                    rendered_source: post_module_container.source,
+                  },
+                ))
+              })
             },
-          );
+          ));
         });
     })
     .await

--- a/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
+++ b/crates/rspack_plugin_css/src/plugin/impl_plugin_for_css_plugin.rs
@@ -195,7 +195,7 @@ impl CssPlugin {
               hooks,
             ))
           };
-          s.spawn(Box::new(
+          s.spawn(
             |(compilation, chunk, module, cur_source, render_conditions, hooks)| {
               Box::pin(async move {
                 let mut post_module_container = {
@@ -230,7 +230,7 @@ impl CssPlugin {
                 ))
               })
             },
-          ));
+          );
         });
     })
     .await

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -552,7 +552,7 @@ impl SourceMapDevToolPlugin {
                 &tls,
               ))
             };
-            s.spawn(Box::new(
+            s.spawn(
               |(plugin, compilation, file_to_chunk, output_path, template, tls)| {
                 Box::pin(async move {
                   let source_map = {
@@ -630,7 +630,7 @@ impl SourceMapDevToolPlugin {
                   Ok(Some((task, source_name_entries)))
                 })
               },
-            ));
+            );
           }
         })
         .await
@@ -667,7 +667,7 @@ impl SourceMapDevToolPlugin {
                 &tls,
               ))
             };
-            s.spawn(Box::new(
+            s.spawn(
               |(plugin, compilation, output_path, f, source, asset_filename, tls)| {
                 Box::pin(async move {
                   let source_map = {
@@ -728,7 +728,7 @@ impl SourceMapDevToolPlugin {
                   Ok(Some((task, source_name_entries)))
                 })
               },
-            ));
+            );
           }
         })
         .await
@@ -875,7 +875,7 @@ impl SourceMapDevToolPlugin {
               source_references,
             ))
           };
-          s.spawn(Box::new(
+          s.spawn(
             |(
               plugin,
               compilation,
@@ -902,7 +902,7 @@ impl SourceMapDevToolPlugin {
                 .await
               })
             },
-          ));
+          );
         },
       );
     })

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -525,209 +525,217 @@ impl SourceMapDevToolPlugin {
       .unwrap_or(default_module_filename_template);
 
     let results: Vec<Result<Option<TaskAndSourceNames>>> = match module_filename_template {
-      ModuleFilenameTemplate::String(template) => rspack_parallel::scope::<
-        _,
-        Result<Option<TaskAndSourceNames>>,
-      >(|token| {
-        for (asset_filename, asset) in compilation_assets {
-          let is_match = if need_match {
-            match_object(&condition_object, &asset_filename)
-          } else {
-            true
-          };
-          if !is_match {
-            continue;
+      ModuleFilenameTemplate::String(template) => {
+        rspack_parallel::scope::<_, Result<Option<TaskAndSourceNames>>>(|token| {
+          for (asset_filename, asset) in compilation_assets {
+            let is_match = if need_match {
+              match_object(&condition_object, &asset_filename)
+            } else {
+              true
+            };
+            if !is_match {
+              continue;
+            }
+            let source = match asset.get_source() {
+              Some(s) => s.clone(),
+              None => continue,
+            };
+
+            let map_options = map_options.clone();
+            let s = unsafe {
+              token.used((
+                self,
+                compilation,
+                file_to_chunk,
+                output_path,
+                template,
+                &tls,
+              ))
+            };
+            s.spawn(Box::new(
+              |(plugin, compilation, file_to_chunk, output_path, template, tls)| {
+                Box::pin(async move {
+                  let source_map = {
+                    let object_pool = tls.get_or(ObjectPool::default);
+                    match source.clone().map_static(object_pool, &map_options) {
+                      Some(sm) => sm,
+                      None => return Ok(None),
+                    }
+                  };
+
+                  let source_references = compute_source_references(compilation, &source_map);
+
+                  let asset_filename: Arc<str> = Arc::from(asset_filename);
+                  let unresolved_source_map_path = plugin
+                    .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
+                    .await?;
+
+                  let chunk = file_to_chunk.get(asset_filename.as_ref());
+                  let path_data = match chunk {
+                    Some(chunk) => PathData::default()
+                      .chunk(chunk.ukey(), compilation)
+                      .chunk_id_optional(chunk.id().map(|id| id.as_str()))
+                      .chunk_name_optional(chunk.name())
+                      .chunk_hash_optional(chunk.rendered_hash(
+                        &compilation.chunk_hashes_artifact,
+                        compilation.options.output.hash_digest_length,
+                      )),
+                    None => PathData::default(),
+                  };
+
+                  let filename = Filename::from(plugin.namespace.clone());
+                  let namespace = compilation.get_path(&filename, path_data).await?;
+
+                  let mut source_name_entries = Vec::with_capacity(source_references.len());
+                  for source_reference in &source_references {
+                    if let SourceReference::Source(sn) = source_reference
+                      && is_schema_source(sn.as_ref())
+                    {
+                      source_name_entries.push((
+                        source_reference.clone(),
+                        SourceNameWithBaseUrl::new(
+                          sn.to_string(),
+                          unresolved_source_map_path.clone(),
+                        ),
+                      ));
+                      continue;
+                    }
+
+                    let source_name = ModuleFilenameHelpers::create_filename_of_string_template(
+                      source_reference,
+                      compilation,
+                      template,
+                      &compilation.options.output,
+                      &namespace,
+                      unresolved_source_map_path.as_ref().map(|p| p.as_path()),
+                    );
+                    source_name_entries.push((
+                      source_reference.clone(),
+                      SourceNameWithBaseUrl::new(source_name, unresolved_source_map_path.clone()),
+                    ));
+                  }
+
+                  let raw_source = match source.source() {
+                    SourceValue::String(cow) => RawStringSource::from(cow.into_owned()).boxed(),
+                    SourceValue::Buffer(cow) => RawBufferSource::from(cow.into_owned()).boxed(),
+                  };
+                  let task = SourceMapTask {
+                    asset_filename,
+                    source: raw_source,
+                    source_map,
+                    unresolved_source_map_path,
+                    source_references,
+                  };
+
+                  Ok(Some((task, source_name_entries)))
+                })
+              },
+            ));
           }
-          let source = match asset.get_source() {
-            Some(s) => s.clone(),
-            None => continue,
-          };
+        })
+        .await
+        .into_iter()
+        .map(|r| r.to_rspack_result().flatten())
+        .collect::<Vec<_>>()
+      }
+      ModuleFilenameTemplate::Fn(f) => {
+        rspack_parallel::scope::<_, Result<Option<TaskAndSourceNames>>>(|token| {
+          for (asset_filename, asset) in compilation_assets {
+            let is_match = if need_match {
+              match_object(&condition_object, &asset_filename)
+            } else {
+              true
+            };
+            if !is_match {
+              continue;
+            }
+            let source = match asset.get_source() {
+              Some(s) => s.clone(),
+              None => continue,
+            };
 
-          let map_options = map_options.clone();
-          let s = unsafe {
-            token.used((
-              self,
-              compilation,
-              file_to_chunk,
-              output_path,
-              template,
-              &tls,
-            ))
-          };
-          s.spawn(
-            |(plugin, compilation, file_to_chunk, output_path, template, tls)| async move {
-              let source_map = {
-                let object_pool = tls.get_or(ObjectPool::default);
-                match source.clone().map_static(object_pool, &map_options) {
-                  Some(sm) => sm,
-                  None => return Ok(None),
-                }
-              };
-
-              let source_references = compute_source_references(compilation, &source_map);
-
-              let asset_filename: Arc<str> = Arc::from(asset_filename);
-              let unresolved_source_map_path = plugin
-                .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
-                .await?;
-
-              let chunk = file_to_chunk.get(asset_filename.as_ref());
-              let path_data = match chunk {
-                Some(chunk) => PathData::default()
-                  .chunk(chunk.ukey(), compilation)
-                  .chunk_id_optional(chunk.id().map(|id| id.as_str()))
-                  .chunk_name_optional(chunk.name())
-                  .chunk_hash_optional(chunk.rendered_hash(
-                    &compilation.chunk_hashes_artifact,
-                    compilation.options.output.hash_digest_length,
-                  )),
-                None => PathData::default(),
-              };
-
-              let filename = Filename::from(plugin.namespace.clone());
-              let namespace = compilation.get_path(&filename, path_data).await?;
-
-              let mut source_name_entries = Vec::with_capacity(source_references.len());
-              for source_reference in &source_references {
-                if let SourceReference::Source(sn) = source_reference
-                  && is_schema_source(sn.as_ref())
-                {
-                  source_name_entries.push((
-                    source_reference.clone(),
-                    SourceNameWithBaseUrl::new(sn.to_string(), unresolved_source_map_path.clone()),
-                  ));
-                  continue;
-                }
-
-                let source_name = ModuleFilenameHelpers::create_filename_of_string_template(
-                  source_reference,
-                  compilation,
-                  template,
-                  &compilation.options.output,
-                  &namespace,
-                  unresolved_source_map_path.as_ref().map(|p| p.as_path()),
-                );
-                source_name_entries.push((
-                  source_reference.clone(),
-                  SourceNameWithBaseUrl::new(source_name, unresolved_source_map_path.clone()),
-                ));
-              }
-
-              let raw_source = match source.source() {
-                SourceValue::String(cow) => RawStringSource::from(cow.into_owned()).boxed(),
-                SourceValue::Buffer(cow) => RawBufferSource::from(cow.into_owned()).boxed(),
-              };
-              let task = SourceMapTask {
+            let asset_filename: Arc<str> = Arc::from(asset_filename);
+            let map_options = map_options.clone();
+            let s = unsafe {
+              token.used((
+                self,
+                compilation,
+                output_path,
+                f,
+                source,
                 asset_filename,
-                source: raw_source,
-                source_map,
-                unresolved_source_map_path,
-                source_references,
-              };
+                &tls,
+              ))
+            };
+            s.spawn(Box::new(
+              |(plugin, compilation, output_path, f, source, asset_filename, tls)| {
+                Box::pin(async move {
+                  let source_map = {
+                    let object_pool = tls.get_or(ObjectPool::default);
+                    match source.clone().map_static(object_pool, &map_options) {
+                      Some(sm) => sm,
+                      None => return Ok(None),
+                    }
+                  };
 
-              Ok(Some((task, source_name_entries)))
-            },
-          );
-        }
-      })
-      .await
-      .into_iter()
-      .map(|r| r.to_rspack_result().flatten())
-      .collect::<Vec<_>>(),
-      ModuleFilenameTemplate::Fn(f) => rspack_parallel::scope::<
-        _,
-        Result<Option<TaskAndSourceNames>>,
-      >(|token| {
-        for (asset_filename, asset) in compilation_assets {
-          let is_match = if need_match {
-            match_object(&condition_object, &asset_filename)
-          } else {
-            true
-          };
-          if !is_match {
-            continue;
+                  let source_references = compute_source_references(compilation, &source_map);
+                  let unresolved_source_map_path = plugin
+                    .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
+                    .await?;
+
+                  let mut source_name_entries = Vec::with_capacity(source_references.len());
+                  for source_reference in &source_references {
+                    if let SourceReference::Source(sn) = source_reference
+                      && is_schema_source(sn.as_ref())
+                    {
+                      source_name_entries.push((
+                        source_reference.clone(),
+                        SourceNameWithBaseUrl::new(
+                          sn.to_string(),
+                          unresolved_source_map_path.clone(),
+                        ),
+                      ));
+                      continue;
+                    }
+
+                    let source_name = ModuleFilenameHelpers::create_filename_of_fn_template(
+                      source_reference,
+                      compilation,
+                      f,
+                      &compilation.options.output,
+                      &plugin.namespace,
+                      unresolved_source_map_path.as_ref().map(|p| p.as_path()),
+                    )
+                    .await?;
+                    source_name_entries.push((
+                      source_reference.clone(),
+                      SourceNameWithBaseUrl::new(source_name, unresolved_source_map_path.clone()),
+                    ));
+                  }
+
+                  let raw_source = match source.source() {
+                    SourceValue::String(cow) => RawStringSource::from(cow.into_owned()).boxed(),
+                    SourceValue::Buffer(cow) => RawBufferSource::from(cow.into_owned()).boxed(),
+                  };
+                  let task = SourceMapTask {
+                    asset_filename,
+                    source: raw_source,
+                    source_map,
+                    unresolved_source_map_path,
+                    source_references,
+                  };
+
+                  Ok(Some((task, source_name_entries)))
+                })
+              },
+            ));
           }
-          let source = match asset.get_source() {
-            Some(s) => s.clone(),
-            None => continue,
-          };
-
-          let asset_filename: Arc<str> = Arc::from(asset_filename);
-          let map_options = map_options.clone();
-          let s = unsafe {
-            token.used((
-              self,
-              compilation,
-              output_path,
-              f,
-              source,
-              asset_filename,
-              &tls,
-            ))
-          };
-          s.spawn(
-            |(plugin, compilation, output_path, f, source, asset_filename, tls)| async move {
-              let source_map = {
-                let object_pool = tls.get_or(ObjectPool::default);
-                match source.clone().map_static(object_pool, &map_options) {
-                  Some(sm) => sm,
-                  None => return Ok(None),
-                }
-              };
-
-              let source_references = compute_source_references(compilation, &source_map);
-              let unresolved_source_map_path = plugin
-                .get_unresolved_source_map_path(compilation, output_path, &asset_filename)
-                .await?;
-
-              let mut source_name_entries = Vec::with_capacity(source_references.len());
-              for source_reference in &source_references {
-                if let SourceReference::Source(sn) = source_reference
-                  && is_schema_source(sn.as_ref())
-                {
-                  source_name_entries.push((
-                    source_reference.clone(),
-                    SourceNameWithBaseUrl::new(sn.to_string(), unresolved_source_map_path.clone()),
-                  ));
-                  continue;
-                }
-
-                let source_name = ModuleFilenameHelpers::create_filename_of_fn_template(
-                  source_reference,
-                  compilation,
-                  f,
-                  &compilation.options.output,
-                  &plugin.namespace,
-                  unresolved_source_map_path.as_ref().map(|p| p.as_path()),
-                )
-                .await?;
-                source_name_entries.push((
-                  source_reference.clone(),
-                  SourceNameWithBaseUrl::new(source_name, unresolved_source_map_path.clone()),
-                ));
-              }
-
-              let raw_source = match source.source() {
-                SourceValue::String(cow) => RawStringSource::from(cow.into_owned()).boxed(),
-                SourceValue::Buffer(cow) => RawBufferSource::from(cow.into_owned()).boxed(),
-              };
-              let task = SourceMapTask {
-                asset_filename,
-                source: raw_source,
-                source_map,
-                unresolved_source_map_path,
-                source_references,
-              };
-
-              Ok(Some((task, source_name_entries)))
-            },
-          );
-        }
-      })
-      .await
-      .into_iter()
-      .map(|r| r.to_rspack_result().flatten())
-      .collect::<Vec<_>>(),
+        })
+        .await
+        .into_iter()
+        .map(|r| r.to_rspack_result().flatten())
+        .collect::<Vec<_>>()
+      }
     };
 
     let mut tasks: Vec<SourceMapTask> = Vec::with_capacity(results.len());
@@ -867,7 +875,7 @@ impl SourceMapDevToolPlugin {
               source_references,
             ))
           };
-          s.spawn(
+          s.spawn(Box::new(
             |(
               plugin,
               compilation,
@@ -878,21 +886,23 @@ impl SourceMapDevToolPlugin {
               source_map,
               unresolved_source_map_path,
               source_references,
-            )| async move {
-              Self::create_mapped_asset(
-                plugin,
-                compilation,
-                file_to_chunk,
-                reference_to_source_name_mapping,
-                asset_filename,
-                source,
-                source_map,
-                unresolved_source_map_path,
-                source_references,
-              )
-              .await
+            )| {
+              Box::pin(async move {
+                Self::create_mapped_asset(
+                  plugin,
+                  compilation,
+                  file_to_chunk,
+                  reference_to_source_name_mapping,
+                  asset_filename,
+                  source,
+                  source_map,
+                  unresolved_source_map_path,
+                  source_references,
+                )
+                .await
+              })
             },
-          );
+          ));
         },
       );
     })

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1433,216 +1433,213 @@ var {} = {{}};
       for (m, info) in concate_modules_map {
         // SAFETY: caller will poll the futures
         let s = unsafe { token.used((compilation, m, info, &runtime_template)) };
-        s.spawn(Box::new(
-          move |(compilation, id, info, runtime_template)| {
-            Box::pin(async move {
-              if compilation
-                .build_chunk_graph_artifact
-                .chunk_graph
-                .get_module_chunks(m)
-                .is_empty()
-              {
-                // orphan module
-                return Ok((info, None));
-              }
+        s.spawn(move |(compilation, id, info, runtime_template)| {
+          Box::pin(async move {
+            if compilation
+              .build_chunk_graph_artifact
+              .chunk_graph
+              .get_module_chunks(m)
+              .is_empty()
+            {
+              // orphan module
+              return Ok((info, None));
+            }
 
-              let chunk_ukey = Self::get_module_chunk(m, compilation)?;
+            let chunk_ukey = Self::get_module_chunk(m, compilation)?;
 
-              let module_graph = compilation.get_module_graph();
+            let module_graph = compilation.get_module_graph();
 
-              match info {
-                rspack_core::ModuleInfo::External(mut external_module_info) => {
-                  let codegen_res = compilation.code_generation_results.get(&id, None);
-                  let has_javascript_source = compilation
-                    .code_generation_results
-                    .get(&id, None)
-                    .get(&SourceType::JavaScript)
-                    .is_some();
-                  let used_in_chunk = !compilation
-                    .build_chunk_graph_artifact
-                    .chunk_graph
-                    .get_module_chunks(id)
-                    .is_empty();
-                  if has_javascript_source && used_in_chunk {
-                    // we use __rspack_require.add({...}) to register modules
-                    external_module_info
-                      .runtime_requirements
-                      .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
-                  }
-                  let mut chunk_init_fragments = codegen_res
-                    .data
-                    .get::<ChunkInitFragments>()
-                    .cloned()
-                    .unwrap_or_default();
-                  chunk_init_fragments.extend(codegen_res.chunk_init_fragments.clone());
-                  Ok((
-                    ModuleInfo::External(external_module_info),
-                    if chunk_init_fragments.is_empty() {
-                      None
-                    } else {
-                      Some((id, chunk_init_fragments))
-                    },
-                  ))
+            match info {
+              rspack_core::ModuleInfo::External(mut external_module_info) => {
+                let codegen_res = compilation.code_generation_results.get(&id, None);
+                let has_javascript_source = compilation
+                  .code_generation_results
+                  .get(&id, None)
+                  .get(&SourceType::JavaScript)
+                  .is_some();
+                let used_in_chunk = !compilation
+                  .build_chunk_graph_artifact
+                  .chunk_graph
+                  .get_module_chunks(id)
+                  .is_empty();
+                if has_javascript_source && used_in_chunk {
+                  // we use __rspack_require.add({...}) to register modules
+                  external_module_info
+                    .runtime_requirements
+                    .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
                 }
-                rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
-                  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
-                  let hooks = hooks.read().await;
-
-                  let codegen_res = compilation.code_generation_results.get(&id, None);
-                  let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
-                    return Ok((ModuleInfo::Concatenated(concate_info), None));
-                  };
-
-                  let mut render_source = RenderSource {
-                    source: js_source.clone(),
-                  };
-                  let mut runtime_requirements = codegen_res.runtime_requirements;
-
-                  let mut chunk_init_fragments = vec![];
-                  hooks
-                    .render_module_content
-                    .call(
-                      compilation,
-                      &chunk_ukey,
-                      module_graph
-                        .module_by_identifier(&m)
-                        .expect("should have module")
-                        .as_ref(),
-                      &mut render_source,
-                      &mut runtime_requirements,
-                      &mut chunk_init_fragments,
-                      runtime_template,
-                    )
-                    .await?;
-                  *concate_info = codegen_res
-                    .concatenation_scope
-                    .as_ref()
-                    .expect("should have concatenation scope")
-                    .current_module
-                    .clone();
-
-                  let m = module_graph
-                    .module_by_identifier(&id)
-                    .expect("should have module");
-                  let jsx = m
-                    .as_ref()
-                    .as_normal_module()
-                    .and_then(|normal_module| normal_module.get_parser_options())
-                    .and_then(|options| {
-                      options
-                        .get_javascript()
-                        .and_then(|js_options| js_options.jsx)
-                    })
-                    .unwrap_or(false);
-                  let source_str = render_source
-                    .source
-                    .source()
-                    .into_string_lossy()
-                    .into_owned();
-                  let allocator = Allocator::new();
-                  let lexer = swc_experimental_ecma_parser::Lexer::new(
-                    &allocator,
-                    Syntax::Es(EsSyntax {
-                      jsx,
-                      ..Default::default()
-                    }),
-                    EsVersion::EsNext,
-                    StringSource::new(&source_str),
-                    None,
-                  );
-                  let mut parser = Parser::new_from(&allocator, lexer);
-                  let module = match parser.parse_module() {
-                    Ok(module) => module,
-                    Err(err) => {
-                      return Err(Error::from_string(
-                        Some(source_str.clone()),
-                        err.span().real_lo() as usize,
-                        err.span().real_hi() as usize,
-                        "JavaScript parse error:\n".to_string(),
-                        err.kind().msg().to_string(),
-                      ));
-                    }
-                  };
-                  let program = Program::Module(allocator.boxed(module));
-                  let semantic = resolver(&program);
-                  let ids = collect_ident(&allocator, &program);
-
-                  concate_info.module_ctxt =
-                    SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
-                  concate_info.global_ctxt =
-                    SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
-
-                  let top_level_scope_id = semantic.top_level_scope_id();
-                  let mut all_used_names = FxHashSet::default();
-                  all_used_names.reserve(ids.len());
-                  concate_info.idents.reserve(ids.len());
-                  concate_info.global_scope_ident.reserve(ids.len());
-                  let mut binding_to_ref: FxIndexMap<
-                    (Atom, SyntaxContext),
-                    Vec<ConcatenatedModuleIdent>,
-                  > = Default::default();
-                  binding_to_ref.reserve(ids.len());
-
-                  for ident in ids {
-                    let scope = semantic.node_scope(&ident.id);
-                    let is_global =
-                      SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
-                    let legacy = if is_global {
-                      let leg = ident.to_legacy(&semantic);
-                      concate_info.global_scope_ident.push(leg.clone());
-                      all_used_names.insert(leg.id.sym.clone());
-                      Some(leg)
-                    } else {
-                      None
-                    };
-                    if ident.is_class_expr_with_ident {
-                      all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                      continue;
-                    }
-                    if scope != top_level_scope_id {
-                      all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                    }
-                    let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
-                    concate_info.idents.push(legacy.clone());
-                    binding_to_ref
-                      .entry((legacy.id.sym.clone(), legacy.id.ctxt))
-                      .or_default()
-                      .push(legacy);
-                  }
-
-                  concate_info.all_used_names = all_used_names;
-                  concate_info.binding_to_ref = binding_to_ref;
-                  concate_info.has_ast = true;
-                  concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-                  concate_info.internal_source = Some(render_source.source.clone());
-                  concate_info.runtime_requirements = runtime_requirements;
-                  concate_info.chunk_init_fragments = codegen_res
-                    .data
-                    .get::<ChunkInitFragments>()
-                    .cloned()
-                    .unwrap_or_default();
-                  concate_info
-                    .chunk_init_fragments
-                    .extend(codegen_res.chunk_init_fragments.clone());
-                  concate_info
-                    .chunk_init_fragments
-                    .extend(chunk_init_fragments);
-                  if let Some(CodeGenerationPublicPathAutoReplace(true)) =
-                    codegen_res
-                      .data
-                      .get::<CodeGenerationPublicPathAutoReplace>()
-                  {
-                    concate_info.public_path_auto_replacement = Some(true);
-                  }
-                  if codegen_res.data.contains::<URLStaticMode>() {
-                    concate_info.static_url_replacement = true;
-                  }
-                  Ok((ModuleInfo::Concatenated(concate_info), None))
-                }
+                let mut chunk_init_fragments = codegen_res
+                  .data
+                  .get::<ChunkInitFragments>()
+                  .cloned()
+                  .unwrap_or_default();
+                chunk_init_fragments.extend(codegen_res.chunk_init_fragments.clone());
+                Ok((
+                  ModuleInfo::External(external_module_info),
+                  if chunk_init_fragments.is_empty() {
+                    None
+                  } else {
+                    Some((id, chunk_init_fragments))
+                  },
+                ))
               }
-            })
-          },
-        ))
+              rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
+                let hooks = JsPlugin::get_compilation_hooks(compilation.id());
+                let hooks = hooks.read().await;
+
+                let codegen_res = compilation.code_generation_results.get(&id, None);
+                let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
+                  return Ok((ModuleInfo::Concatenated(concate_info), None));
+                };
+
+                let mut render_source = RenderSource {
+                  source: js_source.clone(),
+                };
+                let mut runtime_requirements = codegen_res.runtime_requirements;
+
+                let mut chunk_init_fragments = vec![];
+                hooks
+                  .render_module_content
+                  .call(
+                    compilation,
+                    &chunk_ukey,
+                    module_graph
+                      .module_by_identifier(&m)
+                      .expect("should have module")
+                      .as_ref(),
+                    &mut render_source,
+                    &mut runtime_requirements,
+                    &mut chunk_init_fragments,
+                    runtime_template,
+                  )
+                  .await?;
+                *concate_info = codegen_res
+                  .concatenation_scope
+                  .as_ref()
+                  .expect("should have concatenation scope")
+                  .current_module
+                  .clone();
+
+                let m = module_graph
+                  .module_by_identifier(&id)
+                  .expect("should have module");
+                let jsx = m
+                  .as_ref()
+                  .as_normal_module()
+                  .and_then(|normal_module| normal_module.get_parser_options())
+                  .and_then(|options| {
+                    options
+                      .get_javascript()
+                      .and_then(|js_options| js_options.jsx)
+                  })
+                  .unwrap_or(false);
+                let source_str = render_source
+                  .source
+                  .source()
+                  .into_string_lossy()
+                  .into_owned();
+                let allocator = Allocator::new();
+                let lexer = swc_experimental_ecma_parser::Lexer::new(
+                  &allocator,
+                  Syntax::Es(EsSyntax {
+                    jsx,
+                    ..Default::default()
+                  }),
+                  EsVersion::EsNext,
+                  StringSource::new(&source_str),
+                  None,
+                );
+                let mut parser = Parser::new_from(&allocator, lexer);
+                let module = match parser.parse_module() {
+                  Ok(module) => module,
+                  Err(err) => {
+                    return Err(Error::from_string(
+                      Some(source_str.clone()),
+                      err.span().real_lo() as usize,
+                      err.span().real_hi() as usize,
+                      "JavaScript parse error:\n".to_string(),
+                      err.kind().msg().to_string(),
+                    ));
+                  }
+                };
+                let program = Program::Module(allocator.boxed(module));
+                let semantic = resolver(&program);
+                let ids = collect_ident(&allocator, &program);
+
+                concate_info.module_ctxt =
+                  SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
+                concate_info.global_ctxt =
+                  SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
+
+                let top_level_scope_id = semantic.top_level_scope_id();
+                let mut all_used_names = FxHashSet::default();
+                all_used_names.reserve(ids.len());
+                concate_info.idents.reserve(ids.len());
+                concate_info.global_scope_ident.reserve(ids.len());
+                let mut binding_to_ref: FxIndexMap<
+                  (Atom, SyntaxContext),
+                  Vec<ConcatenatedModuleIdent>,
+                > = Default::default();
+                binding_to_ref.reserve(ids.len());
+
+                for ident in ids {
+                  let scope = semantic.node_scope(&ident.id);
+                  let is_global = SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
+                  let legacy = if is_global {
+                    let leg = ident.to_legacy(&semantic);
+                    concate_info.global_scope_ident.push(leg.clone());
+                    all_used_names.insert(leg.id.sym.clone());
+                    Some(leg)
+                  } else {
+                    None
+                  };
+                  if ident.is_class_expr_with_ident {
+                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                    continue;
+                  }
+                  if scope != top_level_scope_id {
+                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                  }
+                  let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
+                  concate_info.idents.push(legacy.clone());
+                  binding_to_ref
+                    .entry((legacy.id.sym.clone(), legacy.id.ctxt))
+                    .or_default()
+                    .push(legacy);
+                }
+
+                concate_info.all_used_names = all_used_names;
+                concate_info.binding_to_ref = binding_to_ref;
+                concate_info.has_ast = true;
+                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
+                concate_info.internal_source = Some(render_source.source.clone());
+                concate_info.runtime_requirements = runtime_requirements;
+                concate_info.chunk_init_fragments = codegen_res
+                  .data
+                  .get::<ChunkInitFragments>()
+                  .cloned()
+                  .unwrap_or_default();
+                concate_info
+                  .chunk_init_fragments
+                  .extend(codegen_res.chunk_init_fragments.clone());
+                concate_info
+                  .chunk_init_fragments
+                  .extend(chunk_init_fragments);
+                if let Some(CodeGenerationPublicPathAutoReplace(true)) =
+                  codegen_res
+                    .data
+                    .get::<CodeGenerationPublicPathAutoReplace>()
+                {
+                  concate_info.public_path_auto_replacement = Some(true);
+                }
+                if codegen_res.data.contains::<URLStaticMode>() {
+                  concate_info.static_url_replacement = true;
+                }
+                Ok((ModuleInfo::Concatenated(concate_info), None))
+              }
+            }
+          })
+        })
       }
     })
     .await;

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1433,214 +1433,216 @@ var {} = {{}};
       for (m, info) in concate_modules_map {
         // SAFETY: caller will poll the futures
         let s = unsafe { token.used((compilation, m, info, &runtime_template)) };
-        s.spawn(
-          async move |(compilation, id, info, runtime_template)| -> Result<(
-            ModuleInfo,
-            Option<(ModuleIdentifier, ChunkInitFragments)>,
-          )> {
-            if compilation
-              .build_chunk_graph_artifact
-              .chunk_graph
-              .get_module_chunks(m)
-              .is_empty()
-            {
-              // orphan module
-              return Ok((info, None));
-            }
-
-            let chunk_ukey = Self::get_module_chunk(m, compilation)?;
-
-            let module_graph = compilation.get_module_graph();
-
-            match info {
-              rspack_core::ModuleInfo::External(mut external_module_info) => {
-                let codegen_res = compilation.code_generation_results.get(&id, None);
-                let has_javascript_source = compilation
-                  .code_generation_results
-                  .get(&id, None)
-                  .get(&SourceType::JavaScript)
-                  .is_some();
-                let used_in_chunk = !compilation
-                  .build_chunk_graph_artifact
-                  .chunk_graph
-                  .get_module_chunks(id)
-                  .is_empty();
-                if has_javascript_source && used_in_chunk {
-                  // we use __rspack_require.add({...}) to register modules
-                  external_module_info
-                    .runtime_requirements
-                    .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
-                }
-                let mut chunk_init_fragments = codegen_res
-                  .data
-                  .get::<ChunkInitFragments>()
-                  .cloned()
-                  .unwrap_or_default();
-                chunk_init_fragments.extend(codegen_res.chunk_init_fragments.clone());
-                Ok((
-                  ModuleInfo::External(external_module_info),
-                  if chunk_init_fragments.is_empty() {
-                    None
-                  } else {
-                    Some((id, chunk_init_fragments))
-                  },
-                ))
+        s.spawn(Box::new(
+          move |(compilation, id, info, runtime_template)| {
+            Box::pin(async move {
+              if compilation
+                .build_chunk_graph_artifact
+                .chunk_graph
+                .get_module_chunks(m)
+                .is_empty()
+              {
+                // orphan module
+                return Ok((info, None));
               }
-              rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
-                let hooks = JsPlugin::get_compilation_hooks(compilation.id());
-                let hooks = hooks.read().await;
 
-                let codegen_res = compilation.code_generation_results.get(&id, None);
-                let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
-                  return Ok((ModuleInfo::Concatenated(concate_info), None));
-                };
+              let chunk_ukey = Self::get_module_chunk(m, compilation)?;
 
-                let mut render_source = RenderSource {
-                  source: js_source.clone(),
-                };
-                let mut runtime_requirements = codegen_res.runtime_requirements;
+              let module_graph = compilation.get_module_graph();
 
-                let mut chunk_init_fragments = vec![];
-                hooks
-                  .render_module_content
-                  .call(
-                    compilation,
-                    &chunk_ukey,
-                    module_graph
-                      .module_by_identifier(&m)
-                      .expect("should have module")
-                      .as_ref(),
-                    &mut render_source,
-                    &mut runtime_requirements,
-                    &mut chunk_init_fragments,
-                    runtime_template,
-                  )
-                  .await?;
-                *concate_info = codegen_res
-                  .concatenation_scope
-                  .as_ref()
-                  .expect("should have concatenation scope")
-                  .current_module
-                  .clone();
-
-                let m = module_graph
-                  .module_by_identifier(&id)
-                  .expect("should have module");
-                let jsx = m
-                  .as_ref()
-                  .as_normal_module()
-                  .and_then(|normal_module| normal_module.get_parser_options())
-                  .and_then(|options| {
-                    options
-                      .get_javascript()
-                      .and_then(|js_options| js_options.jsx)
-                  })
-                  .unwrap_or(false);
-                let source_str = render_source
-                  .source
-                  .source()
-                  .into_string_lossy()
-                  .into_owned();
-                let allocator = Allocator::new();
-                let lexer = swc_experimental_ecma_parser::Lexer::new(
-                  &allocator,
-                  Syntax::Es(EsSyntax {
-                    jsx,
-                    ..Default::default()
-                  }),
-                  EsVersion::EsNext,
-                  StringSource::new(&source_str),
-                  None,
-                );
-                let mut parser = Parser::new_from(&allocator, lexer);
-                let module = match parser.parse_module() {
-                  Ok(module) => module,
-                  Err(err) => {
-                    return Err(Error::from_string(
-                      Some(source_str.clone()),
-                      err.span().real_lo() as usize,
-                      err.span().real_hi() as usize,
-                      "JavaScript parse error:\n".to_string(),
-                      err.kind().msg().to_string(),
-                    ));
+              match info {
+                rspack_core::ModuleInfo::External(mut external_module_info) => {
+                  let codegen_res = compilation.code_generation_results.get(&id, None);
+                  let has_javascript_source = compilation
+                    .code_generation_results
+                    .get(&id, None)
+                    .get(&SourceType::JavaScript)
+                    .is_some();
+                  let used_in_chunk = !compilation
+                    .build_chunk_graph_artifact
+                    .chunk_graph
+                    .get_module_chunks(id)
+                    .is_empty();
+                  if has_javascript_source && used_in_chunk {
+                    // we use __rspack_require.add({...}) to register modules
+                    external_module_info
+                      .runtime_requirements
+                      .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
                   }
-                };
-                let program = Program::Module(allocator.boxed(module));
-                let semantic = resolver(&program);
-                let ids = collect_ident(&allocator, &program);
-
-                concate_info.module_ctxt = SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
-                concate_info.global_ctxt = SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
-
-                let top_level_scope_id = semantic.top_level_scope_id();
-                let mut all_used_names = FxHashSet::default();
-                all_used_names.reserve(ids.len());
-                concate_info.idents.reserve(ids.len());
-                concate_info.global_scope_ident.reserve(ids.len());
-                let mut binding_to_ref: FxIndexMap<
-                  (Atom, SyntaxContext),
-                  Vec<ConcatenatedModuleIdent>,
-                > = Default::default();
-                binding_to_ref.reserve(ids.len());
-
-                for ident in ids {
-                  let scope = semantic.node_scope(&ident.id);
-                  let is_global = SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
-                  let legacy = if is_global {
-                    let leg = ident.to_legacy(&semantic);
-                    concate_info.global_scope_ident.push(leg.clone());
-                    all_used_names.insert(leg.id.sym.clone());
-                    Some(leg)
-                  } else {
-                    None
-                  };
-                  if ident.is_class_expr_with_ident {
-                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                    continue;
-                  }
-                  if scope != top_level_scope_id {
-                    all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                  }
-                  let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
-                  concate_info.idents.push(legacy.clone());
-                  binding_to_ref
-                    .entry((legacy.id.sym.clone(), legacy.id.ctxt))
-                    .or_default()
-                    .push(legacy);
-                }
-
-                concate_info.all_used_names = all_used_names;
-                concate_info.binding_to_ref = binding_to_ref;
-                concate_info.has_ast = true;
-                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-                concate_info.internal_source = Some(render_source.source.clone());
-                concate_info.runtime_requirements = runtime_requirements;
-                concate_info.chunk_init_fragments = codegen_res
-                  .data
-                  .get::<ChunkInitFragments>()
-                  .cloned()
-                  .unwrap_or_default();
-                concate_info
-                  .chunk_init_fragments
-                  .extend(codegen_res.chunk_init_fragments.clone());
-                concate_info
-                  .chunk_init_fragments
-                  .extend(chunk_init_fragments);
-                if let Some(CodeGenerationPublicPathAutoReplace(true)) =
-                  codegen_res
+                  let mut chunk_init_fragments = codegen_res
                     .data
-                    .get::<CodeGenerationPublicPathAutoReplace>()
-                {
-                  concate_info.public_path_auto_replacement = Some(true);
+                    .get::<ChunkInitFragments>()
+                    .cloned()
+                    .unwrap_or_default();
+                  chunk_init_fragments.extend(codegen_res.chunk_init_fragments.clone());
+                  Ok((
+                    ModuleInfo::External(external_module_info),
+                    if chunk_init_fragments.is_empty() {
+                      None
+                    } else {
+                      Some((id, chunk_init_fragments))
+                    },
+                  ))
                 }
-                if codegen_res.data.contains::<URLStaticMode>() {
-                  concate_info.static_url_replacement = true;
+                rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
+                  let hooks = JsPlugin::get_compilation_hooks(compilation.id());
+                  let hooks = hooks.read().await;
+
+                  let codegen_res = compilation.code_generation_results.get(&id, None);
+                  let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
+                    return Ok((ModuleInfo::Concatenated(concate_info), None));
+                  };
+
+                  let mut render_source = RenderSource {
+                    source: js_source.clone(),
+                  };
+                  let mut runtime_requirements = codegen_res.runtime_requirements;
+
+                  let mut chunk_init_fragments = vec![];
+                  hooks
+                    .render_module_content
+                    .call(
+                      compilation,
+                      &chunk_ukey,
+                      module_graph
+                        .module_by_identifier(&m)
+                        .expect("should have module")
+                        .as_ref(),
+                      &mut render_source,
+                      &mut runtime_requirements,
+                      &mut chunk_init_fragments,
+                      runtime_template,
+                    )
+                    .await?;
+                  *concate_info = codegen_res
+                    .concatenation_scope
+                    .as_ref()
+                    .expect("should have concatenation scope")
+                    .current_module
+                    .clone();
+
+                  let m = module_graph
+                    .module_by_identifier(&id)
+                    .expect("should have module");
+                  let jsx = m
+                    .as_ref()
+                    .as_normal_module()
+                    .and_then(|normal_module| normal_module.get_parser_options())
+                    .and_then(|options| {
+                      options
+                        .get_javascript()
+                        .and_then(|js_options| js_options.jsx)
+                    })
+                    .unwrap_or(false);
+                  let source_str = render_source
+                    .source
+                    .source()
+                    .into_string_lossy()
+                    .into_owned();
+                  let allocator = Allocator::new();
+                  let lexer = swc_experimental_ecma_parser::Lexer::new(
+                    &allocator,
+                    Syntax::Es(EsSyntax {
+                      jsx,
+                      ..Default::default()
+                    }),
+                    EsVersion::EsNext,
+                    StringSource::new(&source_str),
+                    None,
+                  );
+                  let mut parser = Parser::new_from(&allocator, lexer);
+                  let module = match parser.parse_module() {
+                    Ok(module) => module,
+                    Err(err) => {
+                      return Err(Error::from_string(
+                        Some(source_str.clone()),
+                        err.span().real_lo() as usize,
+                        err.span().real_hi() as usize,
+                        "JavaScript parse error:\n".to_string(),
+                        err.kind().msg().to_string(),
+                      ));
+                    }
+                  };
+                  let program = Program::Module(allocator.boxed(module));
+                  let semantic = resolver(&program);
+                  let ids = collect_ident(&allocator, &program);
+
+                  concate_info.module_ctxt =
+                    SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
+                  concate_info.global_ctxt =
+                    SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
+
+                  let top_level_scope_id = semantic.top_level_scope_id();
+                  let mut all_used_names = FxHashSet::default();
+                  all_used_names.reserve(ids.len());
+                  concate_info.idents.reserve(ids.len());
+                  concate_info.global_scope_ident.reserve(ids.len());
+                  let mut binding_to_ref: FxIndexMap<
+                    (Atom, SyntaxContext),
+                    Vec<ConcatenatedModuleIdent>,
+                  > = Default::default();
+                  binding_to_ref.reserve(ids.len());
+
+                  for ident in ids {
+                    let scope = semantic.node_scope(&ident.id);
+                    let is_global =
+                      SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
+                    let legacy = if is_global {
+                      let leg = ident.to_legacy(&semantic);
+                      concate_info.global_scope_ident.push(leg.clone());
+                      all_used_names.insert(leg.id.sym.clone());
+                      Some(leg)
+                    } else {
+                      None
+                    };
+                    if ident.is_class_expr_with_ident {
+                      all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                      continue;
+                    }
+                    if scope != top_level_scope_id {
+                      all_used_names.insert(Atom::from(ident.id.sym.as_str()));
+                    }
+                    let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
+                    concate_info.idents.push(legacy.clone());
+                    binding_to_ref
+                      .entry((legacy.id.sym.clone(), legacy.id.ctxt))
+                      .or_default()
+                      .push(legacy);
+                  }
+
+                  concate_info.all_used_names = all_used_names;
+                  concate_info.binding_to_ref = binding_to_ref;
+                  concate_info.has_ast = true;
+                  concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
+                  concate_info.internal_source = Some(render_source.source.clone());
+                  concate_info.runtime_requirements = runtime_requirements;
+                  concate_info.chunk_init_fragments = codegen_res
+                    .data
+                    .get::<ChunkInitFragments>()
+                    .cloned()
+                    .unwrap_or_default();
+                  concate_info
+                    .chunk_init_fragments
+                    .extend(codegen_res.chunk_init_fragments.clone());
+                  concate_info
+                    .chunk_init_fragments
+                    .extend(chunk_init_fragments);
+                  if let Some(CodeGenerationPublicPathAutoReplace(true)) =
+                    codegen_res
+                      .data
+                      .get::<CodeGenerationPublicPathAutoReplace>()
+                  {
+                    concate_info.public_path_auto_replacement = Some(true);
+                  }
+                  if codegen_res.data.contains::<URLStaticMode>() {
+                    concate_info.static_url_replacement = true;
+                  }
+                  Ok((ModuleInfo::Concatenated(concate_info), None))
                 }
-                Ok((ModuleInfo::Concatenated(concate_info), None))
               }
-            }
+            })
           },
-        )
+        ))
       }
     })
     .await;

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -180,45 +180,49 @@ pub(crate) async fn split(groups: &[CacheGroup], compilation: &mut Compilation) 
     modules.iter().copied().for_each(|module_identifier| {
       // SAFETY: `groups` and `compilation` outlive the scope and are only read (not mutated) concurrently.
       let s = unsafe { token.used((groups, &*compilation)) };
-      s.spawn(move |(groups, compilation)| async move {
-        let module_graph = compilation.get_module_graph();
-        let module: &dyn Module = module_graph
-          .module_by_identifier(&module_identifier)
-          .expect("should have module")
-          .as_ref();
-        for (index, group) in groups.iter().enumerate() {
-          if !matches_module_to_cache_group(module, compilation, group).await? {
-            continue;
-          }
-
-          return Ok(match &group.name {
-            ChunkNameGetter::String(name) => Some((Either::Left(name.clone()), module_identifier)),
-            ChunkNameGetter::Disabled => Some((Either::Right(index), module_identifier)),
-            ChunkNameGetter::Fn(func) => {
-              let name_res = func(ChunkNameGetterFnCtx {
-                module,
-                compilation,
-                chunks: &compilation
-                  .build_chunk_graph_artifact
-                  .chunk_graph
-                  .get_module_chunks(module_identifier)
-                  .iter()
-                  .copied()
-                  .collect(),
-                cache_group_key: &group.key,
-              })
-              .await;
-
-              match name_res {
-                Ok(Some(name)) => Some((Either::Left(name), module_identifier)),
-                Ok(None) => Some((Either::Right(index), module_identifier)),
-                Err(err) => return Err(err),
-              }
+      s.spawn(Box::new(move |(groups, compilation)| {
+        Box::pin(async move {
+          let module_graph = compilation.get_module_graph();
+          let module: &dyn Module = module_graph
+            .module_by_identifier(&module_identifier)
+            .expect("should have module")
+            .as_ref();
+          for (index, group) in groups.iter().enumerate() {
+            if !matches_module_to_cache_group(module, compilation, group).await? {
+              continue;
             }
-          });
-        }
-        Ok(None)
-      });
+
+            return Ok(match &group.name {
+              ChunkNameGetter::String(name) => {
+                Some((Either::Left(name.clone()), module_identifier))
+              }
+              ChunkNameGetter::Disabled => Some((Either::Right(index), module_identifier)),
+              ChunkNameGetter::Fn(func) => {
+                let name_res = func(ChunkNameGetterFnCtx {
+                  module,
+                  compilation,
+                  chunks: &compilation
+                    .build_chunk_graph_artifact
+                    .chunk_graph
+                    .get_module_chunks(module_identifier)
+                    .iter()
+                    .copied()
+                    .collect(),
+                  cache_group_key: &group.key,
+                })
+                .await;
+
+                match name_res {
+                  Ok(Some(name)) => Some((Either::Left(name), module_identifier)),
+                  Ok(None) => Some((Either::Right(index), module_identifier)),
+                  Err(err) => return Err(err),
+                }
+              }
+            });
+          }
+          Ok(None)
+        })
+      }));
     });
   })
   .await;

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -180,7 +180,7 @@ pub(crate) async fn split(groups: &[CacheGroup], compilation: &mut Compilation) 
     modules.iter().copied().for_each(|module_identifier| {
       // SAFETY: `groups` and `compilation` outlive the scope and are only read (not mutated) concurrently.
       let s = unsafe { token.used((groups, &*compilation)) };
-      s.spawn(Box::new(move |(groups, compilation)| {
+      s.spawn(move |(groups, compilation)| {
         Box::pin(async move {
           let module_graph = compilation.get_module_graph();
           let module: &dyn Module = module_graph
@@ -222,7 +222,7 @@ pub(crate) async fn split(groups: &[CacheGroup], compilation: &mut Compilation) 
           }
           Ok(None)
         })
-      }));
+      });
     });
   })
   .await;

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1088,7 +1088,7 @@ var {} = {{}};
             runtime_template,
           ))
         };
-        s.spawn(
+        s.spawn(Box::new(
           move |(
             compilation,
             chunk_ukey,
@@ -1097,20 +1097,22 @@ var {} = {{}};
             output_path,
             hooks,
             runtime_template,
-          )| async move {
-            render_module(
-              compilation,
-              chunk_ukey,
-              *module,
-              all_strict,
-              false,
-              output_path,
-              hooks,
-              runtime_template,
-            )
-            .await
+          )| {
+            Box::pin(async move {
+              render_module(
+                compilation,
+                chunk_ukey,
+                *module,
+                all_strict,
+                false,
+                output_path,
+                hooks,
+                runtime_template,
+              )
+              .await
+            })
           },
-        )
+        ))
       });
     })
     .await

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -1088,7 +1088,7 @@ var {} = {{}};
             runtime_template,
           ))
         };
-        s.spawn(Box::new(
+        s.spawn(
           move |(
             compilation,
             chunk_ukey,
@@ -1112,7 +1112,7 @@ var {} = {{}};
               .await
             })
           },
-        ))
+        )
       });
     })
     .await

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1465,45 +1465,47 @@ impl ModuleConcatenationPlugin {
     let new_modules = rspack_parallel::scope::<_, Result<_>>(|token| {
       batch.into_iter().for_each(|config| {
         let s = unsafe { token.used(&*compilation) };
-        s.spawn(move |compilation| async move {
-          let modules_set = config.get_modules();
-          let new_module = create_concatenated_module(compilation, &config).await?;
-          let new_module_id = new_module.identifier();
-          let connections = prepare_concatenated_module_connections(
-            compilation,
-            &new_module_id,
-            modules_set,
-            |m, con, dep| {
-              con.original_module_identifier.as_ref() == Some(m)
-                && !(is_esm_dep_like(dep) && modules_set.contains(con.module_identifier()))
-            },
-          );
-          let (root_outgoings, root_incomings) = prepare_concatenated_root_module_connections(
-            compilation,
-            &config.root_module,
-            |m, c, dep| {
-              let other_module = if c.module_identifier() == m {
-                c.original_module_identifier
-              } else {
-                Some(*c.module_identifier())
-              };
-              let inner_connection = is_esm_dep_like(dep)
-                && if let Some(other_module) = other_module {
-                  modules_set.contains(&other_module)
+        s.spawn(Box::new(move |compilation| {
+          Box::pin(async move {
+            let modules_set = config.get_modules();
+            let new_module = create_concatenated_module(compilation, &config).await?;
+            let new_module_id = new_module.identifier();
+            let connections = prepare_concatenated_module_connections(
+              compilation,
+              &new_module_id,
+              modules_set,
+              |m, con, dep| {
+                con.original_module_identifier.as_ref() == Some(m)
+                  && !(is_esm_dep_like(dep) && modules_set.contains(con.module_identifier()))
+              },
+            );
+            let (root_outgoings, root_incomings) = prepare_concatenated_root_module_connections(
+              compilation,
+              &config.root_module,
+              |m, c, dep| {
+                let other_module = if c.module_identifier() == m {
+                  c.original_module_identifier
                 } else {
-                  false
+                  Some(*c.module_identifier())
                 };
-              !inner_connection
-            },
-          );
-          Ok((
-            new_module,
-            connections,
-            root_outgoings,
-            root_incomings,
-            config,
-          ))
-        });
+                let inner_connection = is_esm_dep_like(dep)
+                  && if let Some(other_module) = other_module {
+                    modules_set.contains(&other_module)
+                  } else {
+                    false
+                  };
+                !inner_connection
+              },
+            );
+            Ok((
+              new_module,
+              connections,
+              root_outgoings,
+              root_incomings,
+              config,
+            ))
+          })
+        }));
       });
     })
     .await

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1465,7 +1465,7 @@ impl ModuleConcatenationPlugin {
     let new_modules = rspack_parallel::scope::<_, Result<_>>(|token| {
       batch.into_iter().for_each(|config| {
         let s = unsafe { token.used(&*compilation) };
-        s.spawn(Box::new(move |compilation| {
+        s.spawn(move |compilation| {
           Box::pin(async move {
             let modules_set = config.get_modules();
             let new_module = create_concatenated_module(compilation, &config).await?;
@@ -1505,7 +1505,7 @@ impl ModuleConcatenationPlugin {
               config,
             ))
           })
-        }));
+        });
       });
     })
     .await

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -45,7 +45,7 @@ pub async fn render_chunk_modules(
           runtime_template,
         ))
       };
-      s.spawn(Box::new(
+      s.spawn(
         |(compilation, chunk_ukey, module, all_strict, output_path, hooks, runtime_template)| {
           Box::pin(async move {
             render_module(
@@ -62,7 +62,7 @@ pub async fn render_chunk_modules(
             .map(|result| result.map(|(s, f, a)| (module.identifier(), s, f, a)))
           })
         },
-      ));
+      );
     });
   })
   .await
@@ -415,7 +415,7 @@ pub(crate) async fn render_runtime_module_sources(
       })
       .for_each(|(source, module)| {
         let s = unsafe { token.used((compilation, source, module)) };
-        s.spawn(Box::new(
+        s.spawn(
           move |(compilation, source, module)| {
             Box::pin(async move {
             if source.size() == 0 {
@@ -484,7 +484,7 @@ pub(crate) async fn render_runtime_module_sources(
               ))
             })
           },
-        ));
+        );
       })
   })
   .await

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -42,25 +42,27 @@ pub async fn render_chunk_modules(
           all_strict,
           output_path,
           hooks,
-          runtime_template
+          runtime_template,
         ))
       };
-      s.spawn(
-        |(compilation, chunk_ukey, module, all_strict, output_path, hooks, runtime_template)| async move {
-          render_module(
-            compilation,
-            chunk_ukey,
-            *module,
-            all_strict,
-            true,
-            output_path,
-            hooks,
-            runtime_template
-          )
-          .await
-          .map(|result| result.map(|(s, f, a)| (module.identifier(), s, f, a)))
+      s.spawn(Box::new(
+        |(compilation, chunk_ukey, module, all_strict, output_path, hooks, runtime_template)| {
+          Box::pin(async move {
+            render_module(
+              compilation,
+              chunk_ukey,
+              *module,
+              all_strict,
+              true,
+              output_path,
+              hooks,
+              runtime_template,
+            )
+            .await
+            .map(|result| result.map(|(s, f, a)| (module.identifier(), s, f, a)))
+          })
         },
-      );
+      ));
     });
   })
   .await
@@ -413,8 +415,9 @@ pub(crate) async fn render_runtime_module_sources(
       })
       .for_each(|(source, module)| {
         let s = unsafe { token.used((compilation, source, module)) };
-        s.spawn(
-          move |(compilation, source, module)| async move {
+        s.spawn(Box::new(
+          move |(compilation, source, module)| {
+            Box::pin(async move {
             if source.size() == 0 {
               return Ok((
                 ConcatSource::default().boxed(),
@@ -473,14 +476,15 @@ pub(crate) async fn render_runtime_module_sources(
               supports_arrow_function,
               matches!(runtime_mode, RuntimeMode::Rspack) && !should_isolate,
             );
-            Ok((
-              sources,
-              generated_requirements,
-              context_requirements,
-              needs_top_level,
-            ))
+              Ok((
+                sources,
+                generated_requirements,
+                context_requirements,
+                needs_top_level,
+              ))
+            })
           },
-        );
+        ));
       })
   })
   .await

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -208,7 +208,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
         .for_each(|(old_hash, asset_names)| {
           let s =
             unsafe { token.used((&hooks, &compilation, &batch_sources, old_hash, asset_names)) };
-          s.spawn(Box::new(
+          s.spawn(
             |(hooks, compilation, batch_sources, old_hash, mut asset_names)| {
               Box::pin(async move {
                 asset_names.sort_unstable();
@@ -239,7 +239,7 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
                 Ok((old_hash.clone(), new_hash))
               })
             },
-          ));
+          );
         });
     })
     .await

--- a/crates/rspack_plugin_real_content_hash/src/lib.rs
+++ b/crates/rspack_plugin_real_content_hash/src/lib.rs
@@ -208,36 +208,38 @@ async fn inner_impl(compilation: &mut Compilation) -> Result<()> {
         .for_each(|(old_hash, asset_names)| {
           let s =
             unsafe { token.used((&hooks, &compilation, &batch_sources, old_hash, asset_names)) };
-          s.spawn(
-            |(hooks, compilation, batch_sources, old_hash, mut asset_names)| async move {
-              asset_names.sort_unstable();
-              let mut asset_contents = asset_names
-                .iter()
-                .filter_map(|name| batch_sources.get(&(old_hash.as_str(), name)))
-                .cloned()
-                .collect::<Vec<_>>();
-              asset_contents.dedup();
-              let updated_hash = hooks
-                .borrow()
-                .update_hash
-                .call(compilation, &asset_contents, &old_hash)
-                .await?;
+          s.spawn(Box::new(
+            |(hooks, compilation, batch_sources, old_hash, mut asset_names)| {
+              Box::pin(async move {
+                asset_names.sort_unstable();
+                let mut asset_contents = asset_names
+                  .iter()
+                  .filter_map(|name| batch_sources.get(&(old_hash.as_str(), name)))
+                  .cloned()
+                  .collect::<Vec<_>>();
+                asset_contents.dedup();
+                let updated_hash = hooks
+                  .borrow()
+                  .update_hash
+                  .call(compilation, &asset_contents, &old_hash)
+                  .await?;
 
-              let new_hash = if let Some(new_hash) = updated_hash {
-                new_hash
-              } else {
-                let mut hasher = RspackHasher::from(&compilation.options.output);
-                for asset_content in asset_contents {
-                  hasher.write(&asset_content.buffer());
-                }
-                let new_hash = hasher.digest(&compilation.options.output.hash_digest);
+                let new_hash = if let Some(new_hash) = updated_hash {
+                  new_hash
+                } else {
+                  let mut hasher = RspackHasher::from(&compilation.options.output);
+                  for asset_content in asset_contents {
+                    hasher.write(&asset_content.buffer());
+                  }
+                  let new_hash = hasher.digest(&compilation.options.output.hash_digest);
 
-                new_hash.rendered(old_hash.len()).to_string()
-              };
+                  new_hash.rendered(old_hash.len()).to_string()
+                };
 
-              Ok((old_hash.clone(), new_hash))
+                Ok((old_hash.clone(), new_hash))
+              })
             },
-          );
+          ));
         });
     })
     .await

--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -145,7 +145,7 @@ async fn after_emit(&self, compilation: &mut Compilation) -> Result<()> {
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((&self, asset, name, max_asset_size)) };
 
-      s.spawn(Box::new(|(plugin, asset, name, max_asset_size)| {
+      s.spawn(|(plugin, asset, name, max_asset_size)| {
         Box::pin(async move {
           if !plugin.asset_filter(name, asset).await {
             return None;
@@ -157,7 +157,7 @@ async fn after_emit(&self, compilation: &mut Compilation) -> Result<()> {
           let is_over_size_limit = size > max_asset_size;
           Some((name.clone(), size, is_over_size_limit))
         })
-      }))
+      })
     })
   })
   .await

--- a/crates/rspack_plugin_size_limits/src/lib.rs
+++ b/crates/rspack_plugin_size_limits/src/lib.rs
@@ -145,17 +145,19 @@ async fn after_emit(&self, compilation: &mut Compilation) -> Result<()> {
       // SAFETY: await immediately and trust caller to poll future entirely
       let s = unsafe { token.used((&self, asset, name, max_asset_size)) };
 
-      s.spawn(|(plugin, asset, name, max_asset_size)| async move {
-        if !plugin.asset_filter(name, asset).await {
-          return None;
-        }
+      s.spawn(Box::new(|(plugin, asset, name, max_asset_size)| {
+        Box::pin(async move {
+          if !plugin.asset_filter(name, asset).await {
+            return None;
+          }
 
-        let source = asset.get_source()?;
+          let source = asset.get_source()?;
 
-        let size = source.size() as f64;
-        let is_over_size_limit = size > max_asset_size;
-        Some((name.clone(), size, is_over_size_limit))
-      })
+          let size = source.size() as f64;
+          let is_over_size_limit = size > max_asset_size;
+          Some((name.clone(), size, is_over_size_limit))
+        })
+      }))
     })
   })
   .await

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -498,7 +498,7 @@ impl SplitChunksPlugin {
             &max_size_setting_map,
           ))
         };
-        s.spawn(Box::new(
+        s.spawn(
           move |(
             compilation,
             chunk,
@@ -577,7 +577,7 @@ impl SplitChunksPlugin {
               }))
             })
           },
-        ));
+        );
       });
     })
     .await

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -498,15 +498,16 @@ impl SplitChunksPlugin {
             &max_size_setting_map,
           ))
         };
-        s.spawn(
+        s.spawn(Box::new(
           move |(
             compilation,
             chunk,
             fallback_cache_group,
             chunk_group_db,
             max_size_setting_map,
-          )| async move {
-            let max_size_setting = max_size_setting_map.get(&chunk.ukey());
+          )| {
+            Box::pin(async move {
+              let max_size_setting = max_size_setting_map.get(&chunk.ukey());
             tracing::trace!(
               "max_size_setting : {max_size_setting:#?} for {:?}",
               chunk.ukey()
@@ -568,14 +569,15 @@ impl SplitChunksPlugin {
               allow_max_size.to_mut().combine_with(min_size, &f64::max);
             }
 
-            Ok(Some(ChunkWithSizeInfo {
-              allow_max_size: allow_max_size.into_owned(),
-              min_size: min_size.clone(),
-              chunk: chunk.ukey(),
-              automatic_name_delimiter: automatic_name_delimiter.clone(),
-            }))
+              Ok(Some(ChunkWithSizeInfo {
+                allow_max_size: allow_max_size.into_owned(),
+                min_size: min_size.clone(),
+                chunk: chunk.ukey(),
+                automatic_name_delimiter: automatic_name_delimiter.clone(),
+              }))
+            })
           },
-        );
+        ));
       });
     })
     .await

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -443,7 +443,7 @@ impl SplitChunksPlugin {
     let module_group_results = rspack_parallel::scope::<_, Result<_>>(|token| {
       all_modules.iter().enumerate().for_each(|(module_index, mid)| {
         let s = unsafe { token.used((&cache_groups, module_index, mid, &module_graph, compilation, &module_group_map, &combinator, module_chunks, chunk_index_map)) };
-        s.spawn(Box::new(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, chunk_index_map)| {
+        s.spawn(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, chunk_index_map)| {
           Box::pin(async move {
           let belong_to_chunks = module_chunks
             .get(module_index)
@@ -605,7 +605,7 @@ impl SplitChunksPlugin {
           }
             Ok(())
           })
-        }));
+        });
       })
     })
     .await

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -443,7 +443,8 @@ impl SplitChunksPlugin {
     let module_group_results = rspack_parallel::scope::<_, Result<_>>(|token| {
       all_modules.iter().enumerate().for_each(|(module_index, mid)| {
         let s = unsafe { token.used((&cache_groups, module_index, mid, &module_graph, compilation, &module_group_map, &combinator, module_chunks, chunk_index_map)) };
-        s.spawn(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, chunk_index_map)| async move {
+        s.spawn(Box::new(|(cache_groups, module_index, mid, module_graph, compilation, module_group_map, combinator, module_chunks, chunk_index_map)| {
+          Box::pin(async move {
           let belong_to_chunks = module_chunks
             .get(module_index)
             .expect("should have module chunks");
@@ -602,8 +603,9 @@ impl SplitChunksPlugin {
               ).await?;
             }
           }
-          Ok(())
-        });
+            Ok(())
+          })
+        }));
       })
     })
     .await


### PR DESCRIPTION
## Summary

- define boxed trait-object aliases for scoped tasks and their futures
- make `Spawner::spawn` accept the erased task type directly
- update every existing `rspack_parallel::scope` call site on `main`

## Why

`Spawner::spawn` previously used generic closure and future parameters, so each call site produced another monomorphized spawn implementation. Erasing both types at the API boundary lets the compiler reuse one implementation. The tradeoff is explicit boxing and dynamic dispatch for each scoped task; task scheduling and lifetime guarantees remain unchanged.

For example:

```rust
// Before
spawner.spawn(move |used| async move {
  process(used).await
});

// After
spawner.spawn(Box::new(move |used| {
  Box::pin(async move {
    process(used).await
  })
}));
```

This PR is intentionally based on `main` and does not include the parallel ensure-chunk-conditions changes from #15093.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rspack_parallel --target-dir /tmp/rspack-parallel-target`
- `cargo clippy -p rspack -p rspack_plugin_copy -p rspack_plugin_size_limits --target-dir /tmp/rspack-dyn-clippy-target -- -D warnings`

---
_by OpenAI Codex_