### PR TITLE
fix(deps): bump rkyv to 0.8.18 (fixes RUSTSEC-2026-0233/0234/0235)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3536,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "d9776093b7ca170454ab1406954f7b7d97a57c51dc6c0642957fb2ef25c2d399"
 dependencies = [
  "bytecheck 0.8.0",
  "bytes",
@@ -3548,7 +3548,7 @@ dependencies = [
  "ptr_meta 0.3.0",
  "rancor",
  "rend 0.5.2",
- "rkyv_derive 0.8.16",
+ "rkyv_derive 0.8.18",
  "smallvec",
  "tinyvec",
  "uuid",
@@ -3567,13 +3567,13 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "1c25ef604ac7dd839d44d64648952ea23c97866f124ff671b0ed2cf3ad9bb06e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3859,7 +3859,7 @@ dependencies = [
  "lightningcss",
  "once_cell",
  "regex",
- "rkyv 0.8.16",
+ "rkyv 0.8.18",
  "rspack-allocative",
  "rspack_cacheable_macros",
  "rspack_resolver",
@@ -3946,7 +3946,7 @@ dependencies = [
  "pretty_assertions",
  "rayon",
  "regex",
- "rkyv 0.8.16",
+ "rkyv 0.8.18",
  "rspack_cacheable",
  "rspack_collections",
  "rspack_dojang",
@@ -5258,7 +5258,7 @@ version = "0.101.9"
 dependencies = [
  "memchr",
  "regex",
- "rkyv 0.8.16",
+ "rkyv 0.8.18",
  "rustc-hash",
  "serde",
  "simd-json",
@@ -7195,6 +7195,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ napi-derive = { version = "3.5.10", default-features = false }
 
 # Serialize and Deserialize
 inventory = { version = "0.3.17", default-features = false }
-rkyv      = { version = "=0.8.16", default-features = false, features = ["std", "bytecheck", "smallvec-1"] }
+rkyv      = { version = "=0.8.18", default-features = false, features = ["std", "bytecheck", "smallvec-1"] }
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.9", default-features = false }

--- a/crates/rspack_cacheable/src/context.rs
+++ b/crates/rspack_cacheable/src/context.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, ops::Deref, path::Path, ptr::NonNull};
+use std::{any::Any, ops::Deref, path::Path};
 
 use rkyv::{
   de::{ErasedPtr, Pooling, PoolingState},
@@ -55,7 +55,7 @@ impl<'a> ContextGuard<'a> {
 
   pub fn add_to_pooling<P: Pooling<Error> + ?Sized>(&self, pooling: &mut P) -> Result<()> {
     unsafe {
-      let ctx_ptr = ErasedPtr::new(NonNull::new_unchecked(self as *const _ as *mut ()));
+      let ctx_ptr = ErasedPtr::new(self as *const _ as *mut ());
       pooling.start_pooling(CONTEXT_ADDR);
       pooling.finish_pooling(CONTEXT_ADDR, ctx_ptr, default_drop)
     }


### PR DESCRIPTION
We need to bump rkyv in our workspace to 0.8.18 for these security advisories but the rspack pin to rkyv 0.8.16 stops us because Cargo requires all 0.8.* versions in the workspace to resolve to a single version. Bumping the rkyv version in rspack will unblock us.

Robot summary below 👇 

---------

## Summary

Bumps the workspace `rkyv` pin from `=0.8.16` to `=0.8.18` to pick up the security fixes shipped in rkyv 0.8.17. Three RUSTSEC advisories affect rkyv `>= 0.8.0-rc.1, < 0.8.17` (i.e. including 0.8.16, which rspack currently pins):

- **[RUSTSEC-2026-0233](https://rustsec.org/advisories/RUSTSEC-2026-0233)** — *Crafted archives can cause a use-after-free during deserialization* (memory-corruption): "Insufficient archive range validation could allow a crafted archive to reach `ArchivedString::deserialize` with an invalid pointer. … AddressSanitizer detected a heap use-after-free during string deserialization." ([rkyv/rkyv#666](https://github.com/rkyv/rkyv/issues/666))
- **[RUSTSEC-2026-0234](https://rustsec.org/advisories/RUSTSEC-2026-0234)** — *Insufficient archive validation can cause out-of-bounds reads in archives containing hash tables* (memory-exposure, DoS): "The archive validator could accept certain malformed relative pointers and invalid `ArchivedHashTable` states." ([rkyv/rkyv#663](https://github.com/rkyv/rkyv/issues/663))
- **[RUSTSEC-2026-0235](https://rustsec.org/advisories/RUSTSEC-2026-0235)** — *Insufficient archive validation can cause out-of-bounds reads in archives containing Rc/Arc* (memory-exposure): "Shared pointer validation keyed already-validated pointees by their address and type, but did not include pointer metadata." ([rkyv/rkyv#670](https://github.com/rkyv/rkyv/issues/670))

Because the pin is exact, every downstream workspace that depends on any rspack crate is also blocked from upgrading rkyv (Cargo unifies all `0.8.x` requirements onto one version), so downstreams currently cannot remediate these advisories at all while using rspack.

## Changes

- `Cargo.toml`: `rkyv = "=0.8.16"` → `"=0.8.18"` (exact-pin style preserved).
- `crates/rspack_cacheable/src/context.rs`: adapt to the one breaking API change in rkyv 0.8.17 — `ErasedPtr::new` now takes a raw `*mut T` instead of `NonNull<()>`.
- `Cargo.lock`: re-resolved for rkyv/rkyv_derive 0.8.18.

## Testing

- `cargo check --workspace --all-targets` passes with rkyv 0.8.18.
