### PR TITLE
fix: exclude import.meta.hot from unknown property warnings

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -387,10 +387,14 @@ impl ImportMetaPlugin {
     if !matches!(self.0.as_ref(), ImportMeta::Enabled)
       || members.first().is_some_and(|property| {
         let name = concat_string!(expr_name::IMPORT_META, ".", property);
-        matches!(
-          name.as_str(),
-          expr_name::IMPORT_META_HOT | expr_name::IMPORT_META_CONTEXT | expr_name::IMPORT_META_GLOB
-        ) || Self::known_property_from_name(&name).is_some()
+        property == "hot"
+          || matches!(
+            name.as_str(),
+            expr_name::IMPORT_META_HOT
+              | expr_name::IMPORT_META_CONTEXT
+              | expr_name::IMPORT_META_GLOB
+          )
+          || Self::known_property_from_name(&name).is_some()
       })
     {
       return;

--- a/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
+++ b/tests/rspack-test/statsOutputCases/track-returned/__snapshots__/stats.txt
@@ -1,13 +1,1 @@
-WARNING in ./index.js
-  ⚠ Module parse warning:
-  ╰─▶   ⚠ Accessing unknown `import.meta` property 'hot' is replaced with undefined.
-           ╭─[468:24]
-       466 │             return routeModule;
-       467 │         } catch (error) {
-       468 │             if (test && import.meta.hot) {
-           ·                         ───────────────
-       469 │                 require("fail36");
-       470 │             }
-           ╰────
-
-Rspack x.x.x compiled with 1 warning in X s
+Rspack x.x.x compiled successfully in X s


### PR DESCRIPTION
## Summary

- Exclude `import.meta.hot` from unknown `import.meta` property warnings.
- Keep the existing replacement behavior unchanged.
- Restore the `statsOutputCases/track-returned` snapshot to a warning-free compilation.

## Why

#14785 suppresses warnings for Rspack's HMR property through `expr_name::IMPORT_META_HOT`, but that constant represents `import.meta.webpackHot`. It does not cover the Vite-compatible `import.meta.hot` spelling, so source that probes for another bundler's HMR API started producing an actionable-looking warning even though the probe is intentional.

For example:

```js
if (import.meta.hot) {
  // Vite HMR path
}
```

Rspack still replaces the unsupported property with `undefined`, but no longer emits the unknown-property warning for this compatibility check. Other statically known unknown properties continue to warn.

## Related links

- Follow-up to #14785

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cargo fmt --all --check`
- `cd tests/rspack-test && pnpm run test -t "statsOutputCases/track-returned"`

## Checklist

- [x] Tests updated.
- [x] Documentation not required.

---
_by OpenAI Codex_