### PR TITLE
fix(stats): generate correct prefetch child assets

### DIFF
--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -857,13 +857,13 @@ impl Stats<'_> {
           ),
         },
         StatschunkGroupChildAssets {
-          preload: get_chunk_group_oreded_child_assets(
+          preload: get_chunk_group_ordered_child_assets(
             &ordered_children,
             &ChunkGroupOrderKey::Preload,
             &build_chunk_graph_artifact.chunk_group_by_ukey,
             &build_chunk_graph_artifact.chunk_by_ukey,
           ),
-          prefetch: get_chunk_group_oreded_child_assets(
+          prefetch: get_chunk_group_ordered_child_assets(
             &ordered_children,
             &ChunkGroupOrderKey::Prefetch,
             &build_chunk_graph_artifact.chunk_group_by_ukey,

--- a/crates/rspack_core/src/stats/utils.rs
+++ b/crates/rspack_core/src/stats/utils.rs
@@ -77,14 +77,14 @@ pub fn get_chunk_group_ordered_children<'a>(
     .collect::<Vec<_>>()
 }
 
-pub fn get_chunk_group_oreded_child_assets<'a>(
+pub fn get_chunk_group_ordered_child_assets<'a>(
   ordered_children: &HashMap<ChunkGroupOrderKey, Vec<ChunkGroupUkey>>,
   order_key: &ChunkGroupOrderKey,
   chunk_group_by_ukey: &ChunkGroupByUkey,
   chunk_by_ukey: &'a ChunkByUkey,
 ) -> Vec<&'a str> {
   ordered_children
-    .get(&ChunkGroupOrderKey::Preload)
+    .get(order_key)
     .unwrap_or_else(|| panic!("should have {order_key} chunk groups"))
     .iter()
     .flat_map(|ukey| {

--- a/tests/rspack-test/statsAPICases/numeric-chunk-ids.js
+++ b/tests/rspack-test/statsAPICases/numeric-chunk-ids.js
@@ -31,7 +31,7 @@ function expectStatsChunkGroup(group) {
 
 /** @type {import("@rspack/test-tools").TStatsAPICaseConfig} */
 module.exports = {
-	description: "should expose numeric chunk ids as numbers in stats JSON",
+	description: "should expose numeric chunk ids and ordered child assets in stats JSON",
 	options(context) {
 		return {
 			context: context.getSource(),
@@ -118,5 +118,11 @@ module.exports = {
 		for (const chunkGroup of namedChunkGroups) {
 			expectStatsChunkGroup(chunkGroup);
 		}
+
+		// Preload and prefetch assets must come from their respective child groups.
+		expect(json.namedChunkGroups.chunk.childAssets).toEqual({
+			preload: ["chunk-b.js"],
+			prefetch: ["chunk-c.js", "chunk-a.js"]
+		});
 	}
 };


### PR DESCRIPTION
## Summary

Stats JSON currently populates `childAssets.prefetch` from preload child groups, causing consumers to receive duplicate or incorrect asset lists. This PR reads the requested child-group order and adds regression coverage that keeps preload and prefetch assets distinct.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).