### PR TITLE
fix: pass HMR error to Preact refresh recovery handler

### DIFF
--- a/crates/rspack_loader_preact_refresh/src/runtime.js
+++ b/crates/rspack_loader_preact_refresh/src/runtime.js
@@ -58,7 +58,7 @@ if (moduleHot) {
       data.moduleExports = __prefresh_utils__.getExports(module);
     });
 
-    moduleHot.accept(function errorRecovery() {
+    moduleHot.accept(function errorRecovery(error) {
       if (
         typeof __prefresh_errors__ !== 'undefined' &&
         __prefresh_errors__ &&


### PR DESCRIPTION
## Summary

When a self-accepted Preact module fails during HMR, the refresh runtime reads an undeclared `error` and can mask the original failure with a `ReferenceError`. This PR accepts the error provided by the HMR callback and forwards it to the Prefresh runtime error handler.

## Related links

https://github.com/web-infra-dev/rspack/pull/15176#discussion_r3773178242

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).