### PR TITLE
docs: document __webpack_layer__

### DIFF
--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -732,6 +732,25 @@ __webpack_module__.id
 
 </Columns>
 
+### \_\_webpack_layer\_\_
+
+<ApiMeta specific={['Rspack', 'Webpack']} />
+
+Access the [layer](/guide/features/layer) of the current module. Its value is the configured layer name, or `null` when the module has no layer.
+
+Rspack replaces `__webpack_layer__` at compile time, allowing optimizers to remove unreachable layer-specific branches.
+
+<Columns>
+```js title=Source
+const currentLayer = __webpack_layer__;
+```
+
+```js title=Compiled
+const currentLayer = 'client';
+```
+
+</Columns>
+
 ### \_\_webpack_require\_\_
 
 <ApiMeta specific={['Rspack', 'Webpack']} />

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -733,6 +733,25 @@ __webpack_module__.id
 
 </Columns>
 
+### \_\_webpack_layer\_\_
+
+<ApiMeta specific={['Rspack', 'Webpack']} />
+
+访问当前模块的 [layer](/guide/features/layer)。它的值是配置的 layer 名称；如果模块未分配 layer，则为 `null`。
+
+Rspack 会在编译时替换 `__webpack_layer__`，使优化器能够移除不可达的特定 layer 分支。
+
+<Columns>
+```js title=源码
+const currentLayer = __webpack_layer__;
+```
+
+```js title=产物
+const currentLayer = 'client';
+```
+
+</Columns>
+
 ### \_\_webpack_require\_\_
 
 <ApiMeta specific={['Rspack', 'Webpack']} />


### PR DESCRIPTION
## Summary

`__webpack_layer__` is a compile-time module variable supported by Rspack and webpack, but it was missing from the Rspack runtime API documentation.

This PR documents its layer name or `null` behavior and compile-time replacement, with source and compiled examples in both English and Chinese.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).