### PR TITLE
feat: implement generation-based memory cache eviction

### DIFF
--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -149,6 +149,7 @@ impl Cache {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
+    storage.memory_cache.start_next_generation();
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.begin_idle()
     } else {

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use rspack_util::fx_hash::FxDashMap;
 
 use super::{
@@ -26,13 +28,62 @@ impl<T> Clone for MemoryCacheGetResult<T> {
   }
 }
 
-/// In-memory cache equivalent to webpack's `MemoryCachePlugin`.
-#[derive(Debug, Default)]
+#[derive(Debug)]
+enum MemoryCacheValue {
+  Miss,
+  Hit(CacheEntry),
+}
+
+#[derive(Debug)]
+struct MemoryCacheEntry {
+  value: MemoryCacheValue,
+  ttl: AtomicU32,
+}
+
+impl MemoryCacheEntry {
+  fn new(value: MemoryCacheValue, ttl: u32) -> Self {
+    Self {
+      value,
+      ttl: AtomicU32::new(ttl),
+    }
+  }
+
+  fn refresh(&self, ttl: u32) {
+    self.ttl.store(ttl, Ordering::Relaxed);
+  }
+
+  fn start_next_generation(&mut self) -> bool {
+    let ttl = self.ttl.get_mut();
+    if *ttl == 0 {
+      false
+    } else {
+      *ttl -= 1;
+      true
+    }
+  }
+}
+
+/// In-memory cache with generation-based garbage collection.
+#[derive(Debug)]
 pub struct MemoryCache {
-  entries: FxDashMap<CacheKey, Option<CacheEntry>>,
+  max_generations: u32,
+  entries: FxDashMap<CacheKey, MemoryCacheEntry>,
+}
+
+impl Default for MemoryCache {
+  fn default() -> Self {
+    Self::new(1)
+  }
 }
 
 impl MemoryCache {
+  pub fn new(max_generations: u32) -> Self {
+    Self {
+      max_generations,
+      entries: FxDashMap::default(),
+    }
+  }
+
   pub fn get<T: CacheValueData>(
     &self,
     key: &CacheKey,
@@ -41,8 +92,10 @@ impl MemoryCache {
     let Some(entry) = self.entries.get(key) else {
       return MemoryCacheGetResult::NotCached;
     };
-    let Some(entry) = entry.value() else {
-      return MemoryCacheGetResult::Miss;
+    entry.refresh(self.max_generations);
+    let entry = match &entry.value {
+      MemoryCacheValue::Miss => return MemoryCacheGetResult::Miss,
+      MemoryCacheValue::Hit(entry) => entry,
     };
     if entry.matches(etag) {
       entry
@@ -56,13 +109,28 @@ impl MemoryCache {
   }
 
   pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
-    self
-      .entries
-      .insert(key, Some(CacheEntry::new(etag, value.erase())));
+    self.entries.insert(
+      key,
+      MemoryCacheEntry::new(
+        MemoryCacheValue::Hit(CacheEntry::new(etag, value.erase())),
+        self.max_generations,
+      ),
+    );
   }
 
   pub fn store_miss(&self, key: CacheKey) {
-    self.entries.insert(key, None);
+    self.entries.insert(
+      key,
+      MemoryCacheEntry::new(MemoryCacheValue::Miss, self.max_generations),
+    );
+  }
+
+  /// Starts a new compilation generation and evicts entries that were not
+  /// accessed during the configured number of previous generations.
+  pub fn start_next_generation(&self) {
+    self
+      .entries
+      .retain(|_, entry| entry.start_next_generation());
   }
 
   pub fn clear(&self) {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -38,8 +38,8 @@ pub fn create_cache(
 
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => return Cache::new_disabled(compiler_path),
-    crate::CacheOptions::Memory { max_generations: _ } => {
-      return Cache::new(compiler_path, MemoryCache::default(), None);
+    crate::CacheOptions::Memory { max_generations } => {
+      return Cache::new(compiler_path, MemoryCache::new(*max_generations), None);
     }
     crate::CacheOptions::Persistent(options) => options,
   };

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -38,8 +38,10 @@ pub fn create_cache(
 
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => return Cache::new_disabled(compiler_path),
-    crate::CacheOptions::Memory { max_generations } => {
-      return Cache::new(compiler_path, MemoryCache::new(*max_generations), None);
+    crate::CacheOptions::Memory {
+      max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
+    } => {
+      return Cache::new(compiler_path, MemoryCache::new(5), None);
     }
     crate::CacheOptions::Persistent(options) => options,
   };


### PR DESCRIPTION
## Summary

Implement generation-based memory cache eviction (maxMemoryGenerations, default to 5)

<!-- Describe what this PR does and why. -->

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>