### PR TITLE
perf(binding): cache converted module original source

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -41,7 +41,6 @@ interface KnownBuildInfo {
 export type BuildInfo = KnownBuildInfo & Record<string, any>;
 
 export interface Module {
-	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;
 	get context(): string | undefined;
 	get layer(): string | undefined;

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -192,7 +192,7 @@ export declare class ConcatenatedModule {
   get rootModule(): Module
   get modules(): Module[]
   readableIdentifier(): string
-  _originalSource(): JsSource
+  _originalSource(): JsSource | undefined
   nameForCondition(): string | undefined
   get blocks(): AsyncDependenciesBlock[]
   get dependencies(): Dependency[]
@@ -203,7 +203,7 @@ export declare class ConcatenatedModule {
 
 export declare class ContextModule {
   readableIdentifier(): string
-  _originalSource(): JsSource
+  _originalSource(): JsSource | undefined
   nameForCondition(): string | undefined
   get blocks(): AsyncDependenciesBlock[]
   get dependencies(): Dependency[]
@@ -268,7 +268,7 @@ export type EntryOptionsDTO = EntryOptionsDto
 
 export declare class ExternalModule {
   readableIdentifier(): string
-  _originalSource(): JsSource
+  _originalSource(): JsSource | undefined
   nameForCondition(): string | undefined
   get blocks(): AsyncDependenciesBlock[]
   get dependencies(): Dependency[]
@@ -445,7 +445,7 @@ export declare class KnownBuildInfo {
 
 export declare class Module {
   readableIdentifier(): string
-  _originalSource(): JsSource
+  _originalSource(): JsSource | undefined
   nameForCondition(): string | undefined
   get blocks(): AsyncDependenciesBlock[]
   get dependencies(): Dependency[]

--- a/crates/node_binding/scripts/banner.d.ts
+++ b/crates/node_binding/scripts/banner.d.ts
@@ -41,7 +41,6 @@ interface KnownBuildInfo {
 export type BuildInfo = KnownBuildInfo & Record<string, any>;
 
 export interface Module {
-	[MODULE_IDENTIFIER_SYMBOL]: string;
 	readonly type: string;
 	get context(): string | undefined;
 	get layer(): string | undefined;

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -1,5 +1,10 @@
 #![allow(deprecated)]
-use std::{any::TypeId, cell::RefCell, ptr::NonNull, sync::Arc};
+use std::{
+  any::TypeId,
+  cell::RefCell,
+  ptr::NonNull,
+  sync::{Arc, Weak},
+};
 
 use napi::{CallContext, JsObject, JsString, JsSymbol, NapiRaw};
 use napi_derive::napi;
@@ -7,9 +12,11 @@ use rspack_collections::{Identifier, IdentifierMap};
 use rspack_core::{
   BindingCell, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, Compilation, CompilerId,
   FactoryMeta, LibIdentOptions, Module as _, ModuleIdentifier, RuntimeModuleCommon,
-  RuntimeModuleStage, SourceType, internal,
+  RuntimeModuleStage, SourceType, internal, rspack_sources::Source,
 };
-use rspack_napi::{OneShotInstanceRef, WeakRef, napi::bindgen_prelude::*, string::JsStringExt};
+use rspack_napi::{
+  OneShotInstanceRef, OneShotRef, WeakRef, napi::bindgen_prelude::*, string::JsStringExt,
+};
 use rspack_plugin_runtime::RuntimeModuleFromJs;
 use rustc_hash::FxHashMap;
 
@@ -275,11 +282,23 @@ pub(crate) fn define_module_properties(
 // module_identifier query in compilation.module_graph returns undefined
 // Raw pointer stored in napi module becomes None
 // Throw an Error to the JavaScript side
+struct OriginalSourceNapiRef {
+  // Only retain a weak pointer for identity comparison. Holding another BoxSource here would
+  // increment its Arc strong count and keep the native source alive after the Module replaces it.
+  // The Weak pointer lets the Source and its owned buffers drop with the Module while also keeping
+  // the old Arc allocation unavailable for pointer reuse, so identity comparisons remain reliable.
+  related_source: Weak<dyn Source>,
+  // Keep the converted JavaScript object alive and return that exact object on cache hits. The
+  // reference is replaced on the next call after `module.source()` points to a different Source.
+  napi_ref: OneShotRef,
+}
+
 #[napi]
 pub struct Module {
   pub(crate) identifier: ModuleIdentifier,
   ptr: Option<NonNull<dyn rspack_core::Module>>,
   compiler_id: CompilerId,
+  original_source_ref: Option<OriginalSourceNapiRef>,
   pub(crate) build_info_ref: Option<WeakRef>,
 }
 
@@ -387,16 +406,35 @@ impl Module {
 
   #[napi(
     js_name = "_originalSource",
-    ts_return_type = "JsSource",
+    ts_return_type = "JsSource | undefined",
     enumerable = false
   )]
-  pub fn original_source(&mut self, env: &Env) -> napi::Result<Either<JsSourceToJs, ()>> {
-    self.with_ref(|_, module| {
-      Ok(match module.source() {
-        Some(source) => Either::A(source.try_into()?),
-        None => Either::B(()),
-      })
-    })
+  pub fn original_source<'a>(&mut self, env: &'a Env) -> napi::Result<Either<Unknown<'a>, ()>> {
+    println!("original_source");
+    let module = self.as_mut()?;
+    let Some(original_source) = module.source() else {
+      return Ok(Either::B(()));
+    };
+    if let Some(OriginalSourceNapiRef {
+      related_source,
+      napi_ref,
+    }) = &self.original_source_ref
+    {
+      if (related_source.ptr_eq(&Arc::downgrade(original_source))) {
+        println!("复用 original_source");
+        return Ok(Either::A(ToNapiValue::into_unknown(napi_ref, env)?));
+      }
+    }
+
+    let binding = JsSourceToJs::try_from(original_source)?;
+    let mut one_shot_ref = OneShotRef::new(env.raw(), binding)?;
+    let result = ToNapiValue::into_unknown(&mut one_shot_ref, env)?;
+    self.original_source_ref = Some(OriginalSourceNapiRef {
+      related_source: Arc::downgrade(original_source),
+      napi_ref: one_shot_ref,
+    });
+
+    Ok(Either::A(result))
   }
 
   #[napi]
@@ -656,6 +694,7 @@ impl ToNapiValue for ModuleObject {
               identifier: val.identifier,
               compiler_id: val.compiler_id,
               ptr: val.ptr,
+              original_source_ref: None,
               build_info_ref: Default::default(),
             };
             let env_wrapper = Env::from_raw(env);

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -442,10 +442,9 @@ impl Module {
       related_source,
       napi_ref,
     }) = &self.original_source_ref
+      && (related_source.ptr_eq(&Arc::downgrade(original_source)))
     {
-      if (related_source.ptr_eq(&Arc::downgrade(original_source))) {
-        return Ok(Either::A(ToNapiValue::into_unknown(napi_ref, env)?));
-      }
+      return Ok(Either::A(ToNapiValue::into_unknown(napi_ref, env)?));
     }
 
     let binding = JsSourceToJs::try_from(original_source)?;

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -410,18 +410,40 @@ impl Module {
     enumerable = false
   )]
   pub fn original_source<'a>(&mut self, env: &'a Env) -> napi::Result<Either<Unknown<'a>, ()>> {
-    println!("original_source");
-    let module = self.as_mut()?;
+    let compiler_reference = COMPILER_REFERENCES.with(|ref_cell| {
+      let references = ref_cell.borrow();
+      references.get(&self.compiler_id).cloned()
+    });
+
+    let compilation = {
+      let Some(this) = compiler_reference
+        .as_ref()
+        .and_then(|compiler_reference| compiler_reference.get())
+      else {
+        return Err(self.compiler_garbage_collected_error());
+      };
+      &this.compiler.compilation
+    };
+
+    let module = {
+      if let Some(module) = compilation.module_by_identifier(&self.identifier) {
+        module.as_ref()
+      } else {
+        return Ok(Either::B(()));
+      }
+    };
+
     let Some(original_source) = module.source() else {
+      self.original_source_ref = None;
       return Ok(Either::B(()));
     };
+
     if let Some(OriginalSourceNapiRef {
       related_source,
       napi_ref,
     }) = &self.original_source_ref
     {
       if (related_source.ptr_eq(&Arc::downgrade(original_source))) {
-        println!("复用 original_source");
         return Ok(Either::A(ToNapiValue::into_unknown(napi_ref, env)?));
       }
     }

--- a/crates/rspack_binding_api/src/modules/macros.rs
+++ b/crates/rspack_binding_api/src/modules/macros.rs
@@ -35,11 +35,15 @@ macro_rules! impl_module_methods {
         self.module.readable_identifier()
       }
 
-      #[napi(js_name = "_originalSource", ts_return_type = "JsSource", enumerable = false)]
-      pub fn original_source(
+      #[napi(
+        js_name = "_originalSource",
+        ts_return_type = "JsSource | undefined",
+        enumerable = false
+      )]
+      pub fn original_source<'a>(
         &mut self,
-        env: &napi::Env,
-      ) -> napi::Result<napi::Either<$crate::source::JsSourceToJs, ()>> {
+        env: &'a napi::Env,
+      ) -> napi::Result<napi::Either<napi::bindgen_prelude::Unknown<'a>, ()>> {
         self.module.original_source(env)
       }
 

--- a/packages/rspack/src/ConcatenatedModule.ts
+++ b/packages/rspack/src/ConcatenatedModule.ts
@@ -6,6 +6,7 @@ Object.defineProperty(binding.ConcatenatedModule.prototype, 'identifier', {
   enumerable: true,
   configurable: true,
   value(this: binding.ConcatenatedModule): string {
+    // @ts-expect-error
     return this[binding.MODULE_IDENTIFIER_SYMBOL];
   },
 });

--- a/packages/rspack/src/ContextModule.ts
+++ b/packages/rspack/src/ContextModule.ts
@@ -6,6 +6,7 @@ Object.defineProperty(binding.ContextModule.prototype, 'identifier', {
   enumerable: true,
   configurable: true,
   value(this: binding.Module): string {
+    // @ts-expect-error
     return this[binding.MODULE_IDENTIFIER_SYMBOL];
   },
 });

--- a/packages/rspack/src/ExternalModule.ts
+++ b/packages/rspack/src/ExternalModule.ts
@@ -9,6 +9,7 @@ Object.defineProperty(binding.ExternalModule.prototype, 'identifier', {
   enumerable: true,
   configurable: true,
   value(this: binding.ExternalModule): string {
+    // @ts-expect-error
     return this[binding.MODULE_IDENTIFIER_SYMBOL];
   },
 });

--- a/packages/rspack/src/Module.ts
+++ b/packages/rspack/src/Module.ts
@@ -168,6 +168,7 @@ Object.defineProperty(binding.Module.prototype, 'identifier', {
   enumerable: true,
   configurable: true,
   value(this: binding.Module): string {
+    // @ts-expect-error
     return this[binding.MODULE_IDENTIFIER_SYMBOL];
   },
 });

--- a/packages/rspack/src/NormalModule.ts
+++ b/packages/rspack/src/NormalModule.ts
@@ -10,6 +10,7 @@ Object.defineProperty(binding.NormalModule.prototype, 'identifier', {
   enumerable: true,
   configurable: true,
   value(this: binding.NormalModule): string {
+    // @ts-expect-error
     return this[binding.MODULE_IDENTIFIER_SYMBOL];
   },
 });


### PR DESCRIPTION
## Summary

- Cache the converted JavaScript `Source` object returned by `Module#originalSource()` to reduce repeated Node-API calls and source conversions. This improves HMR performance for plugins such as TanStack Router, which read every module's source during each rebuild.
- Associate the cached JavaScript object with the native source by storing a `Weak<dyn Source>`. This preserves source identity without extending the lifetime of the native `BoxSource`.
- Reuse the existing N-API reference while the native source remains unchanged, and create a new JavaScript object when `module.source()` changes.
- Correct the generated TypeScript return type of `_originalSource()` to include `undefined`.

## Related links

- TanStack Router reads module sources during HMR rebuilds.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
