### PR TITLE
chore(deps): upgrade pnp to 0.12.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,21 +334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitfield"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,17 +1453,6 @@ name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fancy-regex"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
-dependencies = [
- "bit-set",
- "regex-automata",
- "regex-syntax",
-]
 
 [[package]]
 name = "fast-glob"
@@ -3345,18 +3319,18 @@ checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pnp"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d021b5b4a2ea34bf137831fbbc5856e9c7ca70861f95a0f8dc51323b6e821faa"
+checksum = "e57281b9cdf635e68b57fc347e213b413f099d57cdd708182d5e759418d41485"
 dependencies = [
  "byteorder",
  "concurrent_lru",
- "fancy-regex",
  "flate2",
  "indexmap",
  "nodejs-built-in-modules",
  "pathdiff",
  "radix_trie",
+ "regress",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ inventory = { version = "0.3.17", default-features = false }
 rkyv      = { version = "=0.8.18", default-features = false, features = ["std", "bytecheck", "smallvec-1"] }
 
 # Must be pinned with the same swc versions
-pnp                 = { version = "0.12.9", default-features = false }
+pnp                 = { version = "0.12.11", default-features = false }
 swc                 = { version = "74.0.0", default-features = false }
 swc_atoms           = { version = "10.0.0", default-features = false }
 swc_config          = { version = "6.0.0", default-features = false }
@@ -325,9 +325,6 @@ opt-level = "s"
 opt-level = "s"
 
 [profile.release.package.pnp]
-opt-level = "s"
-
-[profile.release.package.fancy-regex]
 opt-level = "s"
 
 [profile.release.package.swc_ecma_loader]


### PR DESCRIPTION
## Why

`pnp` 0.12.9 → 0.12.11 picks up an upstream correctness fix and drops a dependency.

**Loose-mode fallback fix** — when a package imports an undeclared dependency and `enableTopLevelFallback` is on, the resolver now consults the top-level locator first and only defers to the deduplicated `fallbackPool` when the top-level package provides no concrete binding. Previously it went straight to the pool, which can hold an older duplicated copy. `null` fallback entries are now ignored, and the top-level package itself no longer uses fallbacks — both matching Node's PnP loader.

Before: `issuer` importing an undeclared `dep` resolved to the pool's `dep@0.11.0`.
After: it resolves to the top-level `dep@1.4.0`, same as Node.

**Regex engine swap** — upstream moved `fancy-regex` → `regress`. `ignorePatternData` is an ECMAScript regex Yarn generates via `micromatch.makeRe`, so evaluating it with an ECMAScript engine is the semantically correct read (it also let upstream delete a hand-rolled slash-unescaping pre-pass). Rspack already depends on `regress` 0.11.1 for `rspack_plugin_javascript`, so this removes 3 crates from the tree — `fancy-regex`, `bit-set`, `bit-vec` — and adds none. The binding shrinks 112KB as a result (68.17MB → 68.06MB, -0.16%).

## What

- Bump the workspace `pnp` pin to 0.12.11.
- Drop `[profile.release.package.fancy-regex]`, now a dead entry. The existing `[profile.release.package.regress]` keeps `opt-level = "s"` applied to pnp's regex engine.

No rspack code changes: only `lib.rs` / `util.rs` moved upstream, and the API rspack uses (`find_closest_pnp_manifest_path`, `load_pnp_manifest`, `Manifest`, `Resolution`, `resolve_to_unqualified_via_manifest`, `pnp::fs::*`) is unchanged. `fs.rs` / `zip.rs` / `manifest.rs` / `error.rs` are byte-identical between the two versions.

## Verification

`cargo check --workspace` clean, and `cargo test -p rspack_resolver --all-features` green locally with fixtures installed: 164 lib (1 ignored) + 10 integration + 7 resolve, including all 8 `tests::pnp::*` cases.
