### PR TITLE
fix(esm_library): allow scope hoisting for `new URL` targets in new-url-relative mode

### DIFF
--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -16,11 +16,11 @@ use rspack_core::{
   CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeDependencies,
   CompilationParams, CompilationProcessAssets, CompilationRuntimeRequirementInTree,
   CompilerCompilation, ConcatenatedModuleInfo, ConcatenationScope, DependencyType,
-  ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult, Logger, ModuleFactoryCreateData,
-  ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType, NormalModuleFactoryAfterFactorize,
-  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, REQUIRE_SCOPE_GLOBALS,
-  RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact,
-  SideEffectsStateArtifact, get_target, is_esm_dep_like,
+  ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult, JavascriptParserUrl, Logger,
+  ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType,
+  NormalModuleFactoryAfterFactorize, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
+  Plugin, REQUIRE_SCOPE_GLOBALS, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
+  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, get_target, is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -135,6 +135,8 @@ impl EsmLibraryPlugin {
               dep.dependency_type(),
               DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker
             )
+            && !(matches!(dep.dependency_type(), DependencyType::NewUrl)
+              && matches!(dep.url_mode(), Some(JavascriptParserUrl::NewUrlRelative)))
         })
       {
         logger.debug(format!(

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -132,11 +132,15 @@ impl EsmLibraryPlugin {
         .any(|dep| {
           !is_esm_dep_like(dep)
             && !matches!(
-              dep.dependency_type(),
-              DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker
+              (dep.dependency_type(), dep.url_mode()),
+              (
+                DependencyType::Entry | DependencyType::DynamicImport | DependencyType::NewWorker,
+                _
+              ) | (
+                DependencyType::NewUrl,
+                Some(JavascriptParserUrl::NewUrlRelative)
+              )
             )
-            && !(matches!(dep.dependency_type(), DependencyType::NewUrl)
-              && matches!(dep.url_mode(), Some(JavascriptParserUrl::NewUrlRelative)))
         })
       {
         logger.debug(format!(

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/__snapshots__/esm.snap.txt
@@ -1,0 +1,26 @@
+```mjs title=main.mjs
+import { __webpack_require__ } from "./runtime.mjs";
+
+// ./asset.txt
+const asset_namespaceObject = __webpack_require__.p + "asset.txt";
+// ./index.js
+
+
+const assetUrl = new URL("./asset.txt", import.meta.url)
+
+// Referencing the same asset through both an `import` and a `new URL()` must not
+// pull the asset module out of scope hoisting, which would force it into the
+// `__webpack_require__` module registry and drag the runtime into the output.
+it('should reference the same asset through both `import` and `new URL`', () => {
+	expect(asset_namespaceObject.endsWith('asset.txt')).toBe(true)
+	expect(assetUrl.href.endsWith('asset.txt')).toBe(true)
+})
+
+export {};
+
+```
+
+```txt title=asset.txt
+asset content
+
+```

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,25 @@
+```mjs title=main.mjs
+import { rspackRequire, publicPath } from "./runtime.mjs";
+// ./asset.txt
+const asset_namespaceObject = publicPath + "asset.txt";
+// ./index.js
+
+
+const assetUrl = new URL("./asset.txt", import.meta.url)
+
+// Referencing the same asset through both an `import` and a `new URL()` must not
+// pull the asset module out of scope hoisting, which would force it into the
+// `__webpack_require__` module registry and drag the runtime into the output.
+it('should reference the same asset through both `import` and `new URL`', () => {
+	expect(asset_namespaceObject.endsWith('asset.txt')).toBe(true)
+	expect(assetUrl.href.endsWith('asset.txt')).toBe(true)
+})
+
+export {};
+
+```
+
+```txt title=asset.txt
+asset content
+
+```

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/asset.txt
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/asset.txt
@@ -1,0 +1,1 @@
+asset content

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/index.js
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/index.js
@@ -1,0 +1,11 @@
+import assetPath from './asset.txt'
+
+const assetUrl = new URL('./asset.txt', import.meta.url)
+
+// Referencing the same asset through both an `import` and a `new URL()` must not
+// pull the asset module out of scope hoisting, which would force it into the
+// `__webpack_require__` module registry and drag the runtime into the output.
+it('should reference the same asset through both `import` and `new URL`', () => {
+	expect(assetPath.endsWith('asset.txt')).toBe(true)
+	expect(assetUrl.href.endsWith('asset.txt')).toBe(true)
+})

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/rspack.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        url: 'new-url-relative',
+      },
+    },
+    rules: [
+      {
+        test: /\.txt$/,
+        type: 'asset/resource',
+      },
+    ],
+  },
+  output: {
+    assetModuleFilename: '[name][ext]',
+  },
+};

--- a/tests/rspack-test/esmOutputCases/new-url/mixed-reference/test.config.js
+++ b/tests/rspack-test/esmOutputCases/new-url/mixed-reference/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  snapshotFileFilter(file) {
+    return file.endsWith('main.mjs') || file.endsWith('asset.txt')
+  },
+}


### PR DESCRIPTION
## Summary

In Rslib ESM output scenario, when a file is referenced both by a normal ESM `import` and by `new URL(..., import.meta.url)` under `parser.javascript.url: 'new-url-relative'`, it is excluded from scope hoisting and falls back into the `__webpack_require__` module registry, dragging wrong (call `require()` in ESM output) runtime into dist.

This PR allow `new URL()` targets in `new-url-relative` mode to be scope hoisted.

## Reproduction

https://github.com/elecmonkey/rslib-double-ref-runtime-leak

See:
- `dist`: with `require()` call in ESM
- `dist-we-hope`: this PR

## Root cause

The root cause is an interference between the two references. An asset reached only through `new URL()` has no JavaScript source type at all. Adding an `import` gives it a JavaScript half — the import needs a JS value. That JavaScript module must go through the hoisting check in `EsmLibraryPlugin::mark_modules`, but the `new URL` edge associated with the same module interferes with the check: the import edge itself passes, while the new URL edge causes the module to be rejected.

## Why this combination is safe to hoist

`URLDependencyTemplate::render` dispatches on `dep.mode` into three branches:

| mode | rendered code | calls `module_id()` |
| ---- | ------------- | ------------------- |
| `NewUrlRelative` | `new URL("<placeholder>", import.meta.url)` | no |
| `Relative` | `new __webpack_require__.U(__webpack_require__(id))` | yes |
| `Enable`  | `new URL(__webpack_require__(id), __webpack_require__.b)` | yes |

`NewUrlRelative` renders a string literal that does not mention the target module, so it's safe to hoist.

> The diff is equivalent to: 
> <img width="772" height="175" alt="image" src="https://github.com/user-attachments/assets/0dfb2484-2cff-4658-b1a7-a18e38a76b9c" />
> but this form is rejected by Clippy because it is not the simplest logical expression.