### PR TITLE
chore: bump SWC dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "6.1.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b127110e8724bd19447ac72f31a66a9c06ac6b2b1372d81b6f5f0a2bddc6d1bb"
+checksum = "edf54a7a1bf98e127c22e9e2b9d19619092c74283fdc14e4d67da69780f90db6"
 dependencies = [
  "quote",
  "swc_macros_common",
@@ -2685,11 +2685,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -6188,9 +6188,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "swc"
-version = "74.0.0"
+version = "75.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db0b4ef250cae068222634751f69c348927f23d79c2224f1b332dfef6ab3148"
+checksum = "ef8bdaf419d5cfe175679a6ec6968881898cbb91d1426cca7a3bc49442c1b4b6"
 dependencies = [
  "anyhow",
  "base64",
@@ -6264,9 +6264,9 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "872e3beee92f0d63a7948ac03266c72a91cabf4c54d660ce992d448135ab5aec"
+checksum = "142d2a06cafce623859ca799f5d1935bb8a886f18b66a2585ddeadff210121d0"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -6293,9 +6293,9 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "63.0.0"
+version = "64.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26573f00356a5455d50a117232c08926d6ba1162da78f0a775b7541368294d1f"
+checksum = "3369ee388551ebeb3cb7342a0c238503ddb3279152b45fa4bad56acf14565f0a"
 dependencies = [
  "anyhow",
  "base64",
@@ -6351,9 +6351,9 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "76.0.0"
+version = "77.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52af5f6afc54b2746e92dab457951e2b4621c7b3bf8c96d2ee66358e124b81aa"
+checksum = "e3550b31eb172f3b27c55a05642a9d13520a55552382a708e44bdf286dfcbbe1"
 dependencies = [
  "par-core",
  "swc",
@@ -6380,9 +6380,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b25e2e91491e0e82f932c7a5a07f5c90bd227dbde0c34aeb231d5b3a5e5107"
+checksum = "5a6fd43fc7e90b9d5b252af666c147f5e2ee692add2b075f7f0d6fc2f5357bb6"
 dependencies = [
  "bitflags 2.11.1",
  "cbor4ii",
@@ -6401,9 +6401,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f512e8afa1eb427f87913a0d918f5c509a6d8b26027275025e2856a14883c"
+checksum = "a1b19a1d9f059fb77b0bc321688c7af59fe687a975581379456962586959c5d1"
 dependencies = [
  "ascii",
  "compact_str",
@@ -6436,9 +6436,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "55.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c56a6fd2674b7fc18248e597ad039bb4f43a601c7944361a58892bfb743a5ff"
+checksum = "e324cdd51e883faa063834de0b57c900ccbd68acbd6da89b90d5e2dc180256f7"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6453,9 +6453,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb423e4863bcf4edc391bbcc61dfbd4b99126c6fb18e04296d1b7994126775d"
+checksum = "8c6e148f552507fa5bcb6e06f5f8dc994042e0e0dc5b6ad02dbc2f946af32b3f"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6465,9 +6465,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "54.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3770a6524c4898f747dd8c880cc8fdc8457de8fdccbf160b4802034e40fed69f"
+checksum = "83dfd24601f0cf2985d5220849c6932ae32ca2cf6234d53f9ba2fbb5f3666814"
 dependencies = [
  "arrayvec",
  "indexmap",
@@ -6492,9 +6492,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b3ec2211a8a625387e931f9868b7e2bd63e08d7c3543812617cb5593123c83"
+checksum = "01e7ae4ab604e4b451f82d4f5ba06f02c34e2dc83687fcd59502162cb3de572b"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6505,9 +6505,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c405e7e2d1c991646065000e3d0e04cf75863a7e1566a39a64433f9a1f34335"
+checksum = "c4e5df4c8a68a20da8988aab1ba111ccad9a1f0e00bb7517bc1af7600fa95a4b"
 dependencies = [
  "serde",
  "swc_common",
@@ -6520,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "50.0.0"
+version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3256226830071d3a56e83f45309eca14e68d65141167c0531a0478049baa6d0a"
+checksum = "0c6ce48b26c0a8b5b3818faea97135a1d4b8e34086a87e12d338436bc08cb7b4"
 dependencies = [
  "serde",
  "swc_ecma_ast",
@@ -6534,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4535bc4cd87a4dbbaea03b41908f36046d618d6432a29da6634ff08856f9c09c"
+checksum = "fa556a5f4b4dfdf6fbf500a6482fb9c2d83b5018fbb1988ffb0ba61f957329b3"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6548,9 +6548,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "52.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d73cb98f448617b4827c342c2fe07c6eb4bd6a41f435d6d67e80f4084c484e"
+checksum = "ad49feb666d48da1c6141c85da8e868d30a29de295b86b0d6e9c15560b43ec3b"
 dependencies = [
  "serde",
  "swc_common",
@@ -6565,9 +6565,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "49.0.0"
+version = "50.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a97e7bddbb77e015d18b2f2f5f7cbc1f037e7ba187b5abab68d62d4b25fd990"
+checksum = "20c62a53d5ea29e9c882fe1419e919a4add59364c04a97c67b0cbeb5ccb3b96d"
 dependencies = [
  "swc_ecma_ast",
  "swc_ecma_transformer",
@@ -6578,9 +6578,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "52.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb7be1edb39487ad02aee31329ed00465922636b9993dd22c6502b7f975e254"
+checksum = "a646d434eff8c7324ab2d3eda72e9bfb62c560ebc6b847378aef061ad9cf07a9"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6597,9 +6597,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_regexp"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aad8391849b826fba38c2788e70b85197f2bd9bff3e7f21593acd1c263b4b2d"
+checksum = "c1b93a633bfc99231ab75182d295a4e0c0fcf6c9080e5fbf47cd4ba91f0a745a"
 dependencies = [
  "icu_properties",
  "swc_ecma_regexp_ast",
@@ -6608,9 +6608,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc2e49ad776b5d0315ae2e0bb5fe70a218ee468ac70f7bb472dc2ab4386f420"
+checksum = "6fb95691978e1d3d100fca45dd3a1fcfab8d90d0554e796472023b3fd17bb1cf"
 dependencies = [
  "phf",
  "swc_common",
@@ -6621,9 +6621,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_hooks"
-version = "0.12.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ab2d337400963b24f764b3630eaa31cd28bd0c7f408ca9f41cf3a8fcadb917"
+checksum = "f3abc7b19ffc01d358fe6dfce904cc0a9c30c4db6deed11011b67c320f71682c"
 dependencies = [
  "swc_atoms",
  "swc_common",
@@ -6633,9 +6633,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6692f0223b181325ad3e2f96401c1215a8a4c6ca55ced17ef74d41f30625923"
+checksum = "0b683f212227b0c0594e20c4c560d47425389b445adc4b50650beba70810d0eb"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -6655,9 +6655,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "60.0.0"
+version = "61.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310ab13e49dd014e2f050213d10ddfc34c5684e438bf81844a6e7ae7f7ba91d8"
+checksum = "e69fe76dfd4f43ed4a3e351cee1f183169789c744db2d6db73fbf693ae080424"
 dependencies = [
  "arrayvec",
  "bitflags 2.11.1",
@@ -6690,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c83ff3be8652d2caf9f074853f8c33a4a05b17079c1586f195eec17d3ec553"
+checksum = "75a380e3e36a2167f1a2c6fd725c87a3aee60d404505667ea2c7c9e85763a70e"
 dependencies = [
  "bitflags 2.11.1",
  "compact_str",
@@ -6711,9 +6711,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "62.0.0"
+version = "63.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3bbd3fe0815a3642631b17848861d07d9b92b85b6341e02f4e8bd8d1c2491"
+checksum = "19c218c9d50eca5e5520117af7291de07bc543863e261877951b06dba8a36c13"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
@@ -6736,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_quote_macros"
-version = "44.0.0"
+version = "45.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9940ba4ef303aeebbba66267f7de9deca4e5471b49f1bb090887c633de16fa1a"
+checksum = "44d38f4410bf67bdd824a2cbc3fc955ba7faf0230b4b9d2e9cac9a3ae1d2c131"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6754,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_react_compiler"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b3563be7dd3d5e9717816d82bdf9494811900dacd3b7c0d363056eba2bb2db"
+checksum = "7f502a7ccd43292d50a9ed30b56ed59c9f73e310a48d3990f0697c04cb87cd09"
 dependencies = [
  "forked_react_compiler",
  "forked_react_compiler_ast",
@@ -6775,9 +6775,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "005fabc950f92781ba0e18c7065daccc4353cf0ab94186b3b2098cb94f94083c"
+checksum = "0699de9c2e94b4706723a02d9d30da41d8f7ca526cdfb5328495ef25fceeef2a"
 dependencies = [
  "phf",
  "rustc-hash",
@@ -6791,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_regexp_ast"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614932a326aa5a588d5c50e3858667250f0ba5914fa2ff725016b8a355cd2892"
+checksum = "9c576fb9c0cf62046f6b56961ffe216f032a018f9914f2a942ae1263371377ee"
 dependencies = [
  "bitflags 2.11.1",
  "is-macro",
@@ -6810,9 +6810,9 @@ checksum = "0a0a09a9e4dc09c97f07273695bd4b58e46b99dbb0cb788ce0dad2a181eb1e94"
 
 [[package]]
 name = "swc_ecma_regexp_visit"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea5d3926e65aa44766b9e45014e77c8ad4149438996adb2146d6915aaf52a88"
+checksum = "b113ae22200d9a8710463a2d3134ec51de5fdd42bc667a1d4d3bea6437006212"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -6823,9 +6823,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c265d11f2a7bb5186bcdfe20a71d8d208f786691965f97d6f2cbcb387c0de36"
+checksum = "2d9eca985397245f45f146e13bb4f4aec6c9238fe8a05124ab9e626662f0d813"
 dependencies = [
  "anyhow",
  "hex",
@@ -6836,9 +6836,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transformer"
-version = "20.0.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503863f74566bbe63be8144daaf73de7a9271889a43c967a5a5e26ad1f0582fb"
+checksum = "fe9fa23ed807ef91e6c19a0074a4171ec0cc6f1926b3982211082966f9875b13"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -6855,9 +6855,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms"
-version = "61.0.0"
+version = "62.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f4b84cbfd592c654261083be67f450169680ccb10ca3b2a05b8411529c78c7"
+checksum = "d1582e1975f97a2ad6fd0ccfdc9ff96cb3ca9ba5d2d9f02b43a8055ae3cfc32f"
 dependencies = [
  "par-core",
  "swc_common",
@@ -6874,9 +6874,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b847c1419056e271c11a2fe1d36f988c9f121d0239ec401cbb3e622480ee3e8"
+checksum = "4efb43c0b7a0478fc084c55849e182ce85e7123070eb61cfeba67811ab253051"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -6897,9 +6897,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14764cea2eb983732fb908c075aff0769cc27ae148fa812867fa1fa337506fa2"
+checksum = "000e35655d10295ede5ab608b46e78088b85cf531a45da3e4144d87c572c70d3"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -6910,9 +6910,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "56.0.0"
+version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0237fee1a78c87bfdb4c06723feedb99610b61703f13956d02594683c10540d"
+checksum = "ceb8ffad960e1e24b3b63b2e71ffb2c8d573c93ca8903b7b483b5a75eaf869bd"
 dependencies = [
  "indexmap",
  "par-core",
@@ -6950,9 +6950,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "54.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dadea6bc10d0085ceda08e7964245f4ab5c2bdcb1871226d3dd45bb95f15dc"
+checksum = "0ebbcdacd52372205ba065a432ff75c4ad2917cfb9a5eec0681ff1acd84b7ce3"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -6978,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "51.0.0"
+version = "52.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afbe52092d7b1b929156762f986294a559bba0221ef80a1017e806b1d8f9c34"
+checksum = "b72f337de0b83a0d73865c5dfb7a0f274c914d2460b241bdd707277f95389bde"
 dependencies = [
  "bytes-str",
  "dashmap",
@@ -7003,9 +7003,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "48.0.0"
+version = "49.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5cb9f6274985f2626fdad2dac2c876052a7aee540394d0c9297a9149652b55d"
+checksum = "54961a68a90ffddffba02c4805e3e771131e088b66db1fc4a8d2aa0e25ce8b7e"
 dependencies = [
  "either",
  "rustc-hash",
@@ -7021,9 +7021,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "54.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fa764bc0ea6a9ca6683fe5c32faf50accc8a6b86b96d4b124429473307ef30"
+checksum = "0e0a418b1fed19876f340b9d54aba3acc89c8c3d3d74717d08709d00c17d401b"
 dependencies = [
  "base64",
  "bytes-str",
@@ -7046,9 +7046,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "52.0.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b952ab0bec3f94c9b4424b63c4144ea19bd8f88defb3b22b0003098163f7933"
+checksum = "f76aec842cdbe4ae1c8a953f8b126c9e26a42ee388c9b3c9b68a0e4e5e9747c9"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -7072,9 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "54.0.0"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5e4792f858bd3751db6407e7e230927897e716078c885f8a18c0ab28939cf"
+checksum = "523651c4ea2d6e7a53c5b8f07e8ae5fb33894970cc96c2f1b534992afcc32fe2"
 dependencies = [
  "bytes-str",
  "rustc-hash",
@@ -7090,9 +7090,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0adbc5dd5676057ce6b0f63618838ba8691240972e3374189463f64214dd5e"
+checksum = "a6fb39737b1c2bde685c5d85799aa04107548de69087a77c690a3ca8bbfc5100"
 dependencies = [
  "dragonbox_ecma",
  "indexmap",
@@ -7109,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a8e8f80fdada267a6b556199be3f11ef491184e12270877c76cf2dca522ac0"
+checksum = "a830a070fea84a3a8a8c556463f0551e3bfc6cf2f8bdeecd62fa753e22a72289"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -7135,9 +7135,9 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81f7728b17b0cf39aa968e2f4b6315150e1c649c136401fdcb0ce95d39d4ad5"
+checksum = "997aa1a85b9ebdab127d8819ea5ebfa5b90e5a958d969e25cce4c853c36d26de"
 dependencies = [
  "anyhow",
  "miette",
@@ -7246,9 +7246,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html"
-version = "37.0.0"
+version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54b4b34d0933be1a8dc89db1aa3a9200306373c0443351286ef908ee582e27"
+checksum = "f6133cecde6413ce5cf9ab06cd3562e9ba6648cb9892f697e6a745aac67782d6"
 dependencies = [
  "swc_html_ast",
  "swc_html_codegen",
@@ -7258,9 +7258,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_ast"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5be7b8b8dab4e34eb95440ca38dc2ae83b6741c48344badeb1b690f248ac4"
+checksum = "66332cb009b266aeefe2f88d24a01237fe4caaab288c02cacae16a6f4142b007"
 dependencies = [
  "is-macro",
  "string_enum",
@@ -7270,9 +7270,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_codegen"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "077c866859dad8af83d1e0e2fc4d08101b40cb0c06bbbe628a17c8e92f48d5f4"
+checksum = "2ba16b05a60ce9814a064b54d520a38c5062823d64170cadcfc1abb50685f4f3"
 dependencies = [
  "auto_impl",
  "bitflags 2.11.1",
@@ -7296,9 +7296,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_minifier"
-version = "60.0.0"
+version = "61.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d4c533febfeec24e6f00f669b62305cca03c47c0c63d1449811acf1520a3cf2"
+checksum = "98c54a2bf2731992ca15037798b74f7ff0b4619f9ed504bee1cf1cbc15f941b0"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -7322,9 +7322,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_parser"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ed92f4763a7658ba34d2707a62adc847c83a1fd5e8a52e612db4cd53d8cba2"
+checksum = "630727fc984947b3b2304c9ed84a385522eb034b2a983cb04161baadb4c3bf47"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -7348,9 +7348,9 @@ dependencies = [
 
 [[package]]
 name = "swc_html_visit"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fdedea88cd4bb3e57352c6005f3a6ef6749f3aedd2a120aba65184a3959ab2"
+checksum = "057eeaa04a72ce1a8482e053881b60ff1f05d99b4611e1e0a6d87f2d4378e98a"
 dependencies = [
  "serde",
  "swc_atoms",
@@ -7372,9 +7372,9 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd898d9aa14c05211a183b92c05d94ec427c8b559bc362706900b6f02e57375"
+checksum = "78074bea47c67343e53c85e1bdc9fa8f4bd21b8ab882098108205fd60462193b"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -7384,9 +7384,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa1cb6476767e09b3580f60f1a052051716678bc2b698ef1284dabc75464513"
+checksum = "b13ffe2fc1fb9b1936f6ceaf21d8e2e68f23ac9f0022db414e5f30c5fc52a966"
 dependencies = [
  "better_scoped_tls",
  "cbor4ii",
@@ -7398,9 +7398,9 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff3ca76d6d8db374780265ad47a4e532732d7ca93dcda6e4e04d1226d84dc16"
+checksum = "b761b1092b44eeea1ce8dbbce8a0febb6ef39bcc3d72adecd23ee99d89bf5287"
 dependencies = [
  "anyhow",
  "blake3",
@@ -7437,9 +7437,9 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a573180abbfd2fae241d1e1974b33aef36a562d440f27fca5fd0229aaeabff03"
+checksum = "693ff873dd31f50c44f5c05182631715bc03f7e1123e7805279b25d1db2bed20"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",
@@ -7449,9 +7449,9 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "33.0.0"
+version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eaa22935edad4c9409d11192f705ad8da91369adf59e547ce5328bd2da1f85"
+checksum = "20b1b8fe13010437d3c10ee3ea17c50abd586f78e32342e156c35a73255572e0"
 dependencies = [
  "bitflags 2.11.1",
  "petgraph",
@@ -7585,9 +7585,9 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba142c2b1905b5210b110f6f48a4e2732395eb17bad0097a087b1a5783f145d"
+checksum = "ab499434ba981fb7aada35505f2035e1bae4517c18bafebf8954dd2dc7e979af"
 dependencies = [
  "cargo_metadata",
  "difference",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,16 +141,16 @@ rkyv      = { version = "=0.8.18", default-features = false, features = ["std", 
 
 # Must be pinned with the same swc versions
 pnp                 = { version = "0.12.11", default-features = false }
-swc                 = { version = "74.0.0", default-features = false }
+swc                 = { version = "75.0.0", default-features = false }
 swc_atoms           = { version = "10.0.0", default-features = false }
 swc_config          = { version = "6.0.0", default-features = false }
-swc_core            = { version = "76.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "60.0.0", default-features = false }
-swc_error_reporters = { version = "27.0.0", default-features = false }
-swc_html            = { version = "37.0.0", default-features = false }
-swc_html_minifier   = { version = "60.0.0", default-features = false }
-swc_plugin_runner   = { version = "33.0.0", default-features = false }
-swc_typescript      = { version = "33.0.0", default-features = false }
+swc_core            = { version = "77.0.0", default-features = false, features = ["parallel_rayon"] }
+swc_ecma_minifier   = { version = "61.0.0", default-features = false }
+swc_error_reporters = { version = "28.0.0", default-features = false }
+swc_html            = { version = "38.0.0", default-features = false }
+swc_html_minifier   = { version = "61.0.0", default-features = false }
+swc_plugin_runner   = { version = "34.0.0", default-features = false }
+swc_typescript      = { version = "34.0.0", default-features = false }
 
 swc_experimental_allocator            = { version = "0.11.0", default-features = false }
 swc_experimental_ecma_ast             = { version = "0.11.0", default-features = false }

--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -319,7 +319,7 @@ impl<'a, C: Comments> ServerActions<'a, C> {
 
   // Check if the function or arrow function is an action function,
   // and remove any server function directive.
-  fn has_use_server_for_function(&mut self, maybe_body: Option<&mut BlockStmt>) -> bool {
+  fn has_use_server_for_function(&mut self, maybe_body: Option<&mut FunctionBody>) -> bool {
     let mut found_use_server = false;
 
     // Even if it's a file-level action or cache module, the function body
@@ -416,14 +416,14 @@ impl<'a, C: Comments> ServerActions<'a, C> {
         .swap_remove(&arrow_ident.to_id());
     }
 
-    if let BlockStmtOrExpr::BlockStmt(block) = &mut *arrow.body {
+    if let ArrowFunctionBody::FunctionBody(block) = &mut *arrow.body {
       block.visit_mut_with(&mut ClosureReplacer {
         used_ids: &ids_from_closure,
         private_ctxt: self.private_ctxt,
       });
     }
 
-    let mut new_body: BlockStmtOrExpr = *arrow.body.clone();
+    let mut new_body: ArrowFunctionBody = *arrow.body.clone();
 
     if !ids_from_closure.is_empty() {
       // Prepend the decryption declaration to the body.
@@ -454,11 +454,11 @@ impl<'a, C: Comments> ServerActions<'a, C> {
       };
 
       match &mut new_body {
-        BlockStmtOrExpr::BlockStmt(body) => {
+        ArrowFunctionBody::FunctionBody(body) => {
           body.stmts.insert(0, decryption_decl.into());
         }
-        BlockStmtOrExpr::Expr(body_expr) => {
-          new_body = BlockStmtOrExpr::BlockStmt(BlockStmt {
+        ArrowFunctionBody::Expr(body_expr) => {
+          new_body = ArrowFunctionBody::FunctionBody(FunctionBody {
             span: DUMMY_SP,
             stmts: vec![
               decryption_decl.into(),
@@ -467,7 +467,6 @@ impl<'a, C: Comments> ServerActions<'a, C> {
                 arg: Some(body_expr.take()),
               }),
             ],
-            ..Default::default()
           });
         }
       }
@@ -491,14 +490,13 @@ impl<'a, C: Comments> ServerActions<'a, C> {
               function: Box::new(Function {
                 params: new_params,
                 body: match new_body {
-                  BlockStmtOrExpr::BlockStmt(body) => Some(body),
-                  BlockStmtOrExpr::Expr(expr) => Some(BlockStmt {
+                  ArrowFunctionBody::FunctionBody(body) => Some(body),
+                  ArrowFunctionBody::Expr(expr) => Some(FunctionBody {
                     span: DUMMY_SP,
                     stmts: vec![Stmt::Return(ReturnStmt {
                       span: DUMMY_SP,
                       arg: Some(expr),
                     })],
-                    ..Default::default()
                   }),
                 },
                 is_async: true,
@@ -588,7 +586,7 @@ impl<'a, C: Comments> ServerActions<'a, C> {
       private_ctxt: self.private_ctxt,
     });
 
-    let mut new_body: Option<BlockStmt> = function.body.clone();
+    let mut new_body: Option<FunctionBody> = function.body.clone();
 
     if !ids_from_closure.is_empty() {
       // Prepend the decryption declaration to the body.
@@ -620,10 +618,9 @@ impl<'a, C: Comments> ServerActions<'a, C> {
       if let Some(body) = &mut new_body {
         body.stmts.insert(0, decryption_decl.into());
       } else {
-        new_body = Some(BlockStmt {
+        new_body = Some(FunctionBody {
           span: DUMMY_SP,
           stmts: vec![decryption_decl.into()],
-          ..Default::default()
         });
       }
     }
@@ -1003,12 +1000,13 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
   fn visit_mut_arrow_expr(&mut self, a: &mut ArrowExpr) {
     // Arrow expressions need to be visited in prepass to determine if it's
     // an action function or not.
-    let found_use_server =
-      self.has_use_server_for_function(if let BlockStmtOrExpr::BlockStmt(block) = &mut *a.body {
+    let found_use_server = self.has_use_server_for_function(
+      if let ArrowFunctionBody::FunctionBody(block) = &mut *a.body {
         Some(block)
       } else {
         None
-      });
+      },
+    );
 
     if found_use_server {
       self.this_status = ThisStatus::Forbidden;
@@ -2199,7 +2197,7 @@ fn detect_similar_strings(a: &str, b: &str) -> bool {
 // without mutating the function body or erroring out.
 // This is used to quickly determine if we need to use the module-level
 // directives for this function or not.
-fn is_action_fn(maybe_body: &Option<BlockStmt>) -> bool {
+fn is_action_fn(maybe_body: &Option<FunctionBody>) -> bool {
   let mut result = false;
   if let Some(body) = maybe_body {
     for stmt in body.stmts.iter() {

--- a/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/to_client_ref.rs
@@ -202,7 +202,7 @@ fn throw_error_function(call_error: &str) -> Expr {
   Expr::Fn(FnExpr {
     ident: None,
     function: Box::new(Function {
-      body: Some(BlockStmt {
+      body: Some(FunctionBody {
         span: DUMMY_SP,
         stmts: vec![Stmt::Throw(ThrowStmt {
           span: DUMMY_SP,
@@ -214,7 +214,6 @@ fn throw_error_function(call_error: &str) -> Expr {
             type_args: None,
           })),
         })],
-        ..Default::default()
       }),
       ..Default::default()
     }),

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -1,7 +1,7 @@
 //! This is a generated file. Don't modify it by hand! Run 'cargo codegen' to re-generate the file.
 /// The version of the `swc_core` package used in the current workspace.
 pub const fn rspack_swc_core_version() -> &'static str {
-  "76.0.0"
+  "77.0.0"
 }
 
 /// The version of the JavaScript `@rspack/core` package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,8 +116,8 @@ catalogs:
       specifier: 0.5.23
       version: 0.5.23
     '@swc/plugin-remove-console':
-      specifier: ^12.15.0
-      version: 12.15.0
+      specifier: ^13.0.0
+      version: 13.0.0
     '@swc/types':
       specifier: 0.1.28
       version: 0.1.28
@@ -1091,7 +1091,7 @@ importers:
         version: 0.5.23
       '@swc/plugin-remove-console':
         specifier: 'catalog:'
-        version: 12.15.0
+        version: 13.0.0
       '@types/babel__generator':
         specifier: 'catalog:'
         version: 7.27.0
@@ -3501,8 +3501,8 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@swc/plugin-remove-console@12.15.0':
-    resolution: {integrity: sha512-GlxFDOt8T91N6LtNfuSkLIn2FnJwc0ULI26OFtlSY+VNR4gtM9S5hyssmDRJua2gvFDDKnYhk2St38y7sUwLig==}
+  '@swc/plugin-remove-console@13.0.0':
+    resolution: {integrity: sha512-rZF8EO3LVOOc1gv/KwrEtRfsI5EN655VVracPgUtWYtp/BYYn/zsqkTVXkXCOZHzC9fB/DxXEW1MuSMi4BvpSg==}
 
   '@swc/types@0.1.28':
     resolution: {integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==}
@@ -9934,7 +9934,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/plugin-remove-console@12.15.0':
+  '@swc/plugin-remove-console@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ catalog:
   '@rstackjs/load-config': '^0.1.2'
   '@shikijs/transformers': '^4.4.3'
   '@swc/helpers': '0.5.23'
-  '@swc/plugin-remove-console': '^12.15.0'
+  '@swc/plugin-remove-console': '^13.0.0'
   '@swc/types': '0.1.28'
   '@types/babel__generator': '7.27.0'
   '@types/babel__traverse': '7.28.0'


### PR DESCRIPTION
## Summary

Bumps `swc_core` from 76.0.0 to 77.0.0, aligns the compatible SWC crates, and upgrades `@swc/plugin-remove-console` from 12.15.0 to 13.0.0.

- **Rust API breaking change:** SWC 77 introduces dedicated `FunctionBody` and `ArrowFunctionBody::FunctionBody` AST types. The RSC transforms are updated for the new function-body nodes.
- **WASM plugin breaking change:** SWC 77 changes the serialized AST encoding across the WASM plugin boundary by correcting ignored-field counts. Plugins built against earlier schemas must be rebuilt or upgraded; `@swc/plugin-remove-console` 13.0.0 is the SWC 77-compatible release.

[SWC 76 → 77](https://github.com/swc-project/swc/compare/swc_core%40v76.0.0...swc_core%40v77.0.0) · [WASM encoding change](https://github.com/swc-project/swc/pull/11905) · [Plugin changelog](https://github.com/swc-project/plugins/blob/main/packages/remove-console/CHANGELOG.md)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).