### PR TITLE
ci: add prebuilt Linux CI toolchain image

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -153,8 +153,12 @@ jobs:
               echo "> Not the default branch — the moving tags (\`latest\`, \`${{ steps.versions.outputs.rust_toolchain }}\` semantic) were withheld."
             fi
             echo
-            echo "Pin this digest in consumers:"
-            echo '```yaml'
-            echo "image: ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
-            echo '```'
+            if [[ -n "${{ steps.build.outputs.digest }}" ]]; then
+              echo "Pin this digest in consumers:"
+              echo '```yaml'
+              echo "image: ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
+              echo '```'
+            else
+              echo "_Build-only run — nothing was published, so there is no digest to pin._"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -19,12 +19,9 @@ on:
       - 'package.json'
       - '.github/workflows/ci-dylint.yaml'
       - '.github/workflows/build-ci-image.yml'
+  # Always publishes: the point of a manual run is to get an image you can pull
+  # and try. Off the default branch it only moves the immutable version tag.
   workflow_dispatch:
-    inputs:
-      push:
-        description: 'Push to ghcr.io (uncheck to only build)'
-        type: boolean
-        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -103,7 +100,7 @@ jobs:
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to ghcr.io
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -115,7 +112,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: docker/ci-linux
-          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -138,7 +135,7 @@ jobs:
             echo "| node | \`${{ steps.versions.outputs.node_version }}\` |"
             echo "| pnpm | \`${{ steps.versions.outputs.pnpm_version }}\` |"
             echo "| ref | \`$GITHUB_REF_NAME\` |"
-            echo "| pushed | \`${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}\` |"
+            echo "| pushed | \`${{ github.event_name != 'pull_request' }}\` |"
             echo
             echo "**Tags**"
             echo '```'

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -158,13 +158,14 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # TEMPORARY: the repo has never used a job-level `container:`, and the
-  # self-hosted runners start dockerd lazily (see .github/actions/docker/run).
-  # This proves whether migrating real jobs onto the image is even possible,
-  # using a public image so it does not depend on ci-linux being published.
+  # TEMPORARY: job-level `container:` needs a runner whose dockerd is already up.
+  # The standard labels start it lazily (see .github/actions/docker/run), so they
+  # fail with "Cannot connect to the Docker daemon" during Initialize containers.
+  # rspack-custom-container is the label provisioned for container jobs.
+  # Uses a public image so it does not depend on ci-linux being published yet.
   verify-container-support:
     name: Probe job-level container on self-hosted
-    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    runs-on: rspack-custom-container
     container:
       image: ubuntu:22.04
     steps:
@@ -173,6 +174,7 @@ jobs:
           cat /etc/os-release
           echo "whoami: $(id)"
           echo "pwd: $(pwd)"
+          nproc && free -g | head -2
           df -h /
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -155,26 +155,48 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-  # TEMPORARY: job-level `container:` needs a runner whose dockerd is already up.
-  # The standard labels start it lazily (see .github/actions/docker/run), so they
-  # fail with "Cannot connect to the Docker daemon" during Initialize containers.
-  # rspack-custom-container is the label provisioned for container jobs.
-  # Uses a public image so it does not depend on ci-linux being published yet.
-  verify-container-support:
-    name: Probe job-level container on self-hosted
+  # Proves the published image actually carries what CI expects, so a broken
+  # image is caught here rather than by every job that migrates onto it.
+  # Needs rspack-custom-container: the standard labels start dockerd lazily
+  # and fail with "Cannot connect to the Docker daemon" at Initialize containers.
+  smoke-test-image:
+    name: Smoke-test the ci-linux image
+    needs: [build]
+    if: github.event_name != 'pull_request'
     runs-on: rspack-custom-container
     container:
-      image: ubuntu:22.04
+      image: ghcr.io/web-infra-dev/rspack/ci-linux@sha256:34d893f475de0dcc91d81462f8a989bd36924d0b4ada82e513e1992f95baa197
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash # container jobs default to `sh`, and the checks below need bash
     steps:
-      - name: Inside the container
-        run: |
-          cat /etc/os-release
-          echo "whoami: $(id)"
-          echo "pwd: $(pwd)"
-          nproc && free -g | head -2
-          df -h /
-
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Checkout landed
-        run: ls -la Cargo.toml rust-toolchain.toml
+      - name: Rust toolchain matches rust-toolchain.toml
+        run: |
+          expected=$(sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)".*$/\1/p' rust-toolchain.toml)
+          echo "expected: $expected"
+          rustc -vV
+          rustup toolchain list
+          rustup toolchain list | grep -q "$expected" || { echo "::error::$expected missing"; exit 1; }
+
+      - name: Cargo tools present
+        run: |
+          for t in taplo cargo-deny cargo-shear cargo-workspaces cargo-codspeed cargo-zigbuild cargo-dylint dylint-link cargo-binstall; do
+            command -v "$t" >/dev/null || { echo "::error::$t missing"; exit 1; }
+            echo "ok: $t"
+          done
+
+      - name: Build tools present
+        run: |
+          node -v && pnpm -v
+          zig version && wasm-opt --version
+          clang --version | head -1
+          clang-15 --version | head -1
+          riscv64-linux-gnu-gcc --version | head -1
+
+      - name: Cross targets installed
+        run: rustup target list --installed

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -38,6 +38,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+      digest: ${{ steps.build.outputs.digest }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -165,7 +168,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: rspack-custom-container
     container:
-      image: ghcr.io/web-infra-dev/rspack/ci-linux@sha256:34d893f475de0dcc91d81462f8a989bd36924d0b4ada82e513e1992f95baa197
+      image: ${{ needs.build.outputs.image }}@${{ needs.build.outputs.digest }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -100,9 +100,6 @@ jobs:
             echo "release=$release"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Disk before # TEMPORARY
-        run: df -h / && docker system df
-
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Login to ghcr.io
@@ -122,17 +119,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          no-cache: true # TEMPORARY: force a cold build to prove the disk headroom
           provenance: false
           build-args: |
             RUST_TOOLCHAIN=${{ steps.versions.outputs.rust_toolchain }}
             DYLINT_TOOLCHAIN=${{ steps.versions.outputs.dylint_toolchain }}
             NODE_VERSION=${{ steps.versions.outputs.node_version }}
             PNPM_VERSION=${{ steps.versions.outputs.pnpm_version }}
-
-      - name: Disk after # TEMPORARY
-        if: always()
-        run: df -h / && docker system df && docker buildx du --verbose | tail -5
 
       - name: Summary
         run: |
@@ -165,3 +157,25 @@ jobs:
               echo "_Build-only run — nothing was published, so there is no digest to pin._"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # TEMPORARY: the repo has never used a job-level `container:`, and the
+  # self-hosted runners start dockerd lazily (see .github/actions/docker/run).
+  # This proves whether migrating real jobs onto the image is even possible,
+  # using a public image so it does not depend on ci-linux being published.
+  verify-container-support:
+    name: Probe job-level container on self-hosted
+    runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    container:
+      image: ubuntu:22.04
+    steps:
+      - name: Inside the container
+        run: |
+          cat /etc/os-release
+          echo "whoami: $(id)"
+          echo "pwd: $(pwd)"
+          df -h /
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Checkout landed
+        run: ls -la Cargo.toml rust-toolchain.toml

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -10,6 +10,15 @@ on:
       - 'package.json'
       - '.github/workflows/ci-dylint.yaml'
       - '.github/workflows/build-ci-image.yml'
+  # Build-only, so a change to the image is proven to compile before it lands.
+  pull_request:
+    paths:
+      - 'docker/ci-linux/**'
+      - 'rust-toolchain.toml'
+      - '.nvmrc'
+      - 'package.json'
+      - '.github/workflows/ci-dylint.yaml'
+      - '.github/workflows/build-ci-image.yml'
   workflow_dispatch:
     inputs:
       push:
@@ -98,9 +107,8 @@ jobs:
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
-      # `inputs.push` only exists on workflow_dispatch; a push event must always publish.
       - name: Login to ghcr.io
-        if: github.event_name != 'workflow_dispatch' || inputs.push
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
@@ -112,7 +120,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: docker/ci-linux
-          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -135,7 +143,7 @@ jobs:
             echo "| node | \`${{ steps.versions.outputs.node_version }}\` |"
             echo "| pnpm | \`${{ steps.versions.outputs.pnpm_version }}\` |"
             echo "| ref | \`$GITHUB_REF_NAME\` |"
-            echo "| pushed | \`${{ github.event_name != 'workflow_dispatch' || inputs.push }}\` |"
+            echo "| pushed | \`${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push) }}\` |"
             echo
             echo "**Tags**"
             echo '```'

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -1,0 +1,152 @@
+name: Build CI Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docker/ci-linux/**'
+      - 'rust-toolchain.toml'
+      - '.nvmrc'
+      - 'package.json'
+      - '.github/workflows/ci-dylint.yaml'
+      - '.github/workflows/build-ci-image.yml'
+  workflow_dispatch:
+    inputs:
+      push:
+        description: 'Push to ghcr.io (uncheck to only build)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}/ci-linux
+
+jobs:
+  build:
+    name: Build and push ci-linux image
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # Every version below has exactly one source of truth in the repo. Parsing
+      # them here keeps the image from drifting away from what CI actually uses.
+      - name: Resolve toolchain versions
+        id: versions
+        run: |
+          set -euo pipefail
+
+          # `|| true` keeps a no-match from tripping `set -e` before the check below reports which one failed.
+          rust_toolchain=$(sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)".*$/\1/p' rust-toolchain.toml)
+          dylint_toolchain=$(grep -oE 'rustup toolchain install (nightly-[0-9-]+)' .github/workflows/ci-dylint.yaml | awk '{print $4}' || true)
+          node_version=$(tr -d '[:space:]' < .nvmrc)
+          pnpm_version=$(node -p "require('./package.json').packageManager.split('@')[1]" || true)
+
+          for pair in "rust_toolchain:$rust_toolchain" "dylint_toolchain:$dylint_toolchain" \
+                      "node_version:$node_version" "pnpm_version:$pnpm_version"; do
+            [[ -n "${pair#*:}" ]] || { echo "::error::failed to resolve ${pair%%:*}"; exit 1; }
+          done
+
+          {
+            echo "rust_toolchain=$rust_toolchain"
+            echo "dylint_toolchain=$dylint_toolchain"
+            echo "node_version=$node_version"
+            echo "pnpm_version=$pnpm_version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build tag list
+        id: meta
+        run: |
+          set -euo pipefail
+
+          # ghcr rejects uppercase; forks can have a mixed-case owner.
+          image="${IMAGE,,}"
+
+          # Dated off the commit, not the clock, so re-running a run reproduces the same tag.
+          version="$(git show -s --format=%cd --date=format:%Y%m%d HEAD)-${GITHUB_SHA::7}"
+          semantic="rust-${{ steps.versions.outputs.rust_toolchain }}-node${{ steps.versions.outputs.node_version }}"
+
+          # The version tag is immutable, so it is safe from any ref. The moving
+          # tags are withheld off the default branch to protect existing consumers.
+          tags=("$image:$version")
+          if [[ "$GITHUB_REF_NAME" == "${{ github.event.repository.default_branch }}" ]]; then
+            tags+=("$image:latest" "$image:$semantic")
+            release=true
+          else
+            release=false
+          fi
+
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${tags[@]}"
+            echo "EOF"
+            echo "version=$version"
+            echo "image=$image"
+            echo "release=$release"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Free disk space
+        uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
+        with:
+          tool-cache: false
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      # `inputs.push` only exists on workflow_dispatch; a push event must always publish.
+      - name: Login to ghcr.io
+        if: github.event_name != 'workflow_dispatch' || inputs.push
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: docker/ci-linux
+          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          build-args: |
+            RUST_TOOLCHAIN=${{ steps.versions.outputs.rust_toolchain }}
+            DYLINT_TOOLCHAIN=${{ steps.versions.outputs.dylint_toolchain }}
+            NODE_VERSION=${{ steps.versions.outputs.node_version }}
+            PNPM_VERSION=${{ steps.versions.outputs.pnpm_version }}
+
+      - name: Summary
+        run: |
+          {
+            echo "### ci-linux \`${{ steps.meta.outputs.version }}\`"
+            echo
+            echo "| key | value |"
+            echo "| --- | --- |"
+            echo "| rust | \`${{ steps.versions.outputs.rust_toolchain }}\` |"
+            echo "| dylint rust | \`${{ steps.versions.outputs.dylint_toolchain }}\` |"
+            echo "| node | \`${{ steps.versions.outputs.node_version }}\` |"
+            echo "| pnpm | \`${{ steps.versions.outputs.pnpm_version }}\` |"
+            echo "| ref | \`$GITHUB_REF_NAME\` |"
+            echo "| pushed | \`${{ github.event_name != 'workflow_dispatch' || inputs.push }}\` |"
+            echo
+            echo "**Tags**"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            if [[ "${{ steps.meta.outputs.release }}" != "true" ]]; then
+              echo "> Not the default branch — the moving tags (\`latest\`, \`${{ steps.versions.outputs.rust_toolchain }}\` semantic) were withheld."
+            fi
+            echo
+            echo "Pin this digest in consumers:"
+            echo '```yaml'
+            echo "image: ${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -41,6 +41,9 @@ jobs:
     outputs:
       image: ${{ steps.meta.outputs.image }}
       digest: ${{ steps.build.outputs.digest }}
+      rust_toolchain: ${{ steps.versions.outputs.rust_toolchain }}
+      node_version: ${{ steps.versions.outputs.node_version }}
+      pnpm_version: ${{ steps.versions.outputs.pnpm_version }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
@@ -175,12 +178,13 @@ jobs:
     defaults:
       run:
         shell: bash # container jobs default to `sh`, and the checks below need bash
+    # Deliberately uses no actions: these runners get 429-rate-limited pulling
+    # from codeload.github.com, and every version it checks is already an output
+    # of the build job, so there is nothing to check out.
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
       - name: Rust toolchain matches rust-toolchain.toml
         run: |
-          expected=$(sed -n -E 's/^[ \t]*channel[ \t]*=[ \t]*"([^"]*)".*$/\1/p' rust-toolchain.toml)
+          expected='${{ needs.build.outputs.rust_toolchain }}'
           echo "expected: $expected"
           rustc -vV
           rustup toolchain list
@@ -195,6 +199,8 @@ jobs:
 
       - name: Build tools present
         run: |
+          node -v | grep -q "^v${{ needs.build.outputs.node_version }}\." || { echo "::error::node major mismatch"; exit 1; }
+          pnpm -v | grep -qx "${{ needs.build.outputs.pnpm_version }}" || { echo "::error::pnpm version mismatch"; exit 1; }
           node -v && pnpm -v
           zig version && wasm-opt --version
           clang --version | head -1

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -129,6 +129,12 @@ jobs:
             NODE_VERSION=${{ steps.versions.outputs.node_version }}
             PNPM_VERSION=${{ steps.versions.outputs.pnpm_version }}
 
+      - name: Image size
+        if: steps.build.outputs.digest != ''
+        run: |
+          docker buildx imagetools inspect "${{ steps.meta.outputs.image }}@${{ steps.build.outputs.digest }}" --raw \
+            | python3 -c "import json,sys; m=json.load(sys.stdin); L=m['layers']; t=sum(l['size'] for l in L); print(f'compressed {t/1024**3:.2f} GiB across {len(L)} layers'); print('largest (MiB):', ', '.join(f\"{l['size']/1024**2:.0f}\" for l in sorted(L,key=lambda x:-x['size'])[:6]))"
+
       - name: Summary
         run: |
           {

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -100,10 +100,8 @@ jobs:
             echo "release=$release"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Free disk space
-        uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
-        with:
-          tool-cache: false
+      - name: Disk before # TEMPORARY
+        run: df -h / && docker system df
 
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
@@ -124,12 +122,17 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          no-cache: true # TEMPORARY: force a cold build to prove the disk headroom
           provenance: false
           build-args: |
             RUST_TOOLCHAIN=${{ steps.versions.outputs.rust_toolchain }}
             DYLINT_TOOLCHAIN=${{ steps.versions.outputs.dylint_toolchain }}
             NODE_VERSION=${{ steps.versions.outputs.node_version }}
             PNPM_VERSION=${{ steps.versions.outputs.pnpm_version }}
+
+      - name: Disk after # TEMPORARY
+        if: always()
+        run: df -h / && docker system df && docker buildx du --verbose | tail -5
 
       - name: Summary
         run: |

--- a/.github/workflows/experiment-container-build.yml
+++ b/.github/workflows/experiment-container-build.yml
@@ -38,9 +38,11 @@ jobs:
         run: |
           echo "runner.environment = ${{ runner.environment }}"
           echo "runner.os          = ${{ runner.os }}"
-          nproc && free -g | head -2
-          which node pnpm cargo rustc sccache || true
-          rustc -vV | head -3
+          nproc
+          free -g || true
+          which node pnpm cargo rustc || true
+          command -v sccache || echo 'sccache: not in image (cargo cache step installs it)'
+          rustc -vV
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 

--- a/.github/workflows/experiment-container-build.yml
+++ b/.github/workflows/experiment-container-build.yml
@@ -1,0 +1,73 @@
+name: Experiment Container Build
+
+# TEMPORARY experiment: does building the linux binding inside ci-linux actually
+# save time, and does sccache still work in there? Mirrors the
+# x86_64-unknown-linux-gnu path of reusable-build-build.yml with the steps the
+# image makes redundant removed. Compare against "Build Linux" in the same run.
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'ci-linux image ref (tag or @sha256:...)'
+        required: true
+        default: 'ghcr.io/web-infra-dev/rspack/ci-linux:20260817-28d0f5c'
+
+env:
+  CARGO_INCREMENTAL: 0
+  MEASURE_CARGO_FRESH: '1'
+
+jobs:
+  build-in-container:
+    name: Build x86_64-unknown-linux-gnu in container
+    runs-on: rspack-custom-container
+    timeout-minutes: 60
+    container:
+      image: ${{ inputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash # container jobs default to `sh`
+    steps:
+      - name: Environment facts
+        run: |
+          echo "runner.environment = ${{ runner.environment }}"
+          echo "runner.os          = ${{ runner.os }}"
+          nproc && free -g | head -2
+          which node pnpm cargo rustc sccache || true
+          rustc -vV | head -3
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      # No Pnpm Setup: node and pnpm come from the image.
+      - name: Install Binding Dependencies
+        run: pnpm --filter @rspack/binding install --frozen-lockfile
+
+      # No rustup install / toolchain restore / target add: all in the image.
+      # Only the crate cache layer is kept, which is what actually matters.
+      - name: Cargo cache
+        uses: ./.github/actions/rustup/cargo
+        with:
+          key: x86_64-unknown-linux-gnu-ci
+          save-if: false
+
+      - name: Run Cargo codegen
+        run: cargo codegen
+
+      - name: Trim paths
+        run: |
+          echo $'\n' >> .cargo/config.toml
+          echo 'trim-paths = true' >> .cargo/config.toml
+
+      - name: Enable checksum-freshness
+        run: echo 'checksum-freshness = true' >> .cargo/config.toml
+
+      - name: Build x86_64-unknown-linux-gnu
+        run: RUST_TARGET=x86_64-unknown-linux-gnu USE_NAPI_CROSS=1 pnpm build:binding:ci
+        env:
+          TARGET_CC: clang
+
+      - name: sccache stats
+        if: always()
+        run: "${SCCACHE_PATH:-sccache} --show-stats || echo 'sccache unavailable'"

--- a/.github/workflows/experiment-container-build.yml
+++ b/.github/workflows/experiment-container-build.yml
@@ -5,6 +5,10 @@ name: Experiment Container Build
 # x86_64-unknown-linux-gnu path of reusable-build-build.yml with the steps the
 # image makes redundant removed. Compare against "Build Linux" in the same run.
 on:
+  # Self-limited paths: only runs when this experiment file itself changes.
+  pull_request:
+    paths:
+      - '.github/workflows/experiment-container-build.yml'
   workflow_dispatch:
     inputs:
       image:
@@ -22,7 +26,7 @@ jobs:
     runs-on: rspack-custom-container
     timeout-minutes: 60
     container:
-      image: ${{ inputs.image }}
+      image: ${{ inputs.image || 'ghcr.io/web-infra-dev/rspack/ci-linux:20260817-28d0f5c' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/ci-linux/Dockerfile
+++ b/docker/ci-linux/Dockerfile
@@ -1,0 +1,103 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:22.04
+
+LABEL org.opencontainers.image.source="https://github.com/web-infra-dev/rspack"
+LABEL org.opencontainers.image.description="Prebuilt toolchain for rspack Linux CI"
+LABEL org.opencontainers.image.licenses="MIT"
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# clang-15 is required for the powerpc64le / s390x targets: the default clang
+# lacks the PowerPC and SystemZ backends. Both are kept so TARGET_CC=clang and
+# TARGET_CC=clang-15 keep resolving exactly as they do on GitHub runners.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential \
+      ca-certificates \
+      clang \
+      clang-15 \
+      curl \
+      file \
+      gcc-riscv64-linux-gnu \
+      git \
+      libssl-dev \
+      pkg-config \
+      python3 \
+      unzip \
+      xz-utils \
+      zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------- Node / pnpm
+ARG NODE_VERSION=22
+ARG COREPACK_VERSION=0.31.0
+ARG PNPM_VERSION
+RUN : "${PNPM_VERSION:?required build-arg}" \
+    && node_full="$(curl -fsSL https://nodejs.org/dist/index.json \
+      | python3 -c "import json,sys;print(next(r['version'] for r in json.load(sys.stdin) if r['version'].startswith('v${NODE_VERSION}.')))")" \
+    && curl -fsSL "https://nodejs.org/dist/${node_full}/node-${node_full}-linux-x64.tar.xz" \
+      | tar -xJ -C /usr/local --strip-components=1 \
+        --exclude=CHANGELOG.md --exclude=LICENSE --exclude=README.md \
+    && npm install -g "corepack@${COREPACK_VERSION}" --force \
+    && corepack enable \
+    && corepack prepare "pnpm@${PNPM_VERSION}" --activate \
+    && node -v && pnpm -v
+
+# ------------------------------------------------------------------ Rust
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+ARG RUST_TOOLCHAIN
+ARG DYLINT_TOOLCHAIN
+RUN : "${RUST_TOOLCHAIN:?required build-arg}" "${DYLINT_TOOLCHAIN:?required build-arg}" \
+    && curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused -fsSL https://sh.rustup.rs \
+      | sh -s -- --default-toolchain none -y --no-modify-path \
+    && rustup toolchain install "${RUST_TOOLCHAIN}" \
+      -c rustc -c cargo -c rust-std -c clippy -c rustfmt -c rust-src \
+    && rustup default "${RUST_TOOLCHAIN}" \
+    && rustup toolchain install "${DYLINT_TOOLCHAIN}" \
+      -c rustc-dev -c llvm-tools-preview -c rust-src
+
+ARG RUST_TARGETS="x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu x86_64-unknown-linux-musl aarch64-unknown-linux-musl riscv64gc-unknown-linux-gnu riscv64gc-unknown-linux-musl powerpc64le-unknown-linux-gnu s390x-unknown-linux-gnu wasm32-wasip1-threads"
+RUN rustup target add --toolchain "${RUST_TOOLCHAIN}" ${RUST_TARGETS}
+
+# --------------------------------------------------------------- Cargo tools
+RUN curl -fsSL https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-musl.tgz \
+      | tar -xz -C "${CARGO_HOME}/bin"
+
+ARG CARGO_DENY_VERSION=0.18.3
+ARG CARGO_SHEAR_VERSION=1.11.2
+ARG CARGO_WORKSPACES_VERSION=0.4.0
+ARG CARGO_CODSPEED_VERSION=4.4.1
+RUN cargo binstall --no-confirm --no-track \
+      "cargo-deny@${CARGO_DENY_VERSION}" \
+      "cargo-shear@${CARGO_SHEAR_VERSION}" \
+      "cargo-workspaces@${CARGO_WORKSPACES_VERSION}" \
+      "cargo-codspeed@${CARGO_CODSPEED_VERSION}" \
+      cargo-zigbuild \
+      taplo-cli
+
+# dylint publishes no prebuilt binaries; this is the compile the image exists to amortize.
+RUN cargo install cargo-dylint dylint-link --locked
+
+# ------------------------------------------------------------- Zig / binaryen
+ARG ZIG_VERSION=0.14.1
+RUN curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt \
+    && ln -s "/opt/zig-x86_64-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig \
+    && zig version
+
+ARG BINARYEN_VERSION=131
+RUN curl -fsSL "https://github.com/WebAssembly/binaryen/releases/download/version_${BINARYEN_VERSION}/binaryen-version_${BINARYEN_VERSION}-x86_64-linux.tar.gz" \
+      | tar -xz -C /opt \
+    && ln -s "/opt/binaryen-version_${BINARYEN_VERSION}/bin/wasm-opt" /usr/local/bin/wasm-opt \
+    && wasm-opt --version
+
+# The crate registry is rebuilt per-job from the repo's Cargo.lock, so shipping
+# it here only inflates the image. chmod last: container jobs may run non-root.
+RUN rm -rf "${CARGO_HOME}/registry" "${CARGO_HOME}/git" \
+    && chmod -R a+w "${RUSTUP_HOME}" "${CARGO_HOME}"
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Why

Every Linux job reinstalls the same toolchain from scratch. Two of them compile
cargo subcommands from source on every single run:

| tool | today | where |
| --- | --- | --- |
| `taplo-cli` | `cargo install taplo-cli --locked` | `reusable-rust-test.yml` |
| `cargo-dylint` + `dylint-link` | `cargo install --locked` | `ci-dylint.yaml` |
| nightly + `rustc-dev` `llvm-tools-preview` | `rustup toolchain install` | `ci-dylint.yaml` |

None of it varies per PR, so it is pure repeated cost. The rest (Rust toolchain,
Node, pnpm, `cargo-deny`, `cargo-shear`, `cargo-workspaces`, `cargo-codspeed`,
`cargo-binstall`, `cargo-zigbuild`, zig, binaryen `wasm-opt`, `clang-15`,
`gcc-riscv64-linux-gnu`) is downloaded or apt-installed per job.

This PR bakes all of it into an image published to ghcr.io.

## What

- `docker/ci-linux/Dockerfile` — Ubuntu 22.04 base covering all Linux targets,
  including the cross-compile toolchains for ppc64le / s390x / riscv64 / musl / wasm.
- `.github/workflows/build-ci-image.yml` — builds and publishes on push to `main`
  when any input file changes, plus `workflow_dispatch` for manual/dry runs.

Every build-arg is parsed from its single source of truth, so changing
`rust-toolchain.toml`, `.nvmrc`, `package.json` (`packageManager`) or the dylint
toolchain in `ci-dylint.yaml` rebuilds the image automatically and the image
cannot drift from what CI installs.

Tags on `main`:

```
ghcr.io/web-infra-dev/rspack/ci-linux:20260812-cc5e5fb   # immutable, dated off the commit
ghcr.io/web-infra-dev/rspack/ci-linux:latest
ghcr.io/web-infra-dev/rspack/ci-linux:rust-nightly-2026-04-16-node22
```

Off the default branch only the immutable tag is published, so a manual run on a
branch cannot move `latest` under existing consumers.

## Notes

- No existing workflow is touched. Adopting the image (`container:` on the rust
  jobs, dropping the two `cargo install` steps) is a follow-up PR.
- `clang` and `clang-15` are both installed so `TARGET_CC=clang` and
  `TARGET_CC=clang-15` keep resolving to distinct binaries as they do today.
- The cargo registry is stripped from the image; crate deps still come from the
  existing cache layers.