### PR TITLE
fix: correct documentation typos

### DIFF
--- a/website/docs/en/api/javascript-api/logger.mdx
+++ b/website/docs/en/api/javascript-api/logger.mdx
@@ -184,7 +184,7 @@ LOG from TEST
 
 ### status
 
-Display progress status information, use `console.status` if exists, otherwise fallback to `console.info.
+Display progress status information. Use `console.status` if it exists; otherwise, fall back to `console.info`.
 
 - **Level:** `info`
 - **Type:** `status(...args: any[]): void`

--- a/website/docs/en/blog/announcing-0-5.mdx
+++ b/website/docs/en/blog/announcing-0-5.mdx
@@ -198,7 +198,7 @@ This configuration has no effect on users developing applications in Rspack most
 
 ## Migration guide
 
-v0.5.0 removed lots of deprecated features, except that, v0.5.0 introduced four breaking changes, and you only need to notice two of them if you are developing applications using Rspack. So v0.5.0 is easy to migrate if you already migrate to v0.4+ with no deprecate warnings, if you haven't, checkout the [v0.4.0 migration guide](/blog/announcing-0-4#migration-guide).
+v0.5.0 removed many deprecated features and introduced four breaking changes. If you are developing applications with Rspack, you only need to pay attention to two of them. Migrating to v0.5.0 is straightforward if you have already migrated to v0.4+ and have no deprecation warnings. If you haven't, check out the [v0.4.0 migration guide](/blog/announcing-0-4#migration-guide).
 
 ### Add resolve.extensions
 

--- a/website/docs/en/blog/announcing-0-6.mdx
+++ b/website/docs/en/blog/announcing-0-6.mdx
@@ -45,7 +45,7 @@ export default {
 };
 ```
 
-> There is an basic [project example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/react-with-extract-css).
+> There is a basic [project example](https://github.com/rstackjs/rstack-examples/tree/main/rspack/react-with-extract-css).
 
 ### Enable new tree shaking by default
 

--- a/website/docs/en/blog/announcing-1-3.mdx
+++ b/website/docs/en/blog/announcing-1-3.mdx
@@ -67,7 +67,7 @@ export default {
 
 ### Build HTTP imports
 
-In previous versions, you could import HTTP/HTTPS resources by using [externalsPresets.web](/config/externals#externalspresetsweb) or [externalsPresets.webAsync](/config/externals#externalspresetswebasync) options, which simply externals the these resources and let the browser (or other platform) to fetch them at runtime.
+In previous versions, you could import HTTP/HTTPS resources by using [externalsPresets.web](/config/externals#externalspresetsweb) or [externalsPresets.webAsync](/config/externals#externalspresetswebasync) options, which simply externalize these resources and let the browser (or other platform) fetch them at runtime.
 
 ```js
 import pMap from 'https://esm.sh/p-map';

--- a/website/docs/en/blog/announcing-2-0.mdx
+++ b/website/docs/en/blog/announcing-2-0.mdx
@@ -496,6 +496,6 @@ Rslib, Rstest, and Rspress will also upgrade to Rspack 2.0 soon. At the same tim
 
 ## Acknowledgements
 
-We would like like to thank all Rspack users, contributors, and partners. Every piece of feedback and every contribution has helped move the Rspack ecosystem forward. We also hope that Rspack can continue to contribute to the broader JavaScript ecosystem.
+We would like to thank all Rspack users, contributors, and partners. Every piece of feedback and every contribution has helped move the Rspack ecosystem forward. We also hope that Rspack can continue to contribute to the broader JavaScript ecosystem.
 
 We are equally grateful to the teams behind other bundlers in the community, including esbuild, Parcel, Rollup, Rolldown, Turbopack, and webpack. Their ongoing exploration in different directions has continued to inspire new ideas across the ecosystem, and has helped turn many of them into reality.

--- a/website/docs/en/blog/rspack-next-partner.mdx
+++ b/website/docs/en/blog/rspack-next-partner.mdx
@@ -47,7 +47,7 @@ We deeply appreciate Vercel’s collaboration and shared commitment to improving
 
 Currently, the App Router implementation with `next-rspack` is **slower than Turbopack**, and may even be slower than webpack. This is due to some **JavaScript plugins** that cause heavy Rust-JavaScript communication overhead.
 
-We have **experimentally ported the theses plugins to Rust**, which dramatically improved performance—almost on par with Turbopack. And we are exploring how to address the long-term maintenance challenges that come with deep integration.
+We have **experimentally ported these plugins to Rust**, which dramatically improved performance—almost on par with Turbopack. And we are exploring how to address the long-term maintenance challenges that come with deep integration.
 
 ### Page router users
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -270,20 +270,19 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 - **Type:** `false | RegExp[]`
 - **Default:** `false`
 
-By default, Rspack reads files from disk using a native file system.
-However, it is possible to change the file system using a different kind of file system.
-To accomplish this, one can change the inputFileSystem. For example, you can replace the default inputFileSystem with memfs to virtual Modules.
+By default, Rspack reads files from disk using the native file system.
+However, you can use a different kind of file system by changing `inputFileSystem`. For example, you can replace the default file system with memfs to support virtual modules.
 
-But due to the overheads calling file system implemented in Node.js side, it will slow down Rspack a lot.
-So we make a trade off by providing the `useInputFileSystem` config, to tell rspack to read file from the native file system or from modified inputFileSystem.
+Calling a file system implemented in Node.js adds overhead and can significantly slow down Rspack.
+The `useInputFileSystem` option lets you control whether Rspack reads files from the native file system or a customized `inputFileSystem`.
 
-In below example, you can simply replace the default input file system to any file system satisfied the [`InputFileSystem`](/api/javascript-api/compiler#inputfilesystem-1) interface.
+In the example below, you can replace the default input file system with any file system that satisfies the [`InputFileSystem`](/api/javascript-api/compiler#inputfilesystem-1) interface.
 
 :::info Note
-The replacing of `compiler.inputFileSystem` will only take effect before `compiler.run` called; Replacing after `compiler.run` will not take effect.
+Replacing `compiler.inputFileSystem` only takes effect before `compiler.run` is called. Replacing it after `compiler.run` has no effect.
 :::
 
-More detailed case can be found [here](https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/input-file-system/rspack.config.js)
+A more detailed example can be found [here](https://github.com/web-infra-dev/rspack/tree/main/tests/rspack-test/configCases/input-file-system/rspack.config.js).
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -1219,10 +1219,10 @@ import classes, { class1, class2 } from './index.module.css';
 - **Type:** `boolean`
 - **Default:** `true`
 
-Allow to enable/disables handling the CSS functions url.
+Controls whether Rspack handles the CSS `url()` function.
 
-When using `url: true`, Rspack will resolve the path in `url` function, the resolve file will be treated as an asset.
-When using `url: false`, Rspack will ignore the path in the `url` function, keep the content unchanged.
+When using `url: true`, Rspack will resolve the path in the `url()` function, and the resolved file will be treated as an asset.
+When using `url: false`, Rspack will ignore the path in the `url()` function and keep the content unchanged.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1305,7 +1305,7 @@ The output will be:
 });
 ```
 
-You may specify an object for `library.name` for differing names per targets:
+You may specify an object for `library.name` to use different names for each target:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/errors/swc-plugin-version.mdx
+++ b/website/docs/en/errors/swc-plugin-version.mdx
@@ -8,7 +8,7 @@ description: 'The SWC plugin is still an experimental feature, and the SWC Wasm 
 
 The SWC plugin is still an experimental feature, and the SWC Wasm plugin is currently not backward compatible. The version of the SWC plugin is closely tied to the version of `swc_core` that Rspack depends on.
 
-This means that you must to choose an SWC plugin that matches the current version of `swc_core` to ensure that it works properly. If the version of the SWC plugin you are using does not match the version of `swc_core` that Rspack depends on, Rspack will throw the following error during the build process:
+This means that you must choose an SWC plugin that matches the current version of `swc_core` to ensure that it works properly. If the version of the SWC plugin you are using does not match the version of `swc_core` that Rspack depends on, Rspack will throw the following error during the build process:
 
 ```text
 The version of the SWC Wasm plugin you're using might not be compatible with 'builtin:swc-loader'

--- a/website/docs/en/guide/migration/rspack_0.x.mdx
+++ b/website/docs/en/guide/migration/rspack_0.x.mdx
@@ -208,7 +208,7 @@ export default {
 In Rspack 0.x, we used the built-in `rspack.SwcCssMinimizerRspackPlugin` to compress CSS size.
 Now, we have removed it and replaced it with [rspack.LightningCssMinimizerRspackPlugin](/plugins/rspack/lightning-css-minimizer-rspack-plugin) to handle the same functionality.
 
-If you previously manually registered and configured `rspack.SwcCssMinimizerRspackPlugin`, you should to switch to `rspack.LightningCssMinimizerRspackPlugin`:
+If you previously manually registered and configured `rspack.SwcCssMinimizerRspackPlugin`, you should switch to `rspack.LightningCssMinimizerRspackPlugin`:
 
 ```diff
 import { rspack } from '@rspack/core';

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -107,7 +107,7 @@ Here we also provide an online example based on Wasm and WebContainer on StackBl
 
 ## Manual installation
 
-Start by creating a project directory and generating an npm `package.json':
+Start by creating a project directory and generating an npm `package.json`:
 
 ```bash
 mkdir rspack-demo

--- a/website/docs/en/misc/glossary.mdx
+++ b/website/docs/en/misc/glossary.mdx
@@ -116,12 +116,12 @@ The runtime is all the code Rspack needs to connect your modularized application
 
 ## scope hoisting
 
-Scope hoisting is a technique that concat modules into a single scope when possible, rather than wrapping each module in a separate function. It can make minification more effective and improve runtime performance by reduce module lookup cost.
+Scope hoisting is a technique that concatenates modules into a single scope when possible, rather than wrapping each module in a separate function. It can make minification more effective and improve runtime performance by reducing module lookup costs.
 
 - [optimization.concatenateModules](/config/optimization#optimizationconcatenatemodules)
 
 ## tree shaking
 
-Tree shaking is a technique that allows you to remove unused code from your bundle. It a form of compiler dead code elimination, with a focus on minimizing processing of dead code. Compilers like Rspack will accomplish this by analyzing the static structure of your code, and then removing the unused code.
+Tree shaking is a technique that allows you to remove unused code from your bundle. It is a form of compiler dead code elimination, with a focus on minimizing processing of dead code. Compilers like Rspack will accomplish this by analyzing the static structure of your code, and then removing the unused code.
 
 - [Tree shaking](/guide/optimization/tree-shaking)

--- a/website/docs/zh/api/javascript-api/index.mdx
+++ b/website/docs/zh/api/javascript-api/index.mdx
@@ -104,7 +104,7 @@ function rspack(
 
 ## compiler.run
 
-使用 `run` 方法启动所有编译工作。完成之后，执行传入的的 `callback` 函数。最终记录下来的概括信息（stats）和错误（errors），都应在这个 callback 函数中获取。
+使用 `run` 方法启动所有编译工作。完成之后，执行传入的 `callback` 函数。最终记录下来的概括信息（stats）和错误（errors），都应在这个 callback 函数中获取。
 
 ```js
 import { rspack } from '@rspack/core';

--- a/website/docs/zh/blog/announcing-0-2.mdx
+++ b/website/docs/zh/blog/announcing-0-2.mdx
@@ -29,7 +29,7 @@ _2023 年 6 月 2 日_
 
 ### Plugin hooks
 
-新增一些插件的的钩子
+新增一些插件的钩子
 
 Compiler hooks
 

--- a/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/webpack/split-chunks-plugin.mdx
@@ -223,7 +223,7 @@ export default {
 - **类型：** `number`
 - **默认值：** `30`
 
-每一个入口点所允许的的最大并行请求数。
+每一个入口点所允许的最大并行请求数。
 
 ### splitChunks.enforceSizeThreshold
 
@@ -508,7 +508,7 @@ export default {
 
 :::info
 
-`splitChunks.cacheGroups.{cacheGroup}.name` 可以用来将模块移到其所属 Chunk 的的父 Chunk 中。例如，使用 `name: "entry-name "` 来将模块移到 `entry-name` chunk 中。你也可以使用按需命名的 chunk，但你必须注意所选的模块只在这个 chunk 下使用。
+`splitChunks.cacheGroups.{cacheGroup}.name` 可以用来将模块移到其所属 Chunk 的父 Chunk 中。例如，使用 `name: "entry-name "` 来将模块移到 `entry-name` chunk 中。你也可以使用按需命名的 chunk，但你必须注意所选的模块只在这个 chunk 下使用。
 
 :::
 


### PR DESCRIPTION
## Summary

- fix high-confidence semantic and grammatical typos in the English documentation
- correct malformed Markdown inline-code delimiters
- remove duplicated Chinese characters in the Chinese documentation
- clarify wording around `inputFileSystem` and CSS `url()` handling without changing documented behavior

## Related links

N/A

## Checklist

- [x] Tests updated (not required; documentation-only changes).
- [x] Documentation updated.

## Validation

- `pnpm --filter rspack-website run check:spell`
- `pnpm --filter rspack-website run build`
- `git diff --check`