### PR TITLE
fix(cache): limit shutdown compaction to a single pass

### DIFF
--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -13,7 +13,6 @@ use super::{
 use crate::cache::persistent::codec::CacheCodec;
 
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
-const MAX_IDLE_COMPACTION_PASSES: usize = 10;
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -157,6 +156,7 @@ impl FileCacheStrategy {
 
   pub(super) async fn after_all_stored(
     &mut self,
+    max_compaction_passes: usize,
     mut check_idle_ended: impl FnMut() -> bool,
   ) -> Result<()> {
     if self.readonly {
@@ -199,7 +199,7 @@ impl FileCacheStrategy {
       self.pending_writes.build_dependencies = None;
     }
 
-    for _ in 0..MAX_IDLE_COMPACTION_PASSES {
+    for _ in 0..max_compaction_passes {
       if check_idle_ended() {
         return Ok(());
       }
@@ -213,7 +213,7 @@ impl FileCacheStrategy {
   }
 
   pub async fn shutdown(&mut self) -> Result<()> {
-    self.after_all_stored(|| false).await?;
+    self.after_all_stored(1, || false).await?;
 
     self.database.shutdown()?;
     Ok(())

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -23,6 +23,7 @@ use super::{
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
 const DEFAULT_IDLE_TIMEOUT_AFTER_LARGE_CHANGES: Duration = Duration::from_secs(1);
+const MAX_IDLE_COMPACTION_PASSES: usize = 10;
 
 #[derive(Debug)]
 enum Command {
@@ -170,7 +171,11 @@ impl BackgroundJob {
 
   async fn process_idle_tasks(&mut self, check_idle_ended: impl FnMut() -> bool) {
     let start = Instant::now();
-    if let Err(error) = self.strategy.after_all_stored(check_idle_ended).await {
+    if let Err(error) = self
+      .strategy
+      .after_all_stored(MAX_IDLE_COMPACTION_PASSES, check_idle_ended)
+      .await
+    {
       tracing::warn!("Finalizing idle file cache store failed: {error}");
       return;
     }


### PR DESCRIPTION
## Summary

fix https://github.com/web-infra-dev/rspack/pull/15182#discussion_r3781124308

- Make the maximum compaction passes configurable for file-cache finalization.
- Keep idle compaction at up to 10 passes while limiting shutdown compaction to one pass.

## Testing

Not run (not requested)