### PR TITLE
test: add Baseline query coverage

### DIFF
--- a/tests/rspack-test/configCases/builtin-swc-loader/default-target-by-baseline-query/index.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/default-target-by-baseline-query/index.js
@@ -1,0 +1,15 @@
+const generated = /** @type {string} */ (
+  require('fs').readFileSync(__filename, 'utf-8')
+);
+
+it('should transform optional chaining for an older Baseline target', () => {
+  // START:A
+  const value = { nested: { answer: 42 } };
+  const answer = value?.nested?.answer;
+  // END:A
+  const block = generated.match(/\/\/ START:A([\s\S]*)\/\/ END:A/)[1];
+
+  expect(answer).toBe(42);
+  expect(block).not.toContain('?.');
+  expect(block).toContain('=== null');
+});

--- a/tests/rspack-test/configCases/builtin-swc-loader/default-target-by-baseline-query/rspack.config.js
+++ b/tests/rspack-test/configCases/builtin-swc-loader/default-target-by-baseline-query/rspack.config.js
@@ -1,0 +1,18 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    fs: 'node-commonjs fs',
+  },
+  target: 'browserslist:baseline 2015',
+  node: {
+    __filename: false,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: 'builtin:swc-loader',
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

Rspack supports Baseline queries through browserslist-rs 0.20.0, but the target integration did not have config-case coverage. This PR adds a `baseline 2015` case that verifies `builtin:swc-loader` inherits the target, transforms optional chaining, and produces runnable output.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15167

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).