### PR TITLE
chore(ci): gate binary size on main pushes

### DIFF
--- a/.github/actions/binary-limit/binary-limit-script.js
+++ b/.github/actions/binary-limit/binary-limit-script.js
@@ -1,4 +1,5 @@
 const fs = require('node:fs');
+const { setTimeout: sleep } = require('node:timers/promises');
 
 /**
  * @param {import("@octokit/rest")} github
@@ -13,7 +14,9 @@ module.exports = async function action({ github, context, limit }) {
   let baseCommit;
   let baseSize;
   try {
-    ({ baseCommit, baseSize } = await findBaseCommit(github, context));
+    ({ baseCommit, baseSize } = context.payload.pull_request
+      ? await findBaseCommit(github, context)
+      : await waitForBaseCommit(github, context));
   } catch (e) {
     if (e instanceof PendingBinaryDataError) {
       await tryComment(
@@ -44,6 +47,12 @@ module.exports = async function action({ github, context, limit }) {
 const PER_PAGE = 30;
 const MAX_PAGES = 4;
 
+// The parent's own CI publishes its size about four minutes in, so a commit merged
+// right behind it can reach this job first. Observed window is one to two minutes;
+// ten leaves room for a slow build.
+const PENDING_POLL_INTERVAL_MS = 60_000;
+const PENDING_POLL_ATTEMPTS = 10;
+
 class PendingBinaryDataError extends Error {
   constructor(baseCommit, fallback) {
     super(
@@ -56,6 +65,35 @@ class PendingBinaryDataError extends Error {
   }
 }
 
+// A trunk push has no PR to comment on, so an unpublished baseline can only surface
+// as a red main — noise rather than a size problem. Wait for the parent's data instead
+// of failing on it, and if it never lands, compare against the nearest ancestor that
+// has data: that still measures real growth, it just spans more than one commit.
+async function waitForBaseCommit(github, context) {
+  let pending;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await findBaseCommit(github, context);
+    } catch (e) {
+      if (!(e instanceof PendingBinaryDataError)) throw e;
+      pending = e;
+    }
+
+    if (attempt === PENDING_POLL_ATTEMPTS) break;
+    console.log(
+      `Base size data not published yet, retrying in ${PENDING_POLL_INTERVAL_MS / 1000}s (${attempt}/${PENDING_POLL_ATTEMPTS})`,
+    );
+    await sleep(PENDING_POLL_INTERVAL_MS);
+  }
+
+  if (!pending.fallback) throw pending;
+
+  console.log(
+    `Base data never arrived, comparing against ${pending.fallback.baseCommit.sha} instead`,
+  );
+  return pending.fallback;
+}
+
 // Baseline is the newest trunk commit already contained in the binding CI built,
 // not the fork point: PR CI builds from the merge ref, so head size already
 // includes that trunk tip. Walk trunk history skipping doc-only commits (they
@@ -65,11 +103,7 @@ class PendingBinaryDataError extends Error {
 // a rough number.
 async function findBaseCommit(github, context) {
   const { owner, repo } = context.repo;
-  const pr = context.payload.pull_request;
-  if (!pr) {
-    throw new Error('binary-limit action requires pull_request context');
-  }
-  const baseSha = await resolveBaseSha(github, owner, repo, context, pr);
+  const baseSha = await resolveBaseSha(github, owner, repo, context);
   console.log(`Base trunk commit: ${baseSha}`);
 
   let pendingBase = null;
@@ -125,14 +159,24 @@ async function findBaseCommit(github, context) {
 
 // Size data only exists for trunk commits, so the baseline must be a trunk commit
 // — the newest one the binding under test actually contains.
-async function resolveBaseSha(github, owner, repo, context, pr) {
-  const { data: mergeCommit } = await github.rest.repos.getCommit({
+async function resolveBaseSha(github, owner, repo, context) {
+  const pr = context.payload.pull_request;
+  const { data: commit } = await github.rest.repos.getCommit({
     owner,
     repo,
     ref: context.sha,
   });
-  const [base, head] = mergeCommit.parents ?? [];
-  if (mergeCommit.parents?.length !== 2 || head?.sha !== pr.head.sha) {
+  const [base, head] = commit.parents ?? [];
+
+  // A trunk push measures the pushed commit itself, so its own parent is the baseline.
+  if (!pr) {
+    if (!base) {
+      throw new Error(`Commit ${context.sha} has no parent to compare against`);
+    }
+    return base.sha;
+  }
+
+  if (commit.parents?.length !== 2 || head?.sha !== pr.head.sha) {
     console.log('context.sha is not a PR merge commit, using pr.base.sha');
     return pr.base.sha;
   }
@@ -184,7 +228,7 @@ async function resolveStack(github, owner, repo, pr) {
 }
 
 // A binding is built (and size data produced) only for commits touching non-doc
-// files, mirroring ecosystem-benchmark's `paths-ignore: ['**/*.md', 'website/**']`.
+// files, mirroring the `code_changed` filter in ci.yml that gates the binding build.
 async function triggersBinaryBuild(github, owner, repo, sha) {
   const { data: commit } = await github.rest.repos.getCommit({
     owner,
@@ -197,10 +241,19 @@ async function triggersBinaryBuild(github, owner, repo, sha) {
 }
 
 function isDocFile(filename) {
-  return filename.endsWith('.md') || filename.startsWith('website/');
+  return (
+    filename.endsWith('.md') ||
+    filename.endsWith('.mdx') ||
+    filename.startsWith('website/')
+  );
 }
 
 async function tryComment(github, context, comment) {
+  // A trunk push has no PR to comment on; it reports through the job status alone.
+  if (!context.payload.pull_request) {
+    console.log(comment);
+    return;
+  }
   try {
     await commentToPullRequest(github, context, comment);
   } catch (e) {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,9 @@ jobs:
   size-limit:
     name: Binary Size Limit
     needs: [check-changed, build-linux]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'pull_request' }}
+    # On a PR this only comments (it is deliberately not part of Test Required Check).
+    # On a trunk push it gates: exceeding the threshold fails the job, and with it the run.
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'web-infra-dev/rspack')) }}
     uses: ./.github/workflows/size-limit.yml
 
   ecosystem_ci_per_commit:


### PR DESCRIPTION
## Why

After #15171 the binary size limit gates nothing — it only comments on PRs. That removal was deliberate: a legitimate feature can legitimately grow the binary, and blocking merges on it was the wrong trade. But it leaves no one watching binary growth at all.

This puts the gate where it blocks no one: on the trunk push. A PR still only gets a comment and stays out of `Test Required Check`; once merged, main's CI goes red if the binary grew past `SIZE_LIMIT_THRESHOLD`. Growth stays visible, and raising the threshold is a deliberate act rather than something done under merge pressure.

## What

- **`ci.yml`** — `size-limit` now also runs on `push` (was `pull_request` only). Still absent from `test_required_check.needs`, so PR behavior is unchanged.
- **`resolveBaseSha`** — with no PR context the baseline is the pushed commit's own parent. Previously the script threw `binary-limit action requires pull_request context`.
- **`waitForBaseCommit`** (new) — poll for the parent's size data instead of failing on it; after 10 minutes fall back to the nearest ancestor that has data.
- **`tryComment`** — a push has no PR to comment on, so log the comparison instead.
- **`isDocFile`** — also treat `.mdx` as a doc file.

### Why the polling

The parent's `ci-binary.json` is uploaded by the parent's own CI, and `upload-binary-size` lands about 4.5 minutes into a run. Commits merged seconds apart race it:

| commit | run started | run finished |
| --- | --- | --- |
| `ac3dcd6` (#15163, parent) | 02:54:27 | 03:17:55 |
| `7a11676` (#15171, child) | 02:54:44 | **03:16:02** |

Pushed 17 seconds apart, and the child's run finished first — so the child would read the parent's size before the parent had uploaded it. Failing there would redden main over an upload that has not landed yet, which is noise rather than a size problem. If the data never arrives (e.g. the parent's `build-linux` failed), comparing against the nearest ancestor with data still measures real growth; it just spans more than one commit, and the log says so.

### Why `.mdx`

Three places disagreed on what counts as a doc file:

| | `.mdx` treated as doc |
| --- | --- |
| `ci.yml` push `paths-ignore` | no |
| `check-changed` filter | yes |
| `isDocFile()` | no |

A commit touching only `.mdx` outside `website/` triggers CI but has `code_changed == false`, so it builds no binding and never publishes size data. The baseline walk used to treat it as a build commit and wait for data that would never come. There are currently zero such files, so this is latent, but polling turned the cost from an immediate failure into a 9-minute stall.

## Verification

The script only ever runs in CI, so it was driven against a mocked GitHub API — 17 cases, all passing:

- **push baseline** — parent has data (under/over limit), doc-only parent skipped, no parent
- **polling** — data lands on the 3rd poll, never lands (falls back, under/over limit), no ancestor has data
- **no data** — parent has only the ecosystem benchmark's `rspack-build.json`, `.mdx`-only parent skipped, `.mdx` + code parent still decisive
- **PR regression** — merge commit, over limit, non-merge `context.sha`, stacked PR

Note that the push path itself can only be exercised after merging, since `ci.yml`'s `push` trigger is limited to `main` / `v1.x`. The failure cost is low: the job is not a required check, so nothing is blocked either way.

`v1.x` is unaffected — workflow files travel with the branch, and `v1.x`'s `ci.yml` does not carry this change. It also has no `upload-binary-size` job, so cherry-picking this over would need that job first.
