### PR TITLE
feat: reuse unchanged NormalModule builds in new cache

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -123,6 +123,8 @@ impl Task<TaskContext> for AddTask {
       plugin_driver: context.plugin_driver.clone(),
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),
+      cache: context.cache.clone(),
+      value_cache_versions: context.value_cache_versions.clone(),
       forwarded_ids,
     })])
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, sync::Arc};
 
+use rspack_cacheable::cacheable;
 use rspack_fs::ReadableFileSystem;
 use rustc_hash::FxHashSet;
 
@@ -7,15 +8,58 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
-  CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate, ResolverFactory,
-  SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, Cache, CacheValue,
+  CompilationId, CompilerId, CompilerOptions, DependencyParents, Module, ModuleCodeTemplate,
+  NormalModuleBuildState, OptimizationBailoutItem, ResolverFactory, SharedPluginDriver,
+  ValueCacheVersions,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
+  new_cache::ModuleSnapshot,
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
   },
 };
+
+const MODULES_CACHE_NAMESPACE: &str = "Compilation/modules";
+
+#[cacheable]
+#[derive(Debug)]
+struct ModuleBuildCacheEntry {
+  state: NormalModuleBuildState,
+  dependencies: Vec<BoxDependency>,
+  blocks: Vec<Box<AsyncDependenciesBlock>>,
+  optimization_bailouts: Vec<OptimizationBailoutItem>,
+  snapshot: ModuleSnapshot,
+}
+
+impl ModuleBuildCacheEntry {
+  fn from_build_result(build_result: &BuildResult, snapshot: ModuleSnapshot) -> Option<Self> {
+    let module = build_result.module.as_normal_module()?;
+    module.build_info().cacheable.then(|| Self {
+      state: module.build_state(),
+      dependencies: build_result.dependencies.clone(),
+      blocks: build_result.blocks.clone(),
+      optimization_bailouts: build_result.optimization_bailouts.clone(),
+      snapshot,
+    })
+  }
+
+  fn restore(&self, module: &mut BoxModule) -> Option<()> {
+    module
+      .as_normal_module_mut()?
+      .restore_build_state(&self.state);
+    Some(())
+  }
+
+  fn build_result(&self, module: BoxModule) -> BuildResult {
+    BuildResult {
+      module,
+      dependencies: self.dependencies.clone(),
+      blocks: self.blocks.clone(),
+      optimization_bailouts: self.optimization_bailouts.clone(),
+    }
+  }
+}
 
 #[derive(Debug)]
 pub struct BuildTask {
@@ -27,6 +71,8 @@ pub struct BuildTask {
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
+  pub cache: Cache,
+  pub value_cache_versions: ValueCacheVersions,
   pub forwarded_ids: ForwardedIdSet,
 }
 
@@ -45,8 +91,49 @@ impl Task<TaskContext> for BuildTask {
       runtime_template,
       mut module,
       fs,
+      cache,
+      value_cache_versions,
       forwarded_ids,
     } = *self;
+
+    let module_cache = if cache.is_enabled() && module.as_normal_module().is_some() {
+      Some(
+        cache
+          .facade(MODULES_CACHE_NAMESPACE)
+          .get_item_cache(module.identifier().as_str(), None),
+      )
+    } else {
+      None
+    };
+
+    if let Some(module_cache) = &module_cache {
+      let entry = match module_cache.get::<ModuleBuildCacheEntry>() {
+        Ok(entry) => entry,
+        Err(error) => {
+          tracing::warn!("Restoring NormalModule build cache failed: {error}");
+          None
+        }
+      };
+      if let Some(entry) = entry
+        && !entry
+          .state
+          .has_value_dependencies_diff(&value_cache_versions)
+        && cache.validate_module_snapshot(&entry.snapshot).await
+        && entry.restore(&mut module).is_some()
+      {
+        plugin_driver
+          .compilation_hooks
+          .still_valid_module
+          .call(compiler_id, compilation_id, &mut module)
+          .await?;
+        return Ok(vec![Box::new(BuildResultTask {
+          build_result: Box::new(entry.build_result(module)),
+          plugin_driver,
+          forwarded_ids,
+          invoke_succeed_module: false,
+        })]);
+      }
+    }
 
     plugin_driver
       .compilation_hooks
@@ -69,11 +156,31 @@ impl Task<TaskContext> for BuildTask {
       )
       .await;
 
+    if let Ok(build_result) = &result
+      && let Some(module_cache) = module_cache
+    {
+      let build_info = build_result.module.build_info();
+      if let Some(snapshot) = cache
+        .create_module_snapshot(
+          build_info.file_dependencies.iter().cloned(),
+          build_info.context_dependencies.iter().cloned(),
+          build_info.missing_dependencies.iter().cloned(),
+        )
+        .await
+        && let Some(entry) = ModuleBuildCacheEntry::from_build_result(build_result, snapshot)
+      {
+        if let Err(error) = module_cache.store(CacheValue::new(entry)) {
+          tracing::warn!("Storing NormalModule build cache failed: {error}");
+        }
+      }
+    }
+
     result.map::<Vec<Box<dyn Task<TaskContext>>>, _>(|build_result| {
       vec![Box::new(BuildResultTask {
         build_result: Box::new(build_result),
         plugin_driver,
         forwarded_ids,
+        invoke_succeed_module: true,
       })]
     })
   }
@@ -84,6 +191,7 @@ struct BuildResultTask {
   pub build_result: Box<BuildResult>,
   pub plugin_driver: SharedPluginDriver,
   pub forwarded_ids: ForwardedIdSet,
+  pub invoke_succeed_module: bool,
 }
 
 #[async_trait::async_trait]
@@ -96,14 +204,17 @@ impl Task<TaskContext> for BuildResultTask {
       build_result,
       plugin_driver,
       mut forwarded_ids,
+      invoke_succeed_module,
     } = *self;
     let mut module = build_result.module;
 
-    plugin_driver
-      .compilation_hooks
-      .succeed_module
-      .call(context.compiler_id, context.compilation_id, &mut module)
-      .await?;
+    if invoke_succeed_module {
+      plugin_driver
+        .compilation_hooks
+        .succeed_module
+        .call(context.compiler_id, context.compilation_id, &mut module)
+        .await?;
+    }
 
     let build_info = module.build_info();
 
@@ -114,7 +225,7 @@ impl Task<TaskContext> for BuildResultTask {
         .insert(module.identifier());
     }
 
-    tracing::trace!("Module built: {}", module.identifier());
+    tracing::trace!("Module integrated: {}", module.identifier());
     context
       .artifact
       .module_graph

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -8,8 +8,8 @@ use super::BuildModuleGraphArtifact;
 use crate::{
   Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
-  new_cache::Cache,
+  RuntimeTemplate, SharedPluginDriver, ValueCacheVersions, incremental::Incremental,
+  module_graph::ModuleGraph, new_cache::Cache,
 };
 
 #[derive(Debug)]
@@ -29,7 +29,8 @@ pub struct TaskContext {
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
-  cache: Cache,
+  pub(super) cache: Cache,
+  pub(super) value_cache_versions: ValueCacheVersions,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -57,6 +58,7 @@ impl TaskContext {
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
+      value_cache_versions: compilation.value_cache_versions.clone(),
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -6,6 +6,7 @@ use rspack_paths::ArcPathSet;
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
+  snapshot::{ModuleSnapshot, Snapshot},
 };
 
 /// Cache entry point backed by memory and optional filesystem storage.
@@ -23,6 +24,7 @@ struct CacheStorage {
 struct CacheInner {
   compiler_path: String,
   storage: Option<CacheStorage>,
+  snapshot: Option<Snapshot>,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
@@ -44,6 +46,25 @@ impl Cache {
           memory_cache,
           idle_file_cache,
         }),
+        snapshot: None,
+      }),
+    }
+  }
+
+  pub(crate) fn new_with_snapshot(
+    compiler_path: String,
+    memory_cache: MemoryCache,
+    idle_file_cache: Option<IdleFileCache>,
+    snapshot: Snapshot,
+  ) -> Self {
+    Self {
+      inner: Arc::new(CacheInner {
+        compiler_path,
+        storage: Some(CacheStorage {
+          memory_cache,
+          idle_file_cache,
+        }),
+        snapshot: Some(snapshot),
       }),
     }
   }
@@ -53,8 +74,13 @@ impl Cache {
       inner: Arc::new(CacheInner {
         compiler_path,
         storage: None,
+        snapshot: None,
       }),
     }
+  }
+
+  pub(crate) fn is_enabled(&self) -> bool {
+    self.inner.storage.is_some()
   }
 
   pub(crate) fn facade(&self, name: &str) -> CacheFacade {
@@ -124,6 +150,31 @@ impl Cache {
     } else {
       Ok(())
     }
+  }
+
+  pub(crate) async fn create_module_snapshot(
+    &self,
+    file_dependencies: impl Iterator<Item = rspack_paths::ArcPath>,
+    context_dependencies: impl Iterator<Item = rspack_paths::ArcPath>,
+    missing_dependencies: impl Iterator<Item = rspack_paths::ArcPath>,
+  ) -> Option<ModuleSnapshot> {
+    let snapshot = self.inner.snapshot.as_ref()?;
+    Some(
+      snapshot
+        .create_module(
+          file_dependencies,
+          context_dependencies,
+          missing_dependencies,
+        )
+        .await,
+    )
+  }
+
+  pub(crate) async fn validate_module_snapshot(&self, snapshot: &ModuleSnapshot) -> bool {
+    let Some(snapshot_manager) = self.inner.snapshot.as_ref() else {
+      return false;
+    };
+    snapshot_manager.validate_module(snapshot).await
   }
 
   pub fn has_file_cache(&self) -> bool {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -21,9 +21,11 @@ pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
 use rspack_fs::ReadableFileSystem;
 
+pub(crate) use self::snapshot::ModuleSnapshot;
 use self::snapshot::{BuildDeps, Snapshot};
 use crate::{
-  CompilationLogger, CompilationLogging, CompilerOptions, cache::persistent::codec::CacheCodec,
+  CompilationLogger, CompilationLogging, CompilerOptions,
+  cache::persistent::{codec::CacheCodec, snapshot::SnapshotOptions},
 };
 
 pub fn create_cache(
@@ -41,7 +43,12 @@ pub fn create_cache(
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      return Cache::new(compiler_path, MemoryCache::new(5), None);
+      return Cache::new_with_snapshot(
+        compiler_path,
+        MemoryCache::new(5),
+        None,
+        Snapshot::new(SnapshotOptions::default(), input_filesystem),
+      );
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -55,7 +62,7 @@ pub fn create_cache(
   let snapshot = Snapshot::new(options.snapshot.clone(), input_filesystem.clone());
   let build_deps = BuildDeps::new(
     &options.build_dependencies,
-    input_filesystem,
+    input_filesystem.clone(),
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
   let (base_path, database_path) = match &options.storage {
@@ -75,10 +82,20 @@ pub fn create_cache(
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      return Cache::new(compiler_path, MemoryCache::default(), None);
+      return Cache::new_with_snapshot(
+        compiler_path,
+        MemoryCache::default(),
+        None,
+        Snapshot::new(options.snapshot.clone(), input_filesystem),
+      );
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
 
-  Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
+  Cache::new_with_snapshot(
+    compiler_path,
+    MemoryCache::default(),
+    Some(idle_file_cache),
+    Snapshot::new(options.snapshot.clone(), input_filesystem),
+  )
 }

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -1,14 +1,17 @@
 mod build_deps;
+mod strategy;
 
 use std::sync::Arc;
 
 use rspack_cacheable::cacheable;
 use rspack_fs::ReadableFileSystem;
+use rspack_parallel::FutureConsumer;
 use rspack_paths::{ArcPath, ArcPathSet};
 
 pub use self::build_deps::{BuildDeps, BuildDepsValidationResult};
+use self::strategy::{SnapshotScope, calc_strategy};
 use crate::cache::persistent::snapshot::{
-  SnapshotOptions, SnapshotStrategyOptions, Strategy, StrategyHelper, ValidateResult,
+  SnapshotOptions, Strategy, StrategyHelper, ValidateResult,
 };
 
 #[cacheable]
@@ -16,6 +19,14 @@ use crate::cache::persistent::snapshot::{
 pub struct SnapshotEntry {
   path: ArcPath,
   strategy: Strategy,
+}
+
+#[cacheable]
+#[derive(Debug, Default)]
+pub struct ModuleSnapshot {
+  file_dependencies: Vec<SnapshotEntry>,
+  context_dependencies: Vec<SnapshotEntry>,
+  missing_dependencies: Vec<SnapshotEntry>,
 }
 
 #[cacheable]
@@ -40,33 +51,82 @@ impl Snapshot {
     }
   }
 
-  async fn calc_strategy(&self, helper: &StrategyHelper, path: &ArcPath) -> Option<Strategy> {
-    let path_str = path.to_string_lossy();
-    if self.options.is_immutable_path(&path_str) {
-      return None;
-    }
-    if self.options.is_managed_path(&path_str)
-      && let Some(strategy) = helper.package_version(path).await
-    {
-      return Some(strategy);
-    }
-    Some(
-      helper
-        .dir_strategy(path, SnapshotStrategyOptions::hash())
-        .await,
-    )
+  async fn add_with_scopes(
+    &self,
+    paths: impl Iterator<Item = (SnapshotScope, ArcPath)>,
+  ) -> Vec<(SnapshotScope, SnapshotEntry)> {
+    let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
+    let options = self.options.clone();
+    let mut entries = Vec::with_capacity(paths.size_hint().0);
+    paths
+      .map(|(scope, path)| {
+        let helper = helper.clone();
+        let options = options.clone();
+        async move {
+          calc_strategy(&options, &helper, &path, scope)
+            .await
+            .map(|strategy| (scope, SnapshotEntry { path, strategy }))
+        }
+      })
+      .fut_consume(|entry| entries.extend(entry))
+      .await;
+    entries
   }
 
   #[tracing::instrument("Cache::Snapshot::add", skip_all)]
   pub async fn add(&self, paths: impl Iterator<Item = ArcPath>) -> Vec<SnapshotEntry> {
-    let helper = StrategyHelper::new(self.fs.clone(), self.options.clone());
-    let mut entries = Vec::with_capacity(paths.size_hint().0);
-    for path in paths {
-      if let Some(strategy) = self.calc_strategy(&helper, &path).await {
-        entries.push(SnapshotEntry { path, strategy });
+    self
+      .add_with_scopes(paths.map(|path| (SnapshotScope::Build, path)))
+      .await
+      .into_iter()
+      .map(|(_, entry)| entry)
+      .collect()
+  }
+
+  #[tracing::instrument("Cache::Snapshot::create_module", skip_all)]
+  pub async fn create_module(
+    &self,
+    file_dependencies: impl Iterator<Item = ArcPath>,
+    context_dependencies: impl Iterator<Item = ArcPath>,
+    missing_dependencies: impl Iterator<Item = ArcPath>,
+  ) -> ModuleSnapshot {
+    let entries = self
+      .add_with_scopes(
+        file_dependencies
+          .map(|path| (SnapshotScope::File, path))
+          .chain(context_dependencies.map(|path| (SnapshotScope::Context, path)))
+          .chain(missing_dependencies.map(|path| (SnapshotScope::Missing, path))),
+      )
+      .await;
+    let mut snapshot = ModuleSnapshot::default();
+    for (scope, entry) in entries {
+      match scope {
+        SnapshotScope::File => snapshot.file_dependencies.push(entry),
+        SnapshotScope::Context => snapshot.context_dependencies.push(entry),
+        SnapshotScope::Missing => snapshot.missing_dependencies.push(entry),
+        SnapshotScope::Build => unreachable!("module snapshots do not contain build dependencies"),
       }
     }
-    entries
+    snapshot
+  }
+
+  #[tracing::instrument("Cache::Snapshot::validate_module", skip_all)]
+  pub async fn validate_module(&self, snapshot: &ModuleSnapshot) -> bool {
+    let helper = Arc::new(StrategyHelper::new(self.fs.clone(), self.options.clone()));
+    for entry in snapshot
+      .file_dependencies
+      .iter()
+      .chain(&snapshot.context_dependencies)
+      .chain(&snapshot.missing_dependencies)
+    {
+      if !matches!(
+        helper.validate(&entry.path, &entry.strategy).await,
+        ValidateResult::NoChanged
+      ) {
+        return false;
+      }
+    }
+    true
   }
 
   #[tracing::instrument("Cache::Snapshot::calc_modified_paths", skip_all)]

--- a/crates/rspack_core/src/new_cache/snapshot/strategy.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/strategy.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use rspack_paths::ArcPath;
+
+use crate::cache::persistent::snapshot::{
+  SnapshotOptions, SnapshotStrategyOptions, Strategy, StrategyHelper,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum SnapshotScope {
+  File,
+  Context,
+  Missing,
+  Build,
+}
+
+pub(super) async fn calc_strategy(
+  options: &Arc<SnapshotOptions>,
+  helper: &StrategyHelper,
+  path: &ArcPath,
+  scope: SnapshotScope,
+) -> Option<Strategy> {
+  let path_str = path.to_string_lossy();
+  if options.is_immutable_path(&path_str) {
+    return None;
+  }
+  if options.is_managed_path(&path_str)
+    && let Some(strategy) = helper.package_version(path).await
+  {
+    return Some(strategy);
+  }
+  Some(match scope {
+    SnapshotScope::File => {
+      helper
+        .file_strategy(path, options.dependencies_strategy())
+        .await
+    }
+    SnapshotScope::Context => {
+      helper
+        .dir_strategy(path, options.context_dependencies_strategy())
+        .await
+    }
+    SnapshotScope::Missing => Strategy::Missing,
+    SnapshotScope::Build => {
+      helper
+        .dir_strategy(path, SnapshotStrategyOptions::hash())
+        .await
+    }
+  })
+}

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -33,7 +33,8 @@ use crate::{
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
   ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
   ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
-  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
+  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
+  ValueCacheVersions, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
@@ -149,6 +150,29 @@ pub struct NormalModule {
   source_map_kind: SourceMapKind,
 }
 
+#[cacheable]
+#[derive(Debug)]
+pub(crate) struct NormalModuleBuildState {
+  #[cacheable(with=AsOption<AsPreset>)]
+  source: Option<BoxSource>,
+  diagnostics: Vec<Diagnostic>,
+  code_generation_dependencies: Option<Vec<BoxModuleDependency>>,
+  presentational_dependencies: Option<Vec<BoxDependencyTemplate>>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
+  parsed: bool,
+  source_map_kind: SourceMapKind,
+}
+
+impl NormalModuleBuildState {
+  pub(crate) fn has_value_dependencies_diff(
+    &self,
+    value_cache_versions: &ValueCacheVersions,
+  ) -> bool {
+    value_cache_versions.has_diff(&self.build_info.value_dependencies)
+  }
+}
+
 static DEBUG_ID: AtomicUsize = AtomicUsize::new(1);
 
 impl NormalModule {
@@ -231,6 +255,37 @@ impl NormalModule {
 
   pub fn id(&self) -> ModuleIdentifier {
     self.id
+  }
+
+  pub(crate) fn build_state(&self) -> NormalModuleBuildState {
+    NormalModuleBuildState {
+      source: self.source.clone(),
+      diagnostics: self.diagnostics.clone(),
+      code_generation_dependencies: self.code_generation_dependencies.clone(),
+      presentational_dependencies: self.presentational_dependencies.clone(),
+      build_info: self.build_info.clone(),
+      build_meta: self.build_meta.clone(),
+      parsed: self.parsed,
+      source_map_kind: self.source_map_kind,
+    }
+  }
+
+  pub(crate) fn restore_build_state(&mut self, state: &NormalModuleBuildState) {
+    let import_phase = self.build_info.import_phase;
+    self.source.clone_from(&state.source);
+    self.diagnostics.clone_from(&state.diagnostics);
+    self
+      .code_generation_dependencies
+      .clone_from(&state.code_generation_dependencies);
+    self
+      .presentational_dependencies
+      .clone_from(&state.presentational_dependencies);
+    self.build_info.clone_from(&state.build_info);
+    self.build_info.import_phase = import_phase;
+    self.build_meta.clone_from(&state.build_meta);
+    self.parsed = state.parsed;
+    self.source_map_kind = state.source_map_kind;
+    self.cached_source_sizes = SourceSizeCache::default();
   }
 
   pub fn match_resource(&self) -> Option<&ResourceData> {

--- a/tests/rspack-test/compilerCases/new-cache-normal-module.js
+++ b/tests/rspack-test/compilerCases/new-cache-normal-module.js
@@ -1,0 +1,83 @@
+const fs = require("fs");
+const path = require("path");
+const { createFsFromVolume, Volume } = require("memfs");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCacheNormalModuleTestPlugin";
+
+class NewCacheNormalModuleTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const run = compiler =>
+	new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve();
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should restore unchanged NormalModule builds from the new memory cache",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-normal-module"),
+			entry: "./index.js",
+			cache: true,
+			experiments: {
+				newCache: true
+			},
+			output: {
+				path: "/directory"
+			},
+			plugins: [new NewCacheNormalModuleTestPlugin()]
+		};
+	},
+	compiler(_, compiler) {
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+	},
+	async build(context, compiler) {
+		const source = context.getSource("new-cache-normal-module/index.js");
+		const original = fs.readFileSync(source, "utf-8");
+
+		try {
+			await run(compiler);
+			await run(compiler);
+			fs.writeFileSync(source, 'export default "changed";\n');
+			await run(compiler);
+		} finally {
+			fs.writeFileSync(source, original);
+		}
+
+		const output = compiler.outputFileSystem.readFileSync(
+			path.posix.join("/directory", "main.js"),
+			"utf-8"
+		);
+		expect(output).toContain("changed");
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule",
+			"buildModule",
+			"succeedModule"
+		]);
+	}
+};

--- a/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
+++ b/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
@@ -1,0 +1,84 @@
+const fs = require("node:fs");
+const rspack = require("@rspack/core");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCachePersistentNormalModuleTestPlugin";
+
+class NewCachePersistentNormalModuleTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const runCompiler = (context, cacheDirectory, output) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			context: context.getSource("new-cache-normal-module"),
+			entry: "./index.js",
+			cache: {
+				type: "persistent",
+				storage: {
+					type: "filesystem",
+					location: cacheDirectory
+				}
+			},
+			experiments: {
+				newCache: true
+			},
+			output: {
+				path: output
+			},
+			plugins: [new NewCachePersistentNormalModuleTestPlugin()]
+		});
+
+		compiler.run((error, stats) => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) return reject(finalError);
+				if (stats.hasErrors()) {
+					return reject(
+						new Error(stats.toString({ all: false, errors: true }))
+					);
+				}
+				resolve();
+			});
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should restore unchanged NormalModule builds from the new persistent cache",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-normal-module"),
+			entry: "./index.js"
+		};
+	},
+	async build(context) {
+		const cacheDirectory = context.getDist(
+			"new-cache-persistent-normal-module-cache"
+		);
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+		await runCompiler(context, cacheDirectory, context.getDist("output-1"));
+		await runCompiler(context, cacheDirectory, context.getDist("output-2"));
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule"
+		]);
+	}
+};

--- a/tests/rspack-test/compilerCases/new-cache-value-dependencies.js
+++ b/tests/rspack-test/compilerCases/new-cache-value-dependencies.js
@@ -1,0 +1,95 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCacheValueDependenciesTestPlugin";
+
+class NewCacheValueDependenciesTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const runCompiler = (context, cacheDirectory, output, value) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			context: context.getSource("new-cache-value-dependencies"),
+			entry: "./index.js",
+			cache: {
+				type: "persistent",
+				storage: {
+					type: "filesystem",
+					location: cacheDirectory
+				}
+			},
+			experiments: {
+				newCache: true
+			},
+			output: {
+				path: output
+			},
+			plugins: [
+				new rspack.DefinePlugin({ VALUE: JSON.stringify(value) }),
+				new NewCacheValueDependenciesTestPlugin()
+			]
+		});
+
+		compiler.run((error, stats) => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) return reject(finalError);
+				if (stats.hasErrors()) {
+					return reject(
+						new Error(stats.toString({ all: false, errors: true }))
+					);
+				}
+				resolve();
+			});
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should invalidate the new cache when value dependencies change",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-value-dependencies"),
+			entry: "./index.js"
+		};
+	},
+	async build(context) {
+		const cacheDirectory = context.getDist(
+			"new-cache-value-dependencies-cache"
+		);
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+		await runCompiler(context, cacheDirectory, context.getDist("output-1"), "first");
+		await runCompiler(context, cacheDirectory, context.getDist("output-2"), "first");
+		const output = context.getDist("output-3");
+		await runCompiler(context, cacheDirectory, output, "second");
+
+		expect(fs.readFileSync(path.join(output, "main.js"), "utf-8")).toContain(
+			"second"
+		);
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule",
+			"buildModule",
+			"succeedModule"
+		]);
+	}
+};

--- a/tests/rspack-test/fixtures/new-cache-normal-module/index.js
+++ b/tests/rspack-test/fixtures/new-cache-normal-module/index.js
@@ -1,0 +1,1 @@
+export default "initial";

--- a/tests/rspack-test/fixtures/new-cache-value-dependencies/index.js
+++ b/tests/rspack-test/fixtures/new-cache-value-dependencies/index.js
@@ -1,0 +1,1 @@
+console.log(VALUE);


### PR DESCRIPTION
## Summary

- cache completed `NormalModule` builds in the experimental new cache
- restore unchanged builds from memory or persistent storage after snapshot validation
- rebuild when source or value dependencies change

Closes #15190