### PR TITLE
docs: document Baseline queries

### DIFF
--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -85,13 +85,30 @@ Supported browserslist values:
 - `browserslist:/path/to/config` - explicitly specify browserslist config
 - `browserslist:/path/to/config:modern` - explicitly specify browserslist config and an environment
 
+### Baseline queries
+
+> Rspack >= v2.1.9 supports Baseline queries.
+
+You can use Baseline queries to target browser versions based on a Baseline feature set. For example, to target browsers that support all features classified as [Baseline Widely available](https://web.dev/baseline), configure:
+
+```js title="rspack.config.mjs"
+export default {
+  target: 'browserslist:baseline widely available',
+};
+```
+
+You can also use a year query such as `baseline 2024`, or a fixed-date query such as `baseline widely available on 2025-05-01`.
+
+:::tip
+For more information, see [Use Baseline with Browserslist](https://web.dev/articles/use-baseline-with-browserslist).
+:::
+
 ### Limitations
 
 Rspack uses [browserslist-rs](https://github.com/browserslist/browserslist-rs), a Rust implementation of Browserslist, and does not yet fully support all Browserslist features.
 
 Currently unsupported features:
 
-- Baseline queries, such as `baseline widely available`
 - Custom usage queries, such as `> 0.5% in my stats`
 - Coverage-based usage queries, such as `cover 99.5% in my stats`
 

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -85,13 +85,30 @@ export default {
 - `browserslist:/path/to/config` - 明确指定 browserslist 配置路径
 - `browserslist:/path/to/config:modern` - 明确指定 browserslist 的配置路径和环境
 
+### Baseline 查询 \{#baseline-queries}
+
+> Rspack >= v2.1.9 支持 Baseline 查询。
+
+你可以使用 Baseline 查询，根据 Baseline 特性集指定目标浏览器版本。例如，如需兼容所有被归类为 [Baseline 广泛可用的特性](https://web.dev/baseline)，可以配置：
+
+```js title="rspack.config.mjs"
+export default {
+  target: 'browserslist:baseline widely available',
+};
+```
+
+你还可以使用 `baseline 2024` 等年份查询，或 `baseline widely available on 2025-05-01` 等固定日期查询。
+
+:::tip
+更多信息请参考 [在 Browserslist 中使用 Baseline](https://web.dev/articles/use-baseline-with-browserslist)。
+:::
+
 ### 限制说明
 
 Rspack 使用的是 [browserslist-rs](https://github.com/browserslist/browserslist-rs)。这是 Browserslist 的一个 Rust 实现，目前尚未完全支持 Browserslist 的所有特性。
 
 当前不支持的功能：
 
-- Baseline 查询，例如 `baseline widely available`
 - 自定义使用率查询，例如 `> 0.5% in my stats`
 - 基于覆盖率的使用率查询，例如 `cover 99.5% in my stats`
 


### PR DESCRIPTION
## Summary

Rspack v2.1.9 added support for Baseline queries, while the target documentation still listed them as unsupported. This PR documents Baseline queries in the English and Chinese target guides, adds common query examples, and links to the Baseline documentation.

## Related links

- https://web.dev/articles/use-baseline-with-browserslist

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).