### PR TITLE
chore(ci): drop binary size limit from required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,6 @@ jobs:
         build-s390x,
         test-wasm,
         check-changed,
-        size-limit,
         check-cache,
       ]
     if: ${{ always() && !cancelled() }}
@@ -221,14 +220,7 @@ jobs:
         run: echo ${{ join(needs.*.result, ',') }}
       - name: Test check
         if: ${{ needs.check-changed.outputs.code_changed == 'true'
-          && github.event_name == 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,success,skipped' }}
-        run: echo "Test Failed" && exit 1
-
-      - name: Test check
-        if: ${{ needs.check-changed.outputs.code_changed == 'true'
-          && github.event_name != 'pull_request'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,skipped,skipped' }}
+          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,skipped' }}
         run: echo "Test Failed" && exit 1
 
       - name: No check to Run test


### PR DESCRIPTION
## Why

The binary size limit is a signal, not a hard gate: a legitimate feature can legitimately grow the binary past the 50k threshold, and today that blocks merging until someone bumps `SIZE_LIMIT_THRESHOLD`. Remove it from the `Test Required Check` aggregation so it stops gating merges.

The `size-limit` job still runs on PRs and still comments the size delta — only its influence on the required check is gone.

## What

- Drop `size-limit` from `test_required_check.needs`, and shrink the expected result string accordingly (10 × `success` + `skipped` for the always-skipped `check-cache`).
- With `size-limit` gone, the `pull_request` and non-`pull_request` branches expect the identical result string, so the two `Test check` steps collapse into one guarded only by `code_changed`.

Note: if `Binary Size Limit` is also configured as a required status check in branch protection, it needs to be removed there as well.
