### PR TITLE
perf(binding): exclude perfetto from release WASI builds

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -77,7 +77,7 @@ async function build() {
 		if (process.env.RSPACK_TARGET_BROWSER) {
 			features.push("browser")
 		}
-		if (values.profile !== "release") {
+		if (!["release", "release-wasi"].includes(values.profile)) {
 			features.push("perfetto");
 		}
 		if (values.profile === "release-debug") {


### PR DESCRIPTION
## Summary

`release-wasi` is a production profile, but it still enabled Perfetto after #13932 limited the exclusion to the exact `release` profile. This PR aligns release WASI with native release by omitting the `perfetto` feature; debug, profiling, CI, and development builds continue to include it.

Measured with identical `wasm32-wasip1-threads` release-WASI settings, changing only the feature. All sizes use decimal kb (`1 kb = 1,000 bytes`):

| Artifact | With Perfetto | Without Perfetto | Reduction |
| --- | ---: | ---: | ---: |
| Binding Wasm | 32,813.7 kb | 32,201.4 kb | 612.3 kb (1.9%) |
| Published Wasm after Binaryen 131 `wasm-opt -Oz` | 30,194.9 kb | 29,645.0 kb | 549.9 kb (1.8%) |
| Optimized Wasm, gzip -9 | 9,466.4 kb | 9,344.3 kb | 122.1 kb (1.3%) |
| External debug Wasm | 558,195.3 kb | 546,055.1 kb | 12,140.2 kb (2.2%) |

The generated declarations, 74 runtime JS exports, and Wasm import/export ABI are unchanged. Both variants passed `transformSync` and logger tracing smoke tests. Perfetto is not functional end-to-end on WASI today: wasm32 does not support `File::try_clone`, leaving its writer unset and causing `syncTraceEvent` to panic; without the feature, the existing explicit “Perfetto trace layer is not enabled” error is returned instead. Browser release behavior is also unchanged because global tracing is already a no-op under the `browser` feature.

## Related links

- https://github.com/web-infra-dev/rspack/pull/13932

## Checklist

- [x] Tests updated (not required; feature selection and dual release artifacts were validated).
- [x] Documentation updated (not required; the existing docs already describe Perfetto as debug-binding-only).