### PR TITLE
docs: align stats JSON types with implementation

### DIFF
--- a/website/docs/en/api/javascript-api/stats-json.mdx
+++ b/website/docs/en/api/javascript-api/stats-json.mdx
@@ -17,7 +17,7 @@ $ rspack --json=compilation-stats.json
 
 ## Structure
 
-The top-level structure of the output object is as follows:
+The properties included in the output depend on the [stats configuration](/config/stats). The known fields of the top-level object are as follows:
 
 ```ts
 type StatsCompilation = {
@@ -29,6 +29,8 @@ type StatsCompilation = {
   name?: string;
   // Compilation specific hash
   hash?: string;
+  // Environment information included when `stats.env` is enabled
+  env?: any;
   // Compilation time in milliseconds
   time?: number;
   // Compilation build end timestamp
@@ -41,6 +43,8 @@ type StatsCompilation = {
   assetsByChunkName?: Record<string, string[]>;
   // List of asset objects, refer to the "Asset Object"
   assets?: StatsAsset[];
+  // Number of assets omitted from the output
+  filteredAssets?: number;
   // List of chunk objects, refer to the "Chunk Object"
   chunks?: StatsChunk[];
   // List of module objects, refer to the "Module Object"
@@ -53,11 +57,21 @@ type StatsCompilation = {
   errors?: StatsError[];
   // Number of errors
   errorsCount?: number;
+  // Number of error details omitted from the output
+  filteredErrorDetailsCount?: number;
   // List of warning objects, refer to the "Error/Warning Object"
-  warnings?: StatsWarnings[];
+  warnings?: StatsError[];
   // Number of warnings
   warningsCount?: number;
-};
+  // Number of warning details omitted from the output
+  filteredWarningDetailsCount?: number;
+  // Number of modules omitted from the output
+  filteredModules?: number;
+  // Stats for child compilations
+  children?: StatsCompilation[];
+  // Compilation logs, grouped by logger name
+  logging?: Record<string, StatsLogging>;
+} & Record<string, any>;
 ```
 
 ## Asset object
@@ -65,48 +79,65 @@ type StatsCompilation = {
 Each asset object represents an output file emitted from the compilation, and its structure is as follows:
 
 ```ts
+type StatsAssetInfo = {
+  // Whether the asset can be long-term cached because its name contains a hash
+  immutable?: boolean;
+  // Whether the asset was minimized
+  minimized?: boolean;
+  // Full hash values used by this asset
+  fullhash: string[];
+  // Chunk hash values used by this asset
+  chunkhash: string[];
+  // Content hash values used by this asset
+  contenthash: string[];
+  // Original source filename, when the asset was created from a source file
+  sourceFilename?: string;
+  // Whether the asset was copied from another file
+  copied?: boolean;
+  // Whether the asset exceeds `performance.maxAssetSize`
+  isOverSizeLimit?: boolean;
+  // Whether the asset is only used in development
+  development?: boolean;
+  // Whether the asset contains data for hot module replacement
+  hotModuleReplacement?: boolean;
+  // Whether the asset is JavaScript emitted as an ES module
+  javascriptModule?: boolean;
+  // Related asset filenames, grouped by relationship type
+  related: Record<string, string[]>;
+} & Record<string, any>;
+
 type StatsAsset = {
+  // Stats item type, such as "asset" or a related asset type
+  type: string;
   // The `output` filename
   name: string;
+  // Additional information about the asset
+  info: StatsAssetInfo;
   // The size of the file in bytes
   size: number;
-  // Indicates whether or not the asset made it to the `output` directory
+  // Whether the asset was emitted during this compilation
   emitted: boolean;
-  // The chunk IDs this asset related
-  chunks: Array<string | number | undefined | null>;
-  // The chunks this asset related
-  chunkNames: Array<string>;
-  // The chunk idHints this asset related
-  chunkIdHints: Array<string>;
-  // The chunk IDs this auxiliary asset related
-  auxiliaryChunks: Array<string | number | undefined | null>;
-  // The chunks this auxiliary asset related
-  auxiliaryChunkNames: Array<string>;
-  // The chunk idHints this auxiliary asset related
-  auxiliaryChunkIdHints: Array<string>;
-  info: {
-    // whether the asset is minimized
-    minimized: boolean;
-    // A flag telling whether the asset is only used for development and doesn't count towards user-facing assets
-    development: boolean;
-    // A flag telling whether the asset ships data for updating an existing application (HMR)
-    hotModuleReplacement: boolean;
-    // sourceFilename when asset was created from a source file (potentially transformed)
-    sourceFilename?: string;
-    // true, if the asset can be long term cached forever (contains a hash)
-    immutable: boolean;
-    // true, when asset is javascript and an ESM
-    javascriptModule?: boolean;
-    // the value(s) of the chunk hash used for this asset
-    chunkHash: Array<string>;
-    // the value(s) of the content hash used for this asset
-    contentHash: Array<string>;
-  };
-  // related assets, like source-map
-  related: StatsAsset[];
-  // whether the asset exceeds performance.maxAssetSize
+  // Whether the asset was not emitted during this compilation (`!emitted`)
+  cached: boolean;
+  // Related assets, such as source maps
+  related?: StatsAsset[];
+  // Chunk IDs related to this asset
+  chunks?: Array<string | number | null | undefined>;
+  // Chunk names related to this asset
+  chunkNames?: string[];
+  // Chunk ID hints related to this asset
+  chunkIdHints?: string[];
+  // Chunk IDs related to this auxiliary asset
+  auxiliaryChunks?: Array<string | number | null | undefined>;
+  // Chunk names related to this auxiliary asset
+  auxiliaryChunkNames?: string[];
+  // Chunk ID hints related to this auxiliary asset
+  auxiliaryChunkIdHints?: string[];
+  // Number of related assets omitted from the output
+  filteredRelated?: number;
+  // Whether the asset exceeds `performance.maxAssetSize`
   isOverSizeLimit?: boolean;
-};
+} & Record<string, any>;
 ```
 
 ## Chunk object
@@ -115,27 +146,31 @@ Each chunk object represents a group of modules known as a chunk, and its struct
 
 ```ts
 type StatsChunk = {
+  // Stats item type
+  type: string;
   // The list of product files contained in the chunk
-  files: Array<string>;
+  files: string[];
   // The list of attached product files contained in the chunk
-  auxiliaryFiles: Array<string>;
+  auxiliaryFiles: string[];
   // Chunk ID
   id?: string | number;
   // List of chunk names contained within this chunk
-  names: Array<string>;
+  names: string[];
+  // List of ID hints associated with the chunk
+  idHints: string[];
   // The runtime used by the chunk
-  runtime: Array<string>;
+  runtime: string[];
   // Size of the chunk (in bytes)
   size: number;
   // Total size of chunk modules group by the output type (in bytes)
   sizes: Record<string, number>;
   // Chunk hash
   hash?: string;
-  // Whether the chunk contains the rspack runtime
+  // Whether the chunk contains an entry module
   entry: boolean;
   // Whether the chunk is loaded on initial page load or on demand
   initial: boolean;
-  // Whether the chunk went through Code Generation
+  // Whether the chunk was rendered into an output asset
   rendered: boolean;
 
   // Parent chunk IDs
@@ -144,31 +179,35 @@ type StatsChunk = {
   children?: Array<string | number>;
   // Sibling chunk IDs
   siblings?: Array<string | number>;
+  // Child chunks grouped by loading order
+  childrenByOrder: Record<string, Array<string | number>>;
 
   // Chunk create reason when splitting chunks (need to enable `optimization.splitChunks`).
   reason?: string;
-  // List of idHints of the cache groups hit when splitting chunks (need to enable `optimization.splitChunks`).
-  idHints: Array<string>;
 
   // List of origins describing how the given chunk originated
-  origins: Array<{
-    // Path to the module
-    module: string;
-    // ID of the module
-    moduleId: string;
-    // The identifier of the module
-    moduleIdentifier: string;
-    // Relative path to the module
-    moduleName: string;
-    // Lines of code that generated this chunk
-    loc: string;
-    // The dependency request in the module
-    request: string;
-  }>;
+  origins?: StatsChunkOrigin[];
 
   // List of modules contained in the chunk, for details, refer to the "Module Object"
-  modules?: Array<StatsModule>;
-};
+  modules?: StatsModule[];
+  // Number of modules omitted from the output
+  filteredModules?: number;
+} & Record<string, any>;
+
+type StatsChunkOrigin = {
+  // Module identifier (compatibility alias of `moduleIdentifier`)
+  module: string;
+  // Internal identifier of the originating module
+  moduleIdentifier: string;
+  // Readable name of the originating module
+  moduleName: string;
+  // Location of the dependency in the originating module
+  loc: string;
+  // The dependency request in the module
+  request: string;
+  // ID of the module
+  moduleId?: string | number | null;
+} & Record<string, any>;
 ```
 
 ## Module object
@@ -177,79 +216,103 @@ Each module object represents a module in the dependency graph, and its structur
 
 ```ts
 type StatsModule = {
-  // Module ID
-  id?: string;
+  // Stats item type
+  type: string;
   // Module source type
   moduleType: string;
+  // Module layer
+  layer?: string;
   // A unique identifier used internally
-  identifier: string;
+  identifier?: string;
   // Path to the actual file
-  name: string;
+  name?: string;
+  // Absolute path used by the module for conditional matching
+  nameForCondition?: string;
+  // Legacy aliases for preOrderIndex and postOrderIndex
+  index?: number;
+  index2?: number;
+  // The top-down and bottom-up indexes of the module in the chunk group
+  preOrderIndex?: number;
+  postOrderIndex?: number;
   // Estimated size of the module in bytes
   size: number;
-  // Total size of module group by the output type (in bytes)
+  // Module sizes grouped by source type
   sizes: Record<string, number>;
-
+  // Whether the module can be cached
+  cacheable?: boolean;
   // Whether the module went through loaders and parsing
   built: boolean;
   // Whether the module went through code generation
   codeGenerated: boolean;
-  // Whether the module is run during the compilation (you can see it while using css-extract)
+  // Whether the module was executed during the build
   buildTimeExecuted: boolean;
-  // Whether the module is cached
+  // Whether the module was reused from cache
   cached: boolean;
-  // Whether the module can be cached
-  cacheable: boolean;
-  // Whether the module is optional, and if it is optional, only a warning will be issued when the module is not found
-  optional: boolean;
-  // Whether the module is dependent by other modules
+  // Whether a missing module only produces a warning
+  optional?: boolean;
+  // Whether the module is not included in any chunk
+  orphan?: boolean;
+  // Module ID
+  id?: string | number | null;
+  // Parent module ID
+  issuerId?: string | number | null;
+  // IDs of chunks that contain the module
+  chunks?: Array<string | number>;
+  // Assets generated by the module
+  assets?: string[];
+  // Whether the module is only included as a dependency of another module
   dependent?: boolean;
-
-  // List of reasons why the module is introduced, similar to the structure of chunk.origins
-  reasons?: Array<JsStatsModuleReason>;
   // Unique identifier of the parent module
   issuer?: string;
-  // Parent module ID
-  issuerId?: string;
   // Path to the actual file of parent module
   issuerName?: string;
   // Reference path from the entry to the current module
-  issuerPath: Array<JsStatsModuleIssuer>;
-  // Absolute path used by the module for conditional matching (usually the resource path)
-  nameForCondition?: string;
-  // The top-down index of the module in the ChunkGroup
-  preOrderIndex?: number;
-  // The bottom-up index of the module in the ChunkGroup
-  postOrderIndex?: number;
-  // The level in module graph
-  depth?: number;
-  // Whether the module is not included by any chunk
-  orphan: boolean;
-  // List of IDs of chunks that contain the module
-  chunks: Array<string | number | undefined | null>;
-  // List of assets generated by the module
-  assets?: Array<string>;
-
-  // Whether the module compiles failed
-  failed: boolean;
+  issuerPath?: StatsModuleIssuer[];
+  // Whether the module failed to compile
+  failed?: boolean;
   // Number of errors
-  errors: number;
+  errors?: number;
   // Number of warnings
-  warnings: number;
-
-  // Used module exports, true indicates that all are used, string[] indicates that some fields are used (need to enable `optimization.usedExports`)
-  usedExports?: null | string[] | boolean;
+  warnings?: number;
+  // Reasons why the module is included
+  reasons?: StatsModuleReason[];
+  // Number of reasons omitted from the output
+  filteredReasons?: number;
+  // Used module exports (`true` means all exports are used)
+  usedExports?: boolean | string[] | null;
   // List of fields exported by the module (need to enable `optimization.providedExports`)
-  providedExports?: null | string[];
+  providedExports?: string[] | null;
   // Optimization bailout reasons (need to enable `optimization.concatenateModules`)
-  optimizationBailout?: null | string[];
-
+  optimizationBailout?: string[] | null;
+  // The module's depth in the module graph
+  depth?: number;
   // If current module is generated by scope hoisting, this is the list of the original modules (need to enable `optimization.concatenateModules`)
-  modules?: Array<JsStatsModule>;
-
+  modules?: StatsModule[];
+  // Number of nested modules omitted from the output
+  filteredModules?: number;
   // Source code
   source?: string | Buffer;
-};
+} & Record<string, any>;
+
+type StatsModuleIssuer = {
+  identifier: string;
+  name: string;
+  id?: string | number | null;
+} & Record<string, any>;
+
+type StatsModuleReason = {
+  moduleIdentifier?: string;
+  moduleName?: string;
+  resolvedModuleIdentifier?: string;
+  resolvedModule?: string;
+  type?: string;
+  active: boolean;
+  explanation?: string;
+  userRequest?: string;
+  loc?: string;
+  moduleId?: string | number | null;
+  resolvedModuleId?: string | number | null;
+} & Record<string, any>;
 ```
 
 ## Entry/ChunkGroup Object
@@ -261,10 +324,10 @@ type StatsEntrypoints = Record<string, StatsChunkGroup>;
 type StatsNamedChunkGroups = Record<string, StatsChunkGroup>;
 
 type StatsChunkGroup = {
-  // Name of the entry
+  // Name of the chunk group
   name: string;
   // List of IDs of the chunks included
-  chunks: Array<string | number | undefined | null>;
+  chunks: Array<string | number>;
   // Assets generated by the chunk group
   assets: Array<{
     // File name
@@ -272,6 +335,9 @@ type StatsChunkGroup = {
     // File size
     size: number;
   }>;
+  // Present on entrypoint and named chunk group objects, but omitted from nested children
+  // Total asset count if it exceeds `stats.chunkGroupMaxAssets`; otherwise 0
+  filteredAssets?: number;
   // Total size of the assets generated by the chunk group
   assetsSize: number;
 
@@ -287,20 +353,20 @@ type StatsChunkGroup = {
   // Ordered children chunk groups, order by preload/prefetch
   children?: {
     // preload children chunk groups
-    preload?: Array<StatsChunkGroup>;
+    preload?: StatsChunkGroup[];
     // prefetch children chunk groups
-    prefetch?: Array<StatsChunkGroup>;
+    prefetch?: StatsChunkGroup[];
   };
   // Assets of ordered children chunk groups, order by preload/prefetch
   childAssets?: {
     // preload assets
-    preload?: Array<string>;
+    preload?: string[];
     // prefetch assets
-    prefetch?: Array<string>;
+    prefetch?: string[];
   };
   // Whether the assets of this entrypoint exceeds performance.maxEntrypointSize
   isOverSizeLimit?: boolean;
-};
+} & Record<string, any>;
 ```
 
 ## Error/Warning Object
@@ -311,10 +377,14 @@ Each error or warning object represents an error/warning thrown during the build
 type StatsError = {
   // Visual message of the error/warning
   message: string;
+  // Machine-readable error/warning code
+  code?: StatsErrorCode | string;
   // A custom filename associated with this error/warning.
   file?: string;
   // Detail info of the error/warning
   details?: string;
+  // Number of detail lines omitted because of `stats.errorsSpace` or `stats.warningsSpace`
+  filteredDetails?: number;
   // Stack info of the error/warning
   stack?: string;
   /**
@@ -333,23 +403,12 @@ type StatsError = {
    * - `"./src/index.css"`
    */
   moduleName?: string;
+  // Location of the error/warning in the module
+  loc?: string;
   // ID of the module where the error/warning occurs
-  moduleId?: string;
+  moduleId?: string | number | null;
   // Module import trace from entry module
-  moduleTrace: Array<{
-    // parent module
-    origin: {
-      identifier: string;
-      name?: string;
-      id?: string;
-    };
-    // imported module
-    module: {
-      identifier: string;
-      name?: string;
-      id?: string;
-    };
-  }>;
+  moduleTrace?: StatsModuleTraceItem[];
 
   // ID of the related chunk
   chunkId?: string;
@@ -359,5 +418,38 @@ type StatsError = {
   chunkEntry?: boolean;
   // Whether the related chunk is an initial chunk
   chunkInitial?: boolean;
+} & Record<string, any>;
+
+type StatsModuleTraceItem = {
+  originIdentifier: string;
+  originName: string;
+  moduleIdentifier: string;
+  moduleName: string;
+  originId?: string | number | null;
+  moduleId?: string | number | null;
+  dependencies: StatsModuleTraceDependency[];
 };
+
+type StatsModuleTraceDependency = {
+  loc: string;
+} & Record<string, any>;
+```
+
+## Logging object
+
+Each key in `StatsCompilation.logging` is a logger name, and its value has the following structure:
+
+```ts
+type StatsLogging = {
+  entries: StatsLoggingEntry[];
+  filteredEntries: number;
+  debug: boolean;
+} & Record<string, any>;
+
+type StatsLoggingEntry = {
+  type: string;
+  message: string;
+  trace?: string[] | undefined;
+  children?: StatsLoggingEntry[] | undefined;
+} & Record<string, any>;
 ```

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -1006,7 +1006,7 @@ type StatsFactory = {
     type: string,
     data: any,
     baseContext: Omit<StatsFactoryContext, 'type'>,
-  ): void;
+  ): any;
 };
 ```
   </CollapsePanel>

--- a/website/docs/zh/api/javascript-api/stats-json.mdx
+++ b/website/docs/zh/api/javascript-api/stats-json.mdx
@@ -17,7 +17,7 @@ $ rspack --json=compilation-stats.json
 
 ## 整体结构
 
-输出的对象的顶层结构如下：
+输出中包含的属性取决于 [Stats 配置](/config/stats)，顶层对象的已知字段如下：
 
 ```ts
 type StatsCompilation = {
@@ -29,6 +29,8 @@ type StatsCompilation = {
   name?: string;
   // 编译的哈希值
   hash?: string;
+  // 启用 `stats.env` 时包含的环境信息
+  env?: any;
   // 编译耗时（毫秒）
   time?: number;
   // 编译结束时间戳
@@ -41,6 +43,8 @@ type StatsCompilation = {
   assetsByChunkName?: Record<string, string[]>;
   // asset 对象列表，详细结构参考《Asset 对象结构》章节
   assets?: StatsAsset[];
+  // 输出中省略的 asset 数量
+  filteredAssets?: number;
   // chunk 对象列表，详细结构参考《Chunk 对象结构》章节
   chunks?: StatsChunk[];
   // module 对象列表，详细结构参考《Module 对象结构》章节
@@ -53,11 +57,21 @@ type StatsCompilation = {
   errors?: StatsError[];
   // 错误个数
   errorsCount?: number;
+  // 输出中省略的错误详情数量
+  filteredErrorDetailsCount?: number;
   // warning 对象列表，详细结构参考《Error/Warning 对象结构》章节
-  warnings?: StatsWarnings[];
+  warnings?: StatsError[];
   // 告警个数
   warningsCount?: number;
-};
+  // 输出中省略的警告详情数量
+  filteredWarningDetailsCount?: number;
+  // 输出中省略的 module 数量
+  filteredModules?: number;
+  // 子编译的统计信息
+  children?: StatsCompilation[];
+  // 按 logger 名称分组的编译日志
+  logging?: Record<string, StatsLogging>;
+} & Record<string, any>;
 ```
 
 ## Asset 对象结构
@@ -65,51 +79,65 @@ type StatsCompilation = {
 每个 asset 对象对应一个编译过程中生成的产物文件，它的结构如下：
 
 ```ts
+type StatsAssetInfo = {
+  // 产物名称中包含哈希时，是否可进行长期缓存
+  immutable?: boolean;
+  // 产物是否经过代码压缩
+  minimized?: boolean;
+  // 产物使用的完整哈希值
+  fullhash: string[];
+  // 产物使用的 chunk 哈希值
+  chunkhash: string[];
+  // 产物使用的内容哈希值
+  contenthash: string[];
+  // 从源文件创建产物时的原始文件名
+  sourceFilename?: string;
+  // 产物是否从其他文件复制而来
+  copied?: boolean;
+  // 产物体积是否超过 `performance.maxAssetSize`
+  isOverSizeLimit?: boolean;
+  // 产物是否仅用于 development 环境
+  development?: boolean;
+  // 产物是否包含热模块替换所需的数据
+  hotModuleReplacement?: boolean;
+  // 产物是否为以 ES module 形式输出的 JavaScript
+  javascriptModule?: boolean;
+  // 按关联类型分组的相关产物文件名
+  related: Record<string, string[]>;
+} & Record<string, any>;
+
 type StatsAsset = {
+  // Stats 项目的类型，例如 "asset" 或相关产物的类型
+  type: string;
   // 产物的文件名
   name: string;
+  // 产物的附加信息
+  info: StatsAssetInfo;
   // 产物的文件大小（单位为字节）
   size: number;
-  // 产物文件是否生成到 `output` 目录中
+  // 本次编译是否输出了该产物
   emitted: boolean;
+  // 本次编译是否未输出该产物（其值与 `emitted` 相反）
+  cached: boolean;
+  // 相关联的产物，如 source map
+  related?: StatsAsset[];
   // 产物文件关联的 chunk 的 ID 列表
-  chunks: Array<string | number | undefined | null>;
+  chunks?: Array<string | number | null | undefined>;
   // 产物文件关联的 chunk 的名称列表
-  chunkNames: Array<string>;
+  chunkNames?: string[];
   // 产物文件关联的 chunk 的 idHint 列表
-  chunkIdHInts: Array<string>;
+  chunkIdHints?: string[];
   // 作为附属产物文件关联的 chunk 的 ID 列表
-  auxiliaryChunks: Array<string | number | undefined | null>;
+  auxiliaryChunks?: Array<string | number | null | undefined>;
   // 作为附属产物文件关联的 chunk 的名称列表
-  auxiliaryChunkNames: Array<string>;
+  auxiliaryChunkNames?: string[];
   // 作为附属产物文件关联的 chunk 的 idHint 列表
-  auxiliaryChunkIdHints: Array<string>;
-
-  // 产物的信息
-  info: {
-    // 该产物是否经过代码压缩
-    minimized: boolean;
-    // 该产物是否仅用于 development 环境
-    development: boolean;
-    // 该产物是否仅用于 HMR 更新场景
-    hotModuleReplacement: boolean;
-    // 从源文件创建产物时（可能转换）sourceFilename
-    // 常见于处理 assets 类型的资源和使用 CopyRspackPlugin 等场景
-    sourceFilename?: string;
-    // 该产物是否可被持久化缓存（包含哈希值）
-    immutable: boolean;
-    // 该产物是否为 ESM 文件
-    javascriptModule?: boolean;
-    // 产物的 chunk 哈希值
-    chunkHash: Array<string>;
-    // 产物的内容哈希值
-    contentHash: Array<string>;
-  };
-  // 相关联的产物，如 source-map
-  related: StatsAsset[];
+  auxiliaryChunkIdHints?: string[];
+  // 输出中省略的相关产物数量
+  filteredRelated?: number;
   // 产物体积是否超过 performance.maxAssetSize 配置
   isOverSizeLimit?: boolean;
-};
+} & Record<string, any>;
 ```
 
 ## Chunk 对象结构
@@ -118,27 +146,31 @@ type StatsAsset = {
 
 ```ts
 type StatsChunk = {
+  // Stats 项目的类型
+  type: string;
   // chunk 包含的产物文件列表
-  files: Array<string>;
+  files: string[];
   // chunk 包含的附属产物文件列表
-  auxiliaryFiles: Array<string>;
+  auxiliaryFiles: string[];
   // chunk 的 ID
   id?: string | number;
-  // chunk 包含的 chunk 的名称列表
-  names: Array<string>;
+  // chunk 的名称列表
+  names: string[];
+  // chunk 关联的 ID hint 列表
+  idHints: string[];
   // chunk 所使用的 runtime
-  runtime: Array<string>;
+  runtime: string[];
   // chunk 的大小（单位为字节）
   size: number;
   // chunk 根据模块类型细分的大小（单位为字节）
   sizes: Record<string, number>;
   // chunk 的哈希值
   hash?: string;
-  // chunk 是否包含 runtime
+  // chunk 是否包含入口模块
   entry: boolean;
   // chunk 是否应被页面初始加载
   initial: boolean;
-  // chunk 是否生成产物
+  // 本次编译是否为 chunk 渲染了产物
   rendered: boolean;
 
   // 父级 chunk 的 ID 列表
@@ -147,31 +179,35 @@ type StatsChunk = {
   children?: Array<string | number>;
   // 同级 chunk 的 ID 列表
   siblings?: Array<string | number>;
+  // 按加载顺序分组的子 chunk
+  childrenByOrder: Record<string, Array<string | number>>;
 
   // 生成 chunk 的原因（需开启 optimization.splitChunks）
   reason?: string;
-  // split chunks 时命中的 cache group 的 idHint 列表（需开启 optimization.splitChunks）
-  idHints: Array<string>;
 
   // chunk 的引入来源列表
-  origins: Array<{
-    // 来源 module 的路径
-    module: string;
-    // 来源 module 的 ID
-    moduleId: string;
-    // 来源 module 的唯一标识
-    moduleIdentifier: string;
-    // 来源 module 的相对路径
-    moduleName: string;
-    // 在来源 module 中的代码位置
-    loc: string;
-    // 在来源 module 中的依赖标识
-    request: string;
-  }>;
+  origins?: StatsChunkOrigin[];
 
   // chunk 内包含的 module 列表，详细结构参考《Module 对象结构》章节
-  modules?: Array<StatsModule>;
-};
+  modules?: StatsModule[];
+  // 输出中省略的 module 数量
+  filteredModules?: number;
+} & Record<string, any>;
+
+type StatsChunkOrigin = {
+  // 来源 module 的标识符（`moduleIdentifier` 的兼容别名）
+  module: string;
+  // 来源 module 的内部标识符
+  moduleIdentifier: string;
+  // 来源 module 的可读名称
+  moduleName: string;
+  // 依赖在来源 module 中的位置
+  loc: string;
+  // 在来源 module 中的依赖标识
+  request: string;
+  // 来源 module 的 ID
+  moduleId?: string | number | null;
+} & Record<string, any>;
 ```
 
 ## Module 对象结构
@@ -180,94 +216,118 @@ type StatsChunk = {
 
 ```ts
 type StatsModule = {
-  // 模块的 ID
-  id?: string;
+  // Stats 项目的类型
+  type: string;
   // 模块的类型
   moduleType: string;
+  // 模块所属的 layer
+  layer?: string;
   // 模块的唯一标识
-  identifier: string;
+  identifier?: string;
   // 模块的相对路径
-  name: string;
+  name?: string;
+  // 模块用于条件匹配的绝对路径
+  nameForCondition?: string;
+  // preOrderIndex 和 postOrderIndex 的兼容别名
+  index?: number;
+  index2?: number;
+  // 模块在 chunk group 中自顶向下和自底向上的序号
+  preOrderIndex?: number;
+  postOrderIndex?: number;
   // 模块的大小（单位为字节）
   size: number;
-  // 根据模块类型细分的大小（单位为字节）
+  // 根据 source 类型细分的模块大小
   sizes: Record<string, number>;
-
+  // 模块是否可被缓存
+  cacheable?: boolean;
   // 模块是否经过编译阶段
   built: boolean;
-  // 模块是否经过了代码生成阶段
+  // 模块是否经过代码生成阶段
   codeGenerated: boolean;
-  // 模块是否在编译时运行（常见于 css-extract 等场景）
+  // 模块是否在构建时运行
   buildTimeExecuted: boolean;
-  // 模块是否被缓存
+  // 模块是否来自缓存
   cached: boolean;
-  // 模块是否可被缓存
-  cacheable: boolean;
-  // 模块是否可选，若可选当模块未找到时仅会出现警告
-  optional: boolean;
-  // 模块是否被依赖
+  // 模块是否可选，若可选，当模块未找到时仅会出现警告
+  optional?: boolean;
+  // 模块是否未被任何 chunk 包含
+  orphan?: boolean;
+  // 模块的 ID
+  id?: string | number | null;
+  // 父模块的 ID
+  issuerId?: string | number | null;
+  // 包含模块的 chunk 的 ID 列表
+  chunks?: Array<string | number>;
+  // 模块生成的产物列表
+  assets?: string[];
+  // 模块是否仅作为其他模块的依赖被引入
   dependent?: boolean;
-
-  // 模块被引入的原因列表，与 chunk.origins 结构类似
-  reasons?: Array<JsStatsModuleReason>;
   // 父模块的唯一标识
   issuer?: string;
-  // 父模块的 ID
-  issuerId?: string;
   // 父模块的相对路径
   issuerName?: string;
   // 从 entry 到当前模块的引用路径
-  issuerPath: Array<JsStatsModuleIssuer>;
-  // 模块用于条件匹配的绝对路径（通常是资源路径）
-  nameForCondition?: string;
-  // 模块在 Chunk Group 中自顶向下的序号
-  preOrderIndex?: number;
-  // 模块在 Chunk Group 中自底向上的序号
-  postOrderIndex?: number;
-  // 模块距离 entry 的层级距离
-  depth?: number;
-  // 模块是否未被任何 chunk 包含
-  orphan: boolean;
-  // 包含模块的 chunk 的 ID 列表
-  chunks: Array<string | number | undefined | null>;
-  // 模块相关的产物列表
-  assets?: Array<string>;
-
+  issuerPath?: StatsModuleIssuer[];
   // 模块是否编译失败
-  failed: boolean;
+  failed?: boolean;
   // 模块包含的错误数量
-  errors: number;
+  errors?: number;
   // 模块包含的警告数量
-  warnings: number;
-
-  // 被使用的模块导出，true 表示全部被使用，string[] 表示部分字段被使用（需开启 optimization.usedExports 配置）
-  usedExports?: null | string[] | boolean;
+  warnings?: number;
+  // 模块被引入的原因列表
+  reasons?: StatsModuleReason[];
+  // 输出中省略的模块引入原因数量
+  filteredReasons?: number;
+  // 被使用的模块导出（true 表示全部导出均被使用）
+  usedExports?: boolean | string[] | null;
   // 模块导出的字段列表（需开启 optimization.providedExports 配置）
-  providedExports?: null | string[];
+  providedExports?: string[] | null;
   // 模块优化降级信息（需开启 optimization.concatenateModules 配置）
-  optimizationBailout?: null | string[];
-
+  optimizationBailout?: string[] | null;
+  // 模块在模块图中的层级
+  depth?: number;
   // 若当前模块为作用域提升后生成的新模块，此字段为原始的模块列表（需开启 optimization.concatenateModules 配置）
-  modules?: Array<JsStatsModule>;
-
+  modules?: StatsModule[];
+  // 输出中省略的嵌套 module 数量
+  filteredModules?: number;
   // 模块的源代码
   source?: string | Buffer;
-};
+} & Record<string, any>;
+
+type StatsModuleIssuer = {
+  identifier: string;
+  name: string;
+  id?: string | number | null;
+} & Record<string, any>;
+
+type StatsModuleReason = {
+  moduleIdentifier?: string;
+  moduleName?: string;
+  resolvedModuleIdentifier?: string;
+  resolvedModule?: string;
+  type?: string;
+  active: boolean;
+  explanation?: string;
+  userRequest?: string;
+  loc?: string;
+  moduleId?: string | number | null;
+  resolvedModuleId?: string | number | null;
+} & Record<string, any>;
 ```
 
 ## Entry/ChunkGroup 对象结构
 
-每个 entry 对象对应一个编译入口，它的结构如下：
+每个 entrypoint 或 chunk group 对象表示一组 chunk 和产物，结构如下：
 
 ```ts
 type StatsEntrypoints = Record<string, StatsChunkGroup>;
 type StatsNamedChunkGroups = Record<string, StatsChunkGroup>;
 
 type StatsChunkGroup = {
-  // entry 的名称
+  // chunk group 的名称
   name: string;
   // 包含的 chunk 的 ID 列表
-  chunks: Array<string | number | undefined | null>;
+  chunks: Array<string | number>;
   // chunk group 的产物文件
   assets: Array<{
     // 产物文件名
@@ -275,6 +335,9 @@ type StatsChunkGroup = {
     // 产物文件大小
     size: number;
   }>;
+  // 仅存在于 entrypoint 和 named chunk group 对象中，嵌套的子 chunk group 不包含该字段
+  // 产物总数超过 `stats.chunkGroupMaxAssets` 时记录该总数，否则为 0
+  filteredAssets?: number;
   // chunk group 总产物大小
   assetsSize: number;
   // chunk group 的附属产物文件，如 sourcemap
@@ -289,20 +352,20 @@ type StatsChunkGroup = {
   // 子 chunk group 加载顺序，按照优先级排序
   children?: {
     // 需 preload 的 子 chunk group
-    preload?: Array<StatsChunkGroup>;
+    preload?: StatsChunkGroup[];
     // 需 prefetch 的 子 chunk group
-    prefetch?: Array<StatsChunkGroup>;
+    prefetch?: StatsChunkGroup[];
   };
   // 子 chunk group 加载文件顺序，按照优先级排序
   childAssets?: {
     // 需 preload 的资源文件
-    preload?: Array<string>;
+    preload?: string[];
     // 需 prefetch 的资源文件
-    prefetch?: Array<string>;
+    prefetch?: string[];
   };
   // 是否入口的产物体积超过了 performance.maxEntrypointSize
   isOverSizeLimit?: boolean;
-};
+} & Record<string, any>;
 ```
 
 ## Error/Warning 对象结构
@@ -313,10 +376,14 @@ type StatsChunkGroup = {
 type StatsError = {
   // 错误/警告的可视化提示信息
   message: string;
+  // 便于程序识别的错误/警告代码
+  code?: StatsErrorCode | string;
   // 与此错误/警告关联的自定义文件名
   file?: string;
   // 错误/警告的明细信息
   details?: string;
+  // 因 `stats.errorsSpace` 或 `stats.warningsSpace` 限制而省略的详情行数
+  filteredDetails?: number;
   // 错误/警告的栈信息
   stack?: string;
   /**
@@ -334,9 +401,13 @@ type StatsError = {
    * - `"./src/index.js"`
    * - `"./src/index.css"`
    */
-  moduleId?: string;
+  moduleName?: string;
+  // 错误/警告在模块中的位置
+  loc?: string;
+  // 发生错误/警告的模块 ID
+  moduleId?: string | number | null;
   // 错误/警告的模块引用路径
-  moduleTrace: Array<JsStatsModuleTrace>;
+  moduleTrace?: StatsModuleTraceItem[];
 
   // 若在 chunk 生成时错误/警告，关联的 chunk 名称
   chunkName?: string;
@@ -344,7 +415,40 @@ type StatsError = {
   chunkEntry?: boolean;
   // 若在 chunk 生成时错误/警告，关联的 chunk 是否为 initial
   chunkInitial?: boolean;
-  // 若在 chunk 生成时错误/警告，关联的 chunk 是否为 initial
+  // 若在 chunk 生成时错误/警告，关联的 chunk ID
   chunkId?: string;
+} & Record<string, any>;
+
+type StatsModuleTraceItem = {
+  originIdentifier: string;
+  originName: string;
+  moduleIdentifier: string;
+  moduleName: string;
+  originId?: string | number | null;
+  moduleId?: string | number | null;
+  dependencies: StatsModuleTraceDependency[];
 };
+
+type StatsModuleTraceDependency = {
+  loc: string;
+} & Record<string, any>;
+```
+
+## Logging 对象结构
+
+`StatsCompilation.logging` 的键是 logger 名称，值的结构如下：
+
+```ts
+type StatsLogging = {
+  entries: StatsLoggingEntry[];
+  filteredEntries: number;
+  debug: boolean;
+} & Record<string, any>;
+
+type StatsLoggingEntry = {
+  type: string;
+  message: string;
+  trace?: string[] | undefined;
+  children?: StatsLoggingEntry[] | undefined;
+} & Record<string, any>;
 ```

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -1008,7 +1008,7 @@ type StatsFactory = {
     type: string,
     data: any,
     baseContext: Omit<StatsFactoryContext, 'type'>,
-  ): void;
+  ): any;
 };
 ```
   </CollapsePanel>


### PR DESCRIPTION
## Summary

The Stats JSON documentation contained outdated and incomplete types that no longer matched the current stats output. This PR aligns the English and Chinese API references with the implementation, documents missing structures and fields, and corrects the `StatsFactory.create` return type.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).