### PR TITLE
perf: skip empty JavaScript hook registers

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -337,6 +337,7 @@ export declare class JsCompilation {
 export declare class JsCompiler {
   constructor(compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform)
   setNonSkippableRegisters(kinds: Array<RegisterJsTapKind>): void
+  setRegisterJsTapCount(kind: RegisterJsTapKind, tapCount: number): void
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void
   /** Rebuild with the given option passed to the constructor */

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -418,6 +418,13 @@ impl JsCompiler {
     self.js_hooks_plugin.set_non_skippable_registers(kinds)
   }
 
+  #[napi]
+  pub fn set_register_js_tap_count(&self, kind: RegisterJsTapKind, tap_count: u32) {
+    self
+      .js_hooks_plugin
+      .set_register_js_tap_count(kind, tap_count as usize)
+  }
+
   /// Build with the given option passed to the constructor
   #[napi(ts_args_type = "callback: (err: null | Error) => void")]
   pub fn build(

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -3,7 +3,10 @@ use std::{
   hash::Hash,
   marker::PhantomData,
   ptr::NonNull,
-  sync::{Arc, RwLock},
+  sync::{
+    Arc, RwLock,
+    atomic::{AtomicUsize, Ordering},
+  },
 };
 
 use async_trait::async_trait;
@@ -49,7 +52,7 @@ use rspack_core::{
 };
 use rspack_error::Diagnostic;
 use rspack_hash::RspackHasher;
-use rspack_hook::{Hook, Interceptor};
+use rspack_hook::{Hook, JsTapRegister};
 use rspack_napi::threadsafe_function::DynThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_html::{
@@ -235,31 +238,13 @@ type RegisterFunction = CompilerScopedTsFnHandle<Vec<i32>, RegisterFunctionOutpu
 struct RegisterJsTapsInner {
   register: RegisterFunction,
   cache: RegisterJsTapsCache,
-  non_skippable_registers: Option<NonSkippableRegisters>,
-}
-
-impl Clone for RegisterJsTapsInner {
-  fn clone(&self) -> Self {
-    Self {
-      register: self.register.clone(),
-      cache: self.cache.clone(),
-      non_skippable_registers: self.non_skippable_registers.clone(),
-    }
-  }
+  tap_count: AtomicUsize,
+  always_active: bool,
 }
 
 enum RegisterJsTapsCache {
   NoCache,
-  Cache(Arc<RwLock<Option<RegisterFunctionOutput>>>),
-}
-
-impl Clone for RegisterJsTapsCache {
-  fn clone(&self) -> Self {
-    match self {
-      Self::NoCache => Self::NoCache,
-      Self::Cache(c) => Self::Cache(c.clone()),
-    }
-  }
+  Cache(RwLock<Option<RegisterFunctionOutput>>),
 }
 
 impl RegisterJsTapsCache {
@@ -273,21 +258,33 @@ impl RegisterJsTapsCache {
 }
 
 impl RegisterJsTapsInner {
-  pub fn new(
-    register: RegisterFunction,
-    non_skippable_registers: Option<NonSkippableRegisters>,
-    cache: bool,
-  ) -> Self {
+  pub fn new(register: RegisterFunction, cache: bool, always_active: bool) -> Self {
     Self {
       register,
       cache: RegisterJsTapsCache::new(cache),
-      non_skippable_registers,
+      tap_count: AtomicUsize::new(usize::from(always_active)),
+      always_active,
     }
+  }
+
+  fn tap_count(&self) -> usize {
+    self.tap_count.load(Ordering::Acquire)
+  }
+
+  fn set_tap_count(&self, tap_count: usize) {
+    self.tap_count.store(
+      if self.always_active {
+        tap_count.max(1)
+      } else {
+        tap_count
+      },
+      Ordering::Release,
+    );
   }
 
   pub async fn call_register(
     &self,
-    hook: &impl Hook,
+    used_stages: Vec<i32>,
   ) -> rspack_error::Result<RegisterFunctionOutput> {
     if let RegisterJsTapsCache::Cache(rw) = &self.cache {
       let cache = {
@@ -297,7 +294,7 @@ impl RegisterJsTapsInner {
       Ok(match cache {
         Some(js_taps) => js_taps,
         None => {
-          let js_taps = self.call_register_impl(hook).await?;
+          let js_taps = self.call_register_impl(used_stages).await?;
           {
             #[allow(clippy::unwrap_used)]
             let mut cache = rw.write().unwrap();
@@ -307,17 +304,15 @@ impl RegisterJsTapsInner {
         }
       })
     } else {
-      let js_taps = self.call_register_impl(hook).await?;
+      let js_taps = self.call_register_impl(used_stages).await?;
       Ok(js_taps)
     }
   }
 
   async fn call_register_impl(
     &self,
-    hook: &impl Hook,
+    used_stages: Vec<i32>,
   ) -> rspack_error::Result<RegisterFunctionOutput> {
-    let mut used_stages = Vec::from_iter(hook.used_stages());
-    used_stages.sort_unstable();
     self.register.call_with_sync(used_stages).await
   }
 
@@ -344,17 +339,17 @@ macro_rules! define_register {
   ($name:ident, tap = $tap_name:ident<$arg:ty, Promise<$promise_ret:ty>> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
     define_register!(@BASE_PROMISE $name, $tap_name<$arg, $promise_ret>, $cache);
     define_register!(@SKIP $name, $arg, Promise<$promise_ret>, $cache, $skip);
-    define_register!(@INTERCEPTOR $name, $tap_name, $tap_hook, $cache, $kind);
+    define_register!(@JS_TAP_REGISTER $name, $tap_name, $tap_hook);
   };
   ($name:ident, tap = $tap_name:ident<$arg:ty, $ret:ty> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
     define_register!(@BASE $name, $tap_name<$arg, $ret>, $cache);
     define_register!(@SKIP $name, $arg, $ret, $cache, $skip);
-    define_register!(@INTERCEPTOR $name, $tap_name, $tap_hook, $cache, $kind);
+    define_register!(@JS_TAP_REGISTER $name, $tap_name, $tap_hook);
   };
   (@BASE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      inner: RegisterJsTapsInner,
+      inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -381,7 +376,7 @@ macro_rules! define_register {
   (@BASE_PROMISE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      inner: RegisterJsTapsInner,
+      inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -407,36 +402,39 @@ macro_rules! define_register {
   };
   (@SKIP $name:ident, $arg:ty, $ret:ty, $cache:literal, $skip:literal) => {
     impl $name {
-      pub fn new(register: RegisterFunction, non_skippable_registers: NonSkippableRegisters) -> Self {
+      pub fn new(register: RegisterFunction) -> Self {
         Self {
-          inner: RegisterJsTapsInner::new(register, $skip.then_some(non_skippable_registers), $cache),
+          inner: Arc::new(RegisterJsTapsInner::new(register, $cache, !$skip)),
         }
+      }
+
+      pub fn set_tap_count(&self, tap_count: usize) {
+        self.inner.set_tap_count(tap_count);
       }
     }
   };
-  (@INTERCEPTOR $name:ident, $tap_name:ident, $tap_hook:ty, $cache:literal, $kind:expr) => {
-    #[async_trait]
-    impl Interceptor<$tap_hook> for $name {
-      async fn call(
-        &self,
-        hook: &$tap_hook,
-      ) -> rspack_error::Result<Vec<<$tap_hook as Hook>::Tap>> {
-        if let Some(non_skippable_registers) = &self.inner.non_skippable_registers && !non_skippable_registers.is_non_skippable(&$kind) {
-          return Ok(Vec::new());
-        }
-        let js_taps = self.inner.call_register(hook).await?;
-        let js_taps = js_taps
-          .iter()
-          .map(|t| Box::new($tap_name::new(t.clone())) as <$tap_hook as Hook>::Tap)
-          .collect();
-        Ok(js_taps)
+  (@JS_TAP_REGISTER $name:ident, $tap_name:ident, $tap_hook:ty) => {
+    impl $name {
+      pub fn into_js_tap_register(self) -> JsTapRegister {
+        JsTapRegister::new_async::<RegisterJsTapsInner, <$tap_hook as Hook>::Tap, _, _>(
+          self.inner,
+          RegisterJsTapsInner::tap_count,
+          |inner, used_stages| async move {
+            Ok(inner
+              .call_register(used_stages)
+              .await?
+              .iter()
+              .map(|tap| Box::new($tap_name::new(tap.clone())) as <$tap_hook as Hook>::Tap)
+              .collect())
+          },
+        )
       }
     }
   };
 }
 
 #[napi]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RegisterJsTapKind {
   CompilerThisCompilation,
   CompilerCompilation,
@@ -492,18 +490,61 @@ pub enum RegisterJsTapKind {
   RsdoctorPluginAssets,
 }
 
-#[derive(Default, Clone)]
-pub struct NonSkippableRegisters(Arc<RwLock<Vec<RegisterJsTapKind>>>);
-
-impl NonSkippableRegisters {
-  pub fn set_non_skippable_registers(&self, kinds: Vec<RegisterJsTapKind>) {
-    let mut ks = self.0.write().expect("failed to write lock");
-    *ks = kinds;
-  }
-
-  pub fn is_non_skippable(&self, kind: &RegisterJsTapKind) -> bool {
-    self.0.read().expect("should lock").contains(kind)
-  }
+impl RegisterJsTapKind {
+  pub const ALL: &[Self] = &[
+    Self::CompilerThisCompilation,
+    Self::CompilerCompilation,
+    Self::CompilerMake,
+    Self::CompilerFinishMake,
+    Self::CompilerShouldEmit,
+    Self::CompilerEmit,
+    Self::CompilerAfterEmit,
+    Self::CompilerAssetEmitted,
+    Self::CompilationBuildModule,
+    Self::CompilationStillValidModule,
+    Self::CompilationSucceedModule,
+    Self::CompilationExecuteModule,
+    Self::CompilationFinishModules,
+    Self::CompilationOptimizeModules,
+    Self::CompilationAfterOptimizeModules,
+    Self::CompilationOptimizeTree,
+    Self::CompilationOptimizeChunkModules,
+    Self::CompilationBeforeModuleIds,
+    Self::CompilationAdditionalTreeRuntimeRequirements,
+    Self::CompilationRuntimeRequirementInTree,
+    Self::CompilationRuntimeModule,
+    Self::CompilationChunkHash,
+    Self::CompilationChunkAsset,
+    Self::CompilationProcessAssets,
+    Self::CompilationAfterProcessAssets,
+    Self::CompilationSeal,
+    Self::CompilationAfterSeal,
+    Self::NormalModuleFactoryBeforeResolve,
+    Self::NormalModuleFactoryFactorize,
+    Self::NormalModuleFactoryResolve,
+    Self::NormalModuleFactoryAfterResolve,
+    Self::NormalModuleFactoryCreateModule,
+    Self::NormalModuleFactoryResolveForScheme,
+    Self::ContextModuleFactoryBeforeResolve,
+    Self::ContextModuleFactoryAfterResolve,
+    Self::JavascriptModulesChunkHash,
+    Self::HtmlPluginBeforeAssetTagGeneration,
+    Self::HtmlPluginAlterAssetTags,
+    Self::HtmlPluginAlterAssetTagGroups,
+    Self::HtmlPluginAfterTemplateExecution,
+    Self::HtmlPluginBeforeEmit,
+    Self::HtmlPluginAfterEmit,
+    Self::RuntimePluginCreateScript,
+    Self::RuntimePluginCreateLink,
+    Self::RuntimePluginLinkPreload,
+    Self::RuntimePluginLinkPrefetch,
+    Self::RealContentHashPluginUpdateHash,
+    Self::RsdoctorPluginModuleGraph,
+    Self::RsdoctorPluginChunkGraph,
+    Self::RsdoctorPluginModuleIds,
+    Self::RsdoctorPluginModuleSources,
+    Self::RsdoctorPluginAssets,
+  ];
 }
 
 #[derive(Clone)]

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -355,7 +355,7 @@ macro_rules! define_register {
   (@BASE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      pub(crate) inner: Arc<RegisterJsTapsInner>,
+      inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -382,7 +382,7 @@ macro_rules! define_register {
   (@BASE_PROMISE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      pub(crate) inner: Arc<RegisterJsTapsInner>,
+      inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -420,6 +420,12 @@ macro_rules! define_register {
     }
   };
   (@INTERCEPTOR $name:ident, $tap_name:ident, $tap_hook:ty) => {
+    impl $name {
+      pub(crate) fn js_tap_register(&self) -> Arc<RegisterJsTapsInner> {
+        self.inner.clone()
+      }
+    }
+
     #[async_trait]
     impl Interceptor<$tap_hook> for RegisterJsTapsInner {
       async fn call(

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -52,7 +52,7 @@ use rspack_core::{
 };
 use rspack_error::Diagnostic;
 use rspack_hash::RspackHasher;
-use rspack_hook::{Hook, JsTapRegister};
+use rspack_hook::{Hook, Interceptor, JsTapRegister};
 use rspack_napi::threadsafe_function::DynThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_html::{
@@ -328,6 +328,12 @@ impl RegisterJsTapsInner {
   }
 }
 
+fn create_js_tap_register_is_empty(
+  inner: Arc<RegisterJsTapsInner>,
+) -> Box<dyn Fn() -> bool + Send + Sync> {
+  Box::new(move || inner.tap_count() == 0)
+}
+
 /// define js taps register
 /// cache: add cache for register function, used for `before_resolve` or `build_module`
 ///        which run register function multiple times for every module, cache will ensure
@@ -339,12 +345,12 @@ macro_rules! define_register {
   ($name:ident, tap = $tap_name:ident<$arg:ty, Promise<$promise_ret:ty>> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
     define_register!(@BASE_PROMISE $name, $tap_name<$arg, $promise_ret>, $cache);
     define_register!(@SKIP $name, $arg, Promise<$promise_ret>, $cache, $skip);
-    define_register!(@JS_TAP_REGISTER $name, $tap_name, $tap_hook);
+    define_register!(@INTERCEPTOR $name, $tap_name, $tap_hook);
   };
   ($name:ident, tap = $tap_name:ident<$arg:ty, $ret:ty> @ $tap_hook:ty, cache = $cache:literal, kind = $kind:expr, skip = $skip:tt,) => {
     define_register!(@BASE $name, $tap_name<$arg, $ret>, $cache);
     define_register!(@SKIP $name, $arg, $ret, $cache, $skip);
-    define_register!(@JS_TAP_REGISTER $name, $tap_name, $tap_hook);
+    define_register!(@INTERCEPTOR $name, $tap_name, $tap_hook);
   };
   (@BASE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
@@ -413,20 +419,33 @@ macro_rules! define_register {
       }
     }
   };
-  (@JS_TAP_REGISTER $name:ident, $tap_name:ident, $tap_hook:ty) => {
+  (@INTERCEPTOR $name:ident, $tap_name:ident, $tap_hook:ty) => {
+    #[async_trait]
+    impl Interceptor<$tap_hook> for $name {
+      async fn call(
+        &self,
+        hook: &$tap_hook,
+      ) -> rspack_error::Result<Vec<<$tap_hook as Hook>::Tap>> {
+        if self.inner.tap_count() == 0 {
+          return Ok(Vec::new());
+        }
+        Ok(self
+          .inner
+          .call_register(hook.used_stages())
+          .await?
+          .into_iter()
+          .map(|tap| Box::new($tap_name::new(tap)) as <$tap_hook as Hook>::Tap)
+          .collect())
+      }
+    }
+
     impl $name {
       pub fn into_js_tap_register(self) -> JsTapRegister {
-        JsTapRegister::new_async::<RegisterJsTapsInner, <$tap_hook as Hook>::Tap, _, _>(
-          self.inner,
-          RegisterJsTapsInner::tap_count,
-          |inner, used_stages| async move {
-            Ok(inner
-              .call_register(used_stages)
-              .await?
-              .iter()
-              .map(|tap| Box::new($tap_name::new(tap.clone())) as <$tap_hook as Hook>::Tap)
-              .collect())
-          },
+        let is_empty = create_js_tap_register_is_empty(self.inner.clone());
+        let interceptor: Box<dyn Interceptor<$tap_hook> + Send + Sync> = Box::new(self);
+        JsTapRegister::new(
+          is_empty,
+          Box::new(interceptor),
         )
       }
     }

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -235,7 +235,7 @@ type RegisterFunctionOutput = Vec<ThreadsafeJsTap>;
 // released by `clear_cache()`.
 type RegisterFunction = CompilerScopedTsFnHandle<Vec<i32>, RegisterFunctionOutput>;
 
-struct RegisterJsTapsInner {
+pub(crate) struct RegisterJsTapsInner {
   register: RegisterFunction,
   cache: RegisterJsTapsCache,
   tap_count: AtomicUsize,
@@ -328,10 +328,10 @@ impl RegisterJsTapsInner {
   }
 }
 
-fn create_js_tap_register_is_empty(
-  inner: Arc<RegisterJsTapsInner>,
-) -> Box<dyn Fn() -> bool + Send + Sync> {
-  Box::new(move || inner.tap_count() == 0)
+impl JsTapRegister for RegisterJsTapsInner {
+  fn is_empty(&self) -> bool {
+    self.tap_count() == 0
+  }
 }
 
 /// define js taps register
@@ -355,7 +355,7 @@ macro_rules! define_register {
   (@BASE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      inner: Arc<RegisterJsTapsInner>,
+      pub(crate) inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -382,7 +382,7 @@ macro_rules! define_register {
   (@BASE_PROMISE $name:ident, $tap_name:ident<$arg:ty, $ret:ty>, $cache:literal) => {
     #[derive(Clone)]
     pub struct $name {
-      inner: Arc<RegisterJsTapsInner>,
+      pub(crate) inner: Arc<RegisterJsTapsInner>,
     }
 
     impl $name {
@@ -421,16 +421,15 @@ macro_rules! define_register {
   };
   (@INTERCEPTOR $name:ident, $tap_name:ident, $tap_hook:ty) => {
     #[async_trait]
-    impl Interceptor<$tap_hook> for $name {
+    impl Interceptor<$tap_hook> for RegisterJsTapsInner {
       async fn call(
         &self,
         hook: &$tap_hook,
       ) -> rspack_error::Result<Vec<<$tap_hook as Hook>::Tap>> {
-        if self.inner.tap_count() == 0 {
+        if self.tap_count() == 0 {
           return Ok(Vec::new());
         }
         Ok(self
-          .inner
           .call_register(hook.used_stages())
           .await?
           .into_iter()
@@ -439,16 +438,6 @@ macro_rules! define_register {
       }
     }
 
-    impl $name {
-      pub fn into_js_tap_register(self) -> JsTapRegister {
-        let is_empty = create_js_tap_register_is_empty(self.inner.clone());
-        let interceptor: Box<dyn Interceptor<$tap_hook> + Send + Sync> = Box::new(self);
-        JsTapRegister::new(
-          is_empty,
-          Box::new(interceptor),
-        )
-      }
-    }
   };
 }
 

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -90,71 +90,74 @@ impl Plugin for JsHooksAdapterPlugin {
 
   // #[tracing::instrument("js_hooks_adapter::apply", skip_all)]
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
-    ctx
-      .compiler_hooks
-      .this_compilation
-      .load_js_tap_register(self.register_compiler_this_compilation_taps.inner.clone())?;
+    ctx.compiler_hooks.this_compilation.load_js_tap_register(
+      self
+        .register_compiler_this_compilation_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compiler_hooks
       .compilation
-      .load_js_tap_register(self.register_compiler_compilation_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_compilation_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .make
-      .load_js_tap_register(self.register_compiler_make_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_make_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .finish_make
-      .load_js_tap_register(self.register_compiler_finish_make_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_finish_make_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .should_emit
-      .load_js_tap_register(self.register_compiler_should_emit_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_should_emit_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .emit
-      .load_js_tap_register(self.register_compiler_emit_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_emit_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .after_emit
-      .load_js_tap_register(self.register_compiler_after_emit_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_after_emit_taps.js_tap_register())?;
     ctx
       .compiler_hooks
       .asset_emitted
-      .load_js_tap_register(self.register_compiler_asset_emitted_taps.inner.clone())?;
-    ctx
-      .compilation_hooks
-      .build_module
-      .load_js_tap_register(self.register_compilation_build_module_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compiler_asset_emitted_taps.js_tap_register())?;
+    ctx.compilation_hooks.build_module.load_js_tap_register(
+      self
+        .register_compilation_build_module_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .still_valid_module
       .load_js_tap_register(
         self
           .register_compilation_still_valid_module_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
-    ctx
-      .compilation_hooks
-      .succeed_module
-      .load_js_tap_register(self.register_compilation_succeed_module_taps.inner.clone())?;
-    ctx
-      .compilation_hooks
-      .execute_module
-      .load_js_tap_register(self.register_compilation_execute_module_taps.inner.clone())?;
-    ctx
-      .compilation_hooks
-      .finish_modules
-      .load_js_tap_register(self.register_compilation_finish_modules_taps.inner.clone())?;
+    ctx.compilation_hooks.succeed_module.load_js_tap_register(
+      self
+        .register_compilation_succeed_module_taps
+        .js_tap_register(),
+    )?;
+    ctx.compilation_hooks.execute_module.load_js_tap_register(
+      self
+        .register_compilation_execute_module_taps
+        .js_tap_register(),
+    )?;
+    ctx.compilation_hooks.finish_modules.load_js_tap_register(
+      self
+        .register_compilation_finish_modules_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .optimize_modules
       .load_js_tap_register(
         self
           .register_compilation_optimize_modules_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .compilation_hooks
@@ -162,21 +165,20 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_after_optimize_modules_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
-    ctx
-      .compilation_hooks
-      .optimize_tree
-      .load_js_tap_register(self.register_compilation_optimize_tree_taps.inner.clone())?;
+    ctx.compilation_hooks.optimize_tree.load_js_tap_register(
+      self
+        .register_compilation_optimize_tree_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .optimize_chunk_modules
       .load_js_tap_register(
         self
           .register_compilation_optimize_chunk_modules_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .compilation_hooks
@@ -184,8 +186,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_before_module_ids_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .compilation_hooks
@@ -193,8 +194,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_additional_tree_runtime_requirements_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .compilation_hooks
@@ -202,42 +202,42 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_runtime_requirement_in_tree_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
-    ctx
-      .compilation_hooks
-      .runtime_module
-      .load_js_tap_register(self.register_compilation_runtime_module_taps.inner.clone())?;
+    ctx.compilation_hooks.runtime_module.load_js_tap_register(
+      self
+        .register_compilation_runtime_module_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .chunk_hash
-      .load_js_tap_register(self.register_compilation_chunk_hash_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compilation_chunk_hash_taps.js_tap_register())?;
     ctx
       .compilation_hooks
       .chunk_asset
-      .load_js_tap_register(self.register_compilation_chunk_asset_taps.inner.clone())?;
-    ctx
-      .compilation_hooks
-      .process_assets
-      .load_js_tap_register(self.register_compilation_process_assets_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compilation_chunk_asset_taps.js_tap_register())?;
+    ctx.compilation_hooks.process_assets.load_js_tap_register(
+      self
+        .register_compilation_process_assets_taps
+        .js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .after_process_assets
       .load_js_tap_register(
         self
           .register_compilation_after_process_assets_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .compilation_hooks
       .seal
-      .load_js_tap_register(self.register_compilation_seal_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compilation_seal_taps.js_tap_register())?;
     ctx
       .compilation_hooks
       .after_seal
-      .load_js_tap_register(self.register_compilation_after_seal_taps.inner.clone())?;
+      .load_js_tap_register(self.register_compilation_after_seal_taps.js_tap_register())?;
 
     ctx
       .normal_module_factory_hooks
@@ -245,8 +245,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_before_resolve_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -254,8 +253,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_factorize_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -263,8 +261,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_resolve_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -272,8 +269,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_resolve_for_scheme_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -281,8 +277,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_after_resolve_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -290,8 +285,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_create_module_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .context_module_factory_hooks
@@ -299,8 +293,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_context_module_factory_before_resolve_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
     ctx
       .context_module_factory_hooks
@@ -308,8 +301,7 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_context_module_factory_after_resolve_taps
-          .inner
-          .clone(),
+          .js_tap_register(),
       )?;
 
     ctx
@@ -459,8 +451,7 @@ async fn js_hooks_adapter_compilation(
   hooks.chunk_hash.load_js_tap_register(
     self
       .register_javascript_modules_chunk_hash_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
 
   Ok(())
@@ -477,33 +468,29 @@ async fn html_hooks_adapter_compilation(
   hooks.before_asset_tag_generation.load_js_tap_register(
     self
       .register_html_plugin_before_asset_tag_generation_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   hooks.alter_asset_tags.load_js_tap_register(
     self
       .register_html_plugin_alter_asset_tags_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   hooks.alter_asset_tag_groups.load_js_tap_register(
     self
       .register_html_plugin_alter_asset_tag_groups_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   hooks.after_template_execution.load_js_tap_register(
     self
       .register_html_plugin_after_template_execution_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   hooks
     .before_emit
-    .load_js_tap_register(self.register_html_plugin_before_emit_taps.inner.clone())?;
+    .load_js_tap_register(self.register_html_plugin_before_emit_taps.js_tap_register())?;
   hooks
     .after_emit
-    .load_js_tap_register(self.register_html_plugin_after_emit_taps.inner.clone())?;
+    .load_js_tap_register(self.register_html_plugin_after_emit_taps.js_tap_register())?;
 
   Ok(())
 }
@@ -519,20 +506,22 @@ async fn runtime_hooks_adapter_compilation(
   hooks.create_script.load_js_tap_register(
     self
       .register_runtime_plugin_create_script_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
-  hooks
-    .create_link
-    .load_js_tap_register(self.register_runtime_plugin_create_link_taps.inner.clone())?;
-  hooks
-    .link_preload
-    .load_js_tap_register(self.register_runtime_plugin_link_preload_taps.inner.clone())?;
+  hooks.create_link.load_js_tap_register(
+    self
+      .register_runtime_plugin_create_link_taps
+      .js_tap_register(),
+  )?;
+  hooks.link_preload.load_js_tap_register(
+    self
+      .register_runtime_plugin_link_preload_taps
+      .js_tap_register(),
+  )?;
   hooks.link_prefetch.load_js_tap_register(
     self
       .register_runtime_plugin_link_prefetch_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   Ok(())
 }
@@ -548,23 +537,25 @@ async fn rsdoctor_hooks_adapter_compilation(
   hooks.module_graph.load_js_tap_register(
     self
       .register_rsdoctor_plugin_module_graph_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
+  )?;
+  hooks.chunk_graph.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_chunk_graph_taps
+      .js_tap_register(),
   )?;
   hooks
-    .chunk_graph
-    .load_js_tap_register(self.register_rsdoctor_plugin_chunk_graph_taps.inner.clone())?;
-  hooks
     .assets
-    .load_js_tap_register(self.register_rsdoctor_plugin_assets_taps.inner.clone())?;
-  hooks
-    .module_ids
-    .load_js_tap_register(self.register_rsdoctor_plugin_module_ids_taps.inner.clone())?;
+    .load_js_tap_register(self.register_rsdoctor_plugin_assets_taps.js_tap_register())?;
+  hooks.module_ids.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_module_ids_taps
+      .js_tap_register(),
+  )?;
   hooks.module_sources.load_js_tap_register(
     self
       .register_rsdoctor_plugin_module_sources_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
 
   Ok(())
@@ -581,8 +572,7 @@ async fn real_content_hash_hooks_adapter_compilation(
   hooks.update_hash.load_js_tap_register(
     self
       .register_real_content_hash_plugin_update_hash_taps
-      .inner
-      .clone(),
+      .js_tap_register(),
   )?;
   Ok(())
 }

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -90,95 +90,71 @@ impl Plugin for JsHooksAdapterPlugin {
 
   // #[tracing::instrument("js_hooks_adapter::apply", skip_all)]
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
-    ctx.compiler_hooks.this_compilation.load_js_tap_register(
-      self
-        .register_compiler_this_compilation_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.compilation.load_js_tap_register(
-      self
-        .register_compiler_compilation_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.make.load_js_tap_register(
-      self
-        .register_compiler_make_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.finish_make.load_js_tap_register(
-      self
-        .register_compiler_finish_make_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.should_emit.load_js_tap_register(
-      self
-        .register_compiler_should_emit_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.emit.load_js_tap_register(
-      self
-        .register_compiler_emit_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.after_emit.load_js_tap_register(
-      self
-        .register_compiler_after_emit_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compiler_hooks.asset_emitted.load_js_tap_register(
-      self
-        .register_compiler_asset_emitted_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.build_module.load_js_tap_register(
-      self
-        .register_compilation_build_module_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
+    ctx
+      .compiler_hooks
+      .this_compilation
+      .load_js_tap_register(self.register_compiler_this_compilation_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .compilation
+      .load_js_tap_register(self.register_compiler_compilation_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .make
+      .load_js_tap_register(self.register_compiler_make_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .finish_make
+      .load_js_tap_register(self.register_compiler_finish_make_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .should_emit
+      .load_js_tap_register(self.register_compiler_should_emit_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .emit
+      .load_js_tap_register(self.register_compiler_emit_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .after_emit
+      .load_js_tap_register(self.register_compiler_after_emit_taps.inner.clone())?;
+    ctx
+      .compiler_hooks
+      .asset_emitted
+      .load_js_tap_register(self.register_compiler_asset_emitted_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .build_module
+      .load_js_tap_register(self.register_compilation_build_module_taps.inner.clone())?;
     ctx
       .compilation_hooks
       .still_valid_module
       .load_js_tap_register(
         self
           .register_compilation_still_valid_module_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
-    ctx.compilation_hooks.succeed_module.load_js_tap_register(
-      self
-        .register_compilation_succeed_module_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.execute_module.load_js_tap_register(
-      self
-        .register_compilation_execute_module_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.finish_modules.load_js_tap_register(
-      self
-        .register_compilation_finish_modules_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
+    ctx
+      .compilation_hooks
+      .succeed_module
+      .load_js_tap_register(self.register_compilation_succeed_module_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .execute_module
+      .load_js_tap_register(self.register_compilation_execute_module_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .finish_modules
+      .load_js_tap_register(self.register_compilation_finish_modules_taps.inner.clone())?;
     ctx
       .compilation_hooks
       .optimize_modules
       .load_js_tap_register(
         self
           .register_compilation_optimize_modules_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .compilation_hooks
@@ -186,23 +162,21 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_after_optimize_modules_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
-    ctx.compilation_hooks.optimize_tree.load_js_tap_register(
-      self
-        .register_compilation_optimize_tree_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
+    ctx
+      .compilation_hooks
+      .optimize_tree
+      .load_js_tap_register(self.register_compilation_optimize_tree_taps.inner.clone())?;
     ctx
       .compilation_hooks
       .optimize_chunk_modules
       .load_js_tap_register(
         self
           .register_compilation_optimize_chunk_modules_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .compilation_hooks
@@ -210,8 +184,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_before_module_ids_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .compilation_hooks
@@ -219,8 +193,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_additional_tree_runtime_requirements_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .compilation_hooks
@@ -228,54 +202,42 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_compilation_runtime_requirement_in_tree_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
-    ctx.compilation_hooks.runtime_module.load_js_tap_register(
-      self
-        .register_compilation_runtime_module_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.chunk_hash.load_js_tap_register(
-      self
-        .register_compilation_chunk_hash_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.chunk_asset.load_js_tap_register(
-      self
-        .register_compilation_chunk_asset_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.process_assets.load_js_tap_register(
-      self
-        .register_compilation_process_assets_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
+    ctx
+      .compilation_hooks
+      .runtime_module
+      .load_js_tap_register(self.register_compilation_runtime_module_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .chunk_hash
+      .load_js_tap_register(self.register_compilation_chunk_hash_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .chunk_asset
+      .load_js_tap_register(self.register_compilation_chunk_asset_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .process_assets
+      .load_js_tap_register(self.register_compilation_process_assets_taps.inner.clone())?;
     ctx
       .compilation_hooks
       .after_process_assets
       .load_js_tap_register(
         self
           .register_compilation_after_process_assets_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
-    ctx.compilation_hooks.seal.load_js_tap_register(
-      self
-        .register_compilation_seal_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
-    ctx.compilation_hooks.after_seal.load_js_tap_register(
-      self
-        .register_compilation_after_seal_taps
-        .clone()
-        .into_js_tap_register(),
-    )?;
+    ctx
+      .compilation_hooks
+      .seal
+      .load_js_tap_register(self.register_compilation_seal_taps.inner.clone())?;
+    ctx
+      .compilation_hooks
+      .after_seal
+      .load_js_tap_register(self.register_compilation_after_seal_taps.inner.clone())?;
 
     ctx
       .normal_module_factory_hooks
@@ -283,8 +245,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_before_resolve_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -292,8 +254,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_factorize_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -301,8 +263,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_resolve_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -310,8 +272,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_resolve_for_scheme_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -319,8 +281,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_after_resolve_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .normal_module_factory_hooks
@@ -328,8 +290,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_normal_module_factory_create_module_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .context_module_factory_hooks
@@ -337,8 +299,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_context_module_factory_before_resolve_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
     ctx
       .context_module_factory_hooks
@@ -346,8 +308,8 @@ impl Plugin for JsHooksAdapterPlugin {
       .load_js_tap_register(
         self
           .register_context_module_factory_after_resolve_taps
-          .clone()
-          .into_js_tap_register(),
+          .inner
+          .clone(),
       )?;
 
     ctx
@@ -497,8 +459,8 @@ async fn js_hooks_adapter_compilation(
   hooks.chunk_hash.load_js_tap_register(
     self
       .register_javascript_modules_chunk_hash_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
 
   Ok(())
@@ -515,39 +477,33 @@ async fn html_hooks_adapter_compilation(
   hooks.before_asset_tag_generation.load_js_tap_register(
     self
       .register_html_plugin_before_asset_tag_generation_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
   hooks.alter_asset_tags.load_js_tap_register(
     self
       .register_html_plugin_alter_asset_tags_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
   hooks.alter_asset_tag_groups.load_js_tap_register(
     self
       .register_html_plugin_alter_asset_tag_groups_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
   hooks.after_template_execution.load_js_tap_register(
     self
       .register_html_plugin_after_template_execution_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
-  hooks.before_emit.load_js_tap_register(
-    self
-      .register_html_plugin_before_emit_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
-  hooks.after_emit.load_js_tap_register(
-    self
-      .register_html_plugin_after_emit_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
+  hooks
+    .before_emit
+    .load_js_tap_register(self.register_html_plugin_before_emit_taps.inner.clone())?;
+  hooks
+    .after_emit
+    .load_js_tap_register(self.register_html_plugin_after_emit_taps.inner.clone())?;
 
   Ok(())
 }
@@ -563,26 +519,20 @@ async fn runtime_hooks_adapter_compilation(
   hooks.create_script.load_js_tap_register(
     self
       .register_runtime_plugin_create_script_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
-  hooks.create_link.load_js_tap_register(
-    self
-      .register_runtime_plugin_create_link_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
-  hooks.link_preload.load_js_tap_register(
-    self
-      .register_runtime_plugin_link_preload_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
+  hooks
+    .create_link
+    .load_js_tap_register(self.register_runtime_plugin_create_link_taps.inner.clone())?;
+  hooks
+    .link_preload
+    .load_js_tap_register(self.register_runtime_plugin_link_preload_taps.inner.clone())?;
   hooks.link_prefetch.load_js_tap_register(
     self
       .register_runtime_plugin_link_prefetch_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
   Ok(())
 }
@@ -598,32 +548,23 @@ async fn rsdoctor_hooks_adapter_compilation(
   hooks.module_graph.load_js_tap_register(
     self
       .register_rsdoctor_plugin_module_graph_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
-  hooks.chunk_graph.load_js_tap_register(
-    self
-      .register_rsdoctor_plugin_chunk_graph_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
-  hooks.assets.load_js_tap_register(
-    self
-      .register_rsdoctor_plugin_assets_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
-  hooks.module_ids.load_js_tap_register(
-    self
-      .register_rsdoctor_plugin_module_ids_taps
-      .clone()
-      .into_js_tap_register(),
-  )?;
+  hooks
+    .chunk_graph
+    .load_js_tap_register(self.register_rsdoctor_plugin_chunk_graph_taps.inner.clone())?;
+  hooks
+    .assets
+    .load_js_tap_register(self.register_rsdoctor_plugin_assets_taps.inner.clone())?;
+  hooks
+    .module_ids
+    .load_js_tap_register(self.register_rsdoctor_plugin_module_ids_taps.inner.clone())?;
   hooks.module_sources.load_js_tap_register(
     self
       .register_rsdoctor_plugin_module_sources_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
 
   Ok(())
@@ -640,8 +581,8 @@ async fn real_content_hash_hooks_adapter_compilation(
   hooks.update_hash.load_js_tap_register(
     self
       .register_real_content_hash_plugin_update_hash_taps
-      .clone()
-      .into_js_tap_register(),
+      .inner
+      .clone(),
   )?;
   Ok(())
 }

--- a/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
+++ b/crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs
@@ -18,7 +18,6 @@ use super::interceptor::*;
 #[plugin]
 #[derive(Clone)]
 pub struct JsHooksAdapterPlugin {
-  non_skippable_registers: NonSkippableRegisters,
   register_compiler_this_compilation_taps: RegisterCompilerThisCompilationTaps,
   register_compiler_compilation_taps: RegisterCompilerCompilationTaps,
   register_compiler_make_taps: RegisterCompilerMakeTaps,
@@ -91,163 +90,265 @@ impl Plugin for JsHooksAdapterPlugin {
 
   // #[tracing::instrument("js_hooks_adapter::apply", skip_all)]
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> rspack_error::Result<()> {
-    ctx
-      .compiler_hooks
-      .this_compilation
-      .intercept(self.register_compiler_this_compilation_taps.clone());
-    ctx
-      .compiler_hooks
-      .compilation
-      .intercept(self.register_compiler_compilation_taps.clone());
-    ctx
-      .compiler_hooks
-      .make
-      .intercept(self.register_compiler_make_taps.clone());
-    ctx
-      .compiler_hooks
-      .finish_make
-      .intercept(self.register_compiler_finish_make_taps.clone());
-    ctx
-      .compiler_hooks
-      .should_emit
-      .intercept(self.register_compiler_should_emit_taps.clone());
-    ctx
-      .compiler_hooks
-      .emit
-      .intercept(self.register_compiler_emit_taps.clone());
-    ctx
-      .compiler_hooks
-      .after_emit
-      .intercept(self.register_compiler_after_emit_taps.clone());
-    ctx
-      .compiler_hooks
-      .asset_emitted
-      .intercept(self.register_compiler_asset_emitted_taps.clone());
-    ctx
-      .compilation_hooks
-      .build_module
-      .intercept(self.register_compilation_build_module_taps.clone());
+    ctx.compiler_hooks.this_compilation.load_js_tap_register(
+      self
+        .register_compiler_this_compilation_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.compilation.load_js_tap_register(
+      self
+        .register_compiler_compilation_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.make.load_js_tap_register(
+      self
+        .register_compiler_make_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.finish_make.load_js_tap_register(
+      self
+        .register_compiler_finish_make_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.should_emit.load_js_tap_register(
+      self
+        .register_compiler_should_emit_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.emit.load_js_tap_register(
+      self
+        .register_compiler_emit_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.after_emit.load_js_tap_register(
+      self
+        .register_compiler_after_emit_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compiler_hooks.asset_emitted.load_js_tap_register(
+      self
+        .register_compiler_asset_emitted_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.build_module.load_js_tap_register(
+      self
+        .register_compilation_build_module_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .still_valid_module
-      .intercept(self.register_compilation_still_valid_module_taps.clone());
-    ctx
-      .compilation_hooks
-      .succeed_module
-      .intercept(self.register_compilation_succeed_module_taps.clone());
-    ctx
-      .compilation_hooks
-      .execute_module
-      .intercept(self.register_compilation_execute_module_taps.clone());
-    ctx
-      .compilation_hooks
-      .finish_modules
-      .intercept(self.register_compilation_finish_modules_taps.clone());
+      .load_js_tap_register(
+        self
+          .register_compilation_still_valid_module_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx.compilation_hooks.succeed_module.load_js_tap_register(
+      self
+        .register_compilation_succeed_module_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.execute_module.load_js_tap_register(
+      self
+        .register_compilation_execute_module_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.finish_modules.load_js_tap_register(
+      self
+        .register_compilation_finish_modules_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .optimize_modules
-      .intercept(self.register_compilation_optimize_modules_taps.clone());
-    ctx.compilation_hooks.after_optimize_modules.intercept(
-      self
-        .register_compilation_after_optimize_modules_taps
-        .clone(),
-    );
+      .load_js_tap_register(
+        self
+          .register_compilation_optimize_modules_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .compilation_hooks
-      .optimize_tree
-      .intercept(self.register_compilation_optimize_tree_taps.clone());
-    ctx.compilation_hooks.optimize_chunk_modules.intercept(
+      .after_optimize_modules
+      .load_js_tap_register(
+        self
+          .register_compilation_after_optimize_modules_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx.compilation_hooks.optimize_tree.load_js_tap_register(
       self
-        .register_compilation_optimize_chunk_modules_taps
-        .clone(),
-    );
+        .register_compilation_optimize_tree_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx
+      .compilation_hooks
+      .optimize_chunk_modules
+      .load_js_tap_register(
+        self
+          .register_compilation_optimize_chunk_modules_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .compilation_hooks
       .before_module_ids
-      .intercept(self.register_compilation_before_module_ids_taps.clone());
+      .load_js_tap_register(
+        self
+          .register_compilation_before_module_ids_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .compilation_hooks
       .additional_tree_runtime_requirements
-      .intercept(
+      .load_js_tap_register(
         self
           .register_compilation_additional_tree_runtime_requirements_taps
-          .clone(),
-      );
-    ctx.compilation_hooks.runtime_requirement_in_tree.intercept(
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx
+      .compilation_hooks
+      .runtime_requirement_in_tree
+      .load_js_tap_register(
+        self
+          .register_compilation_runtime_requirement_in_tree_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx.compilation_hooks.runtime_module.load_js_tap_register(
       self
-        .register_compilation_runtime_requirement_in_tree_taps
-        .clone(),
-    );
-    ctx
-      .compilation_hooks
-      .runtime_module
-      .intercept(self.register_compilation_runtime_module_taps.clone());
-    ctx
-      .compilation_hooks
-      .chunk_hash
-      .intercept(self.register_compilation_chunk_hash_taps.clone());
-    ctx
-      .compilation_hooks
-      .chunk_asset
-      .intercept(self.register_compilation_chunk_asset_taps.clone());
-    ctx
-      .compilation_hooks
-      .process_assets
-      .intercept(self.register_compilation_process_assets_taps.clone());
+        .register_compilation_runtime_module_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.chunk_hash.load_js_tap_register(
+      self
+        .register_compilation_chunk_hash_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.chunk_asset.load_js_tap_register(
+      self
+        .register_compilation_chunk_asset_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.process_assets.load_js_tap_register(
+      self
+        .register_compilation_process_assets_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
     ctx
       .compilation_hooks
       .after_process_assets
-      .intercept(self.register_compilation_after_process_assets_taps.clone());
-    ctx
-      .compilation_hooks
-      .seal
-      .intercept(self.register_compilation_seal_taps.clone());
-    ctx
-      .compilation_hooks
-      .after_seal
-      .intercept(self.register_compilation_after_seal_taps.clone());
-
-    ctx.normal_module_factory_hooks.before_resolve.intercept(
+      .load_js_tap_register(
+        self
+          .register_compilation_after_process_assets_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx.compilation_hooks.seal.load_js_tap_register(
       self
-        .register_normal_module_factory_before_resolve_taps
-        .clone(),
-    );
+        .register_compilation_seal_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+    ctx.compilation_hooks.after_seal.load_js_tap_register(
+      self
+        .register_compilation_after_seal_taps
+        .clone()
+        .into_js_tap_register(),
+    )?;
+
+    ctx
+      .normal_module_factory_hooks
+      .before_resolve
+      .load_js_tap_register(
+        self
+          .register_normal_module_factory_before_resolve_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .normal_module_factory_hooks
       .factorize
-      .intercept(self.register_normal_module_factory_factorize_taps.clone());
+      .load_js_tap_register(
+        self
+          .register_normal_module_factory_factorize_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .normal_module_factory_hooks
       .resolve
-      .intercept(self.register_normal_module_factory_resolve_taps.clone());
+      .load_js_tap_register(
+        self
+          .register_normal_module_factory_resolve_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
     ctx
       .normal_module_factory_hooks
       .resolve_for_scheme
-      .intercept(
+      .load_js_tap_register(
         self
           .register_normal_module_factory_resolve_for_scheme_taps
-          .clone(),
-      );
-    ctx.normal_module_factory_hooks.after_resolve.intercept(
-      self
-        .register_normal_module_factory_after_resolve_taps
-        .clone(),
-    );
-    ctx.normal_module_factory_hooks.create_module.intercept(
-      self
-        .register_normal_module_factory_create_module_taps
-        .clone(),
-    );
-    ctx.context_module_factory_hooks.before_resolve.intercept(
-      self
-        .register_context_module_factory_before_resolve_taps
-        .clone(),
-    );
-    ctx.context_module_factory_hooks.after_resolve.intercept(
-      self
-        .register_context_module_factory_after_resolve_taps
-        .clone(),
-    );
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx
+      .normal_module_factory_hooks
+      .after_resolve
+      .load_js_tap_register(
+        self
+          .register_normal_module_factory_after_resolve_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx
+      .normal_module_factory_hooks
+      .create_module
+      .load_js_tap_register(
+        self
+          .register_normal_module_factory_create_module_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx
+      .context_module_factory_hooks
+      .before_resolve
+      .load_js_tap_register(
+        self
+          .register_context_module_factory_before_resolve_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
+    ctx
+      .context_module_factory_hooks
+      .after_resolve
+      .load_js_tap_register(
+        self
+          .register_context_module_factory_after_resolve_taps
+          .clone()
+          .into_js_tap_register(),
+      )?;
 
     ctx
       .compiler_hooks
@@ -393,9 +494,12 @@ async fn js_hooks_adapter_compilation(
 ) -> rspack_error::Result<()> {
   let hooks = JsPlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.write().await;
-  hooks
-    .chunk_hash
-    .intercept(self.register_javascript_modules_chunk_hash_taps.clone());
+  hooks.chunk_hash.load_js_tap_register(
+    self
+      .register_javascript_modules_chunk_hash_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
 
   Ok(())
 }
@@ -408,30 +512,42 @@ async fn html_hooks_adapter_compilation(
 ) -> rspack_error::Result<()> {
   let hooks = HtmlRspackPlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.borrow_mut();
-  hooks.before_asset_tag_generation.intercept(
+  hooks.before_asset_tag_generation.load_js_tap_register(
     self
       .register_html_plugin_before_asset_tag_generation_taps
-      .clone(),
-  );
-  hooks
-    .alter_asset_tags
-    .intercept(self.register_html_plugin_alter_asset_tags_taps.clone());
-  hooks.alter_asset_tag_groups.intercept(
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.alter_asset_tags.load_js_tap_register(
+    self
+      .register_html_plugin_alter_asset_tags_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.alter_asset_tag_groups.load_js_tap_register(
     self
       .register_html_plugin_alter_asset_tag_groups_taps
-      .clone(),
-  );
-  hooks.after_template_execution.intercept(
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.after_template_execution.load_js_tap_register(
     self
       .register_html_plugin_after_template_execution_taps
-      .clone(),
-  );
-  hooks
-    .before_emit
-    .intercept(self.register_html_plugin_before_emit_taps.clone());
-  hooks
-    .after_emit
-    .intercept(self.register_html_plugin_after_emit_taps.clone());
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.before_emit.load_js_tap_register(
+    self
+      .register_html_plugin_before_emit_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.after_emit.load_js_tap_register(
+    self
+      .register_html_plugin_after_emit_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
 
   Ok(())
 }
@@ -444,18 +560,30 @@ async fn runtime_hooks_adapter_compilation(
 ) -> rspack_error::Result<()> {
   let hooks = RuntimePlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.borrow_mut();
-  hooks
-    .create_script
-    .intercept(self.register_runtime_plugin_create_script_taps.clone());
-  hooks
-    .create_link
-    .intercept(self.register_runtime_plugin_create_link_taps.clone());
-  hooks
-    .link_preload
-    .intercept(self.register_runtime_plugin_link_preload_taps.clone());
-  hooks
-    .link_prefetch
-    .intercept(self.register_runtime_plugin_link_prefetch_taps.clone());
+  hooks.create_script.load_js_tap_register(
+    self
+      .register_runtime_plugin_create_script_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.create_link.load_js_tap_register(
+    self
+      .register_runtime_plugin_create_link_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.link_preload.load_js_tap_register(
+    self
+      .register_runtime_plugin_link_preload_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.link_prefetch.load_js_tap_register(
+    self
+      .register_runtime_plugin_link_prefetch_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
   Ok(())
 }
 
@@ -467,21 +595,36 @@ async fn rsdoctor_hooks_adapter_compilation(
 ) -> rspack_error::Result<()> {
   let hooks = RsdoctorPlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.borrow_mut();
-  hooks
-    .module_graph
-    .intercept(self.register_rsdoctor_plugin_module_graph_taps.clone());
-  hooks
-    .chunk_graph
-    .intercept(self.register_rsdoctor_plugin_chunk_graph_taps.clone());
-  hooks
-    .assets
-    .intercept(self.register_rsdoctor_plugin_assets_taps.clone());
-  hooks
-    .module_ids
-    .intercept(self.register_rsdoctor_plugin_module_ids_taps.clone());
-  hooks
-    .module_sources
-    .intercept(self.register_rsdoctor_plugin_module_sources_taps.clone());
+  hooks.module_graph.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_module_graph_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.chunk_graph.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_chunk_graph_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.assets.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_assets_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.module_ids.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_module_ids_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
+  hooks.module_sources.load_js_tap_register(
+    self
+      .register_rsdoctor_plugin_module_sources_taps
+      .clone()
+      .into_js_tap_register(),
+  )?;
 
   Ok(())
 }
@@ -494,253 +637,357 @@ async fn real_content_hash_hooks_adapter_compilation(
 ) -> rspack_error::Result<()> {
   let hooks = RealContentHashPlugin::get_compilation_hooks_mut(compilation.id());
   let mut hooks = hooks.borrow_mut();
-  hooks.update_hash.intercept(
+  hooks.update_hash.load_js_tap_register(
     self
       .register_real_content_hash_plugin_update_hash_taps
-      .clone(),
-  );
+      .clone()
+      .into_js_tap_register(),
+  )?;
   Ok(())
 }
 
 impl JsHooksAdapterPlugin {
   /// The `_env` parameter ensures this function is called on the JS main thread.
   pub fn from_js_hooks(_env: &Env, register_js_taps: RegisterJsTaps) -> Result<Self> {
-    let non_skippable_registers = NonSkippableRegisters::default();
     Ok(JsHooksAdapterPlugin {
       inner: JsHooksAdapterPluginInner {
         register_compiler_this_compilation_taps: RegisterCompilerThisCompilationTaps::new(
           register_js_taps.register_compiler_this_compilation_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_compilation_taps: RegisterCompilerCompilationTaps::new(
           register_js_taps.register_compiler_compilation_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_make_taps: RegisterCompilerMakeTaps::new(
           register_js_taps.register_compiler_make_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_finish_make_taps: RegisterCompilerFinishMakeTaps::new(
           register_js_taps.register_compiler_finish_make_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_should_emit_taps: RegisterCompilerShouldEmitTaps::new(
           register_js_taps.register_compiler_should_emit_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_emit_taps: RegisterCompilerEmitTaps::new(
           register_js_taps.register_compiler_emit_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_after_emit_taps: RegisterCompilerAfterEmitTaps::new(
           register_js_taps.register_compiler_after_emit_taps,
-          non_skippable_registers.clone(),
         ),
         register_compiler_asset_emitted_taps: RegisterCompilerAssetEmittedTaps::new(
           register_js_taps.register_compiler_asset_emitted_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_build_module_taps: RegisterCompilationBuildModuleTaps::new(
           register_js_taps.register_compilation_build_module_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_still_valid_module_taps: RegisterCompilationStillValidModuleTaps::new(
           register_js_taps.register_compilation_still_valid_module_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_succeed_module_taps: RegisterCompilationSucceedModuleTaps::new(
           register_js_taps.register_compilation_succeed_module_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_execute_module_taps: RegisterCompilationExecuteModuleTaps::new(
           register_js_taps.register_compilation_execute_module_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_finish_modules_taps: RegisterCompilationFinishModulesTaps::new(
           register_js_taps.register_compilation_finish_modules_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_optimize_modules_taps: RegisterCompilationOptimizeModulesTaps::new(
           register_js_taps.register_compilation_optimize_modules_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_after_optimize_modules_taps:
           RegisterCompilationAfterOptimizeModulesTaps::new(
             register_js_taps.register_compilation_after_optimize_modules_taps,
-            non_skippable_registers.clone(),
           ),
         register_compilation_optimize_tree_taps: RegisterCompilationOptimizeTreeTaps::new(
           register_js_taps.register_compilation_optimize_tree_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_optimize_chunk_modules_taps:
           RegisterCompilationOptimizeChunkModulesTaps::new(
             register_js_taps.register_compilation_optimize_chunk_modules_taps,
-            non_skippable_registers.clone(),
           ),
         register_compilation_before_module_ids_taps: RegisterCompilationBeforeModuleIdsTaps::new(
           register_js_taps.register_compilation_before_module_ids_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_additional_tree_runtime_requirements_taps:
           RegisterCompilationAdditionalTreeRuntimeRequirementsTaps::new(
             register_js_taps.register_compilation_additional_tree_runtime_requirements_taps,
-            non_skippable_registers.clone(),
           ),
         register_compilation_runtime_requirement_in_tree_taps:
           RegisterCompilationRuntimeRequirementInTreeTaps::new(
             register_js_taps.register_compilation_runtime_requirement_in_tree_taps,
-            non_skippable_registers.clone(),
           ),
         register_compilation_runtime_module_taps: RegisterCompilationRuntimeModuleTaps::new(
           register_js_taps.register_compilation_runtime_module_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_chunk_hash_taps: RegisterCompilationChunkHashTaps::new(
           register_js_taps.register_compilation_chunk_hash_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_chunk_asset_taps: RegisterCompilationChunkAssetTaps::new(
           register_js_taps.register_compilation_chunk_asset_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_process_assets_taps: RegisterCompilationProcessAssetsTaps::new(
           register_js_taps.register_compilation_process_assets_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_after_process_assets_taps:
           RegisterCompilationAfterProcessAssetsTaps::new(
             register_js_taps.register_compilation_after_process_assets_taps,
-            non_skippable_registers.clone(),
           ),
         register_compilation_seal_taps: RegisterCompilationSealTaps::new(
           register_js_taps.register_compilation_seal_taps,
-          non_skippable_registers.clone(),
         ),
         register_compilation_after_seal_taps: RegisterCompilationAfterSealTaps::new(
           register_js_taps.register_compilation_after_seal_taps,
-          non_skippable_registers.clone(),
         ),
         register_normal_module_factory_before_resolve_taps:
           RegisterNormalModuleFactoryBeforeResolveTaps::new(
             register_js_taps.register_normal_module_factory_before_resolve_taps,
-            non_skippable_registers.clone(),
           ),
         register_normal_module_factory_factorize_taps:
           RegisterNormalModuleFactoryFactorizeTaps::new(
             register_js_taps.register_normal_module_factory_factorize_taps,
-            non_skippable_registers.clone(),
           ),
         register_normal_module_factory_resolve_taps: RegisterNormalModuleFactoryResolveTaps::new(
           register_js_taps.register_normal_module_factory_resolve_taps,
-          non_skippable_registers.clone(),
         ),
         register_normal_module_factory_resolve_for_scheme_taps:
           RegisterNormalModuleFactoryResolveForSchemeTaps::new(
             register_js_taps.register_normal_module_factory_resolve_for_scheme_taps,
-            non_skippable_registers.clone(),
           ),
         register_normal_module_factory_after_resolve_taps:
           RegisterNormalModuleFactoryAfterResolveTaps::new(
             register_js_taps.register_normal_module_factory_after_resolve_taps,
-            non_skippable_registers.clone(),
           ),
         register_normal_module_factory_create_module_taps:
           RegisterNormalModuleFactoryCreateModuleTaps::new(
             register_js_taps.register_normal_module_factory_create_module_taps,
-            non_skippable_registers.clone(),
           ),
         register_context_module_factory_before_resolve_taps:
           RegisterContextModuleFactoryBeforeResolveTaps::new(
             register_js_taps.register_context_module_factory_before_resolve_taps,
-            non_skippable_registers.clone(),
           ),
         register_context_module_factory_after_resolve_taps:
           RegisterContextModuleFactoryAfterResolveTaps::new(
             register_js_taps.register_context_module_factory_after_resolve_taps,
-            non_skippable_registers.clone(),
           ),
         register_javascript_modules_chunk_hash_taps: RegisterJavascriptModulesChunkHashTaps::new(
           register_js_taps.register_javascript_modules_chunk_hash_taps,
-          non_skippable_registers.clone(),
         ),
         register_html_plugin_before_asset_tag_generation_taps:
           RegisterHtmlPluginBeforeAssetTagGenerationTaps::new(
             register_js_taps.register_html_plugin_before_asset_tag_generation_taps,
-            non_skippable_registers.clone(),
           ),
         register_html_plugin_alter_asset_tags_taps: RegisterHtmlPluginAlterAssetTagsTaps::new(
           register_js_taps.register_html_plugin_alter_asset_tags_taps,
-          non_skippable_registers.clone(),
         ),
         register_html_plugin_alter_asset_tag_groups_taps:
           RegisterHtmlPluginAlterAssetTagGroupsTaps::new(
             register_js_taps.register_html_plugin_alter_asset_tag_groups_taps,
-            non_skippable_registers.clone(),
           ),
         register_html_plugin_after_template_execution_taps:
           RegisterHtmlPluginAfterTemplateExecutionTaps::new(
             register_js_taps.register_html_plugin_after_template_execution_taps,
-            non_skippable_registers.clone(),
           ),
         register_html_plugin_before_emit_taps: RegisterHtmlPluginBeforeEmitTaps::new(
           register_js_taps.register_html_plugin_before_emit_taps,
-          non_skippable_registers.clone(),
         ),
         register_html_plugin_after_emit_taps: RegisterHtmlPluginAfterEmitTaps::new(
           register_js_taps.register_html_plugin_after_emit_taps,
-          non_skippable_registers.clone(),
         ),
         register_runtime_plugin_create_script_taps: RegisterRuntimePluginCreateScriptTaps::new(
           register_js_taps.register_runtime_plugin_create_script_taps,
-          non_skippable_registers.clone(),
         ),
         register_runtime_plugin_create_link_taps: RegisterRuntimePluginCreateLinkTaps::new(
           register_js_taps.register_runtime_plugin_create_link_taps,
-          non_skippable_registers.clone(),
         ),
         register_runtime_plugin_link_preload_taps: RegisterRuntimePluginLinkPreloadTaps::new(
           register_js_taps.register_runtime_plugin_link_preload_taps,
-          non_skippable_registers.clone(),
         ),
         register_runtime_plugin_link_prefetch_taps: RegisterRuntimePluginLinkPrefetchTaps::new(
           register_js_taps.register_runtime_plugin_link_prefetch_taps,
-          non_skippable_registers.clone(),
         ),
         register_real_content_hash_plugin_update_hash_taps:
           RegisterRealContentHashPluginUpdateHashTaps::new(
             register_js_taps.register_real_content_hash_plugin_update_hash_taps,
-            non_skippable_registers.clone(),
           ),
         register_rsdoctor_plugin_module_graph_taps: RegisterRsdoctorPluginModuleGraphTaps::new(
           register_js_taps.register_rsdoctor_plugin_module_graph_taps,
-          non_skippable_registers.clone(),
         ),
         register_rsdoctor_plugin_chunk_graph_taps: RegisterRsdoctorPluginChunkGraphTaps::new(
           register_js_taps.register_rsdoctor_plugin_chunk_graph_taps,
-          non_skippable_registers.clone(),
         ),
         register_rsdoctor_plugin_assets_taps: RegisterRsdoctorPluginAssetsTaps::new(
           register_js_taps.register_rsdoctor_plugin_assets_taps,
-          non_skippable_registers.clone(),
         ),
         register_rsdoctor_plugin_module_ids_taps: RegisterRsdoctorPluginModuleIdsTaps::new(
           register_js_taps.register_rsdoctor_plugin_module_ids_taps,
-          non_skippable_registers.clone(),
         ),
         register_rsdoctor_plugin_module_sources_taps: RegisterRsdoctorPluginModuleSourcesTaps::new(
           register_js_taps.register_rsdoctor_plugin_module_sources_taps,
-          non_skippable_registers.clone(),
         ),
-        non_skippable_registers,
       }
       .into(),
     })
   }
 
   pub fn set_non_skippable_registers(&self, kinds: Vec<RegisterJsTapKind>) {
-    self
-      .non_skippable_registers
-      .set_non_skippable_registers(kinds);
+    for kind in RegisterJsTapKind::ALL {
+      self.set_register_js_tap_count(*kind, usize::from(kinds.contains(kind)));
+    }
+  }
+
+  pub fn set_register_js_tap_count(&self, kind: RegisterJsTapKind, tap_count: usize) {
+    match kind {
+      RegisterJsTapKind::CompilerThisCompilation => self
+        .register_compiler_this_compilation_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerCompilation => self
+        .register_compiler_compilation_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerMake => self.register_compiler_make_taps.set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerFinishMake => self
+        .register_compiler_finish_make_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerShouldEmit => self
+        .register_compiler_should_emit_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerEmit => self.register_compiler_emit_taps.set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerAfterEmit => self
+        .register_compiler_after_emit_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilerAssetEmitted => self
+        .register_compiler_asset_emitted_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationBuildModule => self
+        .register_compilation_build_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationStillValidModule => self
+        .register_compilation_still_valid_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationSucceedModule => self
+        .register_compilation_succeed_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationExecuteModule => self
+        .register_compilation_execute_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationFinishModules => self
+        .register_compilation_finish_modules_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationOptimizeModules => self
+        .register_compilation_optimize_modules_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationAfterOptimizeModules => self
+        .register_compilation_after_optimize_modules_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationOptimizeTree => self
+        .register_compilation_optimize_tree_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationOptimizeChunkModules => self
+        .register_compilation_optimize_chunk_modules_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationBeforeModuleIds => self
+        .register_compilation_before_module_ids_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationAdditionalTreeRuntimeRequirements => self
+        .register_compilation_additional_tree_runtime_requirements_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationRuntimeRequirementInTree => self
+        .register_compilation_runtime_requirement_in_tree_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationRuntimeModule => self
+        .register_compilation_runtime_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationChunkHash => self
+        .register_compilation_chunk_hash_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationChunkAsset => self
+        .register_compilation_chunk_asset_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationProcessAssets => self
+        .register_compilation_process_assets_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationAfterProcessAssets => self
+        .register_compilation_after_process_assets_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::CompilationSeal => {
+        self.register_compilation_seal_taps.set_tap_count(tap_count)
+      }
+      RegisterJsTapKind::CompilationAfterSeal => self
+        .register_compilation_after_seal_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryBeforeResolve => self
+        .register_normal_module_factory_before_resolve_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryFactorize => self
+        .register_normal_module_factory_factorize_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryResolve => self
+        .register_normal_module_factory_resolve_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryAfterResolve => self
+        .register_normal_module_factory_after_resolve_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryCreateModule => self
+        .register_normal_module_factory_create_module_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::NormalModuleFactoryResolveForScheme => self
+        .register_normal_module_factory_resolve_for_scheme_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::ContextModuleFactoryBeforeResolve => self
+        .register_context_module_factory_before_resolve_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::ContextModuleFactoryAfterResolve => self
+        .register_context_module_factory_after_resolve_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::JavascriptModulesChunkHash => self
+        .register_javascript_modules_chunk_hash_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginBeforeAssetTagGeneration => self
+        .register_html_plugin_before_asset_tag_generation_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginAlterAssetTags => self
+        .register_html_plugin_alter_asset_tags_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginAlterAssetTagGroups => self
+        .register_html_plugin_alter_asset_tag_groups_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginAfterTemplateExecution => self
+        .register_html_plugin_after_template_execution_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginBeforeEmit => self
+        .register_html_plugin_before_emit_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::HtmlPluginAfterEmit => self
+        .register_html_plugin_after_emit_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RuntimePluginCreateScript => self
+        .register_runtime_plugin_create_script_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RuntimePluginCreateLink => self
+        .register_runtime_plugin_create_link_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RuntimePluginLinkPreload => self
+        .register_runtime_plugin_link_preload_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RuntimePluginLinkPrefetch => self
+        .register_runtime_plugin_link_prefetch_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RealContentHashPluginUpdateHash => self
+        .register_real_content_hash_plugin_update_hash_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RsdoctorPluginModuleGraph => self
+        .register_rsdoctor_plugin_module_graph_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RsdoctorPluginChunkGraph => self
+        .register_rsdoctor_plugin_chunk_graph_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RsdoctorPluginModuleIds => self
+        .register_rsdoctor_plugin_module_ids_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RsdoctorPluginModuleSources => self
+        .register_rsdoctor_plugin_module_sources_taps
+        .set_tap_count(tap_count),
+      RegisterJsTapKind::RsdoctorPluginAssets => self
+        .register_rsdoctor_plugin_assets_taps
+        .set_tap_count(tap_count),
+    }
   }
 }

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -1,5 +1,157 @@
+use std::{
+  any::{Any, TypeId},
+  future::Future,
+  pin::Pin,
+  sync::Arc,
+};
+
 use async_trait::async_trait;
-use rspack_error::Result;
+use rspack_error::{Result, error};
+
+type ErasedJsTapRegisterOwner = Arc<dyn Any + Send + Sync>;
+#[doc(hidden)]
+pub type ErasedJsTap = Box<dyn Any + Send + Sync>;
+type AsyncJsTapRegisterFn = Box<
+  dyn Fn(
+      ErasedJsTapRegisterOwner,
+      Vec<i32>,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ErasedJsTap>>> + Send>>
+    + Send
+    + Sync,
+>;
+type BlockingJsTapRegisterFn =
+  Box<dyn Fn(ErasedJsTapRegisterOwner, Vec<i32>) -> Result<Vec<ErasedJsTap>> + Send + Sync>;
+type LoadJsTapCountFn = Box<dyn Fn(&dyn Any) -> usize + Send + Sync>;
+
+enum JsTapRegisterFn {
+  Async(AsyncJsTapRegisterFn),
+  Blocking(BlockingJsTapRegisterFn),
+}
+
+pub struct JsTapRegister {
+  owner: ErasedJsTapRegisterOwner,
+  tap_type_id: TypeId,
+  load_tap_count: LoadJsTapCountFn,
+  function: JsTapRegisterFn,
+}
+
+impl JsTapRegister {
+  pub fn new_async<O, T, F, Fut>(
+    owner: Arc<O>,
+    load_tap_count: fn(&O) -> usize,
+    function: F,
+  ) -> Self
+  where
+    O: Any + Send + Sync,
+    T: Any + Send + Sync,
+    F: Fn(Arc<O>, Vec<i32>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<Vec<T>>> + Send + 'static,
+  {
+    Self {
+      owner,
+      tap_type_id: TypeId::of::<T>(),
+      load_tap_count: Box::new(move |owner| {
+        load_tap_count(
+          owner
+            .downcast_ref::<O>()
+            .expect("JsTapRegister owner type should match"),
+        )
+      }),
+      function: JsTapRegisterFn::Async(Box::new(move |owner, stages| {
+        let owner = Arc::downcast::<O>(owner).expect("JsTapRegister owner type should match");
+        let future = function(owner, stages);
+        Box::pin(async move {
+          Ok(
+            future
+              .await?
+              .into_iter()
+              .map(|tap| Box::new(tap) as ErasedJsTap)
+              .collect(),
+          )
+        })
+      })),
+    }
+  }
+
+  pub fn new_blocking<O, T, F>(owner: Arc<O>, load_tap_count: fn(&O) -> usize, function: F) -> Self
+  where
+    O: Any + Send + Sync,
+    T: Any + Send + Sync,
+    F: Fn(Arc<O>, Vec<i32>) -> Result<Vec<T>> + Send + Sync + 'static,
+  {
+    Self {
+      owner,
+      tap_type_id: TypeId::of::<T>(),
+      load_tap_count: Box::new(move |owner| {
+        load_tap_count(
+          owner
+            .downcast_ref::<O>()
+            .expect("JsTapRegister owner type should match"),
+        )
+      }),
+      function: JsTapRegisterFn::Blocking(Box::new(move |owner, stages| {
+        Ok(
+          function(
+            Arc::downcast::<O>(owner).expect("JsTapRegister owner type should match"),
+            stages,
+          )?
+          .into_iter()
+          .map(|tap| Box::new(tap) as ErasedJsTap)
+          .collect(),
+        )
+      })),
+    }
+  }
+
+  fn tap_count(&self) -> usize {
+    (self.load_tap_count)(self.owner.as_ref())
+  }
+
+  fn is_empty(&self) -> bool {
+    self.tap_count() == 0
+  }
+
+  fn has_tap_type<T: Any>(&self) -> bool {
+    self.tap_type_id == TypeId::of::<T>()
+  }
+
+  async fn call(&self, stages: Vec<i32>) -> Result<Vec<ErasedJsTap>> {
+    match &self.function {
+      JsTapRegisterFn::Async(function) => function(self.owner.clone(), stages).await,
+      JsTapRegisterFn::Blocking(_) => Err(error!(
+        "blocking JS tap register cannot be called from an async hook"
+      )),
+    }
+  }
+
+  fn call_blocking(&self, stages: Vec<i32>) -> Result<Vec<ErasedJsTap>> {
+    match &self.function {
+      JsTapRegisterFn::Async(_) => Err(error!(
+        "async JS tap register cannot be called from a blocking hook"
+      )),
+      JsTapRegisterFn::Blocking(function) => function(self.owner.clone(), stages),
+    }
+  }
+}
+
+pub fn unerase_js_taps<T: Any>(taps: Vec<ErasedJsTap>) -> Result<Vec<T>> {
+  taps
+    .into_iter()
+    .map(|tap| {
+      tap
+        .downcast::<T>()
+        .map(|tap| *tap)
+        .map_err(|_| error!("JS tap register returned an unexpected tap type"))
+    })
+    .collect()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookCallMode {
+  Empty,
+  RustTaps,
+  AdditionalTaps,
+}
 
 pub struct HookMetadata {
   pub name: &'static str,
@@ -9,6 +161,7 @@ pub struct HookCommon {
   metadata: HookMetadata,
   tap_stages: Vec<i32>,
   interceptor_count: usize,
+  js_tap_register: Option<JsTapRegister>,
 }
 
 impl HookCommon {
@@ -17,6 +170,7 @@ impl HookCommon {
       metadata: HookMetadata { name },
       tap_stages: Vec::new(),
       interceptor_count: 0,
+      js_tap_register: None,
     }
   }
 
@@ -51,8 +205,66 @@ impl HookCommon {
     used_stages
   }
 
+  pub fn load_js_tap_register<T: Any>(&mut self, register: JsTapRegister) -> Result<()> {
+    if self.js_tap_register.is_some() {
+      return Err(error!(
+        "JS tap register for hook {} has already been loaded",
+        self.name()
+      ));
+    }
+    if !register.has_tap_type::<T>() {
+      return Err(error!(
+        "JS tap register type does not match hook {}",
+        self.name()
+      ));
+    }
+    self.js_tap_register = Some(register);
+    Ok(())
+  }
+
+  pub fn has_js_taps(&self) -> bool {
+    self
+      .js_tap_register
+      .as_ref()
+      .is_some_and(|register| !register.is_empty())
+  }
+
   pub fn is_empty(&self) -> bool {
-    self.tap_stages.is_empty() && self.interceptor_count == 0
+    self.tap_stages.is_empty() && self.interceptor_count == 0 && !self.has_js_taps()
+  }
+
+  pub fn call_mode(&self) -> HookCallMode {
+    let has_js_taps = self.has_js_taps();
+    if self.tap_stages.is_empty() && self.interceptor_count == 0 && !has_js_taps {
+      HookCallMode::Empty
+    } else if self.interceptor_count == 0 && !has_js_taps {
+      HookCallMode::RustTaps
+    } else {
+      HookCallMode::AdditionalTaps
+    }
+  }
+
+  pub async fn call_js_tap_register(&self) -> Result<Vec<ErasedJsTap>> {
+    if !self.has_js_taps() {
+      return Ok(Vec::new());
+    }
+    self
+      .js_tap_register
+      .as_ref()
+      .expect("JS tap register should exist when JS taps are present")
+      .call(self.used_stages())
+      .await
+  }
+
+  pub fn call_js_tap_register_blocking(&self) -> Result<Vec<ErasedJsTap>> {
+    if !self.has_js_taps() {
+      return Ok(Vec::new());
+    }
+    self
+      .js_tap_register
+      .as_ref()
+      .expect("JS tap register should exist when JS taps are present")
+      .call_blocking(self.used_stages())
   }
 }
 
@@ -184,6 +396,12 @@ pub trait Hook {
   type Tap;
 
   fn used_stages(&self) -> Vec<i32>;
+
+  fn load_js_tap_register(&mut self, register: JsTapRegister) -> Result<()>;
+
+  fn has_js_taps(&self) -> bool;
+
+  fn is_empty(&self) -> bool;
 
   fn intercept(&mut self, interceptor: impl Interceptor<Self> + Send + Sync + 'static)
   where

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -1,35 +1,8 @@
-use std::any::Any;
-
 use async_trait::async_trait;
 use rspack_error::Result;
 
-pub struct JsTapRegister {
-  is_empty: Box<dyn Fn() -> bool + Send + Sync>,
-  interceptor: Option<Box<dyn Any + Send + Sync>>,
-}
-
-impl JsTapRegister {
-  pub fn new(
-    is_empty: Box<dyn Fn() -> bool + Send + Sync>,
-    interceptor: Box<dyn Any + Send + Sync>,
-  ) -> Self {
-    Self {
-      is_empty,
-      interceptor: Some(interceptor),
-    }
-  }
-
-  pub fn is_empty(&self) -> bool {
-    (self.is_empty)()
-  }
-
-  #[doc(hidden)]
-  pub fn take_interceptor(&mut self) -> Box<dyn Any + Send + Sync> {
-    self
-      .interceptor
-      .take()
-      .expect("JS tap register interceptor should only be loaded once")
-  }
+pub trait JsTapRegister {
+  fn is_empty(&self) -> bool;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -228,12 +201,30 @@ pub trait Interceptor<H: Hook> {
   }
 }
 
+#[async_trait]
+impl<H, T> Interceptor<H> for std::sync::Arc<T>
+where
+  H: Hook + Sync,
+  T: Interceptor<H> + Send + Sync,
+{
+  async fn call(&self, hook: &H) -> Result<Vec<H::Tap>> {
+    self.as_ref().call(hook).await
+  }
+
+  fn call_blocking(&self, hook: &H) -> Result<Vec<H::Tap>> {
+    self.as_ref().call_blocking(hook)
+  }
+}
+
 pub trait Hook {
   type Tap;
 
   fn used_stages(&self) -> Vec<i32>;
 
-  fn load_js_tap_register(&mut self, register: JsTapRegister) -> Result<()>;
+  fn load_js_tap_register<R>(&mut self, register: std::sync::Arc<R>) -> Result<()>
+  where
+    Self: Sized + Sync,
+    R: JsTapRegister + Interceptor<Self> + Send + Sync + 'static;
 
   fn has_js_taps(&self) -> bool;
 

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use async_trait::async_trait;
-use rspack_error::Result;
+use rspack_error::{Result, error};
 
 pub trait JsTapRegister {
   fn is_empty(&self) -> bool;
@@ -20,6 +22,7 @@ pub struct HookCommon {
   metadata: HookMetadata,
   tap_stages: Vec<i32>,
   interceptor_count: usize,
+  js_tap_register: Option<Arc<dyn JsTapRegister + Send + Sync>>,
 }
 
 impl HookCommon {
@@ -28,6 +31,7 @@ impl HookCommon {
       metadata: HookMetadata { name },
       tap_stages: Vec::new(),
       interceptor_count: 0,
+      js_tap_register: None,
     }
   }
 
@@ -55,6 +59,27 @@ impl HookCommon {
     self.interceptor_count
   }
 
+  pub fn load_js_tap_register(
+    &mut self,
+    register: Arc<dyn JsTapRegister + Send + Sync>,
+  ) -> Result<()> {
+    if self.js_tap_register.is_some() {
+      return Err(error!(
+        "JS tap register for hook {} has already been loaded",
+        self.name()
+      ));
+    }
+    self.js_tap_register = Some(register);
+    Ok(())
+  }
+
+  pub fn has_js_taps(&self) -> bool {
+    self
+      .js_tap_register
+      .as_ref()
+      .is_some_and(|register| !register.is_empty())
+  }
+
   pub fn used_stages(&self) -> Vec<i32> {
     let mut used_stages = self.tap_stages.clone();
     // tap_stages is kept sorted by stage, so duplicate stages are adjacent.
@@ -62,11 +87,12 @@ impl HookCommon {
     used_stages
   }
 
-  pub fn is_empty(&self, has_js_taps: bool) -> bool {
-    self.tap_stages.is_empty() && self.interceptor_count == 0 && !has_js_taps
+  pub fn is_empty(&self) -> bool {
+    self.tap_stages.is_empty() && self.interceptor_count == 0 && !self.has_js_taps()
   }
 
-  pub fn call_mode(&self, has_js_taps: bool) -> HookCallMode {
+  pub fn call_mode(&self) -> HookCallMode {
+    let has_js_taps = self.has_js_taps();
     if self.tap_stages.is_empty() && self.interceptor_count == 0 && !has_js_taps {
       HookCallMode::Empty
     } else if self.interceptor_count == 0 && !has_js_taps {
@@ -202,7 +228,7 @@ pub trait Interceptor<H: Hook> {
 }
 
 #[async_trait]
-impl<H, T> Interceptor<H> for std::sync::Arc<T>
+impl<H, T> Interceptor<H> for Arc<T>
 where
   H: Hook + Sync,
   T: Interceptor<H> + Send + Sync,
@@ -221,7 +247,7 @@ pub trait Hook {
 
   fn used_stages(&self) -> Vec<i32>;
 
-  fn load_js_tap_register<R>(&mut self, register: std::sync::Arc<R>) -> Result<()>
+  fn load_js_tap_register<R>(&mut self, register: Arc<R>) -> Result<()>
   where
     Self: Sized + Sync,
     R: JsTapRegister + Interceptor<Self> + Send + Sync + 'static;

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -1,149 +1,35 @@
-use std::{
-  any::{Any, TypeId},
-  future::Future,
-  pin::Pin,
-  sync::Arc,
-};
+use std::any::Any;
 
 use async_trait::async_trait;
-use rspack_error::{Result, error};
-
-type ErasedJsTapRegisterOwner = Arc<dyn Any + Send + Sync>;
-#[doc(hidden)]
-pub type ErasedJsTap = Box<dyn Any + Send + Sync>;
-type AsyncJsTapRegisterFn = Box<
-  dyn Fn(
-      ErasedJsTapRegisterOwner,
-      Vec<i32>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<ErasedJsTap>>> + Send>>
-    + Send
-    + Sync,
->;
-type BlockingJsTapRegisterFn =
-  Box<dyn Fn(ErasedJsTapRegisterOwner, Vec<i32>) -> Result<Vec<ErasedJsTap>> + Send + Sync>;
-type LoadJsTapCountFn = Box<dyn Fn(&dyn Any) -> usize + Send + Sync>;
-
-enum JsTapRegisterFn {
-  Async(AsyncJsTapRegisterFn),
-  Blocking(BlockingJsTapRegisterFn),
-}
+use rspack_error::Result;
 
 pub struct JsTapRegister {
-  owner: ErasedJsTapRegisterOwner,
-  tap_type_id: TypeId,
-  load_tap_count: LoadJsTapCountFn,
-  function: JsTapRegisterFn,
+  is_empty: Box<dyn Fn() -> bool + Send + Sync>,
+  interceptor: Option<Box<dyn Any + Send + Sync>>,
 }
 
 impl JsTapRegister {
-  pub fn new_async<O, T, F, Fut>(
-    owner: Arc<O>,
-    load_tap_count: fn(&O) -> usize,
-    function: F,
-  ) -> Self
-  where
-    O: Any + Send + Sync,
-    T: Any + Send + Sync,
-    F: Fn(Arc<O>, Vec<i32>) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<Vec<T>>> + Send + 'static,
-  {
+  pub fn new(
+    is_empty: Box<dyn Fn() -> bool + Send + Sync>,
+    interceptor: Box<dyn Any + Send + Sync>,
+  ) -> Self {
     Self {
-      owner,
-      tap_type_id: TypeId::of::<T>(),
-      load_tap_count: Box::new(move |owner| {
-        load_tap_count(
-          owner
-            .downcast_ref::<O>()
-            .expect("JsTapRegister owner type should match"),
-        )
-      }),
-      function: JsTapRegisterFn::Async(Box::new(move |owner, stages| {
-        let owner = Arc::downcast::<O>(owner).expect("JsTapRegister owner type should match");
-        let future = function(owner, stages);
-        Box::pin(async move {
-          Ok(
-            future
-              .await?
-              .into_iter()
-              .map(|tap| Box::new(tap) as ErasedJsTap)
-              .collect(),
-          )
-        })
-      })),
+      is_empty,
+      interceptor: Some(interceptor),
     }
   }
 
-  pub fn new_blocking<O, T, F>(owner: Arc<O>, load_tap_count: fn(&O) -> usize, function: F) -> Self
-  where
-    O: Any + Send + Sync,
-    T: Any + Send + Sync,
-    F: Fn(Arc<O>, Vec<i32>) -> Result<Vec<T>> + Send + Sync + 'static,
-  {
-    Self {
-      owner,
-      tap_type_id: TypeId::of::<T>(),
-      load_tap_count: Box::new(move |owner| {
-        load_tap_count(
-          owner
-            .downcast_ref::<O>()
-            .expect("JsTapRegister owner type should match"),
-        )
-      }),
-      function: JsTapRegisterFn::Blocking(Box::new(move |owner, stages| {
-        Ok(
-          function(
-            Arc::downcast::<O>(owner).expect("JsTapRegister owner type should match"),
-            stages,
-          )?
-          .into_iter()
-          .map(|tap| Box::new(tap) as ErasedJsTap)
-          .collect(),
-        )
-      })),
-    }
+  pub fn is_empty(&self) -> bool {
+    (self.is_empty)()
   }
 
-  fn tap_count(&self) -> usize {
-    (self.load_tap_count)(self.owner.as_ref())
+  #[doc(hidden)]
+  pub fn take_interceptor(&mut self) -> Box<dyn Any + Send + Sync> {
+    self
+      .interceptor
+      .take()
+      .expect("JS tap register interceptor should only be loaded once")
   }
-
-  fn is_empty(&self) -> bool {
-    self.tap_count() == 0
-  }
-
-  fn has_tap_type<T: Any>(&self) -> bool {
-    self.tap_type_id == TypeId::of::<T>()
-  }
-
-  async fn call(&self, stages: Vec<i32>) -> Result<Vec<ErasedJsTap>> {
-    match &self.function {
-      JsTapRegisterFn::Async(function) => function(self.owner.clone(), stages).await,
-      JsTapRegisterFn::Blocking(_) => Err(error!(
-        "blocking JS tap register cannot be called from an async hook"
-      )),
-    }
-  }
-
-  fn call_blocking(&self, stages: Vec<i32>) -> Result<Vec<ErasedJsTap>> {
-    match &self.function {
-      JsTapRegisterFn::Async(_) => Err(error!(
-        "async JS tap register cannot be called from a blocking hook"
-      )),
-      JsTapRegisterFn::Blocking(function) => function(self.owner.clone(), stages),
-    }
-  }
-}
-
-pub fn unerase_js_taps<T: Any>(taps: Vec<ErasedJsTap>) -> Result<Vec<T>> {
-  taps
-    .into_iter()
-    .map(|tap| {
-      tap
-        .downcast::<T>()
-        .map(|tap| *tap)
-        .map_err(|_| error!("JS tap register returned an unexpected tap type"))
-    })
-    .collect()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,7 +47,6 @@ pub struct HookCommon {
   metadata: HookMetadata,
   tap_stages: Vec<i32>,
   interceptor_count: usize,
-  js_tap_register: Option<JsTapRegister>,
 }
 
 impl HookCommon {
@@ -170,7 +55,6 @@ impl HookCommon {
       metadata: HookMetadata { name },
       tap_stages: Vec::new(),
       interceptor_count: 0,
-      js_tap_register: None,
     }
   }
 
@@ -205,36 +89,11 @@ impl HookCommon {
     used_stages
   }
 
-  pub fn load_js_tap_register<T: Any>(&mut self, register: JsTapRegister) -> Result<()> {
-    if self.js_tap_register.is_some() {
-      return Err(error!(
-        "JS tap register for hook {} has already been loaded",
-        self.name()
-      ));
-    }
-    if !register.has_tap_type::<T>() {
-      return Err(error!(
-        "JS tap register type does not match hook {}",
-        self.name()
-      ));
-    }
-    self.js_tap_register = Some(register);
-    Ok(())
+  pub fn is_empty(&self, has_js_taps: bool) -> bool {
+    self.tap_stages.is_empty() && self.interceptor_count == 0 && !has_js_taps
   }
 
-  pub fn has_js_taps(&self) -> bool {
-    self
-      .js_tap_register
-      .as_ref()
-      .is_some_and(|register| !register.is_empty())
-  }
-
-  pub fn is_empty(&self) -> bool {
-    self.tap_stages.is_empty() && self.interceptor_count == 0 && !self.has_js_taps()
-  }
-
-  pub fn call_mode(&self) -> HookCallMode {
-    let has_js_taps = self.has_js_taps();
+  pub fn call_mode(&self, has_js_taps: bool) -> HookCallMode {
     if self.tap_stages.is_empty() && self.interceptor_count == 0 && !has_js_taps {
       HookCallMode::Empty
     } else if self.interceptor_count == 0 && !has_js_taps {
@@ -242,29 +101,6 @@ impl HookCommon {
     } else {
       HookCallMode::AdditionalTaps
     }
-  }
-
-  pub async fn call_js_tap_register(&self) -> Result<Vec<ErasedJsTap>> {
-    if !self.has_js_taps() {
-      return Ok(Vec::new());
-    }
-    self
-      .js_tap_register
-      .as_ref()
-      .expect("JS tap register should exist when JS taps are present")
-      .call(self.used_stages())
-      .await
-  }
-
-  pub fn call_js_tap_register_blocking(&self) -> Result<Vec<ErasedJsTap>> {
-    if !self.has_js_taps() {
-      return Ok(Vec::new());
-    }
-    self
-      .js_tap_register
-      .as_ref()
-      .expect("JS tap register should exist when JS taps are present")
-      .call_blocking(self.used_stages())
   }
 }
 
@@ -415,7 +251,7 @@ pub trait Hook {
 #[doc(hidden)]
 pub mod __macro_helper {
   pub use async_trait::async_trait;
-  pub use rspack_error::Result;
+  pub use rspack_error::{Result, error};
   pub use tracing;
 }
 

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -153,7 +153,7 @@ impl DefineHookInput {
     let call_fn = if is_async {
       quote! {
         async fn call #method_generics (&self, #args) -> #ret {
-          let call_mode = self.common.call_mode();
+          let call_mode = self.common.call_mode(self.has_js_taps());
           if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
             #empty_return
           }
@@ -163,7 +163,7 @@ impl DefineHookInput {
     } else {
       quote! {
         fn call #method_generics (&self, #args) -> #ret {
-          let call_mode = self.common.call_mode();
+          let call_mode = self.common.call_mode(self.has_js_taps());
           if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
             #empty_return
           }
@@ -184,6 +184,7 @@ impl DefineHookInput {
         common: ::rspack_hook::HookCommon,
         taps: Vec<Box<dyn #trait_name + Send + Sync>>,
         interceptors: Vec<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>,
+        js_tap_register: Option<::rspack_hook::JsTapRegister>,
       }
 
       impl ::rspack_hook::Hook for #hook_name {
@@ -193,16 +194,31 @@ impl DefineHookInput {
           self.common.used_stages()
         }
 
-        fn load_js_tap_register(&mut self, register: ::rspack_hook::JsTapRegister) -> ::rspack_hook::__macro_helper::Result<()> {
-          self.common.load_js_tap_register::<Self::Tap>(register)
+        fn load_js_tap_register(&mut self, mut register: ::rspack_hook::JsTapRegister) -> ::rspack_hook::__macro_helper::Result<()> {
+          if self.js_tap_register.is_some() {
+            return Err(::rspack_hook::__macro_helper::error!(
+              "JS tap register for hook {} has already been loaded",
+              self.common.name()
+            ));
+          }
+          let interceptor = register
+            .take_interceptor()
+            .downcast::<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>()
+            .map_err(|_| ::rspack_hook::__macro_helper::error!(
+              "JS tap register type does not match hook {}",
+              self.common.name()
+            ))?;
+          self.interceptors.push(*interceptor);
+          self.js_tap_register = Some(register);
+          Ok(())
         }
 
         fn has_js_taps(&self) -> bool {
-          self.common.has_js_taps()
+          self.js_tap_register.as_ref().is_some_and(|register| !register.is_empty())
         }
 
         fn is_empty(&self) -> bool {
-          self.common.is_empty()
+          self.common.is_empty(self.has_js_taps())
         }
 
         fn intercept(&mut self, interceptor: impl ::rspack_hook::Interceptor<Self> + Send + Sync + 'static) {
@@ -223,6 +239,7 @@ impl DefineHookInput {
             common: ::rspack_hook::HookCommon::new(#hook_name_lit_str),
             taps: Default::default(),
             interceptors: Default::default(),
+            js_tap_register: Default::default(),
           }
         }
       }
@@ -238,11 +255,11 @@ impl DefineHookInput {
         }
 
         pub fn is_empty(&self) -> bool {
-          self.common.is_empty()
+          self.common.is_empty(self.has_js_taps())
         }
 
         pub fn has_js_taps(&self) -> bool {
-          self.common.has_js_taps()
+          self.js_tap_register.as_ref().is_some_and(|register| !register.is_empty())
         }
       }
     })
@@ -298,23 +315,16 @@ impl ExecKind {
   }
 
   fn additional_taps(&self) -> TokenStream {
-    let (call_interceptor, call_js_register) = if self.is_async() {
-      (
-        quote! { additional_taps.extend(interceptor.call(self).await?); },
-        quote! { self.common.call_js_tap_register().await? },
-      )
+    let call_interceptor = if self.is_async() {
+      quote! { additional_taps.extend(interceptor.call(self).await?); }
     } else {
-      (
-        quote! { additional_taps.extend(interceptor.call_blocking(self)?); },
-        quote! { self.common.call_js_tap_register_blocking()? },
-      )
+      quote! { additional_taps.extend(interceptor.call_blocking(self)?); }
     };
     quote! {
       let mut additional_taps = std::vec::Vec::new();
       for interceptor in self.interceptors.iter() {
         #call_interceptor
       }
-      additional_taps.extend(::rspack_hook::unerase_js_taps::<<Self as ::rspack_hook::Hook>::Tap>(#call_js_register)?);
       let additional_stages: std::vec::Vec<_> = additional_taps.iter().map(|tap| tap.stage()).collect();
     }
   }

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -184,7 +184,7 @@ impl DefineHookInput {
         common: ::rspack_hook::HookCommon,
         taps: Vec<Box<dyn #trait_name + Send + Sync>>,
         interceptors: Vec<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>,
-        js_tap_register: Option<::rspack_hook::JsTapRegister>,
+        js_tap_register: Option<std::sync::Arc<dyn ::rspack_hook::JsTapRegister + Send + Sync>>,
       }
 
       impl ::rspack_hook::Hook for #hook_name {
@@ -194,21 +194,20 @@ impl DefineHookInput {
           self.common.used_stages()
         }
 
-        fn load_js_tap_register(&mut self, mut register: ::rspack_hook::JsTapRegister) -> ::rspack_hook::__macro_helper::Result<()> {
+        fn load_js_tap_register<R>(
+          &mut self,
+          register: std::sync::Arc<R>,
+        ) -> ::rspack_hook::__macro_helper::Result<()>
+        where
+          R: ::rspack_hook::JsTapRegister + ::rspack_hook::Interceptor<Self> + Send + Sync + 'static,
+        {
           if self.js_tap_register.is_some() {
             return Err(::rspack_hook::__macro_helper::error!(
               "JS tap register for hook {} has already been loaded",
               self.common.name()
             ));
           }
-          let interceptor = register
-            .take_interceptor()
-            .downcast::<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>()
-            .map_err(|_| ::rspack_hook::__macro_helper::error!(
-              "JS tap register type does not match hook {}",
-              self.common.name()
-            ))?;
-          self.interceptors.push(*interceptor);
+          self.interceptors.push(Box::new(register.clone()));
           self.js_tap_register = Some(register);
           Ok(())
         }

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -153,7 +153,7 @@ impl DefineHookInput {
     let call_fn = if is_async {
       quote! {
         async fn call #method_generics (&self, #args) -> #ret {
-          let call_mode = self.common.call_mode(self.has_js_taps());
+          let call_mode = self.common.call_mode();
           if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
             #empty_return
           }
@@ -163,7 +163,7 @@ impl DefineHookInput {
     } else {
       quote! {
         fn call #method_generics (&self, #args) -> #ret {
-          let call_mode = self.common.call_mode(self.has_js_taps());
+          let call_mode = self.common.call_mode();
           if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
             #empty_return
           }
@@ -184,7 +184,6 @@ impl DefineHookInput {
         common: ::rspack_hook::HookCommon,
         taps: Vec<Box<dyn #trait_name + Send + Sync>>,
         interceptors: Vec<Box<dyn ::rspack_hook::Interceptor<Self> + Send + Sync>>,
-        js_tap_register: Option<std::sync::Arc<dyn ::rspack_hook::JsTapRegister + Send + Sync>>,
       }
 
       impl ::rspack_hook::Hook for #hook_name {
@@ -201,23 +200,17 @@ impl DefineHookInput {
         where
           R: ::rspack_hook::JsTapRegister + ::rspack_hook::Interceptor<Self> + Send + Sync + 'static,
         {
-          if self.js_tap_register.is_some() {
-            return Err(::rspack_hook::__macro_helper::error!(
-              "JS tap register for hook {} has already been loaded",
-              self.common.name()
-            ));
-          }
-          self.interceptors.push(Box::new(register.clone()));
-          self.js_tap_register = Some(register);
+          self.common.load_js_tap_register(register.clone())?;
+          self.interceptors.push(Box::new(register));
           Ok(())
         }
 
         fn has_js_taps(&self) -> bool {
-          self.js_tap_register.as_ref().is_some_and(|register| !register.is_empty())
+          self.common.has_js_taps()
         }
 
         fn is_empty(&self) -> bool {
-          self.common.is_empty(self.has_js_taps())
+          self.common.is_empty()
         }
 
         fn intercept(&mut self, interceptor: impl ::rspack_hook::Interceptor<Self> + Send + Sync + 'static) {
@@ -238,7 +231,6 @@ impl DefineHookInput {
             common: ::rspack_hook::HookCommon::new(#hook_name_lit_str),
             taps: Default::default(),
             interceptors: Default::default(),
-            js_tap_register: Default::default(),
           }
         }
       }
@@ -254,11 +246,11 @@ impl DefineHookInput {
         }
 
         pub fn is_empty(&self) -> bool {
-          self.common.is_empty(self.has_js_taps())
+          self.common.is_empty()
         }
 
         pub fn has_js_taps(&self) -> bool {
-          self.js_tap_register.as_ref().is_some_and(|register| !register.is_empty())
+          self.common.has_js_taps()
         }
       }
     })

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -129,6 +129,7 @@ impl DefineHookInput {
       .collect::<Result<Punctuated<&Ident, Comma>>>()?;
     let hook_name = Ident::new(&format!("{trait_name}Hook"), trait_name.span());
     let hook_name_lit_str = LitStr::new(&hook_name.to_string(), trait_name.span());
+    let empty_return = exec_kind.empty_return(&arg_names);
     let call_body = exec_kind.body(arg_names);
     let call_body = if tracing.is_none_or(|bool_lit| bool_lit.value) {
       let tracing_span_name = LitStr::new(&format!("hook:{trait_name}"), trait_name.span());
@@ -152,12 +153,20 @@ impl DefineHookInput {
     let call_fn = if is_async {
       quote! {
         async fn call #method_generics (&self, #args) -> #ret {
+          let call_mode = self.common.call_mode();
+          if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
+            #empty_return
+          }
           #call_body
         }
       }
     } else {
       quote! {
         fn call #method_generics (&self, #args) -> #ret {
+          let call_mode = self.common.call_mode();
+          if matches!(call_mode, ::rspack_hook::HookCallMode::Empty) {
+            #empty_return
+          }
           #call_body
         }
       }
@@ -182,6 +191,18 @@ impl DefineHookInput {
 
         fn used_stages(&self) -> Vec<i32> {
           self.common.used_stages()
+        }
+
+        fn load_js_tap_register(&mut self, register: ::rspack_hook::JsTapRegister) -> ::rspack_hook::__macro_helper::Result<()> {
+          self.common.load_js_tap_register::<Self::Tap>(register)
+        }
+
+        fn has_js_taps(&self) -> bool {
+          self.common.has_js_taps()
+        }
+
+        fn is_empty(&self) -> bool {
+          self.common.is_empty()
         }
 
         fn intercept(&mut self, interceptor: impl ::rspack_hook::Interceptor<Self> + Send + Sync + 'static) {
@@ -218,6 +239,10 @@ impl DefineHookInput {
 
         pub fn is_empty(&self) -> bool {
           self.common.is_empty()
+        }
+
+        pub fn has_js_taps(&self) -> bool {
+          self.common.has_js_taps()
         }
       }
     })
@@ -273,17 +298,40 @@ impl ExecKind {
   }
 
   fn additional_taps(&self) -> TokenStream {
-    let call = if self.is_async() {
-      quote! { additional_taps.extend(interceptor.call(self).await?); }
+    let (call_interceptor, call_js_register) = if self.is_async() {
+      (
+        quote! { additional_taps.extend(interceptor.call(self).await?); },
+        quote! { self.common.call_js_tap_register().await? },
+      )
     } else {
-      quote! { additional_taps.extend(interceptor.call_blocking(self)?); }
+      (
+        quote! { additional_taps.extend(interceptor.call_blocking(self)?); },
+        quote! { self.common.call_js_tap_register_blocking()? },
+      )
     };
     quote! {
       let mut additional_taps = std::vec::Vec::new();
       for interceptor in self.interceptors.iter() {
-        #call
+        #call_interceptor
       }
+      additional_taps.extend(::rspack_hook::unerase_js_taps::<<Self as ::rspack_hook::Hook>::Tap>(#call_js_register)?);
       let additional_stages: std::vec::Vec<_> = additional_taps.iter().map(|tap| tap.stage()).collect();
+    }
+  }
+
+  fn empty_return(&self, args: &Punctuated<&Ident, Comma>) -> TokenStream {
+    match self {
+      Self::SeriesBail { .. } => quote! { return Ok(None); },
+      Self::SeriesWaterfall { .. } => {
+        let data_arg = args
+          .iter()
+          .copied()
+          .find(|arg| *arg == "data")
+          .or_else(|| args.first().copied())
+          .expect("waterfall hooks must have at least one argument");
+        quote! { return Ok(#data_arg); }
+      }
+      _ => quote! { return Ok(()); },
     }
   }
 
@@ -292,7 +340,7 @@ impl ExecKind {
     match self {
       Self::Series => {
         quote! {
-          if self.common.interceptor_count() == 0 {
+          if matches!(call_mode, ::rspack_hook::HookCallMode::RustTaps) {
             for tap in &self.taps {
               tap.run(#args).await?;
             }
@@ -312,7 +360,7 @@ impl ExecKind {
       }
       Self::Sync => {
         quote! {
-          if self.common.interceptor_count() == 0 {
+          if matches!(call_mode, ::rspack_hook::HookCallMode::RustTaps) {
             for tap in &self.taps {
               tap.run(#args)?;
             }
@@ -332,7 +380,7 @@ impl ExecKind {
       }
       Self::SeriesBail { .. } => {
         quote! {
-          if self.common.interceptor_count() == 0 {
+          if matches!(call_mode, ::rspack_hook::HookCallMode::RustTaps) {
             for tap in &self.taps {
               if let Some(res) = tap.run(#args).await? {
                 return Ok(Some(res));
@@ -374,7 +422,7 @@ impl ExecKind {
           .collect::<Vec<_>>();
         quote! {
           let mut data = #data_arg;
-          if self.common.interceptor_count() == 0 {
+          if matches!(call_mode, ::rspack_hook::HookCallMode::RustTaps) {
             for tap in &self.taps {
               data = tap.run(#(#tap_args),*).await?
             }
@@ -394,7 +442,7 @@ impl ExecKind {
       }
       Self::Parallel => {
         quote! {
-          if self.common.interceptor_count() == 0 {
+          if matches!(call_mode, ::rspack_hook::HookCallMode::RustTaps) {
             let futs: std::vec::Vec<_> = self.taps.iter().map(|t| t.run(#args)).collect();
             futures_concurrency::vec::TryJoin(futs).await?;
             return Ok(());

--- a/crates/rspack_macros_test/tests/hook.rs
+++ b/crates/rspack_macros_test/tests/hook.rs
@@ -177,3 +177,268 @@ mod stage_order {
     Ok(())
   }
 }
+
+mod js_tap_register {
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
+
+  use rspack_hook::{Hook as _, JsTapRegister};
+
+  use super::*;
+
+  define_hook!(Render: Series(source: &mut String));
+  define_hook!(Other: Series());
+
+  struct Tap {
+    label: &'static str,
+    stage: i32,
+  }
+
+  #[async_trait::async_trait]
+  impl Render for Tap {
+    async fn run(&self, source: &mut String) -> Result<()> {
+      source.push_str(self.label);
+      Ok(())
+    }
+
+    fn stage(&self) -> i32 {
+      self.stage
+    }
+  }
+
+  struct OtherTap;
+
+  #[async_trait::async_trait]
+  impl Other for OtherTap {
+    async fn run(&self) -> Result<()> {
+      Ok(())
+    }
+  }
+
+  struct AdditionalTaps;
+
+  #[async_trait::async_trait]
+  impl rspack_hook::Interceptor<RenderHook> for AdditionalTaps {
+    async fn call(
+      &self,
+      _hook: &RenderHook,
+    ) -> Result<Vec<<RenderHook as rspack_hook::Hook>::Tap>> {
+      Ok(vec![Box::new(Tap {
+        label: "interceptor",
+        stage: 5,
+      })])
+    }
+  }
+
+  #[derive(Default)]
+  struct RegisterState {
+    tap_count: AtomicUsize,
+    call_count: AtomicUsize,
+  }
+
+  impl RegisterState {
+    fn tap_count(&self) -> usize {
+      self.tap_count.load(Ordering::Acquire)
+    }
+  }
+
+  #[tokio::test]
+  async fn skips_empty_js_register_without_calling_it() -> Result<()> {
+    let state = Arc::new(RegisterState::default());
+    let mut hook = RenderHook::default();
+    hook.load_js_tap_register(JsTapRegister::new_async::<
+      RegisterState,
+      <RenderHook as rspack_hook::Hook>::Tap,
+      _,
+      _,
+    >(
+      state.clone(),
+      RegisterState::tap_count,
+      |state, _stages| async move {
+        state.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(vec![Box::new(Tap {
+          label: "js",
+          stage: 0,
+        }) as <RenderHook as rspack_hook::Hook>::Tap])
+      },
+    ))?;
+
+    assert!(hook.is_empty());
+    assert!(!hook.has_js_taps());
+
+    let mut source = String::new();
+    hook.call(&mut source).await?;
+    assert!(source.is_empty());
+    assert_eq!(state.call_count.load(Ordering::Relaxed), 0);
+
+    state.tap_count.store(1, Ordering::Release);
+    assert!(!hook.is_empty());
+    assert!(hook.has_js_taps());
+
+    hook.call(&mut source).await?;
+    assert_eq!(source, "js");
+    assert_eq!(state.call_count.load(Ordering::Relaxed), 1);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn merges_rust_interceptor_and_js_taps_by_stage() -> Result<()> {
+    let state = Arc::new(RegisterState {
+      tap_count: AtomicUsize::new(1),
+      call_count: AtomicUsize::new(0),
+    });
+    let mut hook = RenderHook::default();
+    hook.tap(Tap {
+      label: "rust",
+      stage: 5,
+    });
+    hook.intercept(AdditionalTaps);
+    hook.load_js_tap_register(JsTapRegister::new_async::<
+      RegisterState,
+      <RenderHook as rspack_hook::Hook>::Tap,
+      _,
+      _,
+    >(
+      state.clone(),
+      RegisterState::tap_count,
+      |state, _stages| async move {
+        state.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(vec![Box::new(Tap {
+          label: "js",
+          stage: 5,
+        }) as <RenderHook as rspack_hook::Hook>::Tap])
+      },
+    ))?;
+
+    let mut source = String::new();
+    hook.call(&mut source).await?;
+    assert_eq!(source, "rustinterceptorjs");
+    assert_eq!(state.call_count.load(Ordering::Relaxed), 1);
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn runs_rust_taps_without_loading_an_empty_js_register() -> Result<()> {
+    let state = Arc::new(RegisterState::default());
+    let mut hook = RenderHook::default();
+    hook.tap(Tap {
+      label: "rust",
+      stage: 0,
+    });
+    hook.load_js_tap_register(JsTapRegister::new_async::<
+      RegisterState,
+      <RenderHook as rspack_hook::Hook>::Tap,
+      _,
+      _,
+    >(
+      state.clone(),
+      RegisterState::tap_count,
+      |state, _stages| async move {
+        state.call_count.fetch_add(1, Ordering::Relaxed);
+        Ok(vec![Box::new(Tap {
+          label: "js",
+          stage: 0,
+        }) as <RenderHook as rspack_hook::Hook>::Tap])
+      },
+    ))?;
+
+    let mut source = String::new();
+    hook.call(&mut source).await?;
+    assert_eq!(source, "rust");
+    assert_eq!(state.call_count.load(Ordering::Relaxed), 0);
+    Ok(())
+  }
+
+  #[test]
+  fn rejects_a_register_for_another_hook_tap_type() {
+    let state = Arc::new(RegisterState::default());
+    let register =
+      JsTapRegister::new_async::<RegisterState, <OtherHook as rspack_hook::Hook>::Tap, _, _>(
+        state,
+        RegisterState::tap_count,
+        |_state, _stages| async move {
+          Ok(vec![
+            Box::new(OtherTap) as <OtherHook as rspack_hook::Hook>::Tap
+          ])
+        },
+      );
+
+    let error = RenderHook::default()
+      .load_js_tap_register(register)
+      .expect_err("tap types should be validated when loading a register");
+    assert!(error.to_string().contains("type does not match"));
+  }
+}
+
+mod blocking_js_tap_register {
+  use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  };
+
+  use rspack_hook::{Hook as _, JsTapRegister};
+
+  use super::*;
+
+  define_hook!(Render: Sync(source: &mut String));
+
+  struct Tap;
+
+  impl Render for Tap {
+    fn run(&self, source: &mut String) -> Result<()> {
+      source.push_str("js");
+      Ok(())
+    }
+  }
+
+  struct RegisterState(AtomicUsize);
+
+  impl RegisterState {
+    fn tap_count(&self) -> usize {
+      self.0.load(Ordering::Acquire)
+    }
+  }
+
+  #[test]
+  fn supports_sync_hooks_without_calling_async_code() -> Result<()> {
+    let state = Arc::new(RegisterState(AtomicUsize::new(1)));
+    let mut hook = RenderHook::default();
+    hook.load_js_tap_register(JsTapRegister::new_blocking::<
+      RegisterState,
+      <RenderHook as rspack_hook::Hook>::Tap,
+      _,
+    >(state, RegisterState::tap_count, |_state, _stages| {
+      Ok(vec![Box::new(Tap) as <RenderHook as rspack_hook::Hook>::Tap])
+    }))?;
+
+    let mut source = String::new();
+    hook.call(&mut source)?;
+    assert_eq!(source, "js");
+    Ok(())
+  }
+}
+
+mod empty_hook_returns {
+  use super::*;
+
+  define_hook!(EmptySeries: Series());
+  define_hook!(EmptySync: Sync());
+  define_hook!(EmptyBail: SeriesBail() -> bool);
+  define_hook!(EmptyWaterfall: SeriesWaterfall(data: String) -> String);
+
+  #[tokio::test]
+  async fn preserves_each_hook_kinds_empty_return() -> Result<()> {
+    EmptySeriesHook::default().call().await?;
+    EmptySyncHook::default().call()?;
+    assert_eq!(EmptyBailHook::default().call().await?, None);
+    assert_eq!(
+      EmptyWaterfallHook::default()
+        .call("input".to_string())
+        .await?,
+      "input"
+    );
+    Ok(())
+  }
+}

--- a/crates/rspack_macros_test/tests/hook.rs
+++ b/crates/rspack_macros_test/tests/hook.rs
@@ -184,7 +184,7 @@ mod js_tap_register {
     atomic::{AtomicUsize, Ordering},
   };
 
-  use rspack_hook::{Hook as _, JsTapRegister};
+  use rspack_hook::{Hook as _, Interceptor, JsTapRegister};
 
   use super::*;
 
@@ -208,15 +208,6 @@ mod js_tap_register {
     }
   }
 
-  struct OtherTap;
-
-  #[async_trait::async_trait]
-  impl Other for OtherTap {
-    async fn run(&self) -> Result<()> {
-      Ok(())
-    }
-  }
-
   struct AdditionalTaps;
 
   #[async_trait::async_trait]
@@ -232,6 +223,15 @@ mod js_tap_register {
     }
   }
 
+  struct OtherRegisterInterceptor;
+
+  #[async_trait::async_trait]
+  impl Interceptor<OtherHook> for OtherRegisterInterceptor {
+    async fn call(&self, _hook: &OtherHook) -> Result<Vec<<OtherHook as rspack_hook::Hook>::Tap>> {
+      Ok(Vec::new())
+    }
+  }
+
   #[derive(Default)]
   struct RegisterState {
     tap_count: AtomicUsize,
@@ -244,26 +244,40 @@ mod js_tap_register {
     }
   }
 
+  struct RegisterInterceptor {
+    state: Arc<RegisterState>,
+    stage: i32,
+  }
+
+  #[async_trait::async_trait]
+  impl Interceptor<RenderHook> for RegisterInterceptor {
+    async fn call(
+      &self,
+      _hook: &RenderHook,
+    ) -> Result<Vec<<RenderHook as rspack_hook::Hook>::Tap>> {
+      self.state.call_count.fetch_add(1, Ordering::Relaxed);
+      Ok(vec![Box::new(Tap {
+        label: "js",
+        stage: self.stage,
+      })])
+    }
+  }
+
+  fn create_register(state: Arc<RegisterState>, stage: i32) -> JsTapRegister {
+    let count_state = state.clone();
+    let interceptor: Box<dyn Interceptor<RenderHook> + Send + Sync> =
+      Box::new(RegisterInterceptor { state, stage });
+    JsTapRegister::new(
+      Box::new(move || count_state.tap_count() == 0),
+      Box::new(interceptor),
+    )
+  }
+
   #[tokio::test]
   async fn skips_empty_js_register_without_calling_it() -> Result<()> {
     let state = Arc::new(RegisterState::default());
     let mut hook = RenderHook::default();
-    hook.load_js_tap_register(JsTapRegister::new_async::<
-      RegisterState,
-      <RenderHook as rspack_hook::Hook>::Tap,
-      _,
-      _,
-    >(
-      state.clone(),
-      RegisterState::tap_count,
-      |state, _stages| async move {
-        state.call_count.fetch_add(1, Ordering::Relaxed);
-        Ok(vec![Box::new(Tap {
-          label: "js",
-          stage: 0,
-        }) as <RenderHook as rspack_hook::Hook>::Tap])
-      },
-    ))?;
+    hook.load_js_tap_register(create_register(state.clone(), 0))?;
 
     assert!(hook.is_empty());
     assert!(!hook.has_js_taps());
@@ -295,22 +309,7 @@ mod js_tap_register {
       stage: 5,
     });
     hook.intercept(AdditionalTaps);
-    hook.load_js_tap_register(JsTapRegister::new_async::<
-      RegisterState,
-      <RenderHook as rspack_hook::Hook>::Tap,
-      _,
-      _,
-    >(
-      state.clone(),
-      RegisterState::tap_count,
-      |state, _stages| async move {
-        state.call_count.fetch_add(1, Ordering::Relaxed);
-        Ok(vec![Box::new(Tap {
-          label: "js",
-          stage: 5,
-        }) as <RenderHook as rspack_hook::Hook>::Tap])
-      },
-    ))?;
+    hook.load_js_tap_register(create_register(state.clone(), 5))?;
 
     let mut source = String::new();
     hook.call(&mut source).await?;
@@ -327,22 +326,7 @@ mod js_tap_register {
       label: "rust",
       stage: 0,
     });
-    hook.load_js_tap_register(JsTapRegister::new_async::<
-      RegisterState,
-      <RenderHook as rspack_hook::Hook>::Tap,
-      _,
-      _,
-    >(
-      state.clone(),
-      RegisterState::tap_count,
-      |state, _stages| async move {
-        state.call_count.fetch_add(1, Ordering::Relaxed);
-        Ok(vec![Box::new(Tap {
-          label: "js",
-          stage: 0,
-        }) as <RenderHook as rspack_hook::Hook>::Tap])
-      },
-    ))?;
+    hook.load_js_tap_register(create_register(state.clone(), 0))?;
 
     let mut source = String::new();
     hook.call(&mut source).await?;
@@ -352,22 +336,14 @@ mod js_tap_register {
   }
 
   #[test]
-  fn rejects_a_register_for_another_hook_tap_type() {
-    let state = Arc::new(RegisterState::default());
-    let register =
-      JsTapRegister::new_async::<RegisterState, <OtherHook as rspack_hook::Hook>::Tap, _, _>(
-        state,
-        RegisterState::tap_count,
-        |_state, _stages| async move {
-          Ok(vec![
-            Box::new(OtherTap) as <OtherHook as rspack_hook::Hook>::Tap
-          ])
-        },
-      );
+  fn rejects_a_register_for_another_hook() {
+    let interceptor: Box<dyn Interceptor<OtherHook> + Send + Sync> =
+      Box::new(OtherRegisterInterceptor);
+    let register = JsTapRegister::new(Box::new(|| false), Box::new(interceptor));
 
     let error = RenderHook::default()
       .load_js_tap_register(register)
-      .expect_err("tap types should be validated when loading a register");
+      .expect_err("interceptor types should be validated when loading a register");
     assert!(error.to_string().contains("type does not match"));
   }
 }
@@ -378,7 +354,7 @@ mod blocking_js_tap_register {
     atomic::{AtomicUsize, Ordering},
   };
 
-  use rspack_hook::{Hook as _, JsTapRegister};
+  use rspack_hook::{Hook as _, Interceptor, JsTapRegister};
 
   use super::*;
 
@@ -401,17 +377,27 @@ mod blocking_js_tap_register {
     }
   }
 
+  struct RegisterInterceptor;
+
+  impl Interceptor<RenderHook> for RegisterInterceptor {
+    fn call_blocking(
+      &self,
+      _hook: &RenderHook,
+    ) -> Result<Vec<<RenderHook as rspack_hook::Hook>::Tap>> {
+      Ok(vec![Box::new(Tap)])
+    }
+  }
+
   #[test]
   fn supports_sync_hooks_without_calling_async_code() -> Result<()> {
     let state = Arc::new(RegisterState(AtomicUsize::new(1)));
     let mut hook = RenderHook::default();
-    hook.load_js_tap_register(JsTapRegister::new_blocking::<
-      RegisterState,
-      <RenderHook as rspack_hook::Hook>::Tap,
-      _,
-    >(state, RegisterState::tap_count, |_state, _stages| {
-      Ok(vec![Box::new(Tap) as <RenderHook as rspack_hook::Hook>::Tap])
-    }))?;
+    let count_state = state;
+    let interceptor: Box<dyn Interceptor<RenderHook> + Send + Sync> = Box::new(RegisterInterceptor);
+    hook.load_js_tap_register(JsTapRegister::new(
+      Box::new(move || count_state.tap_count() == 0),
+      Box::new(interceptor),
+    ))?;
 
     let mut source = String::new();
     hook.call(&mut source)?;

--- a/crates/rspack_macros_test/tests/hook.rs
+++ b/crates/rspack_macros_test/tests/hook.rs
@@ -189,7 +189,6 @@ mod js_tap_register {
   use super::*;
 
   define_hook!(Render: Series(source: &mut String));
-  define_hook!(Other: Series());
 
   struct Tap {
     label: &'static str,
@@ -223,19 +222,11 @@ mod js_tap_register {
     }
   }
 
-  struct OtherRegisterInterceptor;
-
-  #[async_trait::async_trait]
-  impl Interceptor<OtherHook> for OtherRegisterInterceptor {
-    async fn call(&self, _hook: &OtherHook) -> Result<Vec<<OtherHook as rspack_hook::Hook>::Tap>> {
-      Ok(Vec::new())
-    }
-  }
-
   #[derive(Default)]
   struct RegisterState {
     tap_count: AtomicUsize,
     call_count: AtomicUsize,
+    stage: i32,
   }
 
   impl RegisterState {
@@ -244,18 +235,13 @@ mod js_tap_register {
     }
   }
 
-  struct RegisterInterceptor {
-    state: Arc<RegisterState>,
-    stage: i32,
-  }
-
   #[async_trait::async_trait]
-  impl Interceptor<RenderHook> for RegisterInterceptor {
+  impl Interceptor<RenderHook> for RegisterState {
     async fn call(
       &self,
       _hook: &RenderHook,
     ) -> Result<Vec<<RenderHook as rspack_hook::Hook>::Tap>> {
-      self.state.call_count.fetch_add(1, Ordering::Relaxed);
+      self.call_count.fetch_add(1, Ordering::Relaxed);
       Ok(vec![Box::new(Tap {
         label: "js",
         stage: self.stage,
@@ -263,21 +249,17 @@ mod js_tap_register {
     }
   }
 
-  fn create_register(state: Arc<RegisterState>, stage: i32) -> JsTapRegister {
-    let count_state = state.clone();
-    let interceptor: Box<dyn Interceptor<RenderHook> + Send + Sync> =
-      Box::new(RegisterInterceptor { state, stage });
-    JsTapRegister::new(
-      Box::new(move || count_state.tap_count() == 0),
-      Box::new(interceptor),
-    )
+  impl JsTapRegister for RegisterState {
+    fn is_empty(&self) -> bool {
+      self.tap_count() == 0
+    }
   }
 
   #[tokio::test]
   async fn skips_empty_js_register_without_calling_it() -> Result<()> {
     let state = Arc::new(RegisterState::default());
     let mut hook = RenderHook::default();
-    hook.load_js_tap_register(create_register(state.clone(), 0))?;
+    hook.load_js_tap_register(state.clone())?;
 
     assert!(hook.is_empty());
     assert!(!hook.has_js_taps());
@@ -302,6 +284,7 @@ mod js_tap_register {
     let state = Arc::new(RegisterState {
       tap_count: AtomicUsize::new(1),
       call_count: AtomicUsize::new(0),
+      stage: 5,
     });
     let mut hook = RenderHook::default();
     hook.tap(Tap {
@@ -309,7 +292,7 @@ mod js_tap_register {
       stage: 5,
     });
     hook.intercept(AdditionalTaps);
-    hook.load_js_tap_register(create_register(state.clone(), 5))?;
+    hook.load_js_tap_register(state.clone())?;
 
     let mut source = String::new();
     hook.call(&mut source).await?;
@@ -326,25 +309,13 @@ mod js_tap_register {
       label: "rust",
       stage: 0,
     });
-    hook.load_js_tap_register(create_register(state.clone(), 0))?;
+    hook.load_js_tap_register(state.clone())?;
 
     let mut source = String::new();
     hook.call(&mut source).await?;
     assert_eq!(source, "rust");
     assert_eq!(state.call_count.load(Ordering::Relaxed), 0);
     Ok(())
-  }
-
-  #[test]
-  fn rejects_a_register_for_another_hook() {
-    let interceptor: Box<dyn Interceptor<OtherHook> + Send + Sync> =
-      Box::new(OtherRegisterInterceptor);
-    let register = JsTapRegister::new(Box::new(|| false), Box::new(interceptor));
-
-    let error = RenderHook::default()
-      .load_js_tap_register(register)
-      .expect_err("interceptor types should be validated when loading a register");
-    assert!(error.to_string().contains("type does not match"));
   }
 }
 
@@ -377,9 +348,7 @@ mod blocking_js_tap_register {
     }
   }
 
-  struct RegisterInterceptor;
-
-  impl Interceptor<RenderHook> for RegisterInterceptor {
+  impl Interceptor<RenderHook> for RegisterState {
     fn call_blocking(
       &self,
       _hook: &RenderHook,
@@ -388,16 +357,17 @@ mod blocking_js_tap_register {
     }
   }
 
+  impl JsTapRegister for RegisterState {
+    fn is_empty(&self) -> bool {
+      self.tap_count() == 0
+    }
+  }
+
   #[test]
   fn supports_sync_hooks_without_calling_async_code() -> Result<()> {
     let state = Arc::new(RegisterState(AtomicUsize::new(1)));
     let mut hook = RenderHook::default();
-    let count_state = state;
-    let interceptor: Box<dyn Interceptor<RenderHook> + Send + Sync> = Box::new(RegisterInterceptor);
-    hook.load_js_tap_register(JsTapRegister::new(
-      Box::new(move || count_state.tap_count() == 0),
-      Box::new(interceptor),
-    ))?;
+    hook.load_js_tap_register(state)?;
 
     let mut source = String::new();
     hook.call(&mut source)?;

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -1086,7 +1086,10 @@ class Compiler {
     const getTaps = (stages: number[]) => {
       const compiler = that.deref()!;
       const hook = getHook();
-      if (!hook.isUsed()) return [];
+      if (!hook.isUsed()) {
+        compiler.#instance!.setRegisterJsTapCount(registerKind, 0);
+        return [];
+      }
       const breakpoints = [
         liteTapable.minStage,
         ...stages,
@@ -1105,6 +1108,7 @@ class Compiler {
         });
       }
       compiler.#decorateJsTaps(jsTaps);
+      compiler.#instance!.setRegisterJsTapCount(registerKind, jsTaps.length);
       return jsTaps;
     };
     getTaps.registerKind = registerKind;
@@ -1125,7 +1129,10 @@ class Compiler {
     const getTaps = (stages: number[]) => {
       const compiler = that.deref()!;
       const map = getHookMap();
-      if (!map.isUsed()) return [];
+      if (!map.isUsed()) {
+        compiler.#instance!.setRegisterJsTapCount(registerKind, 0);
+        return [];
+      }
       const breakpoints = [
         liteTapable.minStage,
         ...stages,
@@ -1144,6 +1151,7 @@ class Compiler {
         });
       }
       compiler.#decorateJsTaps(jsTaps);
+      compiler.#instance!.setRegisterJsTapCount(registerKind, jsTaps.length);
       return jsTaps;
     };
     getTaps.registerKind = registerKind;

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,325 @@
+# JS Hook Register 感知真实 Tap 的执行计划
+
+## 目标
+
+当前 `JsHooksAdapterPlugin` 把每个 JS hook register 当作普通 `Interceptor` 安装到 Rust hook。这样即使 JS 侧没有真实 tap，`HookCommon::is_empty()` 也会因为存在 interceptor 返回 `false`，hook 调用仍会进入 tracing、register/附加 tap 分支，Rust 侧也无法单独判断 JS hook 是否被使用。
+
+本次改造需要达到以下结果：
+
+- JS register 不再占用通用 interceptor 槽位，而是通过 hook 的专用加载接口安装。
+- 新增 `JsTapRegister`，用类型擦除的函数封装“按 Rust tap stages 获取 JS taps”的过程，并在 Rust 侧保存 JS register 最近一次上报的 tap 数量。
+- `Hook::is_empty()` 同时考虑 Rust taps、普通 interceptors 和 JS 真实 taps；仅安装了一个当前为空的 JS register 时仍然返回 `true`。
+- hook 对外提供 `has_js_taps()`，不触发 N-API/register 调用即可检查 JS 侧是否有 tap。
+- 每种 hook 的 `call` 在创建 tracing span、调用 register 或准备 futures 之前先检查 `is_empty()`，为空时按该 hook 的返回语义直接结束。
+- `define_hook!` 只生成 hook 参数签名和具体 `tap.run(...)` 所必需的代码；JS register 存储、空状态、执行路径选择、类型校验和 stage 准备下沉到 `rspack_hook` 的非泛型共享实现，避免每个 hook 重复展开以及引入新的泛型单态化膨胀。
+- 保持现有 Rust/JS tap 的 stage 排序、register 缓存、动态 tap 状态更新以及普通 interceptor 行为不变。
+
+## 当前执行流
+
+涉及文件：
+
+- `crates/rspack_hook/src/lib.rs`
+- `crates/rspack_macros/src/hook.rs`
+- `crates/rspack_binding_api/src/plugins/interceptor.rs`
+- `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`
+- `packages/rspack/src/Compiler.ts`
+
+```text
+Compiler.ts
+  根据 lite-tapable 的 isUsed() 更新 NonSkippableRegisters
+       ↓
+JsHooksAdapterPlugin::apply / compilation adapter
+  将每个 Register* 克隆后通过 hook.intercept(...) 安装
+       ↓
+HookCommon
+  interceptor_count > 0，因此 is_empty() 恒为 false
+       ↓
+Hook::call
+  调用所有 interceptor
+       ↓
+RegisterJsTapsInner
+  检查 NonSkippableRegisters，必要时调用 JS register
+       ↓
+将返回的 JS taps 与 Rust taps 按 stage 合并执行
+```
+
+问题的核心是：JS 侧已经能计算 hook 是否被使用、register 也能得到最终生成的 `JsTap[]`，但这些信息没有记录到具体 Rust hook。目标不是让 `is_empty()` 回调 JS 查询，而是由 JS 在既有注册流程中主动把数量同步到 Rust，之后热路径只读 Rust 本地状态。
+
+## 目标设计
+
+### 1. 在 `rspack_hook` 增加非泛型的 `JsTapRegister`
+
+在 `crates/rspack_hook/src/lib.rs` 中增加单一的非泛型 `JsTapRegister`。不要定义 `JsTapRegister<T>`，也不要为每种 hook tap trait 单态化一套 register 容器。建议包含以下成员：
+
+- `owner`：对 binding 提供的 `Arc<RegisterJsTapsInner>` 做所有权类型擦除后得到的单一 `Arc<dyn Any + Send + Sync>`（或等价 erased owner）。它与各 `Register*` 指向同一个 inner allocation，不再单独分配 `Arc<AtomicUsize>`。
+- `load_tap_count`：非捕获 Rust function pointer/accessor，从 erased owner 中读取 inner 内嵌的 `AtomicUsize`；`is_empty()` 只经过这层 Rust 本地访问，不触发 JS/N-API 调度。
+- `tap_type_id: TypeId`：记录 register 输出中承载的具体 hook tap trait-object 类型，在加载 register 时校验一次，避免错误 register 到执行期才静默失败。
+- `function`：以 erased owner 和 Rust hook 已使用的 `Vec<i32>` 为输入，返回类型擦除的 tap payload，例如 `Vec<Box<dyn Any + Send + Sync>>`。用内部枚举保存以下两种已擦除函数：
+  - async：非泛型 boxed function，返回类型擦除 tap vector 的 boxed future；
+  - blocking：非泛型 boxed function，直接返回类型擦除 tap vector。
+
+当前 binding 中的 JS hooks 都走 async register 构造；blocking 变体用于保证 hook 抽象完整，并允许在宏测试中覆盖 `Sync` hook。不要在同步 hook 中阻塞等待 async future。
+
+为该类型提供最小接口：
+
+- `new_async<T, O>(owner: Arc<O>, ...)` / `new_blocking<T, O>(...)`：泛型只出现在很薄的所有权/类型擦除边界，用来记录 `TypeId`，把 owner 和 `Vec<T>` 擦除；容器、存储和实际调度方法本身保持非泛型。
+- `tap_count()` / `is_empty()`：通过 Rust accessor 对 inner 内嵌的 `AtomicUsize` 做 acquire load，供 hook 的 `is_empty()` 和 `has_js_taps()` 使用。
+- `call_erased(used_stages)` / `call_erased_blocking(used_stages)`：共享、非泛型调度方法；仅在确认存在 JS taps 后调用匹配执行模式的 register 函数。
+
+使用按值传入的 `Vec<i32>` 和 `'static` boxed future，避免让公共类型依赖具体 hook 类型或 binding 类型，也避免把 `rspack_binding_api` 的 N-API 类型泄漏到 `rspack_hook`。`JsTapRegister` 持有 erased owner，因此异步 future 可以安全借用或克隆同一个 inner owner；不使用裸指针指向内嵌 count。类型擦除带来的转换只发生在 JS register 边界，不改变 Rust 原生 taps 的存储和热执行路径。
+
+### 2. 将 hook 共享状态和决策下沉到 `HookCommon`
+
+扩展 `crates/rspack_hook/src/lib.rs` 的非泛型 `HookCommon`，集中保存和实现：
+
+- `js_tap_register: Option<JsTapRegister>`，默认值为 `None`，每个 hook 最多加载一个 JS register。
+- `load_js_tap_register(register, expected_tap_type_id)`：校验输出 tap 类型并设置 register，不增加 `interceptor_count`；重复加载必须显式报错或断言。
+- `has_js_taps()`、`is_empty()`、`used_stages()` 等状态查询。
+- 非泛型的 `HookCallMode`（例如 `Empty`、`RustOnly`、`WithAdditionalTaps`），让宏生成的 call 只做一次共享决策，不重复生成 interceptor/JS register 状态组合判断。
+- JS register 的非泛型调用、计数读取以及 erased tap vector 的返回。
+
+不要新增 `HookStorage<T>`、`HookCommon<T>` 或把整套执行器做成泛型 helper；这类抽象虽然减少 token 数，却仍会为每种 tap 类型单态化，不能解决最终二进制膨胀。
+
+### 3. 让 `define_hook!` 只生成不可共享的薄胶水
+
+修改 `crates/rspack_macros/src/hook.rs`，生成的具体 hook 继续只保存强类型 Rust taps 和普通 interceptors，但 JS register 留在 `HookCommon`。宏生成代码缩减为：
+
+- hook trait 与参数/返回值签名。
+- `tap()` 时把 stage 和强类型 Rust tap 写入现有存储。
+- `Hook` trait 方法对 `HookCommon` 的薄委托，包括专用 `load_js_tap_register(...)`。
+- `call` 最外层根据 `HookCommon::call_mode()` 处理空返回；需要 JS taps 时调用共享的 erased register，再通过一个很薄的 `unerase_taps::<Self::Tap>` 边界恢复本 hook 的 tap trait object。
+- 各执行类型真正无法共享的 `tap.run(args...)`、bail/waterfall 返回传播和 parallel future 组装。
+
+类型恢复 helper 允许有一个很小的泛型实例，但只负责 `TypeId` 校验后的 downcast/unbox；register 调度、状态机、计数、缓存入口和 stage 索引逻辑不能放进该泛型函数。这样把单态化范围限制在必要的 tap 类型转换上。
+
+`Hook` trait 增加专用加载入口，使 binding adapter 可以统一安装 register；具体 hook 同时保留易于调用的 `has_js_taps()`/`is_empty()` 查询方法，但这些方法体只委托 `HookCommon`，不在每个宏展开中复制状态逻辑。
+
+### 4. 在所有 hook call 的真正入口增加空路径快速返回
+
+在宏生成 `call` 的最外层先执行 `self.is_empty()`，并且把检查放在 tracing span 和 register 调用之前。不同 hook 类型的空返回值如下：
+
+| Hook 类型 | 空 hook 返回值 |
+| --- | --- |
+| `Series` / `Sync` / `Parallel` | `Ok(())` |
+| `SeriesBail` | `Ok(None)` |
+| `SeriesWaterfall` | `Ok(data)`，原样返回 waterfall 输入 |
+
+通过空检查后，再区分两条执行路径：
+
+- 没有普通 interceptor 且 `has_js_taps() == false`：直接执行已排序的 Rust taps，不构造额外 tap 容器。
+- 存在普通 interceptor 或 JS taps：收集普通 interceptor 返回的 taps；仅当 `has_js_taps()` 为真时调用 JS register；最后复用 `merged_tap_indices_by_stage` 合并执行。
+
+这样即使 hook 有 Rust taps、但 JS register 当前为空，也不会为 JS register 支付 N-API 或 future 分配成本。
+
+### 5. 将 binding register 转换为 `JsTapRegister`
+
+修改 `crates/rspack_binding_api/src/plugins/interceptor.rs`：
+
+- 将所有 `Register*` 改为 `inner: Arc<RegisterJsTapsInner>`；`Clone` 只克隆这一层 owner，不再手工 clone inner 的 register、cache 和状态字段。
+- `RegisterJsTapsInner` 直接内嵌 `tap_count: AtomicUsize`、`always_active`/bootstrap 标记和 register cache。`RegisterJsTapsCache::Cache` 改为直接持有 `RwLock<Option<RegisterFunctionOutput>>`，因为外层 inner 已经由 `Arc` 共享，不需要 `Arc<RwLock<...>>` 的第二层共享所有权。
+- 在 inner 上集中提供 `tap_count()` 和 `set_tap_count(count)`；setter 对 `always_active` 统一执行 `max(count, 1)`，所有单个/批量更新都必须走该方法，避免某条路径把 bootstrap register 写成 0。
+- `RegisterJsTapsInner::call_register` 改为直接接收 `Vec<i32>`（或 stages slice 后在边界复制），不再接收 `impl Hook`；排序/去重由 hook 的 `used_stages()` 保证。
+- `RegisterJsTapsInner` 不再保存 `Option<NonSkippableRegisters>`，也不再另外分配 `Arc<AtomicUsize>`；`JsTapRegister` 类型擦除并持有同一个 `Arc<RegisterJsTapsInner>`，从 inner 内部读取 count。
+- `skip = false` 的 bootstrap register 初始计数设为非零，避免首次 `CompilerThisCompilation` 被空路径跳过；`skip = true` 的 register 初始为 0，并由首次 bootstrap 状态同步写入 0/非 0。
+- 调整 `define_register!`：删除各 `Register*` 对 `Interceptor<SpecificHook>` 的实现，改为生成非泛型 `JsTapRegister`。宏只在构造边界把具体 `$tap_name` trait object 包装成 erased tap payload，不为每个 hook 生成一套 register 调度实现。
+- register function 通过 `JsTapRegister` 持有的 erased owner 取回 `RegisterJsTapsInner`，调用原有缓存逻辑，并继续把类型擦除的 `ThreadsafeJsTap` 转成对应的 `$tap_name` trait object，再统一擦除输出；function 本身不额外捕获另一份状态 `Arc`。
+- 各 `Register*::clear_cache()` 直接操作 `self.inner.cache`，确保 adapter、hook 和 plugin cache cleanup 始终落在同一个 inner allocation。
+
+新的所有权关系如下：
+
+```text
+Register* ───────────────┐
+JsTapRegister(erased) ───┼─ Arc<RegisterJsTapsInner>
+binding count setter ────┘      ├─ RegisterFunction
+                                ├─ RwLock<Cache>
+                                ├─ AtomicUsize tap_count
+                                └─ bootstrap/always_active 标记
+```
+
+这里存在多个 `Arc` handle，但只有一层 `Arc` allocation，不是 `Arc<Inner>` 再嵌套 `Arc<AtomicUsize>`/`Arc<RwLock<...>>`。inner 不反向引用 hook 或 plugin，因此不会形成引用环。
+
+### 6. 由 JS register 主动向 Rust 上报数量
+
+修改 `crates/rspack_binding_api/src/lib.rs` 和 `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`：
+
+- 增加同步 N-API 方法 `setRegisterJsTapCount(kind, count)`；它只根据 `RegisterJsTapKind` 找到对应 register 并调用 `register.inner.set_tap_count(count)`，不执行 hook/register，也不反向调用 JS。
+- 删除 `NonSkippableRegisters(Arc<RwLock<Vec<...>>>)`。`JsHooksAdapterPlugin` 已持有全部 `Register*`，因此 count 更新可以直接按 kind 路由到对应 inner。
+- 现有 `setNonSkippableRegisters(kinds)` 暂时保留为 bootstrap/动态失效的批量 N-API 入口，但不再写全局集合：它遍历/路由各 `Register*`，把 kind 在集合中的 inner count 写成 1、其余写成 0；`always_active` 项保持至少为 1。
+- 单个 count 更新和批量状态更新最终都写各自 `RegisterJsTapsInner` 内同一个 `AtomicUsize`，不维护额外的共享 map、count handle 或全局锁。
+
+修改 `packages/rspack/src/Compiler.ts`：
+
+- 在 `#createHookRegisterTaps` 和 `#createHookMapRegisterTaps` 生成的 JS register 中，完成 stage range 查询并得到最终 `jsTaps` 后，额外同步调用一次 `setRegisterJsTapCount(registerKind, jsTaps.length)`，再返回 `jsTaps`。
+- 这个额外调用发生在 JS register 本来就已被 Rust 调度到 JS 的过程中，不由 `is_empty()` 发起；因此不会给每次空检查增加 Rust/JS 往返。
+- 保留 `#updateNonSkippableRegisters()` 的职责，用于首次 `thisCompilation` bootstrap，以及 tap 在执行过程中新增/移除后、下一次 register 尚未运行前，批量同步 0/非 0 状态。register 真正运行后再用 `jsTaps.length` 覆盖为精确数量。
+- `#decorateJsTaps` 仍在最后一个 tap 完成后刷新状态，避免 tap 自移除后 Rust 继续把该 hook 判断为非空。
+
+计数的语义是“本次 register 生成的 JS stage-range tap 包装数量”。对于 `is_empty()`，只要求 `0` 与 `> 0` 准确；bootstrap 批量同步可以先写 0/1，register 执行后再写精确值。
+
+### 7. 替换所有 JS adapter 的安装点
+
+修改 `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`，将所有 JS register 的：
+
+```text
+hook.intercept(register.clone())
+```
+
+统一替换为：
+
+```text
+hook.load_js_tap_register(register.clone().into_js_tap_register())
+```
+
+覆盖以下安装阶段，避免遗漏仅在 compilation 创建后才取得的插件 hooks：
+
+- `JsHooksAdapterPlugin::apply` 中的 compiler、compilation、NormalModuleFactory、ContextModuleFactory hooks。
+- `js_hooks_adapter_compilation` 中的 JavaScript modules hooks。
+- `html_hooks_adapter_compilation` 中的 HtmlRspackPlugin hooks。
+- `runtime_hooks_adapter_compilation` 中的 RuntimePlugin hooks。
+- `real_content_hash_hooks_adapter_compilation` 中的 RealContentHashPlugin hooks。
+- `rsdoctor_hooks_adapter_compilation` 中的 RsdoctorPlugin hooks。
+
+普通 Rust interceptor 的 API 和已有测试保持不动；本次只迁移 JS register。
+
+## 改造后的执行流
+
+```text
+Compiler.ts
+  thisCompilation bootstrap / 动态变更
+  根据 hook/hookMap.isUsed() 批量同步 0/非 0
+       ↓
+binding 的 Register*
+  在薄构造边界生成非泛型 JsTapRegister
+  └─ 类型擦除同一个 Arc<RegisterJsTapsInner>
+       ├─ AtomicUsize tap_count
+       ├─ RwLock cache
+       └─ RegisterFunction
+       ↓
+hook.load_js_tap_register(...)
+  HookCommon 校验 TypeId 后存入共享槽位
+  不计入 interceptor_count
+       ↓
+Hook::call 最前面检查 is_empty()
+  HookCommon::call_mode() 只读取 Rust 本地状态
+  ├─ Rust tap / interceptor / JS tap 全部为空 → 按 hook 类型直接返回
+  ├─ 仅 Rust taps → 直接执行强类型 taps
+  └─ 需要 additional taps
+       ↓
+has_js_taps()
+  ├─ false → 不调用 JS register，只执行 Rust taps/普通 interceptors
+  └─ true  → HookCommon 调用非泛型 register，得到 erased JS taps
+       ↓
+JS register
+  setRegisterJsTapCount(kind, jsTaps.length)
+  同步把本次精确数量写回 Rust
+       ↓
+define_hook 薄胶水
+  校验后恢复为当前 hook 的 tap trait object
+       ↓
+merged_tap_indices_by_stage
+  合并 Rust taps、普通 interceptor taps 和 JS taps
+       ↓
+按 Series / Bail / Waterfall / Parallel 语义执行
+```
+
+## 顺序与兼容性约束
+
+- Rust tap 在 `tap()` 时仍按 stage 稳定插入；JS register 返回的 tap stage 仍由 `Compiler.ts` 的 stage range 查询生成。
+- 继续使用 `merged_tap_indices_by_stage`，确保 Rust/JS taps 的主排序规则不变；相同 stage 时保持当前 Rust base tap 优先于 additional/JS tap 的规则。
+- JS register 是单独的 additional tap 来源；若同时存在普通 interceptors，应固定收集顺序并加测试，保证同 stage 的结果确定。建议普通 interceptors 保持注册顺序，JS taps 固定追加在其后。
+- `has_js_taps()` 只表示 JS 侧状态，不把 Rust taps 或普通 interceptors 算进去；`is_empty()` 才表示整个 hook 是否为空。
+- `JsTapRegister`、`HookCommon`、register function enum、erased tap 容器和 call-mode 状态机必须是非泛型具体类型；禁止把它们改成按 hook/tap 类型实例化的泛型 storage/executor。
+- 宏展开中只保留强类型参数调用所必需的逻辑。共享状态判断、JS register 调度和类型检查不得以内联 token 的形式在每个 `define_hook!` 展开中复制。
+- erased tap 恢复产生的额外分配/转换只允许出现在 JS register 路径；Rust-only fast path不能增加 `Any`、downcast、boxed future 或额外分配。
+- `has_js_taps()` 和空路径检查不得调用类型擦除的 register，也不得触发 JS/N-API 调度；共享 helper 只能通过 Rust accessor 读取 `Arc<RegisterJsTapsInner>` 内嵌的 `AtomicUsize`。JS→Rust 的额外调用只能出现在 JS register 已经执行的路径中。
+- count/cache/register 必须共享同一个 `Arc<RegisterJsTapsInner>` owner；禁止重新引入 `Arc<AtomicUsize>`、`Arc<RwLock<Cache>>` 或全局 `NonSkippableRegisters` 锁。
+- JS 写入 count 后，后续 Rust `is_empty()` 必须直接看到更新；使用成对的 release store / acquire load（或更强顺序）明确跨线程可见性。
+- `skip = false` 的 register 初始计数继续保持非零；这是现有 JS register 状态初始化的 bootstrap 约束，不能在首次 `thisCompilation` 前把它判断为空。
+- 批量 0/1 更新与 register 的精确 count 更新可能先后发生，必须按调用时序写入同一原子值；不要让较旧的异步任务覆盖较新的状态。新增的 N-API setter 应为同步写入。
+- register 抛错、JS tap 抛错、bail 和 waterfall 的错误/返回传播方式保持现状。
+
+## 测试计划
+
+### Rust 宏行为测试
+
+在专用测试 crate 的 `crates/rspack_macros_test/tests/hook.rs` 中增加一个由 `Arc<MockRegisterInner>` 整体共享、count 内嵌为 `AtomicUsize` 的 mock `JsTapRegister`，覆盖：
+
+1. 默认 hook：`is_empty() == true`、`has_js_taps() == false`，调用后直接返回。
+2. 已加载但计数为 0 的 JS register：hook 仍为空，且 register 回调调用次数保持为 0。
+3. Rust 计数从 0 切换为非零：`has_js_taps()` 和 `is_empty()` 立即反映变化，调用时执行 JS tap；断言空检查没有调用任何状态查询函数。
+4. 存在 Rust tap、JS register 为空：只执行 Rust tap，不调用 JS register。
+5. Rust tap、普通 interceptor tap、JS tap 同时存在：验证 stage 合并和同 stage 的确定性顺序。
+6. 分别覆盖 `Series`、`Sync`、`SeriesBail`、`SeriesWaterfall`、`Parallel` 的空返回语义，尤其验证 waterfall 原样返回输入、bail 返回 `None`。
+7. 定义至少两个 tap trait 不同的 hook，验证它们共用同一个非泛型 `JsTapRegister`/`HookCommon` 路径；错误的 tap `TypeId` 在加载时被拒绝，而不是执行时 panic。
+8. 保留并运行现有 `AdditionalTaps` 测试，确认通用 interceptor 没有回归。
+
+### 生成代码与单态化检查
+
+- 检查 `define_hook!` 展开结果，确认 `is_empty`、`has_js_taps`、JS register 调度和 call-mode 分支只是调用 `HookCommon`，没有为每个 hook 复制完整实现。
+- 对比改造前后的 release 构建符号/LLVM lines（优先使用仓库已有二进制体积流程；本地工具可用时使用 `cargo llvm-lines` 或等价工具），确认没有按每个 `Hook::Tap` 生成 `JsTapRegister<T>`、泛型 storage 或泛型 executor 实例。
+- 记录允许保留的单态化边界：`new_async::<Tap>`/`new_blocking::<Tap>` 的薄擦除构造和 `unerase_taps::<Tap>` 的薄恢复函数；若这两部分体积明显增长，再改成宏内最小转换，不扩大共享执行器的泛型范围。
+
+### Binding 与 JS 回归验证
+
+- 通过编译保证所有 `Register*` 都能转换为目标 hook 的 trait object，所有 adapter 安装点均已迁移。
+- 验证克隆 `Register*`、加载到 `HookCommon` 的 erased owner、调用 `clear_cache()` 和 N-API count setter 操作的是同一个 `RegisterJsTapsInner`；释放 plugin/hook 后没有 owner cycle。
+- 验证 JS register 返回空数组和非空数组时，`setRegisterJsTapCount` 分别写入 0 和 `jsTaps.length`，且下一次 Rust hook call 按本地计数选择快速路径。
+- 验证首次 compilation 仍由非零 bootstrap count 驱动，并能批量初始化其他 register；否则初始为 0 的 hook 会永远没有机会执行 register。
+- 验证 JS tap 在执行期间自移除/新增后，`#decorateJsTaps` 的批量更新不会留下过期的非零/零计数。
+- 运行已有 stage 与 hook 用例，例如 `configCases/hooks/stage-make`、`configCases/hooks/stage-compilation`、`hookCases/compilation#processAssets`，确认 JS tap 仍执行且顺序不变。
+- 如需要新增集成覆盖，只在现有 `tests/rspack-test` runner 下增加 case，不创建新的顶层 `test.js` runner；case 应验证“无 JS tap 不影响构建”和“有 JS tap 仍被调用”，性能快速路径本身由 Rust mock 的调用计数断言。
+
+### 建议验证命令
+
+```bash
+cargo test -p rspack_macros_test --test hook
+pnpm run build:binding:dev
+cd tests/rspack-test && pnpm run test -t "configCases/hooks/stage-make"
+cd tests/rspack-test && pnpm run test -t "configCases/hooks/stage-compilation"
+pnpm run test:rs
+pnpm run lint:rs
+cargo lint
+```
+
+按项目约定，不运行会在 sandbox 中卡住的 storage 和 native watcher 相关测试。
+
+## 实施顺序
+
+1. 在 `rspack_hook` 定义非泛型 `JsTapRegister`、erased tap payload、共享计数接口和 call-mode 枚举。
+2. 扩展非泛型 `HookCommon`，把 JS register 槽位、类型校验、空状态、路径选择和 erased register 调度全部收进去。
+3. 精简 `define_hook!`：只生成参数签名、强类型 Rust tap 存储、对 `HookCommon` 的薄委托，以及各 hook 类型不可共享的 `tap.run(...)`/返回传播逻辑。
+4. 在 `rspack_macros_test` 用 mock register 固化空状态、动态状态、类型校验和各 hook 类型语义，并确认 Rust-only 路径不进入类型擦除逻辑。
+5. 改造 binding 的 `RegisterJsTapsInner` 与 `define_register!`：用单层 `Arc<RegisterJsTapsInner>` 统一拥有 register、cache、count 和 bootstrap 状态，并从 `Interceptor` 实现切换为非泛型 `JsTapRegister` 构造。
+6. 增加 `setRegisterJsTapCount`，再修改两个 JS register factory，在返回 `JsTap[]` 前同步上报数组长度。
+7. 删除全局 `NonSkippableRegisters` 状态，让现有 `setNonSkippableRegisters` 批量入口直接更新各 register inner 的 count，并验证首次 bootstrap 和 tap 动态变化时的 0/非 0 更新。
+8. 批量迁移 `JsHooksAdapterPlugin` 的全部安装点，并用搜索确认不再有 JS register 走 `.intercept(...)`。
+9. 编译 binding，运行宏测试和现有 JS hook/stage 回归用例。
+10. 检查宏展开和 release 单态化/体积变化，确认共享实现没有以泛型 helper 的形式重新膨胀。
+11. 运行 Rust 测试与 lint，最后检查 diff 中没有改变 JS register 的缓存清理，并确认 `is_empty()` 路径没有任何 JS/N-API 调用。
+
+## 实施结果
+
+已按上述设计完成实现：
+
+- `JsTapRegister`、`HookCommon` 和 `HookCallMode` 已集中在 `rspack_hook`；空状态只读取 Rust 本地 count，register 调度与 tracing 均位于空路径之后。
+- 52 个 binding register 全部改为共享单层 `Arc<RegisterJsTapsInner>`，inner 直接内嵌 cache、`AtomicUsize` 和 `always_active`；旧 `NonSkippableRegisters` 全局锁已删除。
+- 52 个 adapter 安装点全部从 `.intercept(...)` 迁移到 `.load_js_tap_register(...)`，普通 interceptor 保持原 API 和执行顺序。
+- JS hook 与 HookMap register 都会把最终 `JsTap[]` 长度同步到新的 `setRegisterJsTapCount`；批量 bootstrap API 保留并直接写同一批 inner count。
+- 宏专项测试覆盖空 register、动态 count、Rust-only 快路径、同步 register、错误 tap 类型、stage 合并，以及 Series/Sync/Bail/Waterfall 空返回；现有 interceptor 测试继续通过。仓库当前没有使用 `Parallel` hook，专项测试 crate 也没有宏展开所需的 `futures_concurrency` 依赖，因此没有为测试单独引入新的运行时依赖；Parallel 的空分支与 Series 一样生成 `Ok(())`。
+
+已完成验证：
+
+```text
+pnpm run build:cli:dev
+cargo test -p rspack_macros_test --test hook
+cargo clippy -p rspack_hook -p rspack_macros -p rspack_binding_api -p rspack_macros_test --tests -- -D warnings
+pnpm run lint:rs
+pnpm run lint:js
+pnpm run test -t "Hook"
+pnpm run test -t "compilerCases/hooks-closure"
+pnpm run test -t "configCases/hooks/stage-make"
+pnpm run test -t "configCases/hooks/stage-compilation"
+pnpm run test -t "hookCases/compilation#processAssets"
+```
+
+本地未安装 `cargo llvm-lines`/`cargo expand`，因此没有生成额外的 LLVM lines 数值对比；代码检查确认共享 storage、状态机和 erased 调度均为非泛型具体类型，只在 `new_async`/`new_blocking` 与 `unerase_js_taps` 保留计划允许的薄泛型边界。

--- a/plan.md
+++ b/plan.md
@@ -14,12 +14,12 @@ RegisterJsTapsInner
   AtomicUsize 保存 tap_count
        ↓ Arc 共享同一个 inner
 JsTapRegister
-  is_empty 闭包只读取 inner.tap_count
-  类型擦除保存原 Interceptor<具体 Hook>
-       ↓ hook.load_js_tap_register 时 downcast 一次
+  trait 只暴露 is_empty()
+       ↓ 仅 RegisterJsTapsInner 实现
 Hook
-  js_tap_register 字段：只负责 has_js_taps/is_empty
-  interceptors 字段：按原路径执行 JS register
+  泛型 load_js_tap_register<RegisterJsTapsInner>
+  ├─ Arc 擦除为非泛型 JsTapRegister 状态字段
+  └─ Arc clone 放进原 interceptors 字段
        ↓
 hook.call
   empty -> tracing/register 前直接返回
@@ -27,25 +27,24 @@ hook.call
   additional -> 执行原 interceptors，按 stage 合并 taps
 ```
 
-## 1. `rspack_hook`：轻量 `JsTapRegister`
+## 1. `rspack_hook`：轻量 `JsTapRegister` trait
 
 文件：`crates/rspack_hook/src/lib.rs`
 
-- `JsTapRegister` 只保存：
-  - 一个类型擦除的 Rust `is_empty` 闭包；
-  - 一个待 hook 加载的类型擦除 interceptor。
-- `new` 直接接收擦除后的值，不提供泛型构造器或 `new_erased`。
-- 删除 register owner、erased taps、async/blocking register function 等第二套执行抽象。
+- `JsTapRegister` 是只包含 `is_empty()` 的非泛型 trait，不保存 executor、owner 或 tap payload。
+- 为 `Arc<T>` 复用 `Interceptor<H>` 调用；生产代码中的 `T` 只有 `RegisterJsTapsInner`。
+- 删除 erased owner/taps、闭包、`Any`、downcast 和 async/blocking register function 等第二套执行抽象。
 - `HookCommon` 只保存所有 hook 共享的 metadata、Rust tap stages 和普通 interceptor 数量。
 - `HookCommon::call_mode(has_js_taps)` 根据本地布尔状态返回 `Empty`、`RustTaps` 或 `AdditionalTaps`。
 
-## 2. `define_hook!`：只增加状态字段并恢复 interceptor
+## 2. `define_hook!`：泛型加载，原 interceptor 路径执行
 
 文件：`crates/rspack_macros/src/hook.rs`
 
-- 每个 hook 增加 `js_tap_register: Option<JsTapRegister>`。
-- `load_js_tap_register` 将擦除对象 downcast 为 `Box<dyn Interceptor<Self>>`，放入现有 `interceptors`；这个 JS interceptor 不增加普通 interceptor count。
-- `has_js_taps()` 只调用 register 的 Rust `is_empty` 闭包。
+- 每个 hook 增加 `js_tap_register: Option<Arc<dyn JsTapRegister>>`，只用于保存 inner 所有权并查询状态。
+- `load_js_tap_register<R>` 要求 `R: JsTapRegister + Interceptor<Self>`；生产侧唯一 concrete `R` 是 `RegisterJsTapsInner`。
+- 加载时 clone 同一个 inner `Arc` 到现有 `interceptors`，但不增加普通 interceptor count；另一个 Arc handle 擦除为非泛型状态字段，不增加 inner allocation。
+- `has_js_taps()` 只调用 Rust trait 的 `is_empty()`。
 - `call` 在 tracing span 和 interceptor/register 调用前计算 call mode；空 hook 直接返回对应空值。
 - additional taps 完全走现有 interceptor 循环和 stage merge，不生成 erased JS taps 的加载/还原代码。
 
@@ -67,13 +66,11 @@ hook.call
 
 文件：`crates/rspack_binding_api/src/plugins/interceptor.rs`
 
-- 恢复/保留每个 `Register*` 对 `Interceptor<具体 Hook>` 的实现。
-- interceptor 首先读取 `inner.tap_count`；0 时返回空 taps，否则调用已有 register/cache 逻辑并转换具体 tap。
-- `into_js_tap_register`：
-  - clone 同一个 `Arc<RegisterJsTapsInner>` 到共享的 `is_empty` 闭包；
-  - 将 `self` 转为 `Box<dyn Interceptor<具体 Hook>>` 后再做 `Any` 类型擦除；
-  - 构造非泛型 `JsTapRegister`。
-- 不生成新的 async/blocking executor、owner downcast、whole-vector downcast 或逐 tap downcast。
+- 只为 `RegisterJsTapsInner` 实现一次 `JsTapRegister`。
+- 宏为同一个 `RegisterJsTapsInner` 生成各具体 Hook 必需的 `Interceptor<具体 Hook>` 实现。
+- interceptor 首先读取 `tap_count`；0 时返回空 taps，否则调用已有 register/cache 逻辑并转换具体 tap。
+- adapter 调用点直接把各 `Register*` 内的 `Arc<RegisterJsTapsInner>` 传给 hook；删除 `into_js_tap_register`。
+- 不生成新的 async/blocking executor、owner/downcast、whole-vector downcast或逐 tap downcast。
 
 ## 5. JS 状态同步
 
@@ -95,7 +92,7 @@ hook.call
   - JS tap 从 0 变为非 0 后，hook 能立即感知；
   - Rust taps、普通 interceptors、JS taps 按 stage 合并；
   - 只有 Rust taps 且 JS register 为空时走快速路径；
-  - 同步 hook 也能加载类型擦除的 interceptor。
+  - 同步 hook 也能通过同一泛型加载接口运行 register interceptor。
 - 运行 `cargo test -p rspack_macros_test --test hook`。
 - 运行 binding/macros test crate 的 clippy。
 - 运行 JS formatter 检查。
@@ -107,7 +104,7 @@ hook.call
 - [x] `RegisterJsTapsInner` 改为单层 `Arc`，内嵌 cache 和 count。
 - [x] 删除 `NonSkippableRegisters`。
 - [x] hook 空路径在 tracing/register 前返回。
-- [x] `JsTapRegister` 收敛为状态检查 + 类型擦除 interceptor。
+- [x] `JsTapRegister` 收敛为仅含本地状态检查的 trait，且仅由 `RegisterJsTapsInner` 实现。
 - [x] `define_register!` 复用原 `Interceptor` 执行路径。
-- [x] 完成最终测试和 CI profile 体积比较（stripped native binding `+36,856 bytes`，低于 50 KiB 阈值）。
+- [x] 完成最终测试和 CI profile 体积比较（stripped native binding `+20,472 bytes`，低于 50 KiB 阈值）。
 - [x] 更新 draft PR。

--- a/plan.md
+++ b/plan.md
@@ -12,41 +12,42 @@ JS hook 注册/移除 tap
        ↓ 一次 JS -> Rust 同步
 RegisterJsTapsInner
   AtomicUsize 保存 tap_count
-       ↓ Arc 共享同一个 inner
+       ↓ Register* 方法隐藏 Arc clone
 JsTapRegister
-  trait 只暴露 is_empty()
-       ↓ 仅 RegisterJsTapsInner 实现
-Hook
-  泛型 load_js_tap_register<RegisterJsTapsInner>
-  ├─ Arc 擦除为非泛型 JsTapRegister 状态字段
-  └─ Arc clone 放进原 interceptors 字段
+  非泛型 trait 只暴露 is_empty
+       ↓ Arc<dyn JsTapRegister> 存入非泛型 HookCommon
+load_js_tap_register<R>
+  在具体 Hook 边界要求 R: Interceptor<Self>
+  同一个 Arc<R> 延迟转换为当前 Hook 的 interceptor
        ↓
-hook.call
+Hook.call
+  通过原 interceptors 路径调用 register
+       ↓
   empty -> tracing/register 前直接返回
   rust only -> 直接执行 Rust taps
-  additional -> 执行原 interceptors，按 stage 合并 taps
+  additional -> 执行普通 interceptors 和 JS interceptor，按 stage 合并 taps
 ```
 
-## 1. `rspack_hook`：轻量 `JsTapRegister` trait
+## 1. `rspack_hook`：非泛型 `JsTapRegister` trait
 
 文件：`crates/rspack_hook/src/lib.rs`
 
-- `JsTapRegister` 是只包含 `is_empty()` 的非泛型 trait，不保存 executor、owner 或 tap payload。
-- 为 `Arc<T>` 复用 `Interceptor<H>` 调用；生产代码中的 `T` 只有 `RegisterJsTapsInner`。
-- 删除 erased owner/taps、闭包、`Any`、downcast 和 async/blocking register function 等第二套执行抽象。
-- `HookCommon` 只保存所有 hook 共享的 metadata、Rust tap stages 和普通 interceptor 数量。
-- `HookCommon::call_mode(has_js_taps)` 根据本地布尔状态返回 `Empty`、`RustTaps` 或 `AdditionalTaps`。
+- `JsTapRegister` 是 object-safe 的非泛型 trait，只暴露本地 `is_empty()`。
+- 非泛型 `HookCommon` 保存 `Arc<dyn JsTapRegister>`，统一管理重复加载、`has_js_taps()`、`is_empty()` 和 call mode。
+- 不使用闭包、`Any`、downcast 或手写函数指针表。
+- `HookCommon::call_mode()` 根据 Rust taps、普通 interceptors 和本地 JS tap 状态返回 `Empty`、`RustTaps` 或 `AdditionalTaps`。
 
-## 2. `define_hook!`：泛型加载，原 interceptor 路径执行
+## 2. `define_hook!`：在具体 Hook 边界延迟转换
 
 文件：`crates/rspack_macros/src/hook.rs`
 
-- 每个 hook 增加 `js_tap_register: Option<Arc<dyn JsTapRegister>>`，只用于保存 inner 所有权并查询状态。
-- `load_js_tap_register<R>` 要求 `R: JsTapRegister + Interceptor<Self>`；生产侧唯一 concrete `R` 是 `RegisterJsTapsInner`。
-- 加载时 clone 同一个 inner `Arc` 到现有 `interceptors`，但不增加普通 interceptor count；另一个 Arc handle 擦除为非泛型状态字段，不增加 inner allocation。
-- `has_js_taps()` 只调用 Rust trait 的 `is_empty()`。
+- 生成的 hook 不再增加独立的 JS register 字段；非泛型状态 Arc 由 `HookCommon` 保存。
+- `load_js_tap_register<R>` 在实际加载到具体 Hook 时要求 `R: JsTapRegister + Interceptor<Self>`。
+- 同一个 `Arc<R>` 一份擦除为非泛型状态 trait object，另一份在该 Hook 边界转为原 `Interceptor<Self>` trait object；不增加 inner allocation。
+- additional 路径完全复用原 interceptor 循环。
+- `has_js_taps()` 只读取 Rust 本地状态。
 - `call` 在 tracing span 和 interceptor/register 调用前计算 call mode；空 hook 直接返回对应空值。
-- additional taps 完全走现有 interceptor 循环和 stage merge，不生成 erased JS taps 的加载/还原代码。
+- JS taps 仍作为当前 hook 的具体 tap 返回，与普通 interceptor taps 走同一个 stage merge。
 
 ## 3. `RegisterJsTapsInner`：单层共享状态
 
@@ -62,15 +63,16 @@ hook.call
 - `set_tap_count` 是所有 JS 状态更新的唯一入口；`always_active` register 至少保持为 1。
 - 删除全局 `NonSkippableRegisters` 和独立的 `Arc<AtomicUsize>`。
 
-## 4. `define_register!`：复用原 interceptor
+## 4. `define_register!`：状态非泛型，执行延迟绑定 Hook
 
 文件：`crates/rspack_binding_api/src/plugins/interceptor.rs`
 
-- 只为 `RegisterJsTapsInner` 实现一次 `JsTapRegister`。
-- 宏为同一个 `RegisterJsTapsInner` 生成各具体 Hook 必需的 `Interceptor<具体 Hook>` 实现。
+- `RegisterJsTapsInner` 只实现一次非泛型 `JsTapRegister` 状态 trait。
+- 宏为 inner 生成各具体 Hook 必需的 `Interceptor<具体 Hook>`；转换只发生在 `load_js_tap_register<R>` 的具体 Hook 边界。
 - interceptor 首先读取 `tap_count`；0 时返回空 taps，否则调用已有 register/cache 逻辑并转换具体 tap。
-- adapter 调用点直接把各 `Register*` 内的 `Arc<RegisterJsTapsInner>` 传给 hook；删除 `into_js_tap_register`。
-- 不生成新的 async/blocking executor、owner/downcast、whole-vector downcast或逐 tap downcast。
+- `Register*::js_tap_register()` 只 clone 已有 inner Arc，隐藏 adapter 调用点的 `inner.clone()`，不创建新的 owner allocation。
+- adapter 只把 `js_tap_register()` 的结果传给 hook，不接触内部 Arc。
+- 不进行运行时 downcast，也不擦除或 downcast 每个 tap。
 
 ## 5. JS 状态同步
 
@@ -92,7 +94,7 @@ hook.call
   - JS tap 从 0 变为非 0 后，hook 能立即感知；
   - Rust taps、普通 interceptors、JS taps 按 stage 合并；
   - 只有 Rust taps 且 JS register 为空时走快速路径；
-  - 同步 hook 也能通过同一泛型加载接口运行 register interceptor。
+  - 同步 hook 也能通过同一延迟转换接口运行 register interceptor。
 - 运行 `cargo test -p rspack_macros_test --test hook`。
 - 运行 binding/macros test crate 的 clippy。
 - 运行 JS formatter 检查。
@@ -104,7 +106,9 @@ hook.call
 - [x] `RegisterJsTapsInner` 改为单层 `Arc`，内嵌 cache 和 count。
 - [x] 删除 `NonSkippableRegisters`。
 - [x] hook 空路径在 tracing/register 前返回。
-- [x] `JsTapRegister` 收敛为仅含本地状态检查的 trait，且仅由 `RegisterJsTapsInner` 实现。
-- [x] `define_register!` 复用原 `Interceptor` 执行路径。
-- [x] 完成最终测试和 CI profile 体积比较（stripped native binding `+20,472 bytes`，低于 50 KiB 阈值）。
-- [x] 更新 draft PR。
+- [x] `JsTapRegister` 和 `HookCommon` 保持非泛型，`HookCommon` 保存 `Arc<dyn JsTapRegister>`。
+- [x] 只在具体 Hook 的加载边界把同一个 inner Arc 转为 `Interceptor<Self>`。
+- [x] adapter 通过生成对象的方法隐藏 `inner.clone()`。
+- [x] 当前延迟转换实现通过 hook 测试、`-D warnings` clippy 和完整 CI profile binding 构建。
+- [x] 当前未提交实现 stripped native binding 为 `70,694,224` bytes：相对 merge-base `-28,680 bytes`，相对上一版 `-49,152 bytes`。
+- [ ] 用户确认后再提交、推送并更新 draft PR。

--- a/plan.md
+++ b/plan.md
@@ -1,325 +1,113 @@
-# JS Hook Register 感知真实 Tap 的执行计划
+# JS hook register 感知真实 tap 的执行计划
 
 ## 目标
 
-当前 `JsHooksAdapterPlugin` 把每个 JS hook register 当作普通 `Interceptor` 安装到 Rust hook。这样即使 JS 侧没有真实 tap，`HookCommon::is_empty()` 也会因为存在 interceptor 返回 `false`，hook 调用仍会进入 tracing、register/附加 tap 分支，Rust 侧也无法单独判断 JS hook 是否被使用。
+JS hook register 不再作为普通 interceptor 计入 hook 的非空状态。JS 侧主动把真实 tap 数量同步到 Rust；hook 的空路径只读取 Rust 本地状态，不调用 JS。register 真正执行时继续复用现有 `Interceptor<Hook>`，不增加第二套执行和 tap 类型擦除逻辑。
 
-本次改造需要达到以下结果：
-
-- JS register 不再占用通用 interceptor 槽位，而是通过 hook 的专用加载接口安装。
-- 新增 `JsTapRegister`，用类型擦除的函数封装“按 Rust tap stages 获取 JS taps”的过程，并在 Rust 侧保存 JS register 最近一次上报的 tap 数量。
-- `Hook::is_empty()` 同时考虑 Rust taps、普通 interceptors 和 JS 真实 taps；仅安装了一个当前为空的 JS register 时仍然返回 `true`。
-- hook 对外提供 `has_js_taps()`，不触发 N-API/register 调用即可检查 JS 侧是否有 tap。
-- 每种 hook 的 `call` 在创建 tracing span、调用 register 或准备 futures 之前先检查 `is_empty()`，为空时按该 hook 的返回语义直接结束。
-- `define_hook!` 只生成 hook 参数签名和具体 `tap.run(...)` 所必需的代码；JS register 存储、空状态、执行路径选择、类型校验和 stage 准备下沉到 `rspack_hook` 的非泛型共享实现，避免每个 hook 重复展开以及引入新的泛型单态化膨胀。
-- 保持现有 Rust/JS tap 的 stage 排序、register 缓存、动态 tap 状态更新以及普通 interceptor 行为不变。
-
-## 当前执行流
-
-涉及文件：
-
-- `crates/rspack_hook/src/lib.rs`
-- `crates/rspack_macros/src/hook.rs`
-- `crates/rspack_binding_api/src/plugins/interceptor.rs`
-- `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`
-- `packages/rspack/src/Compiler.ts`
+## 执行流
 
 ```text
-Compiler.ts
-  根据 lite-tapable 的 isUsed() 更新 NonSkippableRegisters
-       ↓
-JsHooksAdapterPlugin::apply / compilation adapter
-  将每个 Register* 克隆后通过 hook.intercept(...) 安装
-       ↓
-HookCommon
-  interceptor_count > 0，因此 is_empty() 恒为 false
-       ↓
-Hook::call
-  调用所有 interceptor
-       ↓
+JS hook 注册/移除 tap
+  读取 lite-tapable isUsed()/tap 数量
+       ↓ 一次 JS -> Rust 同步
 RegisterJsTapsInner
-  检查 NonSkippableRegisters，必要时调用 JS register
+  AtomicUsize 保存 tap_count
+       ↓ Arc 共享同一个 inner
+JsTapRegister
+  is_empty 闭包只读取 inner.tap_count
+  类型擦除保存原 Interceptor<具体 Hook>
+       ↓ hook.load_js_tap_register 时 downcast 一次
+Hook
+  js_tap_register 字段：只负责 has_js_taps/is_empty
+  interceptors 字段：按原路径执行 JS register
        ↓
-将返回的 JS taps 与 Rust taps 按 stage 合并执行
+hook.call
+  empty -> tracing/register 前直接返回
+  rust only -> 直接执行 Rust taps
+  additional -> 执行原 interceptors，按 stage 合并 taps
 ```
 
-问题的核心是：JS 侧已经能计算 hook 是否被使用、register 也能得到最终生成的 `JsTap[]`，但这些信息没有记录到具体 Rust hook。目标不是让 `is_empty()` 回调 JS 查询，而是由 JS 在既有注册流程中主动把数量同步到 Rust，之后热路径只读 Rust 本地状态。
-
-## 目标设计
-
-### 1. 在 `rspack_hook` 增加非泛型的 `JsTapRegister`
-
-在 `crates/rspack_hook/src/lib.rs` 中增加单一的非泛型 `JsTapRegister`。不要定义 `JsTapRegister<T>`，也不要为每种 hook tap trait 单态化一套 register 容器。建议包含以下成员：
-
-- `owner`：对 binding 提供的 `Arc<RegisterJsTapsInner>` 做所有权类型擦除后得到的单一 `Arc<dyn Any + Send + Sync>`（或等价 erased owner）。它与各 `Register*` 指向同一个 inner allocation，不再单独分配 `Arc<AtomicUsize>`。
-- `load_tap_count`：非捕获 Rust function pointer/accessor，从 erased owner 中读取 inner 内嵌的 `AtomicUsize`；`is_empty()` 只经过这层 Rust 本地访问，不触发 JS/N-API 调度。
-- `tap_type_id: TypeId`：记录 register 输出中承载的具体 hook tap trait-object 类型，在加载 register 时校验一次，避免错误 register 到执行期才静默失败。
-- `function`：以 erased owner 和 Rust hook 已使用的 `Vec<i32>` 为输入，返回类型擦除的 tap payload，例如 `Vec<Box<dyn Any + Send + Sync>>`。用内部枚举保存以下两种已擦除函数：
-  - async：非泛型 boxed function，返回类型擦除 tap vector 的 boxed future；
-  - blocking：非泛型 boxed function，直接返回类型擦除 tap vector。
-
-当前 binding 中的 JS hooks 都走 async register 构造；blocking 变体用于保证 hook 抽象完整，并允许在宏测试中覆盖 `Sync` hook。不要在同步 hook 中阻塞等待 async future。
-
-为该类型提供最小接口：
-
-- `new_async<T, O>(owner: Arc<O>, ...)` / `new_blocking<T, O>(...)`：泛型只出现在很薄的所有权/类型擦除边界，用来记录 `TypeId`，把 owner 和 `Vec<T>` 擦除；容器、存储和实际调度方法本身保持非泛型。
-- `tap_count()` / `is_empty()`：通过 Rust accessor 对 inner 内嵌的 `AtomicUsize` 做 acquire load，供 hook 的 `is_empty()` 和 `has_js_taps()` 使用。
-- `call_erased(used_stages)` / `call_erased_blocking(used_stages)`：共享、非泛型调度方法；仅在确认存在 JS taps 后调用匹配执行模式的 register 函数。
-
-使用按值传入的 `Vec<i32>` 和 `'static` boxed future，避免让公共类型依赖具体 hook 类型或 binding 类型，也避免把 `rspack_binding_api` 的 N-API 类型泄漏到 `rspack_hook`。`JsTapRegister` 持有 erased owner，因此异步 future 可以安全借用或克隆同一个 inner owner；不使用裸指针指向内嵌 count。类型擦除带来的转换只发生在 JS register 边界，不改变 Rust 原生 taps 的存储和热执行路径。
-
-### 2. 将 hook 共享状态和决策下沉到 `HookCommon`
-
-扩展 `crates/rspack_hook/src/lib.rs` 的非泛型 `HookCommon`，集中保存和实现：
-
-- `js_tap_register: Option<JsTapRegister>`，默认值为 `None`，每个 hook 最多加载一个 JS register。
-- `load_js_tap_register(register, expected_tap_type_id)`：校验输出 tap 类型并设置 register，不增加 `interceptor_count`；重复加载必须显式报错或断言。
-- `has_js_taps()`、`is_empty()`、`used_stages()` 等状态查询。
-- 非泛型的 `HookCallMode`（例如 `Empty`、`RustOnly`、`WithAdditionalTaps`），让宏生成的 call 只做一次共享决策，不重复生成 interceptor/JS register 状态组合判断。
-- JS register 的非泛型调用、计数读取以及 erased tap vector 的返回。
-
-不要新增 `HookStorage<T>`、`HookCommon<T>` 或把整套执行器做成泛型 helper；这类抽象虽然减少 token 数，却仍会为每种 tap 类型单态化，不能解决最终二进制膨胀。
-
-### 3. 让 `define_hook!` 只生成不可共享的薄胶水
-
-修改 `crates/rspack_macros/src/hook.rs`，生成的具体 hook 继续只保存强类型 Rust taps 和普通 interceptors，但 JS register 留在 `HookCommon`。宏生成代码缩减为：
-
-- hook trait 与参数/返回值签名。
-- `tap()` 时把 stage 和强类型 Rust tap 写入现有存储。
-- `Hook` trait 方法对 `HookCommon` 的薄委托，包括专用 `load_js_tap_register(...)`。
-- `call` 最外层根据 `HookCommon::call_mode()` 处理空返回；需要 JS taps 时调用共享的 erased register，再通过一个很薄的 `unerase_taps::<Self::Tap>` 边界恢复本 hook 的 tap trait object。
-- 各执行类型真正无法共享的 `tap.run(args...)`、bail/waterfall 返回传播和 parallel future 组装。
-
-类型恢复 helper 允许有一个很小的泛型实例，但只负责 `TypeId` 校验后的 downcast/unbox；register 调度、状态机、计数、缓存入口和 stage 索引逻辑不能放进该泛型函数。这样把单态化范围限制在必要的 tap 类型转换上。
-
-`Hook` trait 增加专用加载入口，使 binding adapter 可以统一安装 register；具体 hook 同时保留易于调用的 `has_js_taps()`/`is_empty()` 查询方法，但这些方法体只委托 `HookCommon`，不在每个宏展开中复制状态逻辑。
-
-### 4. 在所有 hook call 的真正入口增加空路径快速返回
-
-在宏生成 `call` 的最外层先执行 `self.is_empty()`，并且把检查放在 tracing span 和 register 调用之前。不同 hook 类型的空返回值如下：
-
-| Hook 类型 | 空 hook 返回值 |
-| --- | --- |
-| `Series` / `Sync` / `Parallel` | `Ok(())` |
-| `SeriesBail` | `Ok(None)` |
-| `SeriesWaterfall` | `Ok(data)`，原样返回 waterfall 输入 |
-
-通过空检查后，再区分两条执行路径：
-
-- 没有普通 interceptor 且 `has_js_taps() == false`：直接执行已排序的 Rust taps，不构造额外 tap 容器。
-- 存在普通 interceptor 或 JS taps：收集普通 interceptor 返回的 taps；仅当 `has_js_taps()` 为真时调用 JS register；最后复用 `merged_tap_indices_by_stage` 合并执行。
-
-这样即使 hook 有 Rust taps、但 JS register 当前为空，也不会为 JS register 支付 N-API 或 future 分配成本。
-
-### 5. 将 binding register 转换为 `JsTapRegister`
-
-修改 `crates/rspack_binding_api/src/plugins/interceptor.rs`：
-
-- 将所有 `Register*` 改为 `inner: Arc<RegisterJsTapsInner>`；`Clone` 只克隆这一层 owner，不再手工 clone inner 的 register、cache 和状态字段。
-- `RegisterJsTapsInner` 直接内嵌 `tap_count: AtomicUsize`、`always_active`/bootstrap 标记和 register cache。`RegisterJsTapsCache::Cache` 改为直接持有 `RwLock<Option<RegisterFunctionOutput>>`，因为外层 inner 已经由 `Arc` 共享，不需要 `Arc<RwLock<...>>` 的第二层共享所有权。
-- 在 inner 上集中提供 `tap_count()` 和 `set_tap_count(count)`；setter 对 `always_active` 统一执行 `max(count, 1)`，所有单个/批量更新都必须走该方法，避免某条路径把 bootstrap register 写成 0。
-- `RegisterJsTapsInner::call_register` 改为直接接收 `Vec<i32>`（或 stages slice 后在边界复制），不再接收 `impl Hook`；排序/去重由 hook 的 `used_stages()` 保证。
-- `RegisterJsTapsInner` 不再保存 `Option<NonSkippableRegisters>`，也不再另外分配 `Arc<AtomicUsize>`；`JsTapRegister` 类型擦除并持有同一个 `Arc<RegisterJsTapsInner>`，从 inner 内部读取 count。
-- `skip = false` 的 bootstrap register 初始计数设为非零，避免首次 `CompilerThisCompilation` 被空路径跳过；`skip = true` 的 register 初始为 0，并由首次 bootstrap 状态同步写入 0/非 0。
-- 调整 `define_register!`：删除各 `Register*` 对 `Interceptor<SpecificHook>` 的实现，改为生成非泛型 `JsTapRegister`。宏只在构造边界把具体 `$tap_name` trait object 包装成 erased tap payload，不为每个 hook 生成一套 register 调度实现。
-- register function 通过 `JsTapRegister` 持有的 erased owner 取回 `RegisterJsTapsInner`，调用原有缓存逻辑，并继续把类型擦除的 `ThreadsafeJsTap` 转成对应的 `$tap_name` trait object，再统一擦除输出；function 本身不额外捕获另一份状态 `Arc`。
-- 各 `Register*::clear_cache()` 直接操作 `self.inner.cache`，确保 adapter、hook 和 plugin cache cleanup 始终落在同一个 inner allocation。
-
-新的所有权关系如下：
-
-```text
-Register* ───────────────┐
-JsTapRegister(erased) ───┼─ Arc<RegisterJsTapsInner>
-binding count setter ────┘      ├─ RegisterFunction
-                                ├─ RwLock<Cache>
-                                ├─ AtomicUsize tap_count
-                                └─ bootstrap/always_active 标记
-```
-
-这里存在多个 `Arc` handle，但只有一层 `Arc` allocation，不是 `Arc<Inner>` 再嵌套 `Arc<AtomicUsize>`/`Arc<RwLock<...>>`。inner 不反向引用 hook 或 plugin，因此不会形成引用环。
-
-### 6. 由 JS register 主动向 Rust 上报数量
-
-修改 `crates/rspack_binding_api/src/lib.rs` 和 `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`：
-
-- 增加同步 N-API 方法 `setRegisterJsTapCount(kind, count)`；它只根据 `RegisterJsTapKind` 找到对应 register 并调用 `register.inner.set_tap_count(count)`，不执行 hook/register，也不反向调用 JS。
-- 删除 `NonSkippableRegisters(Arc<RwLock<Vec<...>>>)`。`JsHooksAdapterPlugin` 已持有全部 `Register*`，因此 count 更新可以直接按 kind 路由到对应 inner。
-- 现有 `setNonSkippableRegisters(kinds)` 暂时保留为 bootstrap/动态失效的批量 N-API 入口，但不再写全局集合：它遍历/路由各 `Register*`，把 kind 在集合中的 inner count 写成 1、其余写成 0；`always_active` 项保持至少为 1。
-- 单个 count 更新和批量状态更新最终都写各自 `RegisterJsTapsInner` 内同一个 `AtomicUsize`，不维护额外的共享 map、count handle 或全局锁。
-
-修改 `packages/rspack/src/Compiler.ts`：
-
-- 在 `#createHookRegisterTaps` 和 `#createHookMapRegisterTaps` 生成的 JS register 中，完成 stage range 查询并得到最终 `jsTaps` 后，额外同步调用一次 `setRegisterJsTapCount(registerKind, jsTaps.length)`，再返回 `jsTaps`。
-- 这个额外调用发生在 JS register 本来就已被 Rust 调度到 JS 的过程中，不由 `is_empty()` 发起；因此不会给每次空检查增加 Rust/JS 往返。
-- 保留 `#updateNonSkippableRegisters()` 的职责，用于首次 `thisCompilation` bootstrap，以及 tap 在执行过程中新增/移除后、下一次 register 尚未运行前，批量同步 0/非 0 状态。register 真正运行后再用 `jsTaps.length` 覆盖为精确数量。
-- `#decorateJsTaps` 仍在最后一个 tap 完成后刷新状态，避免 tap 自移除后 Rust 继续把该 hook 判断为非空。
-
-计数的语义是“本次 register 生成的 JS stage-range tap 包装数量”。对于 `is_empty()`，只要求 `0` 与 `> 0` 准确；bootstrap 批量同步可以先写 0/1，register 执行后再写精确值。
-
-### 7. 替换所有 JS adapter 的安装点
-
-修改 `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`，将所有 JS register 的：
-
-```text
-hook.intercept(register.clone())
-```
-
-统一替换为：
-
-```text
-hook.load_js_tap_register(register.clone().into_js_tap_register())
-```
-
-覆盖以下安装阶段，避免遗漏仅在 compilation 创建后才取得的插件 hooks：
-
-- `JsHooksAdapterPlugin::apply` 中的 compiler、compilation、NormalModuleFactory、ContextModuleFactory hooks。
-- `js_hooks_adapter_compilation` 中的 JavaScript modules hooks。
-- `html_hooks_adapter_compilation` 中的 HtmlRspackPlugin hooks。
-- `runtime_hooks_adapter_compilation` 中的 RuntimePlugin hooks。
-- `real_content_hash_hooks_adapter_compilation` 中的 RealContentHashPlugin hooks。
-- `rsdoctor_hooks_adapter_compilation` 中的 RsdoctorPlugin hooks。
-
-普通 Rust interceptor 的 API 和已有测试保持不动；本次只迁移 JS register。
-
-## 改造后的执行流
-
-```text
-Compiler.ts
-  thisCompilation bootstrap / 动态变更
-  根据 hook/hookMap.isUsed() 批量同步 0/非 0
-       ↓
-binding 的 Register*
-  在薄构造边界生成非泛型 JsTapRegister
-  └─ 类型擦除同一个 Arc<RegisterJsTapsInner>
-       ├─ AtomicUsize tap_count
-       ├─ RwLock cache
-       └─ RegisterFunction
-       ↓
-hook.load_js_tap_register(...)
-  HookCommon 校验 TypeId 后存入共享槽位
-  不计入 interceptor_count
-       ↓
-Hook::call 最前面检查 is_empty()
-  HookCommon::call_mode() 只读取 Rust 本地状态
-  ├─ Rust tap / interceptor / JS tap 全部为空 → 按 hook 类型直接返回
-  ├─ 仅 Rust taps → 直接执行强类型 taps
-  └─ 需要 additional taps
-       ↓
-has_js_taps()
-  ├─ false → 不调用 JS register，只执行 Rust taps/普通 interceptors
-  └─ true  → HookCommon 调用非泛型 register，得到 erased JS taps
-       ↓
-JS register
-  setRegisterJsTapCount(kind, jsTaps.length)
-  同步把本次精确数量写回 Rust
-       ↓
-define_hook 薄胶水
-  校验后恢复为当前 hook 的 tap trait object
-       ↓
-merged_tap_indices_by_stage
-  合并 Rust taps、普通 interceptor taps 和 JS taps
-       ↓
-按 Series / Bail / Waterfall / Parallel 语义执行
-```
-
-## 顺序与兼容性约束
-
-- Rust tap 在 `tap()` 时仍按 stage 稳定插入；JS register 返回的 tap stage 仍由 `Compiler.ts` 的 stage range 查询生成。
-- 继续使用 `merged_tap_indices_by_stage`，确保 Rust/JS taps 的主排序规则不变；相同 stage 时保持当前 Rust base tap 优先于 additional/JS tap 的规则。
-- JS register 是单独的 additional tap 来源；若同时存在普通 interceptors，应固定收集顺序并加测试，保证同 stage 的结果确定。建议普通 interceptors 保持注册顺序，JS taps 固定追加在其后。
-- `has_js_taps()` 只表示 JS 侧状态，不把 Rust taps 或普通 interceptors 算进去；`is_empty()` 才表示整个 hook 是否为空。
-- `JsTapRegister`、`HookCommon`、register function enum、erased tap 容器和 call-mode 状态机必须是非泛型具体类型；禁止把它们改成按 hook/tap 类型实例化的泛型 storage/executor。
-- 宏展开中只保留强类型参数调用所必需的逻辑。共享状态判断、JS register 调度和类型检查不得以内联 token 的形式在每个 `define_hook!` 展开中复制。
-- erased tap 恢复产生的额外分配/转换只允许出现在 JS register 路径；Rust-only fast path不能增加 `Any`、downcast、boxed future 或额外分配。
-- `has_js_taps()` 和空路径检查不得调用类型擦除的 register，也不得触发 JS/N-API 调度；共享 helper 只能通过 Rust accessor 读取 `Arc<RegisterJsTapsInner>` 内嵌的 `AtomicUsize`。JS→Rust 的额外调用只能出现在 JS register 已经执行的路径中。
-- count/cache/register 必须共享同一个 `Arc<RegisterJsTapsInner>` owner；禁止重新引入 `Arc<AtomicUsize>`、`Arc<RwLock<Cache>>` 或全局 `NonSkippableRegisters` 锁。
-- JS 写入 count 后，后续 Rust `is_empty()` 必须直接看到更新；使用成对的 release store / acquire load（或更强顺序）明确跨线程可见性。
-- `skip = false` 的 register 初始计数继续保持非零；这是现有 JS register 状态初始化的 bootstrap 约束，不能在首次 `thisCompilation` 前把它判断为空。
-- 批量 0/1 更新与 register 的精确 count 更新可能先后发生，必须按调用时序写入同一原子值；不要让较旧的异步任务覆盖较新的状态。新增的 N-API setter 应为同步写入。
-- register 抛错、JS tap 抛错、bail 和 waterfall 的错误/返回传播方式保持现状。
-
-## 测试计划
-
-### Rust 宏行为测试
-
-在专用测试 crate 的 `crates/rspack_macros_test/tests/hook.rs` 中增加一个由 `Arc<MockRegisterInner>` 整体共享、count 内嵌为 `AtomicUsize` 的 mock `JsTapRegister`，覆盖：
-
-1. 默认 hook：`is_empty() == true`、`has_js_taps() == false`，调用后直接返回。
-2. 已加载但计数为 0 的 JS register：hook 仍为空，且 register 回调调用次数保持为 0。
-3. Rust 计数从 0 切换为非零：`has_js_taps()` 和 `is_empty()` 立即反映变化，调用时执行 JS tap；断言空检查没有调用任何状态查询函数。
-4. 存在 Rust tap、JS register 为空：只执行 Rust tap，不调用 JS register。
-5. Rust tap、普通 interceptor tap、JS tap 同时存在：验证 stage 合并和同 stage 的确定性顺序。
-6. 分别覆盖 `Series`、`Sync`、`SeriesBail`、`SeriesWaterfall`、`Parallel` 的空返回语义，尤其验证 waterfall 原样返回输入、bail 返回 `None`。
-7. 定义至少两个 tap trait 不同的 hook，验证它们共用同一个非泛型 `JsTapRegister`/`HookCommon` 路径；错误的 tap `TypeId` 在加载时被拒绝，而不是执行时 panic。
-8. 保留并运行现有 `AdditionalTaps` 测试，确认通用 interceptor 没有回归。
-
-### 生成代码与单态化检查
-
-- 检查 `define_hook!` 展开结果，确认 `is_empty`、`has_js_taps`、JS register 调度和 call-mode 分支只是调用 `HookCommon`，没有为每个 hook 复制完整实现。
-- 对比改造前后的 release 构建符号/LLVM lines（优先使用仓库已有二进制体积流程；本地工具可用时使用 `cargo llvm-lines` 或等价工具），确认没有按每个 `Hook::Tap` 生成 `JsTapRegister<T>`、泛型 storage 或泛型 executor 实例。
-- 记录允许保留的单态化边界：`new_async::<Tap>`/`new_blocking::<Tap>` 的薄擦除构造和 `unerase_taps::<Tap>` 的薄恢复函数；若这两部分体积明显增长，再改成宏内最小转换，不扩大共享执行器的泛型范围。
-
-### Binding 与 JS 回归验证
-
-- 通过编译保证所有 `Register*` 都能转换为目标 hook 的 trait object，所有 adapter 安装点均已迁移。
-- 验证克隆 `Register*`、加载到 `HookCommon` 的 erased owner、调用 `clear_cache()` 和 N-API count setter 操作的是同一个 `RegisterJsTapsInner`；释放 plugin/hook 后没有 owner cycle。
-- 验证 JS register 返回空数组和非空数组时，`setRegisterJsTapCount` 分别写入 0 和 `jsTaps.length`，且下一次 Rust hook call 按本地计数选择快速路径。
-- 验证首次 compilation 仍由非零 bootstrap count 驱动，并能批量初始化其他 register；否则初始为 0 的 hook 会永远没有机会执行 register。
-- 验证 JS tap 在执行期间自移除/新增后，`#decorateJsTaps` 的批量更新不会留下过期的非零/零计数。
-- 运行已有 stage 与 hook 用例，例如 `configCases/hooks/stage-make`、`configCases/hooks/stage-compilation`、`hookCases/compilation#processAssets`，确认 JS tap 仍执行且顺序不变。
-- 如需要新增集成覆盖，只在现有 `tests/rspack-test` runner 下增加 case，不创建新的顶层 `test.js` runner；case 应验证“无 JS tap 不影响构建”和“有 JS tap 仍被调用”，性能快速路径本身由 Rust mock 的调用计数断言。
-
-### 建议验证命令
-
-```bash
-cargo test -p rspack_macros_test --test hook
-pnpm run build:binding:dev
-cd tests/rspack-test && pnpm run test -t "configCases/hooks/stage-make"
-cd tests/rspack-test && pnpm run test -t "configCases/hooks/stage-compilation"
-pnpm run test:rs
-pnpm run lint:rs
-cargo lint
-```
-
-按项目约定，不运行会在 sandbox 中卡住的 storage 和 native watcher 相关测试。
-
-## 实施顺序
-
-1. 在 `rspack_hook` 定义非泛型 `JsTapRegister`、erased tap payload、共享计数接口和 call-mode 枚举。
-2. 扩展非泛型 `HookCommon`，把 JS register 槽位、类型校验、空状态、路径选择和 erased register 调度全部收进去。
-3. 精简 `define_hook!`：只生成参数签名、强类型 Rust tap 存储、对 `HookCommon` 的薄委托，以及各 hook 类型不可共享的 `tap.run(...)`/返回传播逻辑。
-4. 在 `rspack_macros_test` 用 mock register 固化空状态、动态状态、类型校验和各 hook 类型语义，并确认 Rust-only 路径不进入类型擦除逻辑。
-5. 改造 binding 的 `RegisterJsTapsInner` 与 `define_register!`：用单层 `Arc<RegisterJsTapsInner>` 统一拥有 register、cache、count 和 bootstrap 状态，并从 `Interceptor` 实现切换为非泛型 `JsTapRegister` 构造。
-6. 增加 `setRegisterJsTapCount`，再修改两个 JS register factory，在返回 `JsTap[]` 前同步上报数组长度。
-7. 删除全局 `NonSkippableRegisters` 状态，让现有 `setNonSkippableRegisters` 批量入口直接更新各 register inner 的 count，并验证首次 bootstrap 和 tap 动态变化时的 0/非 0 更新。
-8. 批量迁移 `JsHooksAdapterPlugin` 的全部安装点，并用搜索确认不再有 JS register 走 `.intercept(...)`。
-9. 编译 binding，运行宏测试和现有 JS hook/stage 回归用例。
-10. 检查宏展开和 release 单态化/体积变化，确认共享实现没有以泛型 helper 的形式重新膨胀。
-11. 运行 Rust 测试与 lint，最后检查 diff 中没有改变 JS register 的缓存清理，并确认 `is_empty()` 路径没有任何 JS/N-API 调用。
-
-## 实施结果
-
-已按上述设计完成实现：
-
-- `JsTapRegister`、`HookCommon` 和 `HookCallMode` 已集中在 `rspack_hook`；空状态只读取 Rust 本地 count，register 调度与 tracing 均位于空路径之后。
-- 52 个 binding register 全部改为共享单层 `Arc<RegisterJsTapsInner>`，inner 直接内嵌 cache、`AtomicUsize` 和 `always_active`；旧 `NonSkippableRegisters` 全局锁已删除。
-- 52 个 adapter 安装点全部从 `.intercept(...)` 迁移到 `.load_js_tap_register(...)`，普通 interceptor 保持原 API 和执行顺序。
-- JS hook 与 HookMap register 都会把最终 `JsTap[]` 长度同步到新的 `setRegisterJsTapCount`；批量 bootstrap API 保留并直接写同一批 inner count。
-- 宏专项测试覆盖空 register、动态 count、Rust-only 快路径、同步 register、错误 tap 类型、stage 合并，以及 Series/Sync/Bail/Waterfall 空返回；现有 interceptor 测试继续通过。仓库当前没有使用 `Parallel` hook，专项测试 crate 也没有宏展开所需的 `futures_concurrency` 依赖，因此没有为测试单独引入新的运行时依赖；Parallel 的空分支与 Series 一样生成 `Ok(())`。
-
-已完成验证：
-
-```text
-pnpm run build:cli:dev
-cargo test -p rspack_macros_test --test hook
-cargo clippy -p rspack_hook -p rspack_macros -p rspack_binding_api -p rspack_macros_test --tests -- -D warnings
-pnpm run lint:rs
-pnpm run lint:js
-pnpm run test -t "Hook"
-pnpm run test -t "compilerCases/hooks-closure"
-pnpm run test -t "configCases/hooks/stage-make"
-pnpm run test -t "configCases/hooks/stage-compilation"
-pnpm run test -t "hookCases/compilation#processAssets"
-```
-
-本地未安装 `cargo llvm-lines`/`cargo expand`，因此没有生成额外的 LLVM lines 数值对比；代码检查确认共享 storage、状态机和 erased 调度均为非泛型具体类型，只在 `new_async`/`new_blocking` 与 `unerase_js_taps` 保留计划允许的薄泛型边界。
+## 1. `rspack_hook`：轻量 `JsTapRegister`
+
+文件：`crates/rspack_hook/src/lib.rs`
+
+- `JsTapRegister` 只保存：
+  - 一个类型擦除的 Rust `is_empty` 闭包；
+  - 一个待 hook 加载的类型擦除 interceptor。
+- `new` 直接接收擦除后的值，不提供泛型构造器或 `new_erased`。
+- 删除 register owner、erased taps、async/blocking register function 等第二套执行抽象。
+- `HookCommon` 只保存所有 hook 共享的 metadata、Rust tap stages 和普通 interceptor 数量。
+- `HookCommon::call_mode(has_js_taps)` 根据本地布尔状态返回 `Empty`、`RustTaps` 或 `AdditionalTaps`。
+
+## 2. `define_hook!`：只增加状态字段并恢复 interceptor
+
+文件：`crates/rspack_macros/src/hook.rs`
+
+- 每个 hook 增加 `js_tap_register: Option<JsTapRegister>`。
+- `load_js_tap_register` 将擦除对象 downcast 为 `Box<dyn Interceptor<Self>>`，放入现有 `interceptors`；这个 JS interceptor 不增加普通 interceptor count。
+- `has_js_taps()` 只调用 register 的 Rust `is_empty` 闭包。
+- `call` 在 tracing span 和 interceptor/register 调用前计算 call mode；空 hook 直接返回对应空值。
+- additional taps 完全走现有 interceptor 循环和 stage merge，不生成 erased JS taps 的加载/还原代码。
+
+## 3. `RegisterJsTapsInner`：单层共享状态
+
+文件：`crates/rspack_binding_api/src/plugins/interceptor.rs`
+
+- 所有 `Register*` 使用 `Arc<RegisterJsTapsInner>`。
+- inner 直接内嵌：
+  - compiler-scoped register callback；
+  - register cache；
+  - `AtomicUsize tap_count`；
+  - `always_active` bootstrap 标记。
+- cache 直接保存 `RwLock<Option<...>>`，不增加第二层 `Arc`。
+- `set_tap_count` 是所有 JS 状态更新的唯一入口；`always_active` register 至少保持为 1。
+- 删除全局 `NonSkippableRegisters` 和独立的 `Arc<AtomicUsize>`。
+
+## 4. `define_register!`：复用原 interceptor
+
+文件：`crates/rspack_binding_api/src/plugins/interceptor.rs`
+
+- 恢复/保留每个 `Register*` 对 `Interceptor<具体 Hook>` 的实现。
+- interceptor 首先读取 `inner.tap_count`；0 时返回空 taps，否则调用已有 register/cache 逻辑并转换具体 tap。
+- `into_js_tap_register`：
+  - clone 同一个 `Arc<RegisterJsTapsInner>` 到共享的 `is_empty` 闭包；
+  - 将 `self` 转为 `Box<dyn Interceptor<具体 Hook>>` 后再做 `Any` 类型擦除；
+  - 构造非泛型 `JsTapRegister`。
+- 不生成新的 async/blocking executor、owner downcast、whole-vector downcast 或逐 tap downcast。
+
+## 5. JS 状态同步
+
+文件：
+
+- `packages/rspack/src/Compiler.ts`
+- `packages/rspack/src/lite-tapable/index.ts`
+- `crates/node_binding/src/lib.rs`
+- `crates/rspack_binding_api/src/plugins/js_hooks_plugin.rs`
+
+- JS register 每次实际运行后，把 `jsTaps.length` 同步给 Rust。
+- tap 新增、移除或 bootstrap 状态变化时，继续通过批量入口同步是否非空，避免下一次 register 执行前状态过期。
+- `is_empty()`、`has_js_taps()` 不进行 JS/N-API 调用。
+
+## 6. 验证
+
+- Rust hook 测试覆盖：
+  - JS tap 数量为 0 时，空 hook 跳过 register；
+  - JS tap 从 0 变为非 0 后，hook 能立即感知；
+  - Rust taps、普通 interceptors、JS taps 按 stage 合并；
+  - 只有 Rust taps 且 JS register 为空时走快速路径；
+  - 同步 hook 也能加载类型擦除的 interceptor。
+- 运行 `cargo test -p rspack_macros_test --test hook`。
+- 运行 binding/macros test crate 的 clippy。
+- 运行 JS formatter 检查。
+- 使用 CI profile 构建并 strip native binding，与 PR merge-base 精确比较二进制大小。
+
+## 当前进度
+
+- [x] JS 侧向 Rust 同步 tap 状态。
+- [x] `RegisterJsTapsInner` 改为单层 `Arc`，内嵌 cache 和 count。
+- [x] 删除 `NonSkippableRegisters`。
+- [x] hook 空路径在 tracing/register 前返回。
+- [x] `JsTapRegister` 收敛为状态检查 + 类型擦除 interceptor。
+- [x] `define_register!` 复用原 `Interceptor` 执行路径。
+- [x] 完成最终测试和 CI profile 体积比较（stripped native binding `+36,856 bytes`，低于 50 KiB 阈值）。
+- [x] 更新 draft PR。


### PR DESCRIPTION
## Summary

- add a small non-generic `JsTapRegister` trait that only exposes Rust-local empty-state checks
- implement that trait once for `RegisterJsTapsInner`; the same inner also implements each required `Interceptor<Hook>`
- load `Arc<RegisterJsTapsInner>` through a generic hook boundary, clone the Arc into the existing interceptor path, and retain a non-generic trait object only for `has_js_taps()/is_empty()`
- return from generated hook calls before tracing/register dispatch when Rust taps, ordinary interceptors, and real JS taps are all empty
- share each binding register through one `Arc<RegisterJsTapsInner>`, with the cache and `AtomicUsize` embedded directly in the inner allocation
- report the final `JsTap[]` length synchronously from JavaScript to Rust and remove the global `NonSkippableRegisters` lock

Example: a frequently called `buildModule` hook with no JavaScript taps previously still appeared non-empty because its JS register was installed as an ordinary interceptor. Every call entered tracing and the additional-tap path before Rust could discover that there was nothing to run. With this change, JavaScript records a count of `0` in the shared register inner, so the hook returns using only a Rust-local atomic read and performs no Rust-to-JavaScript dispatch.

When a plugin later installs a JavaScript tap, the existing bootstrap/dynamic refresh updates the same atomic state to non-zero. The next hook call executes the same `RegisterJsTapsInner` through its existing typed `Interceptor<BuildModuleHook>` implementation. There is no `into_js_tap_register`, closure, `Any`, downcast, erased tap payload, or second register executor.

## Related links

N/A

## Validation

- `pnpm run build:binding:dev`
- `cargo test -p rspack_macros_test --test hook` (9 passed)
- `cargo clippy -p rspack_binding_api -p rspack_macros_test --tests -- -D warnings`
- `pnpm run format-ci:js`
- merge-base CI-profile stripped native binding: `+20,472 bytes` (below the 50 KiB limit by `30,728 bytes`)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_