### PR TITLE
perf: preallocate identifier path buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,7 +5669,6 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "simd-json",
- "smallvec",
  "sugar_path",
  "swc_core",
  "swc_experimental_ecma_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5669,6 +5669,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "simd-json",
+ "smallvec",
  "sugar_path",
  "swc_core",
  "swc_experimental_ecma_ast",

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -28,7 +28,6 @@ ryu-js           = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
 simd-json        = { workspace = true }
-smallvec         = { workspace = true }
 sugar_path       = { workspace = true }
 unicase          = { workspace = true }
 

--- a/crates/rspack_util/Cargo.toml
+++ b/crates/rspack_util/Cargo.toml
@@ -28,6 +28,7 @@ ryu-js           = { workspace = true }
 serde            = { workspace = true }
 serde_json       = { workspace = true }
 simd-json        = { workspace = true }
+smallvec         = { workspace = true }
 sugar_path       = { workspace = true }
 unicase          = { workspace = true }
 

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -1,12 +1,15 @@
 use std::{
   borrow::Cow,
+  ops::Range,
   path::{Path, PathBuf},
   sync::LazyLock,
 };
 
 use concat_string::concat_string;
 use cow_utils::CowUtils;
+use memchr::memchr2_iter;
 use regex::Regex;
+use smallvec::SmallVec;
 use sugar_path::SugarPath;
 
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
@@ -165,49 +168,76 @@ fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String
   }
 }
 
-pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
-  let mut result = String::with_capacity(
-    context
-      .len()
-      .saturating_add(identifier.len())
-      .saturating_add(1),
-  );
+fn identifier_segment_ranges(identifier: &str) -> SmallVec<[Range<u32>; 4]> {
+  let identifier_len =
+    u32::try_from(identifier.len()).expect("identifier length should fit into u32");
+  let mut ranges = SmallVec::new();
   let mut last = 0;
 
-  for (index, byte) in identifier.bytes().enumerate() {
-    if matches!(byte, b'|' | b'!') {
-      push_request_to_absolute(context, &identifier[last..index], &mut result);
-      result.push(byte as char);
-      last = index + 1;
+  for index in memchr2_iter(b'|', b'!', identifier.as_bytes()) {
+    ranges.push(last as u32..index as u32);
+    last = index + 1;
+  }
+  ranges.push(last as u32..identifier_len);
+  ranges
+}
+
+pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
+  let ranges = identifier_segment_ranges(identifier);
+  let relative_segment_count = ranges
+    .iter()
+    .filter(|range| {
+      let segment = &identifier[range.start as usize..range.end as usize];
+      segment.starts_with("./") || segment.starts_with("../")
+    })
+    .count();
+  let result_capacity = context
+    .len()
+    .saturating_add(1)
+    .saturating_mul(relative_segment_count)
+    .saturating_add(identifier.len());
+  let mut result = String::with_capacity(result_capacity);
+
+  for range in ranges {
+    let start = range.start as usize;
+    let end = range.end as usize;
+    push_request_to_absolute(context, &identifier[start..end], &mut result);
+    if end < identifier.len() {
+      result.push(identifier.as_bytes()[end] as char);
     }
   }
-
-  push_request_to_absolute(context, &identifier[last..], &mut result);
   result
 }
 
-fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
-  let mut last = 0;
+pub fn make_paths_relative(context: &str, identifier: &str) -> String {
+  let ranges = identifier_segment_ranges(identifier);
+  let absolute_segment_count = ranges
+    .iter()
+    .filter(|range| {
+      let segment = &identifier[range.start as usize..range.end as usize];
+      segment.starts_with('/') || is_windows_absolute_path(segment)
+    })
+    .count();
+  // Each context component can add `../`. Single-byte components separated by
+  // a path separator give the maximum possible component count for a given
+  // context length.
+  let context_component_upper_bound = context.len().saturating_add(1) / 2;
+  let absolute_segment_extra = context_component_upper_bound
+    .saturating_mul(3)
+    .saturating_add(2);
+  let result_capacity = absolute_segment_extra
+    .saturating_mul(absolute_segment_count)
+    .saturating_add(identifier.len());
+  let mut result = String::with_capacity(result_capacity);
 
-  for (index, byte) in identifier.bytes().enumerate() {
-    if matches!(byte, b'|' | b'!') {
-      push_absolute_to_request(context, &identifier[last..index], out);
-      out.push(byte as char);
-      last = index + 1;
+  for range in ranges {
+    let start = range.start as usize;
+    let end = range.end as usize;
+    push_absolute_to_request(context, &identifier[start..end], &mut result);
+    if end < identifier.len() {
+      result.push(identifier.as_bytes()[end] as char);
     }
   }
-
-  push_absolute_to_request(context, &identifier[last..], out);
-}
-
-pub fn make_paths_relative(context: &str, identifier: &str) -> String {
-  let mut result = String::with_capacity(
-    context
-      .len()
-      .saturating_add(identifier.len())
-      .saturating_add(2),
-  );
-  push_make_paths_relative(context, identifier, &mut result);
   result
 }
 

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -1,15 +1,12 @@
 use std::{
   borrow::Cow,
-  ops::Range,
   path::{Path, PathBuf},
   sync::LazyLock,
 };
 
 use concat_string::concat_string;
 use cow_utils::CowUtils;
-use memchr::memchr2_iter;
 use regex::Regex;
-use smallvec::SmallVec;
 use sugar_path::SugarPath;
 
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
@@ -169,36 +166,28 @@ fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String
 }
 
 pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
-  let identifier_len =
-    u32::try_from(identifier.len()).expect("identifier length should fit into u32");
-  let mut segment_ranges = SmallVec::<[Range<u32>; 4]>::new();
-  let mut result_capacity = identifier.len();
-  let relative_segment_extra = context.len().saturating_add(1);
+  let relative_segment_count = identifier
+    .split(['|', '!'])
+    .filter(|segment| segment.starts_with("./") || segment.starts_with("../"))
+    .count();
+  let mut result = String::with_capacity(
+    context
+      .len()
+      .saturating_add(1)
+      .saturating_mul(relative_segment_count)
+      .saturating_add(identifier.len()),
+  );
   let mut last = 0;
 
-  for index in memchr2_iter(b'|', b'!', identifier.as_bytes()) {
-    let segment = &identifier[last..index];
-    if segment.starts_with("./") || segment.starts_with("../") {
-      result_capacity = result_capacity.saturating_add(relative_segment_extra);
+  for (index, byte) in identifier.bytes().enumerate() {
+    if matches!(byte, b'|' | b'!') {
+      push_request_to_absolute(context, &identifier[last..index], &mut result);
+      result.push(byte as char);
+      last = index + 1;
     }
-    segment_ranges.push(last as u32..index as u32);
-    last = index + 1;
   }
-  let segment = &identifier[last..];
-  if segment.starts_with("./") || segment.starts_with("../") {
-    result_capacity = result_capacity.saturating_add(relative_segment_extra);
-  }
-  segment_ranges.push(last as u32..identifier_len);
 
-  let mut result = String::with_capacity(result_capacity);
-  for range in segment_ranges {
-    let start = range.start as usize;
-    let end = range.end as usize;
-    push_request_to_absolute(context, &identifier[start..end], &mut result);
-    if end < identifier.len() {
-      result.push(identifier.as_bytes()[end] as char);
-    }
-  }
+  push_request_to_absolute(context, &identifier[last..], &mut result);
   result
 }
 

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -9,8 +9,6 @@ use cow_utils::CowUtils;
 use regex::Regex;
 use sugar_path::SugarPath;
 
-static SEGMENTS_SPLIT_REGEXP: LazyLock<Regex> =
-  LazyLock::new(|| Regex::new(r"([|!])").expect("should be a valid regex"));
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
 
 /// # Example
@@ -41,7 +39,12 @@ pub fn absolute_to_request<'b>(context: &str, maybe_absolute_path: &'b str) -> C
     return Cow::Borrowed(maybe_absolute_path);
   }
 
-  let mut result = String::with_capacity(maybe_absolute_path.len());
+  let mut result = String::with_capacity(
+    context
+      .len()
+      .saturating_add(maybe_absolute_path.len())
+      .saturating_add(2),
+  );
   push_absolute_to_request(context, maybe_absolute_path, &mut result);
   Cow::Owned(result)
 }
@@ -138,7 +141,7 @@ pub fn push_absolute_to_request(context: &str, maybe_absolute_path: &str, out: &
   out.push_str(maybe_absolute_path);
 }
 
-fn request_to_absolute(context: &str, relative_path: &str) -> String {
+fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String) {
   if relative_path.starts_with("./") || relative_path.starts_with("../") {
     let relative_path = if relative_path.starts_with("./") {
       relative_path
@@ -147,20 +150,40 @@ fn request_to_absolute(context: &str, relative_path: &str) -> String {
     } else {
       relative_path
     };
-    Path::new(context)
-      .join(relative_path)
-      .to_string_lossy()
-      .to_string()
+
+    let mut absolute_path = PathBuf::with_capacity(
+      context
+        .len()
+        .saturating_add(relative_path.len())
+        .saturating_add(1),
+    );
+    absolute_path.push(context);
+    absolute_path.push(relative_path);
+    out.push_str(&absolute_path.to_string_lossy());
   } else {
-    PathBuf::from(relative_path).to_string_lossy().to_string()
+    out.push_str(relative_path);
   }
 }
 
 pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
-  split_keep(&SEGMENTS_SPLIT_REGEXP, identifier)
-    .into_iter()
-    .map(|str| request_to_absolute(context, str))
-    .collect()
+  let mut result = String::with_capacity(
+    context
+      .len()
+      .saturating_add(identifier.len())
+      .saturating_add(1),
+  );
+  let mut last = 0;
+
+  for (index, byte) in identifier.bytes().enumerate() {
+    if matches!(byte, b'|' | b'!') {
+      push_request_to_absolute(context, &identifier[last..index], &mut result);
+      result.push(byte as char);
+      last = index + 1;
+    }
+  }
+
+  push_request_to_absolute(context, &identifier[last..], &mut result);
+  result
 }
 
 fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
@@ -178,7 +201,12 @@ fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
 }
 
 pub fn make_paths_relative(context: &str, identifier: &str) -> String {
-  let mut result = String::with_capacity(identifier.len());
+  let mut result = String::with_capacity(
+    context
+      .len()
+      .saturating_add(identifier.len())
+      .saturating_add(2),
+  );
   push_make_paths_relative(context, identifier, &mut result);
   result
 }
@@ -189,22 +217,6 @@ pub fn strip_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
 
 pub fn insert_zero_width_space_for_fragment(s: &str) -> Cow<'_, str> {
   s.cow_replace("#", "\u{200b}#")
-}
-
-fn split_keep<'a>(r: &Regex, text: &'a str) -> Vec<&'a str> {
-  let mut result = Vec::new();
-  let mut last = 0;
-  for (index, matched) in text.match_indices(r) {
-    if last != index {
-      result.push(&text[last..index]);
-    }
-    result.push(matched);
-    last = index + matched.len();
-  }
-  if last < text.len() {
-    result.push(&text[last..]);
-  }
-  result
 }
 
 static REQUEST_TO_ID_REGEX1: LazyLock<Regex> =

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -166,16 +166,11 @@ fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String
 }
 
 pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
-  let relative_segment_count = identifier
-    .split(['|', '!'])
-    .filter(|segment| segment.starts_with("./") || segment.starts_with("../"))
-    .count();
   let mut result = String::with_capacity(
     context
       .len()
-      .saturating_add(1)
-      .saturating_mul(relative_segment_count)
-      .saturating_add(identifier.len()),
+      .saturating_add(identifier.len())
+      .saturating_add(1),
   );
   let mut last = 0;
 
@@ -206,20 +201,11 @@ fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
 }
 
 pub fn make_paths_relative(context: &str, identifier: &str) -> String {
-  let absolute_segment_count = identifier
-    .split(['|', '!'])
-    .filter(|segment| segment.starts_with('/') || is_windows_absolute_path(segment))
-    .count();
-  let context_component_count = context
-    .split(WINDOWS_PATH_SEPARATOR)
-    .filter(|component| !component.is_empty())
-    .count();
   let mut result = String::with_capacity(
-    context_component_count
-      .saturating_mul(3)
-      .saturating_add(2)
-      .saturating_mul(absolute_segment_count)
-      .saturating_add(identifier.len()),
+    context
+      .len()
+      .saturating_add(identifier.len())
+      .saturating_add(2),
   );
   push_make_paths_relative(context, identifier, &mut result);
   result

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -1,12 +1,15 @@
 use std::{
   borrow::Cow,
+  ops::Range,
   path::{Path, PathBuf},
   sync::LazyLock,
 };
 
 use concat_string::concat_string;
 use cow_utils::CowUtils;
+use memchr::memchr2_iter;
 use regex::Regex;
+use smallvec::SmallVec;
 use sugar_path::SugarPath;
 
 static WINDOWS_PATH_SEPARATOR: &[char] = &['/', '\\'];
@@ -166,28 +169,36 @@ fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String
 }
 
 pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
-  let relative_segment_count = identifier
-    .split(['|', '!'])
-    .filter(|segment| segment.starts_with("./") || segment.starts_with("../"))
-    .count();
-  let mut result = String::with_capacity(
-    context
-      .len()
-      .saturating_add(1)
-      .saturating_mul(relative_segment_count)
-      .saturating_add(identifier.len()),
-  );
+  let identifier_len =
+    u32::try_from(identifier.len()).expect("identifier length should fit into u32");
+  let mut segment_ranges = SmallVec::<[Range<u32>; 4]>::new();
+  let mut result_capacity = identifier.len();
+  let relative_segment_extra = context.len().saturating_add(1);
   let mut last = 0;
 
-  for (index, byte) in identifier.bytes().enumerate() {
-    if matches!(byte, b'|' | b'!') {
-      push_request_to_absolute(context, &identifier[last..index], &mut result);
-      result.push(byte as char);
-      last = index + 1;
+  for index in memchr2_iter(b'|', b'!', identifier.as_bytes()) {
+    let segment = &identifier[last..index];
+    if segment.starts_with("./") || segment.starts_with("../") {
+      result_capacity = result_capacity.saturating_add(relative_segment_extra);
+    }
+    segment_ranges.push(last as u32..index as u32);
+    last = index + 1;
+  }
+  let segment = &identifier[last..];
+  if segment.starts_with("./") || segment.starts_with("../") {
+    result_capacity = result_capacity.saturating_add(relative_segment_extra);
+  }
+  segment_ranges.push(last as u32..identifier_len);
+
+  let mut result = String::with_capacity(result_capacity);
+  for range in segment_ranges {
+    let start = range.start as usize;
+    let end = range.end as usize;
+    push_request_to_absolute(context, &identifier[start..end], &mut result);
+    if end < identifier.len() {
+      result.push(identifier.as_bytes()[end] as char);
     }
   }
-
-  push_request_to_absolute(context, &identifier[last..], &mut result);
   result
 }
 

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -166,11 +166,16 @@ fn push_request_to_absolute(context: &str, relative_path: &str, out: &mut String
 }
 
 pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
+  let relative_segment_count = identifier
+    .split(['|', '!'])
+    .filter(|segment| segment.starts_with("./") || segment.starts_with("../"))
+    .count();
   let mut result = String::with_capacity(
     context
       .len()
-      .saturating_add(identifier.len())
-      .saturating_add(1),
+      .saturating_add(1)
+      .saturating_mul(relative_segment_count)
+      .saturating_add(identifier.len()),
   );
   let mut last = 0;
 
@@ -201,11 +206,20 @@ fn push_make_paths_relative(context: &str, identifier: &str, out: &mut String) {
 }
 
 pub fn make_paths_relative(context: &str, identifier: &str) -> String {
+  let absolute_segment_count = identifier
+    .split(['|', '!'])
+    .filter(|segment| segment.starts_with('/') || is_windows_absolute_path(segment))
+    .count();
+  let context_component_count = context
+    .split(WINDOWS_PATH_SEPARATOR)
+    .filter(|component| !component.is_empty())
+    .count();
   let mut result = String::with_capacity(
-    context
-      .len()
-      .saturating_add(identifier.len())
-      .saturating_add(2),
+    context_component_count
+      .saturating_mul(3)
+      .saturating_add(2)
+      .saturating_mul(absolute_segment_count)
+      .saturating_add(identifier.len()),
   );
   push_make_paths_relative(context, identifier, &mut result);
   result

--- a/crates/rspack_util/src/identifier.rs
+++ b/crates/rspack_util/src/identifier.rs
@@ -211,22 +211,9 @@ pub fn make_paths_absolute(context: &str, identifier: &str) -> String {
 
 pub fn make_paths_relative(context: &str, identifier: &str) -> String {
   let ranges = identifier_segment_ranges(identifier);
-  let absolute_segment_count = ranges
-    .iter()
-    .filter(|range| {
-      let segment = &identifier[range.start as usize..range.end as usize];
-      segment.starts_with('/') || is_windows_absolute_path(segment)
-    })
-    .count();
-  // Each context component can add `../`. Single-byte components separated by
-  // a path separator give the maximum possible component count for a given
-  // context length.
-  let context_component_upper_bound = context.len().saturating_add(1) / 2;
-  let absolute_segment_extra = context_component_upper_bound
-    .saturating_mul(3)
-    .saturating_add(2);
-  let result_capacity = absolute_segment_extra
-    .saturating_mul(absolute_segment_count)
+  let segment_capacity = context.len().saturating_mul(2).saturating_add(2);
+  let result_capacity = segment_capacity
+    .saturating_mul(ranges.len())
     .saturating_add(identifier.len());
   let mut result = String::with_capacity(result_capacity);
 


### PR DESCRIPTION
## Summary

This PR preallocates the buffers used by identifier path conversion and removes intermediate per-segment allocations.

The primary goal is to reduce allocator-sensitive noise in CI CodSpeed results. These helpers run in frequently measured compilation paths, so an avoidable `String` or `PathBuf` reallocation can move an otherwise unrelated benchmark across CodSpeed's significance threshold.

## Why

Without sufficient capacity, path conversion can grow its output buffer while processing loader-style identifiers. That reallocation allocates a larger buffer, copies the existing contents, and frees the old allocation. The cost is small in isolation, but it adds allocator- and code-layout-sensitive variance to simulation benchmarks.

This branch encountered that kind of noise in practice. During development of [#15219](https://github.com/web-infra-dev/rspack/pull/15219), an earlier CodSpeed run reported unrelated regressions in `create_concatenate_module_bailouts` (-2.36%) and `create_module_hashes` (-2.2%); a later run reported all 50 benchmarks as unchanged. Removing known reallocations from shared identifier utilities makes results less sensitive to this noise and helps performance reports reflect the change under test.

The current CodSpeed report shows `create_module_ids` improving by 3.74%. Because CodSpeed also detected different runtime environments, this PR treats that number as directional evidence rather than its primary justification.

## What changed

- preallocate context-aware `String` buffers for absolute and relative identifier conversion
- preallocate the temporary `PathBuf` used to join relative requests
- scan `|` and `!` separators once with `memchr2_iter`
- store common segment ranges inline as compact `Range<u32>` values
- append converted segments directly into one output buffer
- remove the regex split vector and per-segment owned strings

For example, converting:

```text
./src/index.js!./loaders/a.js
```

previously created a segment vector and separate owned strings before collecting the final result. It now records the segment ranges once, computes the required capacity, and writes both converted paths directly into the preallocated output.

## Validation

- `pnpm run build:binding:dev`
- `cargo test -p rspack_util`
- `cargo clippy -p rspack_util --all-targets -- -D warnings`
- `cargo fmt --all -- --check`

## Related links

- [#15219](https://github.com/web-infra-dev/rspack/pull/15219) — example of unrelated CodSpeed fluctuations disappearing on a later run

## Checklist

- [x] Tests updated (not required; existing unit tests pass).
- [x] Documentation updated (not required; no API or behavior change).

---
_by OpenAI Codex_