### PR TITLE
fix: make Module.blocks and Module.dependencies fail gracefully while the module graph is under construction

### DIFF
--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -475,7 +475,11 @@ impl Module {
   )]
   pub fn blocks(&mut self) -> napi::Result<Vec<AsyncDependenciesBlockWrapper>> {
     self.with_ref(|compilation, module| {
-      let module_graph = compilation.get_module_graph();
+      let Some(module_graph) = compilation.try_get_module_graph() else {
+        return Err(napi::Error::from_reason(
+          "Module.blocks is unavailable while the module graph is under construction (e.g. inside a loader during compilation.rebuildModule)",
+        ));
+      };
       let blocks = module.get_blocks();
       Ok(
         blocks
@@ -493,7 +497,11 @@ impl Module {
   #[napi(getter, ts_return_type = "Dependency[]")]
   pub fn dependencies(&mut self) -> napi::Result<Vec<DependencyWrapper>> {
     self.with_ref(|compilation, module| {
-      let module_graph = compilation.get_module_graph();
+      let Some(module_graph) = compilation.try_get_module_graph() else {
+        return Err(napi::Error::from_reason(
+          "Module.dependencies is unavailable while the module graph is under construction (e.g. inside a loader during compilation.rebuildModule)",
+        ));
+      };
       let dependencies = module.get_dependencies();
       Ok(
         dependencies

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -461,6 +461,13 @@ impl Compilation {
     self.build_module_graph_artifact.get_module_graph()
   }
 
+  pub fn try_get_module_graph(&self) -> Option<&ModuleGraph> {
+    self
+      .build_module_graph_artifact
+      .try_read()
+      .map(|artifact| artifact.get_module_graph())
+  }
+
   // it will return None during make phase since mg is incomplete
   pub fn module_by_identifier(&self, identifier: &ModuleIdentifier) -> Option<&BoxModule> {
     if self.build_module_graph_artifact.is_stolen() {

--- a/tests/rspack-test/configCases/compilation/rebuild-module-getters/a.js
+++ b/tests/rspack-test/configCases/compilation/rebuild-module-getters/a.js
@@ -1,0 +1,1 @@
+export const a = 1;

--- a/tests/rspack-test/configCases/compilation/rebuild-module-getters/index.js
+++ b/tests/rspack-test/configCases/compilation/rebuild-module-getters/index.js
@@ -1,0 +1,11 @@
+import { a, blocksError, dependenciesError } from "./a";
+
+it("module getters should fail gracefully while the module graph is under construction", () => {
+	expect(a).toEqual(1);
+	expect(blocksError).toContain(
+		"unavailable while the module graph is under construction",
+	);
+	expect(dependenciesError).toContain(
+		"unavailable while the module graph is under construction",
+	);
+});

--- a/tests/rspack-test/configCases/compilation/rebuild-module-getters/loader.js
+++ b/tests/rspack-test/configCases/compilation/rebuild-module-getters/loader.js
@@ -1,0 +1,24 @@
+let count = 0;
+module.exports = function (source) {
+	count++;
+	if (count === 1) {
+		return source;
+	}
+	let blocksError = '';
+	let dependenciesError = '';
+	try {
+		this._module.blocks;
+	} catch (e) {
+		blocksError = String((e && e.message) || e);
+	}
+	try {
+		this._module.dependencies;
+	} catch (e) {
+		dependenciesError = String((e && e.message) || e);
+	}
+	return (
+		source +
+		`\nexport const blocksError = ${JSON.stringify(blocksError)};` +
+		`\nexport const dependenciesError = ${JSON.stringify(dependenciesError)};`
+	);
+};

--- a/tests/rspack-test/configCases/compilation/rebuild-module-getters/rspack.config.js
+++ b/tests/rspack-test/configCases/compilation/rebuild-module-getters/rspack.config.js
@@ -1,0 +1,50 @@
+const pluginName = 'plugin';
+
+class Plugin {
+  apply(compiler) {
+    let initial = true;
+    compiler.hooks.compilation.tap(pluginName, (compilation) => {
+      compilation.hooks.finishModules.tapPromise(
+        pluginName,
+        async (modules) => {
+          if (!initial) {
+            return;
+          }
+          initial = false;
+          const oldModule = [...modules].find((item) =>
+            item.resource.endsWith('a.js'),
+          );
+          if (!oldModule) {
+            throw new Error('module not found');
+          }
+          await new Promise((res, rej) => {
+            compilation.rebuildModule(oldModule, function (err, m) {
+              if (err) {
+                rej(err);
+              } else {
+                res(m);
+              }
+            });
+          });
+        },
+      );
+    });
+  }
+}
+
+/**@type {import("@rspack/core").Configuration}*/
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /a\.js$/,
+        use: [
+          {
+            loader: './loader',
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [new Plugin()],
+};


### PR DESCRIPTION
### Summary

Reading `this._module.blocks` (or `dependencies`) from a loader that runs inside `compilation.rebuildModule()` panics and aborts the whole Node.js process:

```
thread '<unnamed>' panicked:
attempted to read from stolen value: rspack_core::artifacts::build_module_graph_artifact::BuildModuleGraphArtifact
```

This is easy to hit without writing such loader code: pause on a breakpoint inside any loader while `rebuildModule` is running and hover over `this._module` in VS Code — the debugger evaluates every property getter, reaches `blocks`, and the process dies with `SIGABRT`.

Minimal reproduction: https://github.com/upupming/rspack-stolen-artifact-repro

### Root cause

- `Compilation::rebuild_module` steals `build_module_graph_artifact` for the whole rebuild, and loaders run inside that window (the initial make phase has the same window via `add_entry_batch`).
- The `Module.blocks` / `Module.dependencies` napi getters call `compilation.get_module_graph()`, which derefs the stolen `StealCell` and panics.

### Fix

- Add `Compilation::try_get_module_graph()` on top of the existing `StealCell::try_read`, mirroring the defensive pattern `module_by_identifier` already uses.
- The two getters now return a `napi::Error` ("unavailable while the module graph is under construction") instead of aborting, so a debugger hover shows an error message and programmatic access gets a catchable JS exception.

Other bindings that read the module graph (`chunk_graph.rs`, `dependency.rs`, `module_graph.rs`, …) have the same theoretical window; happy to extend the same guard there if you prefer, this PR keeps the scope to the getters reachable from a debugger hover over a module inside a loader.

### Test

`configCases/compilation/rebuild-module-getters`: a loader touches both getters during `rebuildModule` and the build asserts it receives the graceful error while the process survives.

### Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).