### PR TITLE
fix(cli): normalize string `context` from loaded config

### DIFF
--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -39,7 +39,9 @@ const loadConfigByPath = async (
     );
   }
 
-  return normalizeContext(content);
+  return options.configLoader === 'native'
+    ? content
+    : normalizeContext(content);
 };
 
 const isConfigObject = (value: unknown): value is Record<string, unknown> =>

--- a/packages/rspack-cli/src/utils/loadConfig.ts
+++ b/packages/rspack-cli/src/utils/loadConfig.ts
@@ -39,7 +39,7 @@ const loadConfigByPath = async (
     );
   }
 
-  return content;
+  return normalizeContext(content);
 };
 
 const isConfigObject = (value: unknown): value is Record<string, unknown> =>
@@ -53,6 +53,21 @@ const isRspackConfig = (
 const checkIsMultiRspackOptions = (
   config: RspackOptions | MultiRspackOptions,
 ): config is MultiRspackOptions => Array.isArray(config);
+
+/**
+ * jiti exposes a POSIX-style `__dirname` on Windows, so a `context` built from
+ * it keeps forward slashes and no longer matches the native paths the compiler
+ * compares it against. Drop this once jiti stops rewriting `__dirname`.
+ */
+const normalizeContext = (config: LoadedRspackConfig): LoadedRspackConfig => {
+  for (const item of checkIsMultiRspackOptions(config) ? config : [config]) {
+    if (typeof item.context === 'string') {
+      item.context = path.normalize(item.context);
+    }
+  }
+
+  return config;
+};
 
 /**
  * Loads and merges configurations from the 'extends' property


### PR DESCRIPTION
## Why

Since `@rspack/cli` 2.0.0 the TS config is loaded through the prebundled jiti, which derives `__dirname` from a file URL. On Windows that yields a POSIX-style path, so a config doing `context: __dirname` hands the compiler `D:/proj/app` instead of `D:\proj\app`.

The compiler compares that `context` against native paths, so the same physical file can end up with two module records differing only by the first separator — the bundle then contains two copies of the module and module-level singletons (DI tokens, `instanceof`) break.

Before / after on Windows, for `context: __dirname`:

```
before: compiler.context === "D:/Projects/app/demo"
after:  compiler.context === "D:\\Projects\\app\\demo"
```

The CLI now runs `path.normalize` over a string `context` right after the config is loaded, for both single and multi-compiler configs, so what reaches the compiler matches `process.cwd()` again. No-op on POSIX. Can be dropped once jiti stops rewriting `__dirname`.

Closes #15145
