### PR TITLE
perf(binding): optimize React Compiler crates for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,6 +300,48 @@ strip    = "none"
 
 [profile.release.package]
 
+# React Compiler is an opt-in transform, but these crates contribute significantly to the
+# release binding size. `s` reduces that footprint while avoiding the substantial transform
+# slowdown observed with `z`.
+[profile.release.package.forked_react_compiler]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_ast]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_diagnostics]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_hir]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_inference]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_lowering]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_optimization]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_reactive_scopes]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_ssa]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_typeinference]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_utils]
+opt-level = "s"
+
+[profile.release.package.forked_react_compiler_validation]
+opt-level = "s"
+
+[profile.release.package.swc_ecma_react_compiler]
+opt-level = "s"
+
 [profile.release.package.lightningcss]
 opt-level = "s"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,8 +301,8 @@ strip    = "none"
 [profile.release.package]
 
 # React Compiler is an opt-in transform, but these crates contribute significantly to the
-# release binding size. `s` reduces that footprint while avoiding the substantial transform
-# slowdown observed with `z`.
+# release binding size. Keep inference, lowering, and reactive scopes at the release default
+# (`3`) because they are performance-sensitive; use `s` for the remaining crates.
 [profile.release.package.forked_react_compiler]
 opt-level = "s"
 
@@ -315,16 +315,7 @@ opt-level = "s"
 [profile.release.package.forked_react_compiler_hir]
 opt-level = "s"
 
-[profile.release.package.forked_react_compiler_inference]
-opt-level = "s"
-
-[profile.release.package.forked_react_compiler_lowering]
-opt-level = "s"
-
 [profile.release.package.forked_react_compiler_optimization]
-opt-level = "s"
-
-[profile.release.package.forked_react_compiler_reactive_scopes]
 opt-level = "s"
 
 [profile.release.package.forked_react_compiler_ssa]


### PR DESCRIPTION
## Summary

- Compile 10 non-hot-path React Compiler crates with `opt-level = "s"` in the native release profile.
- Keep inference, lowering, and reactive scopes at the release default (`opt-level = 3`) because they are performance-sensitive.
- Keep `release-wasi` behavior unchanged because that profile already uses `opt-level = "s"`.

### Size

Measured from the macOS arm64 release binding.

| Artifact | Before | After | Change |
| --- | ---: | ---: | ---: |
| Raw binding | 42,156.4 kb | 41,826.5 kb | -329.9 kb |

### Performance

On Apple M3 Max, a production build containing 1,000 generated React components with React Compiler enabled took **50.2 ms longer on average (1.8% of the 2,754.1 ms baseline build time)**.

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).
