### PR TITLE
perf(binding): align release WASI optimizations

### DIFF
--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -19,7 +19,7 @@ const CARGO_SAFELY_EXIT_CODE = 0;
 const watch = process.argv.includes("--watch");
 
 const measureFresh = process.env.MEASURE_CARGO_FRESH === "1" && !watch;
-const isReleaseProfile = ["release", "release-wasi"].includes(values.profile);
+const isReleaseProfile = values.profile === "release" || values.profile === "release-wasi";
 
 build().then((value) => {
 	// Regarding cargo's non-zero exit code as an error.

--- a/crates/node_binding/scripts/build.js
+++ b/crates/node_binding/scripts/build.js
@@ -19,6 +19,7 @@ const CARGO_SAFELY_EXIT_CODE = 0;
 const watch = process.argv.includes("--watch");
 
 const measureFresh = process.env.MEASURE_CARGO_FRESH === "1" && !watch;
+const isReleaseProfile = ["release", "release-wasi"].includes(values.profile);
 
 build().then((value) => {
 	// Regarding cargo's non-zero exit code as an error.
@@ -71,13 +72,13 @@ async function build() {
 			features.push("plugin");
 		}
 		// Internal test loaders should not ship in production artifacts.
-		if (!["release", "release-wasi"].includes(values.profile)) {
+		if (!isReleaseProfile) {
 			features.push("test-loader");
 		}
 		if (process.env.RSPACK_TARGET_BROWSER) {
 			features.push("browser")
 		}
-		if (!["release", "release-wasi"].includes(values.profile)) {
+		if (!isReleaseProfile) {
 			features.push("perfetto");
 		}
 		if (values.profile === "release-debug") {
@@ -95,7 +96,7 @@ async function build() {
 		if (process.env.TRACY) {
 			features.push("tracy-client");
 		}
-		if (values.profile === "release") {
+		if (isReleaseProfile) {
 			features.push("info-level");
 			rustflags.push("-Zlocation-detail=none");
 			if (process.env.RUST_TARGET && !process.env.RUST_TARGET.includes("windows-msvc")) {


### PR DESCRIPTION
## Summary

This PR aligns the `release-wasi` profile with the native `release` optimizations and centralizes the shared profile check in `isReleaseProfile`.

It enables `info-level`, removes source-location details, and disables unwind tables for non-MSVC release WASI builds. This does not change the public API or compilation output; release diagnostics intentionally omit DEBUG/TRACE logs and redact panic source locations.

Size was remeasured from the latest `main`, which includes #15221, with Binaryen 131 (`wasm-opt -Oz`). All sizes use decimal kb (`1 kb = 1,000 bytes`):

| Artifact | Before (kb) | After (kb) | Change |
| --- | ---: | ---: | ---: |
| Pre-`wasm-opt` Wasm | 32,202.0 | 31,689.2 | -512.8 (-1.6%) |
| `wasm-opt -Oz` Wasm | 29,645.7 | 29,111.8 | -533.9 (-1.8%) |
| gzip -9 | 9,344.3 | 9,163.8 | -180.5 (-1.9%) |

Both Node and browser release WASI builds completed successfully, followed by the CI-equivalent `wasm-opt -Oz` step.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15221

## Checklist

- [x] Tests updated (not required; this only changes release build configuration).
- [x] Documentation updated (not required).