### PR TITLE
perf(binding): exclude test loaders from release builds

### DIFF
--- a/crates/node_binding/Cargo.toml
+++ b/crates/node_binding/Cargo.toml
@@ -20,6 +20,7 @@ perfetto         = ["rspack_binding_api/perfetto"]
 plugin           = ["rspack_binding_api/plugin"]
 sftrace-setup    = ["rspack_binding_api/sftrace-setup"]
 system-allocator = ["rspack_binding_api/system-allocator"]
+test-loader      = ["rspack_binding_api/test-loader"]
 tracy-client     = ["rspack_binding_api/tracy-client"]
 
 [package.metadata.cargo-shear]

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -70,6 +70,10 @@ async function build() {
 			args.push("--no-default-features");
 			features.push("plugin");
 		}
+		// Internal test loaders should not ship in production artifacts.
+		if (!["release", "release-wasi"].includes(values.profile)) {
+			features.push("test-loader");
+		}
 		if (process.env.RSPACK_TARGET_BROWSER) {
 			features.push("browser")
 		}

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -18,6 +18,7 @@ perfetto         = ["dep:rspack_tracing_perfetto", "rspack_tracing/perfetto"]
 plugin           = ["rspack_loader_swc/plugin", "rspack_util/plugin"]
 sftrace-setup    = ["dep:sftrace-setup", "rspack_allocator/sftrace-setup"]
 system-allocator = ["rspack_allocator/system-allocator"]
+test-loader      = ["dep:rspack_loader_testing"]
 tracy-client     = ["dep:tracy-client", "rspack_allocator/tracy-client"]
 
 [dependencies]
@@ -71,7 +72,7 @@ rspack_loader_preact_refresh           = { workspace = true }
 rspack_loader_react_refresh            = { workspace = true }
 rspack_loader_runner                   = { workspace = true }
 rspack_loader_swc                      = { workspace = true }
-rspack_loader_testing                  = { workspace = true }
+rspack_loader_testing                  = { workspace = true, optional = true }
 rspack_napi_macros                     = { workspace = true }
 rspack_plugin_asset                    = { workspace = true }
 rspack_plugin_banner                   = { workspace = true }

--- a/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
@@ -33,7 +33,7 @@ impl Loader<RunnerContext> for JsLoader {
   }
 }
 
-// TODO: should be compiled with a different cfg
+#[cfg(feature = "test-loader")]
 pub fn get_builtin_test_loader(builtin: &str) -> Option<BoxLoader> {
   if builtin.starts_with(rspack_loader_testing::SIMPLE_ASYNC_LOADER_IDENTIFIER) {
     return Some(Arc::new(rspack_loader_testing::SimpleAsyncLoader));
@@ -70,6 +70,7 @@ pub(crate) async fn resolve_loader(
     Utf8Path::new(loader_request)
   };
 
+  #[cfg(feature = "test-loader")]
   if loader_request.starts_with("builtin:test") {
     return Ok(get_builtin_test_loader(loader_request));
   }

--- a/crates/rspack_loader_testing/Cargo.toml
+++ b/crates/rspack_loader_testing/Cargo.toml
@@ -3,9 +3,8 @@ description       = "rspack loader test"
 edition.workspace = true
 license           = "MIT"
 name              = "rspack_loader_testing"
-# Should publish this package for now,
-# as `rspack_loader_test` is used in `rspack_binding_api`
-# and we don't have a `cfg` to get rid off test code in release code
+# Keep publishing this package because `rspack_binding_api`'s
+# `test-loader` feature depends on it.
 # publish           = false
 repository        = "https://github.com/web-infra-dev/rspack"
 version.workspace = true


### PR DESCRIPTION
## Summary

This PR prevents internal test loaders from being linked into release and release-wasi bindings, avoiding shipping test-only native code. It gates `rspack_loader_testing` behind a `test-loader` feature that remains enabled for development and CI builds.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).