### PR TITLE
feat(loader): support opt-in per-loader caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ dependencies = [
  "rspack_collections",
  "rspack_error",
  "rspack_fs",
+ "rspack_hash",
  "rspack_paths",
  "rspack_sources",
  "rspack_util",

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -407,6 +407,11 @@ export declare class JsExportsInfo {
   getUsed(name: string | string[], runtime: string | string[] | undefined):  0 | 1 | 2 | 3 | 4
 }
 
+export declare class JsLoaderCache {
+  get(loaderIndex: number, content: string | Uint8Array): JsLoaderCacheEntry | null
+  store(loaderIndex: number, output: JsLoaderCacheEntry): void
+}
+
 export declare class JsModuleGraph {
   getModule(dependency: Dependency): Module | null
   getResolvedModule(dependency: Dependency): Module | null
@@ -950,6 +955,11 @@ export interface JsLinkPreloadData {
   chunk: Chunk
 }
 
+export interface JsLoaderCacheEntry {
+  content: null | string | Uint8Array
+  sourceMap?: Uint8Array
+}
+
 export interface JsLoaderContext {
   resource: string
   _module: Module
@@ -968,6 +978,7 @@ export interface JsLoaderContext {
   loaderIndex: number
   loaderState: Readonly<JsLoaderState>
   __internal__error?: RspackError
+  __internal__loaderCache?: JsLoaderCache | undefined
   /**
    * UTF-8 hint for `content`
    * - Some(true): `content` is a `UTF-8` encoded sequence
@@ -978,6 +989,7 @@ export interface JsLoaderContext {
 export interface JsLoaderItem {
   loader: string
   type: string
+  cache: boolean
   data: any
   normalExecuted: boolean
   pitchExecuted: boolean
@@ -2749,11 +2761,14 @@ export interface RawModuleRule {
 export interface RawModuleRuleUse {
   loader: string
   options?: string
+  cache: boolean
+  optionsCacheKey: string
 }
 
 export interface RawNewCache {
   codeGeneration: boolean
   devtool: boolean
+  loader: boolean
   minimize: boolean
 }
 

--- a/crates/rspack/tests/loader.rs
+++ b/crates/rspack/tests/loader.rs
@@ -28,6 +28,8 @@ async fn lightningcss() {
           options: Some(json!({
             "include": 1 // lower nesting syntax
           }).to_string()),
+          cache: false,
+          options_cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -79,6 +81,8 @@ async fn swc() {
               }
             }
           }).to_string()),
+          cache: false,
+          options_cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -114,7 +118,9 @@ async fn react_refresh() {
           r#use: ModuleRuleUse::Array(vec![
           ModuleRuleUseLoader {
             loader: "builtin:react-refresh-loader".to_string(),
-            options: None
+            options: None,
+            cache: false,
+            options_cache_key: String::new(),
           },
           ModuleRuleUseLoader {
           loader: "builtin:swc-loader".to_string(),
@@ -135,6 +141,8 @@ async fn react_refresh() {
               }
             }
           }).to_string()),
+          cache: false,
+          options_cache_key: String::new(),
         }]),
           ..Default::default()
         },
@@ -171,7 +179,9 @@ async fn preact_refresh() {
           r#use: ModuleRuleUse::Array(vec![
           ModuleRuleUseLoader {
             loader: "builtin:preact-refresh-loader".to_string(),
-            options: None
+            options: None,
+            cache: false,
+            options_cache_key: String::new(),
           },
           ModuleRuleUseLoader {
           loader: "builtin:swc-loader".to_string(),
@@ -192,6 +202,8 @@ async fn preact_refresh() {
               }
             }
           }).to_string()),
+          cache: false,
+          options_cache_key: String::new(),
         }]),
           ..Default::default()
         },

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1751,6 +1751,7 @@ CompilerOptions {
         new_cache: NewCacheOptions {
             code_generation: false,
             devtool: false,
+            loader: false,
             minimize: false,
         },
         defer_import: false,

--- a/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
@@ -1,0 +1,209 @@
+use std::sync::{Arc, Mutex};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use rspack_cacheable::cacheable;
+use rspack_core::{
+  CacheFacade, CacheValue, Content, Etag, Resolver, loader_cache_etag, loader_cache_item,
+};
+use rspack_error::Result;
+use rspack_hash::{HashFunction, RspackHasher};
+use rspack_loader_runner::LoaderRunnerOptions;
+use rspack_paths::Utf8Path;
+
+#[cacheable]
+#[derive(Clone)]
+struct LoaderCacheEntry {
+  content: Option<Vec<u8>>,
+  content_is_string: bool,
+  source_map: Option<Vec<u8>>,
+}
+
+#[napi(object)]
+pub struct JsLoaderCacheEntry {
+  pub content: Either3<Null, String, Uint8Array>,
+  pub source_map: Option<Uint8Array>,
+}
+
+#[napi]
+pub struct JsLoaderCache {
+  cache: CacheFacade,
+  module_identifier: String,
+  loaders: Vec<LoaderRunnerOptions>,
+  pending_etags: Arc<Mutex<Vec<Option<Etag>>>>,
+}
+
+pub struct JsLoaderCacheObject(JsLoaderCache);
+
+impl FromNapiValue for JsLoaderCacheObject {
+  unsafe fn from_napi_value(
+    env: napi::sys::napi_env,
+    napi_val: napi::sys::napi_value,
+  ) -> napi::Result<Self> {
+    let instance =
+      unsafe { <ClassInstance<JsLoaderCache> as FromNapiValue>::from_napi_value(env, napi_val)? };
+    Ok(Self(JsLoaderCache {
+      cache: instance.cache.clone(),
+      module_identifier: instance.module_identifier.clone(),
+      loaders: instance.loaders.clone(),
+      pending_etags: instance.pending_etags.clone(),
+    }))
+  }
+}
+
+impl ToNapiValue for JsLoaderCacheObject {
+  unsafe fn to_napi_value(
+    env: napi::sys::napi_env,
+    value: Self,
+  ) -> napi::Result<napi::sys::napi_value> {
+    unsafe { ToNapiValue::to_napi_value(env, value.0) }
+  }
+}
+
+impl TypeName for JsLoaderCacheObject {
+  fn type_name() -> &'static str {
+    "JsLoaderCache"
+  }
+
+  fn value_type() -> napi::ValueType {
+    napi::ValueType::Object
+  }
+}
+
+impl ValidateNapiValue for JsLoaderCacheObject {}
+
+impl JsLoaderCache {
+  fn new(cache: CacheFacade, module_identifier: String, loaders: Vec<LoaderRunnerOptions>) -> Self {
+    let pending_etags = Arc::new(Mutex::new(vec![None; loaders.len()]));
+    Self {
+      cache,
+      module_identifier,
+      loaders,
+      pending_etags,
+    }
+  }
+
+  fn loader(&self, loader_index: u32) -> napi::Result<&LoaderRunnerOptions> {
+    self
+      .loaders
+      .get(loader_index as usize)
+      .ok_or_else(|| napi::Error::from_reason(format!("Invalid loader index {loader_index}")))
+  }
+
+  fn set_pending_etag(&self, loader_index: u32, etag: Option<Etag>) -> napi::Result<()> {
+    let mut pending_etags = self
+      .pending_etags
+      .lock()
+      .map_err(|_| napi::Error::from_reason("Loader cache state is poisoned"))?;
+    let pending_etag = pending_etags
+      .get_mut(loader_index as usize)
+      .ok_or_else(|| napi::Error::from_reason(format!("Invalid loader index {loader_index}")))?;
+    *pending_etag = etag;
+    Ok(())
+  }
+
+  fn take_pending_etag(&self, loader_index: u32) -> napi::Result<Option<Etag>> {
+    let mut pending_etags = self
+      .pending_etags
+      .lock()
+      .map_err(|_| napi::Error::from_reason("Loader cache state is poisoned"))?;
+    Ok(
+      pending_etags
+        .get_mut(loader_index as usize)
+        .ok_or_else(|| napi::Error::from_reason(format!("Invalid loader index {loader_index}")))?
+        .take(),
+    )
+  }
+}
+
+impl JsLoaderCacheObject {
+  pub(super) fn new(
+    cache: CacheFacade,
+    module_identifier: String,
+    loaders: Vec<LoaderRunnerOptions>,
+  ) -> Self {
+    Self(JsLoaderCache::new(cache, module_identifier, loaders))
+  }
+}
+
+pub(crate) async fn loader_cache_version(
+  resolver: &Resolver,
+  path: &Utf8Path,
+) -> Result<Option<String>> {
+  // V1 fingerprints only the resolved loader entry file. Files that the
+  // loader imports or requires are intentionally not included yet.
+  let contents = resolver.inner_fs().read(path).await?;
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  hasher.write(&contents);
+  Ok(Some(format!("file:{:016x}", hasher.finish())))
+}
+
+#[napi]
+impl JsLoaderCache {
+  #[napi]
+  pub fn get(
+    &self,
+    loader_index: u32,
+    content: Either<String, Uint8Array>,
+  ) -> napi::Result<Option<JsLoaderCacheEntry>> {
+    let loader = self.loader(loader_index)?;
+    let content = match content {
+      Either::A(content) => content.into_bytes(),
+      Either::B(content) => content.to_vec(),
+    };
+    let etag = loader_cache_etag(
+      &Content::Buffer(content),
+      &loader.options_cache_key,
+      &loader.loader_version,
+    );
+    let item_cache = loader_cache_item(
+      &self.cache,
+      &self.module_identifier,
+      &loader.loader_name,
+      etag.clone(),
+    );
+    let Some(entry) = item_cache
+      .get::<LoaderCacheEntry>()
+      .map_err(|error| napi::Error::from_reason(error.to_string()))?
+    else {
+      self.set_pending_etag(loader_index, Some(etag))?;
+      return Ok(None);
+    };
+    self.set_pending_etag(loader_index, None)?;
+
+    Ok(Some(JsLoaderCacheEntry {
+      content: match (&entry.content, entry.content_is_string) {
+        (None, _) => Either3::A(Null),
+        (Some(content), true) => {
+          Either3::B(String::from_utf8(content.clone()).map_err(|error| {
+            napi::Error::from_reason(format!("Invalid UTF-8 in loader cache entry: {error}"))
+          })?)
+        }
+        (Some(content), false) => Either3::C(content.clone().into()),
+      },
+      source_map: entry.source_map.clone().map(Into::into),
+    }))
+  }
+
+  #[napi]
+  pub fn store(&self, loader_index: u32, output: JsLoaderCacheEntry) -> napi::Result<()> {
+    let loader_name = &self.loader(loader_index)?.loader_name;
+    let Some(etag) = self.take_pending_etag(loader_index)? else {
+      return Ok(());
+    };
+    let (content, content_is_string) = match output.content {
+      Either3::A(_) => (None, false),
+      Either3::B(content) => (Some(content.into_bytes()), true),
+      Either3::C(content) => (Some(content.to_vec()), false),
+    };
+    let entry = LoaderCacheEntry {
+      content,
+      content_is_string,
+      source_map: output.source_map.map(|source_map| source_map.to_vec()),
+    };
+    let item_cache = loader_cache_item(&self.cache, &self.module_identifier, loader_name, etag);
+    item_cache
+      .store(CacheValue::new(entry))
+      .map_err(|error| napi::Error::from_reason(error.to_string()))
+  }
+}

--- a/crates/rspack_binding_api/src/plugins/js_loader/context.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/context.rs
@@ -2,12 +2,14 @@ use std::{ptr::NonNull, sync::Arc};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
+use rspack_collections::Identifiable;
 use rspack_core::{LoaderContext, Module, RunnerContext};
 use rspack_error::ToStringResultToRspackResultExt;
 use rspack_loader_runner::State as LoaderState;
 use rspack_napi::threadsafe_js_value_ref::ThreadsafeJsValueRef;
 use rustc_hash::FxHashMap as HashMap;
 
+use super::cache::JsLoaderCacheObject;
 use crate::{error::RspackError, module::ModuleObject};
 
 #[napi(object)]
@@ -15,6 +17,7 @@ use crate::{error::RspackError, module::ModuleObject};
 pub struct JsLoaderItem {
   pub loader: String,
   pub r#type: String,
+  pub cache: bool,
 
   // data
   pub data: serde_json::Value,
@@ -31,6 +34,7 @@ impl From<&rspack_loader_runner::LoaderItem<RunnerContext>> for JsLoaderItem {
     JsLoaderItem {
       loader: value.request().to_string(),
       r#type: value.r#type().to_string(),
+      cache: value.cache(),
 
       data: value.data().clone(),
       normal_executed: value.normal_executed(),
@@ -53,6 +57,7 @@ where
         loader: ident.to_string(),
         data: serde_json::Value::Null,
         r#type: r#type.to_string(),
+        cache: false,
         pitch_executed: false,
         normal_executed: false,
         no_pitch: false,
@@ -62,6 +67,7 @@ where
       loader: identifier.to_string(),
       data: serde_json::Value::Null,
       r#type: String::default(),
+      cache: false,
       pitch_executed: false,
       normal_executed: false,
       no_pitch: false,
@@ -114,6 +120,11 @@ pub struct JsLoaderContext {
   pub loader_state: JsLoaderState,
   #[napi(js_name = "__internal__error")]
   pub error: Option<RspackError>,
+  #[napi(
+    js_name = "__internal__loaderCache",
+    ts_type = "JsLoaderCache | undefined"
+  )]
+  pub loader_cache: Option<JsLoaderCacheObject>,
 
   /// UTF-8 hint for `content`
   /// - Some(true): `content` is a `UTF-8` encoded sequence
@@ -178,6 +189,20 @@ impl TryFrom<&mut LoaderContext<RunnerContext>> for JsLoaderContext {
       loader_index: cx.loader_index,
       loader_state: cx.state().into(),
       error: None,
+      loader_cache: cx
+        .loader_items
+        .iter()
+        .any(|loader| loader.cache())
+        .then(|| {
+          JsLoaderCacheObject::new(
+            cx.context.loader_cache.clone(),
+            module.identifier().to_string(),
+            cx.loader_items
+              .iter()
+              .map(|loader| loader.cache_options().cloned().unwrap_or_default())
+              .collect(),
+          )
+        }),
       utf8_hint: None,
     })
   }

--- a/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/mod.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod context;
 mod resolver;
 mod scheduler;
@@ -9,6 +10,7 @@ use std::{
   sync::{Arc, Mutex},
 };
 
+pub use cache::{JsLoaderCache, JsLoaderCacheEntry};
 pub use context::{JsLoaderContext, JsLoaderItem};
 use napi::{
   bindgen_prelude::*,

--- a/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/resolver.rs
@@ -13,13 +13,14 @@ use rspack_error::Result;
 use rspack_hook::plugin_hook;
 use rspack_paths::Utf8Path;
 
-use super::{JsLoaderRspackPlugin, JsLoaderRspackPluginInner};
+use super::{JsLoaderRspackPlugin, JsLoaderRspackPluginInner, cache::loader_cache_version};
 
 #[cacheable]
 #[derive(Debug)]
 pub struct JsLoader(
   pub Identifier,
   /* LoaderType */ #[cacheable(with=AsOption<AsRefStr>)] pub Option<Cow<'static, str>>,
+  pub Option<String>,
 );
 
 #[cacheable_dyn]
@@ -30,6 +31,10 @@ impl Loader<RunnerContext> for JsLoader {
 
   fn r#type(&self) -> Option<&str> {
     self.1.as_deref()
+  }
+
+  fn cache_version(&self) -> Option<&str> {
+    self.2.as_deref()
   }
 }
 
@@ -69,7 +74,6 @@ pub(crate) async fn resolve_loader(
   } else {
     Utf8Path::new(loader_request)
   };
-
   #[cfg(feature = "test-loader")]
   if loader_request.starts_with("builtin:test") {
     return Ok(get_builtin_test_loader(loader_request));
@@ -96,6 +100,12 @@ pub(crate) async fn resolve_loader(
       // Use `str::ends_with` instead of `Path::extension` to avoid unnecessary allocation
       let path = path.as_str();
 
+      let cache_version = if l.cache {
+        loader_cache_version(resolver, Utf8Path::new(path)).await?
+      } else {
+        None
+      };
+
       let r#type = if path.ends_with(".mjs") {
         Some(Cow::Borrowed("module"))
       } else if path.ends_with(".cjs") {
@@ -116,7 +126,11 @@ pub(crate) async fn resolve_loader(
       } else {
         format!("{path}{query}")
       };
-      Ok(Some(Arc::new(JsLoader(resource.into(), r#type))))
+      Ok(Some(Arc::new(JsLoader(
+        resource.into(),
+        r#type,
+        cache_version,
+      ))))
     }
     ResolveResult::Ignored => Ok(None),
   }

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
@@ -6,6 +6,7 @@ use rspack_core::NewCacheOptions;
 pub struct RawNewCache {
   pub code_generation: bool,
   pub devtool: bool,
+  pub loader: bool,
   pub minimize: bool,
 }
 
@@ -14,6 +15,7 @@ impl From<RawNewCache> for NewCacheOptions {
     Self {
       code_generation: value.code_generation,
       devtool: value.devtool,
+      loader: value.loader,
       minimize: value.minimize,
     }
   }

--- a/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_module/mod.rs
@@ -49,6 +49,8 @@ use crate::{
 pub struct RawModuleRuleUse {
   pub loader: String,
   pub options: Option<String>,
+  pub cache: bool,
+  pub options_cache_key: String,
 }
 
 #[rspack_napi_macros::tagged_union]
@@ -1021,6 +1023,8 @@ impl TryFrom<RawModuleRule> for ModuleRule {
           .map(|rule_use| ModuleRuleUseLoader {
             loader: rule_use.loader,
             options: rule_use.options,
+            cache: rule_use.cache,
+            options_cache_key: rule_use.options_cache_key,
           })
           .collect::<Vec<_>>();
         Ok::<ModuleRuleUse, rspack_error::Error>(ModuleRuleUse::Array(uses))
@@ -1035,6 +1039,8 @@ impl TryFrom<RawModuleRule> for ModuleRule {
                 .map(|rule_use| ModuleRuleUseLoader {
                   loader: rule_use.loader,
                   options: rule_use.options,
+                  cache: rule_use.cache,
+                  options_cache_key: rule_use.options_cache_key,
                 })
                 .collect::<Vec<_>>()
             })

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -120,6 +120,7 @@ impl Task<TaskContext> for AddTask {
       module: self.module,
       resolver_factory: context.resolver_factory.clone(),
       compiler_options: context.compiler_options.clone(),
+      loader_cache: context.cache.facade("loader"),
       plugin_driver: context.plugin_driver.clone(),
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -7,9 +7,9 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CompilationId,
-  CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate, ResolverFactory,
-  SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheFacade,
+  CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
+  ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
   utils::{
     ResourceId,
@@ -24,6 +24,7 @@ pub struct BuildTask {
   pub module: BoxModule,
   pub resolver_factory: Arc<ResolverFactory>,
   pub compiler_options: Arc<CompilerOptions>,
+  pub loader_cache: CacheFacade,
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
@@ -40,6 +41,7 @@ impl Task<TaskContext> for BuildTask {
       compiler_id,
       compilation_id,
       compiler_options,
+      loader_cache,
       resolver_factory,
       plugin_driver,
       runtime_template,
@@ -60,6 +62,7 @@ impl Task<TaskContext> for BuildTask {
           compiler_id,
           compilation_id,
           compiler_options: compiler_options.clone(),
+          loader_cache,
           resolver_factory: resolver_factory.clone(),
           plugin_driver: plugin_driver.clone(),
           runtime_template,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -29,7 +29,7 @@ pub struct TaskContext {
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
-  cache: Cache,
+  pub(crate) cache: Cache,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -1,0 +1,159 @@
+use rspack_cacheable::cacheable;
+use rspack_collections::Identifiable;
+use rspack_error::Result;
+use rspack_hash::{HashFunction, RspackHasher};
+use rspack_loader_runner::{Content, LoaderContext};
+use rspack_sources::SourceMap;
+
+use crate::{CacheFacade, CacheValue, Etag, ItemCacheFacade, Module, RunnerContext};
+
+fn loader_cache_key(module_identifier: &str, loader_name: &str) -> String {
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  rspack_hash::rspack_hash_object!(&mut hasher, {
+    "module" => module_identifier,
+    "loader" => loader_name,
+  });
+  format!("{:016x}", hasher.finish())
+}
+
+#[doc(hidden)]
+pub fn loader_cache_etag(content: &Content, options_cache_key: &str, loader_version: &str) -> Etag {
+  let mut hasher = RspackHasher::new(&HashFunction::Xxhash64);
+  rspack_hash::rspack_hash_object!(&mut hasher, {
+    "content" => content,
+    "options" => options_cache_key,
+    "version" => loader_version,
+  });
+  Etag::from(format!("{:016x}", hasher.finish()))
+}
+
+#[doc(hidden)]
+pub fn loader_cache_item(
+  storage: &CacheFacade,
+  module_identifier: &str,
+  loader_name: &str,
+  etag: Etag,
+) -> ItemCacheFacade {
+  let key = loader_cache_key(module_identifier, loader_name);
+  storage.get_item_cache(&key, Some(etag))
+}
+
+#[cacheable]
+#[derive(Clone)]
+struct LoaderCacheEntry {
+  content: Option<Vec<u8>>,
+  content_is_string: bool,
+  source_map: Option<String>,
+}
+
+pub(crate) struct LoaderCacheMissState {
+  etag: Etag,
+  diagnostics_len: usize,
+}
+
+pub(crate) enum LoaderCacheAction {
+  Disabled,
+  Hit,
+  Miss(Box<LoaderCacheMissState>),
+}
+
+fn cache_miss_action(context: &LoaderContext<RunnerContext>, etag: Etag) -> LoaderCacheAction {
+  LoaderCacheAction::Miss(Box::new(LoaderCacheMissState {
+    etag,
+    diagnostics_len: context.diagnostics.len(),
+  }))
+}
+
+fn input_etag(context: &LoaderContext<RunnerContext>) -> Option<Etag> {
+  let loader = context.current_loader();
+  Some(loader_cache_etag(
+    context.content()?,
+    loader.options_cache_key(),
+    loader.loader_version(),
+  ))
+}
+
+pub(crate) fn before_normal_loader(
+  context: &mut LoaderContext<RunnerContext>,
+) -> Result<LoaderCacheAction> {
+  debug_assert!(context.current_loader().cache());
+  if !context.cacheable {
+    return Ok(LoaderCacheAction::Disabled);
+  }
+  // The minimal cache only supports loaders whose observable input is content and source map.
+  if context.additional_data().is_some()
+    || !context.parse_meta.is_empty()
+    || !context.context.module.build_info().assets.is_empty()
+    || !context.context.module.build_info().extras.is_empty()
+  {
+    return Ok(LoaderCacheAction::Disabled);
+  }
+  let Some(etag) = input_etag(context) else {
+    return Ok(LoaderCacheAction::Disabled);
+  };
+  let loader_name = context.current_loader().loader_name();
+  let module_identifier = context.context.module.identifier();
+  let item_cache = loader_cache_item(
+    &context.context.loader_cache,
+    module_identifier.as_str(),
+    loader_name,
+    etag.clone(),
+  );
+
+  if let Some(entry) = item_cache.get::<LoaderCacheEntry>()? {
+    let content = match (&entry.content, entry.content_is_string) {
+      (Some(content), true) => {
+        // SAFETY: String cache entries are written exclusively from `Content::String`.
+        let content = unsafe { String::from_utf8_unchecked(content.clone()) };
+        Some(Content::String(content))
+      }
+      (Some(content), false) => Some(Content::Buffer(content.clone())),
+      (None, _) => None,
+    };
+    let source_map = entry
+      .source_map
+      .clone()
+      .and_then(|source_map| SourceMap::from_json(source_map).ok());
+    context.__finish_with((content, source_map, None));
+    return Ok(LoaderCacheAction::Hit);
+  }
+
+  Ok(cache_miss_action(context, etag))
+}
+
+pub(crate) fn after_normal_loader(
+  context: &LoaderContext<RunnerContext>,
+  state: &LoaderCacheMissState,
+) -> Result<()> {
+  if !context.cacheable
+    || context.diagnostics.len() != state.diagnostics_len
+    || !context.context.module.build_info().assets.is_empty()
+    || !context.context.module.build_info().extras.is_empty()
+    || context.additional_data().is_some()
+    || !context.parse_meta.is_empty()
+  {
+    return Ok(());
+  }
+
+  // Dynamic loader dependencies are intentionally outside the minimal cache
+  // contract and are neither stored nor replayed on a cache hit.
+  let (content, content_is_string) = match context.content() {
+    Some(Content::String(content)) => (Some(content.as_bytes().to_vec()), true),
+    Some(Content::Buffer(content)) => (Some(content.clone()), false),
+    None => (None, false),
+  };
+  let entry = LoaderCacheEntry {
+    content,
+    content_is_string,
+    source_map: context.source_map().map(SourceMap::to_json),
+  };
+  let loader_name = context.current_loader().loader_name();
+  let module_identifier = context.context.module.identifier();
+  let item_cache = loader_cache_item(
+    &context.context.loader_cache,
+    module_identifier.as_str(),
+    loader_name,
+    state.etag.clone(),
+  );
+  item_cache.store(CacheValue::new(entry))
+}

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -22,7 +22,8 @@ pub fn loader_cache_etag(content: &Content, options_cache_key: &str, loader_vers
   rspack_hash::rspack_hash_object!(&mut hasher, {
     "content" => content,
     "options" => options_cache_key,
-    "version" => loader_version,
+    "loader_version" => loader_version,
+    "rspack_version" => rspack_workspace::rspack_pkg_version!(),
   });
   Etag::from(format!("{:016x}", hasher.finish()))
 }

--- a/crates/rspack_core/src/loader/loader_runner.rs
+++ b/crates/rspack_core/src/loader/loader_runner.rs
@@ -1,15 +1,18 @@
 use std::sync::Arc;
 
-pub use rspack_loader_runner::{Content, Loader, LoaderContext, run_loaders};
+pub use rspack_loader_runner::{Content, Loader, LoaderContext, LoaderRunnerOptions, run_loaders};
 use rspack_util::source_map::SourceMapKind;
 
-use crate::{CompilationId, CompilerId, CompilerOptions, NormalModule, ResolverFactory};
+use crate::{
+  CacheFacade, CompilationId, CompilerId, CompilerOptions, NormalModule, ResolverFactory,
+};
 
 #[derive(Debug)]
 pub struct RunnerContext {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub options: Arc<CompilerOptions>,
+  pub loader_cache: CacheFacade,
   pub resolver_factory: Arc<ResolverFactory>,
   pub module: Box<NormalModule>,
   pub source_map_kind: SourceMapKind,

--- a/crates/rspack_core/src/loader/mod.rs
+++ b/crates/rspack_core/src/loader/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod loader_cache;
+pub use loader_cache::{loader_cache_etag, loader_cache_item};
 mod loader_runner;
 pub use loader_runner::*;
 mod rspack_loader;

--- a/crates/rspack_core/src/loader/rspack_loader.rs
+++ b/crates/rspack_core/src/loader/rspack_loader.rs
@@ -2,11 +2,15 @@ use std::sync::Arc;
 
 use rspack_error::{Diagnostic, Result};
 use rspack_fs::ReadableFileSystem;
-use rspack_loader_runner::{Content, LoaderContext, LoaderRunnerPlugin, ResourceData};
+use rspack_loader_runner::{Content, Loader, LoaderContext, LoaderRunnerPlugin, ResourceData};
 use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
-use crate::{RunnerContext, SharedPluginDriver, utils::extract_source_map};
+use crate::{
+  RunnerContext, SharedPluginDriver,
+  loader::loader_cache::{LoaderCacheAction, after_normal_loader, before_normal_loader},
+  utils::extract_source_map,
+};
 
 pub struct RspackLoaderRunnerPlugin {
   pub plugin_driver: SharedPluginDriver,
@@ -120,5 +124,30 @@ impl LoaderRunnerPlugin for RspackLoaderRunnerPlugin {
       .loader_yield
       .call(context)
       .await
+  }
+
+  async fn run_normal_loader(
+    &self,
+    context: &mut LoaderContext<Self::Context>,
+    loader: Arc<dyn Loader<Self::Context>>,
+  ) -> Result<()> {
+    let cache_action = if context.current_loader().cache() {
+      before_normal_loader(context)?
+    } else {
+      LoaderCacheAction::Disabled
+    };
+    if matches!(cache_action, LoaderCacheAction::Hit) {
+      context.current_loader().set_finish_called();
+      return Ok(());
+    }
+
+    loader.run(context).await?;
+    if !context.current_loader().finish_called() {
+      context.finish_with_empty();
+    }
+    if let LoaderCacheAction::Miss(state) = cache_action {
+      after_normal_loader(context, &state)?;
+    }
+    Ok(())
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -29,7 +29,7 @@ use smol_str::SmolStr;
 use swc_core::atoms::Wtf8Atom;
 
 use crate::{
-  AsyncDependenciesBlock, BindingCell, BoxDependency, ChunkGraph, ChunkUkey,
+  AsyncDependenciesBlock, BindingCell, BoxDependency, CacheFacade, ChunkGraph, ChunkUkey,
   CodeGenerationResultBuilder, CollectedTypeScriptInfo, Compilation, CompilationAsset,
   CompilationId, CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
   ContextModule, CssExportType, DependenciesBlock, DependencyCodeGenerationRef, DependencyId,
@@ -45,6 +45,7 @@ pub struct BuildContext {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
   pub compiler_options: Arc<CompilerOptions>,
+  pub loader_cache: CacheFacade,
   pub resolver_factory: Arc<ResolverFactory>,
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -16,7 +16,9 @@ use rspack_error::{Diagnosable, Diagnostic, Result, error};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
-use rspack_loader_runner::{AdditionalData, Content, LoaderContext, ResourceData, run_loaders};
+use rspack_loader_runner::{
+  AdditionalData, Content, LoaderContext, LoaderRunnerOptions, ResourceData, run_loaders,
+};
 use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
@@ -119,6 +121,7 @@ pub struct NormalModule {
   /// Loaders for the module
   #[debug(skip)]
   loaders: Vec<BoxLoader>,
+  loader_options: Option<Vec<LoaderRunnerOptions>>,
 
   /// Built source of this module (passed with loaders)
   #[cacheable(with=AsOption<AsPreset>)]
@@ -187,6 +190,7 @@ impl NormalModule {
     resource_data: Arc<ResourceData>,
     resolve_options: Option<Arc<Resolve>>,
     loaders: Vec<BoxLoader>,
+    loader_options: Option<Vec<LoaderRunnerOptions>>,
     context: Option<Context>,
     extract_source_map: Option<bool>,
     import_phase: ImportPhase,
@@ -213,6 +217,7 @@ impl NormalModule {
       resource_data,
       resolve_options,
       loaders,
+      loader_options,
       source: None,
       debug_id: DEBUG_ID.fetch_add(1, Ordering::Relaxed),
       extract_source_map,
@@ -398,12 +403,14 @@ impl Module for NormalModule {
     let fs = build_context.fs.clone();
     let (mut loader_result, err) = run_loaders(
       self.loaders.clone(),
+      self.loader_options.clone(),
       self.resource_data.clone(),
       Some(plugin.clone()),
       RunnerContext {
         compiler_id,
         compilation_id,
         options: compiler_options,
+        loader_cache: build_context.loader_cache,
         resolver_factory,
         source_map_kind: self.source_map_kind,
         module: self,

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
-use rspack_loader_runner::{Loader, Scheme, get_scheme};
+use rspack_loader_runner::{Loader, LoaderRunnerOptions, Scheme, get_scheme};
 use rspack_paths::InternedPathSet;
 use rspack_util::{MergeFrom, fx_hash::FxDashMap};
 use sugar_path::SugarPath;
@@ -852,6 +852,8 @@ impl NormalModuleFactory {
                 .get(ident)
                 .map(|object| object.to_string())
             }),
+            cache: false,
+            options_cache_key: String::new(),
           }
         }));
         scheme = get_scheme(unresolved_resource);
@@ -998,7 +1000,7 @@ module.exports = "data:,";
       }
     };
 
-    let loaders: Vec<BoxLoader> = {
+    let resolved_loaders: Vec<ResolvedLoader> = {
       let mut pre_loaders: Vec<ModuleRuleUseLoader> = vec![];
       let mut post_loaders: Vec<ModuleRuleUseLoader> = vec![];
       let mut normal_loaders: Vec<ModuleRuleUseLoader> = vec![];
@@ -1048,41 +1050,70 @@ module.exports = "data:,";
       );
 
       for l in post_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        all_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options, &loader_resolver, &l).await?,
+        )
       }
 
       let mut resolved_normal_loaders = vec![];
       for l in normal_loaders {
-        resolved_normal_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        resolved_normal_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options, &loader_resolver, &l).await?,
+        )
       }
 
       if match_resource_data.is_some() {
         all_loaders.extend(resolved_normal_loaders);
-        all_loaders.extend(resolved_inline_loaders);
+        all_loaders.extend(
+          resolved_inline_loaders
+            .into_iter()
+            .map(ResolvedLoader::uncached),
+        );
       } else {
-        all_loaders.extend(resolved_inline_loaders);
+        all_loaders.extend(
+          resolved_inline_loaders
+            .into_iter()
+            .map(ResolvedLoader::uncached),
+        );
         all_loaders.extend(resolved_normal_loaders);
       }
 
       for l in pre_loaders {
-        all_loaders
-          .push(resolve_each(plugin_driver, &self.options.context, &loader_resolver, &l).await?)
+        all_loaders.push(
+          resolve_each_with_options(plugin_driver, &self.options, &loader_resolver, &l).await?,
+        )
       }
 
       all_loaders
     };
 
-    let request = if !loaders.is_empty() {
-      let s = loaders
+    let request = if !resolved_loaders.is_empty() {
+      let s = resolved_loaders
         .iter()
-        .map(|i| i.identifier().as_str())
+        .map(|i| i.loader.identifier().as_str())
         .collect::<Vec<_>>()
         .join("!");
       format!("{s}!{}", resource_data.resource())
     } else {
       resource_data.resource().to_owned()
+    };
+    let has_cached_loader = resolved_loaders
+      .iter()
+      .any(|resolved| resolved.options.cache);
+    let (loaders, loader_options) = if has_cached_loader {
+      let (loaders, loader_options) = resolved_loaders
+        .into_iter()
+        .map(|resolved| (resolved.loader, resolved.options))
+        .unzip();
+      (loaders, Some(loader_options))
+    } else {
+      (
+        resolved_loaders
+          .into_iter()
+          .map(|resolved| resolved.loader)
+          .collect(),
+        None,
+      )
     };
 
     let resolved_module_type = self.calculate_module_type(match_module_type, &matched_module_rules);
@@ -1165,6 +1196,7 @@ module.exports = "data:,";
         resource_resolve_data,
         resolved_resolve_options,
         loaders,
+        loader_options,
         create_data.context.clone().map(|x| x.into()),
         resolved_extract_source_map,
         dependency_phase,
@@ -1331,6 +1363,59 @@ async fn resolve_each(
     .call(context, loader_resolver, l)
     .await?
     .ok_or_else(|| error!("Unable to resolve loader {}", l.loader))
+}
+
+struct ResolvedLoader {
+  loader: BoxLoader,
+  options: LoaderRunnerOptions,
+}
+
+impl ResolvedLoader {
+  fn uncached(loader: BoxLoader) -> Self {
+    Self {
+      loader,
+      options: LoaderRunnerOptions::default(),
+    }
+  }
+}
+
+async fn resolve_each_with_options(
+  plugin_driver: &SharedPluginDriver,
+  options: &CompilerOptions,
+  loader_resolver: &Resolver,
+  loader: &ModuleRuleUseLoader,
+) -> Result<ResolvedLoader> {
+  let uncached_loader;
+  let loader = if options.experiments.new_cache.loader {
+    loader
+  } else {
+    uncached_loader = ModuleRuleUseLoader {
+      cache: false,
+      ..loader.clone()
+    };
+    &uncached_loader
+  };
+  let resolved = resolve_each(plugin_driver, &options.context, loader_resolver, loader).await?;
+  if !loader.cache {
+    return Ok(ResolvedLoader::uncached(resolved));
+  }
+  let loader_name = parse_resource(&loader.loader).map_or_else(
+    || loader.loader.clone(),
+    |resource| resource.path.to_string(),
+  );
+  let loader_version = resolved
+    .cache_version()
+    .unwrap_or(rspack_workspace::rspack_pkg_version!())
+    .to_owned();
+  Ok(ResolvedLoader {
+    loader: resolved,
+    options: LoaderRunnerOptions {
+      cache: true,
+      loader_name,
+      options_cache_key: loader.options_cache_key.clone(),
+      loader_version,
+    },
+  })
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -27,6 +27,7 @@ use runtime_mode::RuntimeMode;
 pub struct NewCacheOptions {
   pub code_generation: bool,
   pub devtool: bool,
+  pub loader: bool,
   pub minimize: bool,
 }
 
@@ -35,12 +36,13 @@ impl NewCacheOptions {
     Self {
       code_generation: true,
       devtool: true,
+      loader: true,
       minimize: true,
     }
   }
 
   pub const fn is_enabled(self) -> bool {
-    self.code_generation || self.devtool || self.minimize
+    self.code_generation || self.devtool || self.loader || self.minimize
   }
 }
 

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -1672,6 +1672,10 @@ pub struct ModuleRuleUseLoader {
   /// Loader options
   /// This only exists if the loader is a built-in loader.
   pub options: Option<String>,
+  /// Cache this loader.
+  pub cache: bool,
+  /// Stable serialization of the public loader options.
+  pub options_cache_key: String,
 }
 
 pub type FnUse =

--- a/crates/rspack_loader_runner/Cargo.toml
+++ b/crates/rspack_loader_runner/Cargo.toml
@@ -18,6 +18,7 @@ rspack_cacheable   = { workspace = true }
 rspack_collections = { workspace = true }
 rspack_error       = { workspace = true }
 rspack_fs          = { workspace = true }
+rspack_hash        = { workspace = true }
 rspack_paths       = { workspace = true }
 rspack_sources     = { workspace = true }
 rspack_util        = { workspace = true }

--- a/crates/rspack_loader_runner/src/cache.rs
+++ b/crates/rspack_loader_runner/src/cache.rs
@@ -1,0 +1,13 @@
+use rspack_cacheable::cacheable;
+
+#[cacheable]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LoaderRunnerOptions {
+  pub cache: bool,
+  /// Loader name used as part of the cache key.
+  pub loader_name: String,
+  /// Stable serialization of the loader options used as part of the etag.
+  pub options_cache_key: String,
+  /// Loader implementation version or file hash used as part of the etag.
+  pub loader_version: String,
+}

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -12,6 +12,7 @@ use rspack_cacheable::{
   with::{As, AsInner, AsOption, AsPreset},
 };
 use rspack_error::{Error, Result, ToStringResultToRspackResultExt};
+use rspack_hash::{RspackHash, RspackHasher};
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rustc_hash::FxHashMap;
 
@@ -21,6 +22,15 @@ use crate::{Scheme, get_scheme, parse_resource};
 pub enum Content {
   String(String),
   Buffer(Vec<u8>),
+}
+
+impl RspackHash for Content {
+  fn hash(&self, state: &mut RspackHasher) {
+    match self {
+      Self::String(content) => content.hash(state),
+      Self::Buffer(content) => state.write(content),
+    }
+  }
 }
 
 impl Content {

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(string_from_utf8_lossy_owned)]
 
+mod cache;
 mod content;
 mod context;
 mod loader;
@@ -16,3 +17,4 @@ pub use runner::{LoaderResult, run_loaders};
 pub use scheme::{Scheme, get_scheme};
 
 pub const BUILTIN_LOADER_PREFIX: &str = "builtin:";
+pub use cache::LoaderRunnerOptions;

--- a/crates/rspack_loader_runner/src/loader.rs
+++ b/crates/rspack_loader_runner/src/loader.rs
@@ -15,7 +15,7 @@ use rspack_error::Result;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 use rspack_util::identifier::strip_zero_width_space_for_fragment;
 
-use super::LoaderContext;
+use super::{LoaderContext, LoaderRunnerOptions};
 
 #[derive(Debug)]
 pub struct LoaderItem<Context: Send> {
@@ -38,6 +38,7 @@ pub struct LoaderItem<Context: Send> {
   /// Data shared between pitching and normal
   data: serde_json::Value,
   r#type: String,
+  cache_options: Option<Box<LoaderRunnerOptions>>,
   pitch_executed: AtomicBool,
   normal_executed: AtomicBool,
   /// Whether loader was called with [LoaderContext::finish_with].
@@ -73,6 +74,40 @@ impl<C: Send> LoaderItem<C> {
   #[inline]
   pub fn r#type(&self) -> &str {
     &self.r#type
+  }
+
+  #[inline]
+  pub fn cache(&self) -> bool {
+    self.cache_options.is_some()
+  }
+
+  #[inline]
+  pub fn loader_name(&self) -> &str {
+    self
+      .cache_options
+      .as_deref()
+      .map_or("", |options| &options.loader_name)
+  }
+
+  #[inline]
+  pub fn options_cache_key(&self) -> &str {
+    self
+      .cache_options
+      .as_deref()
+      .map_or("", |options| &options.options_cache_key)
+  }
+
+  #[inline]
+  pub fn loader_version(&self) -> &str {
+    self
+      .cache_options
+      .as_deref()
+      .map_or("", |options| &options.loader_version)
+  }
+
+  #[inline]
+  pub fn cache_options(&self) -> Option<&LoaderRunnerOptions> {
+    self.cache_options.as_deref()
   }
 
   #[inline]
@@ -196,10 +231,22 @@ where
   fn r#type(&self) -> Option<&str> {
     None
   }
+
+  /// Version identity used by loader caching.
+  fn cache_version(&self) -> Option<&str> {
+    None
+  }
 }
 
 impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
   fn from(loader: Arc<dyn Loader<C>>) -> Self {
+    Self::new(loader, LoaderRunnerOptions::default())
+  }
+}
+
+impl<C: Send> LoaderItem<C> {
+  pub(crate) fn new(loader: Arc<dyn Loader<C>>, options: LoaderRunnerOptions) -> Self {
+    let cache_options = options.cache.then(|| Box::new(options));
     let ident = &**loader.identifier();
     if let Some(r#type) = loader.r#type() {
       let ResourceParsedData {
@@ -216,6 +263,7 @@ impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
         fragment,
         data: serde_json::Value::Null,
         r#type: ty,
+        cache_options,
         pitch_executed: AtomicBool::new(false),
         normal_executed: AtomicBool::new(false),
         finish_called: AtomicBool::new(false),
@@ -235,6 +283,7 @@ impl<C: Send> From<Arc<dyn Loader<C>>> for LoaderItem<C> {
       fragment,
       data: serde_json::Value::Null,
       r#type: String::default(),
+      cache_options,
       pitch_executed: AtomicBool::new(false),
       normal_executed: AtomicBool::new(false),
       finish_called: AtomicBool::new(false),

--- a/crates/rspack_loader_runner/src/plugin.rs
+++ b/crates/rspack_loader_runner/src/plugin.rs
@@ -6,7 +6,7 @@ use rspack_sources::SourceMap;
 use rustc_hash::FxHashSet as HashSet;
 
 use crate::{
-  LoaderContext,
+  Loader, LoaderContext,
   content::{Content, ResourceData},
 };
 
@@ -27,6 +27,18 @@ pub trait LoaderRunnerPlugin: Send + Sync {
   }
 
   async fn start_yielding(&self, _context: &mut LoaderContext<Self::Context>) -> Result<()> {
+    Ok(())
+  }
+
+  async fn run_normal_loader(
+    &self,
+    context: &mut LoaderContext<Self::Context>,
+    loader: Arc<dyn Loader<Self::Context>>,
+  ) -> Result<()> {
+    loader.run(context).await?;
+    if !context.current_loader().finish_called() {
+      context.finish_with_empty();
+    }
     Ok(())
   }
 

--- a/crates/rspack_loader_runner/src/runner.rs
+++ b/crates/rspack_loader_runner/src/runner.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashSet as HashSet;
 use tracing::{Instrument, info_span};
 
 use crate::{
-  ParseMeta,
+  LoaderRunnerOptions, ParseMeta,
   content::{AdditionalData, Content, ResourceData},
   context::{LoaderContext, State},
   loader::{Loader, LoaderItem},
@@ -98,15 +98,26 @@ fn create_loader_context<Context: Send>(
 #[tracing::instrument("LoaderRunner:run_loaders", skip_all, level = "trace")]
 pub async fn run_loaders<Context: Send>(
   loaders: Vec<Arc<dyn Loader<Context>>>,
+  loader_options: Option<Vec<LoaderRunnerOptions>>,
   resource_data: Arc<ResourceData>,
   plugin: Option<Arc<dyn LoaderRunnerPlugin<Context = Context>>>,
   context: Context,
   fs: Arc<dyn ReadableFileSystem>,
 ) -> (LoaderResult<Context>, Option<Error>) {
-  let loaders = loaders
-    .into_iter()
-    .map(|i| i.into())
-    .collect::<Vec<LoaderItem<Context>>>();
+  let loaders = if let Some(loader_options) = loader_options {
+    assert_eq!(
+      loaders.len(),
+      loader_options.len(),
+      "loader options must stay aligned with loaders"
+    );
+    loaders
+      .into_iter()
+      .zip(loader_options)
+      .map(|(loader, options)| LoaderItem::new(loader, options))
+      .collect::<Vec<LoaderItem<Context>>>()
+  } else {
+    loaders.into_iter().map(LoaderItem::from).collect()
+  };
   let mut cx = create_loader_context(loaders, resource_data, plugin, context);
   let result = run_loaders_impl(&mut cx, fs).await;
   (LoaderResult::new(cx), result.err())
@@ -184,12 +195,19 @@ async fn run_loaders_impl<Context: Send>(
         let loader = cx.current_loader().loader().clone();
 
         let span = info_span!("run_loader:normal", resource);
-        loader.run(cx).instrument(span).await?;
-        if !cx.current_loader().finish_called() {
-          // If nothing is returned from this loader,
-          // we set everything to [None] and move to the next loader.
-          // This mocks the behavior of webpack loader-runner.
-          cx.finish_with_empty();
+        if let Some(plugin) = cx.plugin.clone() {
+          plugin
+            .run_normal_loader(cx, loader)
+            .instrument(span)
+            .await?;
+        } else {
+          loader.run(cx).instrument(span).await?;
+          if !cx.current_loader().finish_called() {
+            // If nothing is returned from this loader,
+            // we set everything to [None] and move to the next loader.
+            // This mocks the behavior of webpack loader-runner.
+            cx.finish_with_empty();
+          }
         }
       }
       State::Finished => break,
@@ -445,6 +463,7 @@ mod test {
     assert!(
       run_loaders(
         vec![p1, p2, c1, c2],
+        None,
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -465,6 +484,7 @@ mod test {
     assert!(
       run_loaders(
         vec![p1, p2, p3],
+        None,
         rs.clone(),
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -538,6 +558,7 @@ mod test {
     assert!(
       run_loaders(
         vec![Arc::new(Normal) as Arc<dyn Loader>, Arc::new(Normal2)],
+        None,
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),
@@ -595,6 +616,7 @@ mod test {
     assert!(
       run_loaders(
         vec![Arc::new(Normal2), Arc::new(Normal)],
+        None,
         rs,
         Some(Arc::new(TestContentPlugin)),
         (),

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1787,6 +1787,7 @@ async fn create_concatenated_module(
         resolver_factory: compilation.resolver_factory.clone(),
         plugin_driver: compilation.plugin_driver.clone(),
         compiler_options: compilation.options.clone(),
+        loader_cache: compilation.get_cache("loader"),
         fs: compilation.input_filesystem.clone(),
         runtime_template: compilation.runtime_template.create_module_code_template(),
       },

--- a/packages/rspack/src/browser/service.ts
+++ b/packages/rspack/src/browser/service.ts
@@ -17,6 +17,8 @@ export enum RequestType {
   SetCacheable = 'SetCacheable',
   ImportModule = 'ImportModule',
   UpdateLoaderObjects = 'UpdateLoaderObjects',
+  LoaderCacheGet = 'LoaderCacheGet',
+  LoaderCacheStore = 'LoaderCacheStore',
   CompilationGetPath = 'CompilationGetPath',
   CompilationGetPathWithInfo = 'CompilationGetPathWithInfo',
   CompilationGetAssetPath = 'CompilationGetAssetPath',

--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -535,9 +535,11 @@ function createRawModuleRuleUsesImpl(
 
   return uses.filter(Boolean).map((use, index) => {
     let o: string | undefined;
+    let fingerprintOptions = use.options;
     let isBuiltin = false;
     if (use.loader.startsWith(BUILTIN_LOADER_PREFIX)) {
       const temp = getBuiltinLoaderOptions(use.loader, use.options, options);
+      fingerprintOptions = temp;
       // keep json with indent so miette can show pretty error
       o = isNil(temp)
         ? undefined
@@ -555,6 +557,10 @@ function createRawModuleRuleUsesImpl(
         isBuiltin,
       ),
       options: o,
+      cache: use.cache ?? false,
+      optionsCacheKey: use.cache
+        ? (JSON.stringify(fingerprintOptions) ?? '')
+        : '',
     };
   });
 }

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -283,6 +283,7 @@ const applyExperimentsDefaults = (
   if (typeof experiments.newCache === 'object') {
     D(experiments.newCache, 'codeGeneration', true);
     D(experiments.newCache, 'devtool', true);
+    D(experiments.newCache, 'loader', true);
     D(experiments.newCache, 'minimize', true);
   }
   D(experiments, 'asyncWebAssembly', true);

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -891,6 +891,13 @@ export type RuleSetLoaderWithOptions = {
    */
   parallel?: boolean | { maxWorkers?: number };
 
+  /**
+   * Cache this loader in `experiments.newCache`.
+   * This is an experimental API and may change or be removed in the future.
+   * @experimental
+   */
+  cache?: boolean;
+
   options?: RuleSetLoaderOptions;
 };
 
@@ -3105,6 +3112,8 @@ export type NewCache = {
   codeGeneration?: boolean;
   /** Enable the devtool asset cache. @default true */
   devtool?: boolean;
+  /** Enable the per-loader cache. @default true */
+  loader?: boolean;
   /** Enable the asset minimization cache. @default true */
   minimize?: boolean;
 };

--- a/packages/rspack/src/loader-runner/cache.ts
+++ b/packages/rspack/src/loader-runner/cache.ts
@@ -1,0 +1,88 @@
+import type { JsLoaderContext } from '@rspack/binding';
+
+import { isNil } from '../util';
+
+type LoaderCacheContent = string | Uint8Array;
+
+export type LoaderCacheEntry = {
+  content: LoaderCacheContent | null;
+  sourceMap?: Uint8Array;
+};
+
+type LoaderCacheApi = {
+  get(
+    loaderIndex: number,
+    content: LoaderCacheContent,
+  ): LoaderCacheEntry | null;
+  store(loaderIndex: number, output: LoaderCacheEntry): void;
+};
+
+export class LoaderCache {
+  readonly #api: LoaderCacheApi;
+  readonly #context: JsLoaderContext;
+
+  constructor(context: JsLoaderContext) {
+    this.#context = context;
+    this.#api = (context as any).__internal__loaderCache as LoaderCacheApi;
+  }
+
+  get(
+    loaderIndex: number,
+    content: LoaderCacheContent | null | undefined,
+    additionalData: unknown,
+  ): LoaderCacheEntry | null | undefined {
+    const context = this.#context;
+    const loader = context.loaderItems[loaderIndex];
+    if (
+      !context.cacheable ||
+      !loader ||
+      isNil(content) ||
+      !isNil(additionalData) ||
+      Object.keys(context.__internal__parseMeta).length > 0
+    ) {
+      return undefined;
+    }
+
+    return this.#api.get(loaderIndex, content);
+  }
+
+  store(
+    loaderIndex: number,
+    content: LoaderCacheContent | null | undefined,
+    sourceMap: Uint8Array | undefined,
+    additionalData: unknown,
+  ) {
+    const context = this.#context;
+    if (
+      !context.cacheable ||
+      !isNil(additionalData) ||
+      Object.keys(context.__internal__parseMeta).length > 0
+    ) {
+      return;
+    }
+
+    this.#api.store(loaderIndex, {
+      content: isNil(content) ? null : content,
+      sourceMap,
+    });
+  }
+
+  workerGet(
+    loaderIndex: number,
+    content: LoaderCacheContent | null | undefined,
+    additionalData: unknown,
+  ) {
+    const hit = this.get(loaderIndex, content, additionalData);
+    if (!hit) return undefined;
+    return hit;
+  }
+
+  workerStore(
+    loaderIndex: number,
+    content: LoaderCacheContent | null | undefined,
+    sourceMap: Uint8Array | undefined,
+    additionalData: unknown,
+  ) {
+    this.store(loaderIndex, content, sourceMap, additionalData);
+  }
+}

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -969,6 +969,11 @@ export async function runLoaders(
   };
 
   const enableParallelism = (currentLoaderObject: any) => {
+    // A buffer backed by WASM linear memory retains the entire backing store
+    // after crossing the worker boundary, so a cached loader must stay on the
+    // main thread to avoid copying the whole WASM memory through N-API.
+    if (process.env.WASM && currentLoaderObject?.loaderItem.cache) return false;
+
     return currentLoaderObject?.parallel;
   };
 

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -54,6 +54,7 @@ import {
 } from '../util/identifier';
 import { memoize } from '../util/memoize';
 import { ModuleError, ModuleWarning } from './ModuleError';
+import { LoaderCache, type LoaderCacheEntry } from './cache';
 import * as pool from './service';
 import { type HandleIncomingRequest, RequestType } from './service';
 import {
@@ -190,7 +191,7 @@ export class LoaderObject {
 }
 
 class JsSourceMap {
-  static __from_binding(map?: Buffer) {
+  static __from_binding(map?: Uint8Array) {
     return isNil(map) ? undefined : toObject(map);
   }
 
@@ -267,6 +268,9 @@ export async function runLoaders(
   const contextDependencies = context.contextDependencies;
   const missingDependencies = context.missingDependencies;
   const buildDependencies = context.buildDependencies;
+  const loaderCache = context.__internal__loaderCache
+    ? new LoaderCache(context)
+    : undefined;
 
   /// Construct `loaderContext`
   const loaderContext = {} as LoaderContext;
@@ -920,6 +924,19 @@ export async function runLoaders(
             });
             break;
           }
+          case RequestType.LoaderCacheGet: {
+            const [loaderIndex, content, additionalData] = args;
+            return loaderCache?.workerGet(loaderIndex, content, additionalData);
+          }
+          case RequestType.LoaderCacheStore: {
+            const [loaderIndex, content, sourceMap, additionalData] = args;
+            return loaderCache?.workerStore(
+              loaderIndex,
+              content,
+              sourceMap,
+              additionalData,
+            );
+          }
           case RequestType.CompilationGetPath: {
             const filename = args[0];
             const data = args[1];
@@ -1051,7 +1068,8 @@ export async function runLoaders(
         break;
       }
       case JsLoaderState.Normal: {
-        let content = context.content;
+        let content: Parameters<typeof toBuffer>[0] | null | undefined =
+          context.content;
         const rawSourceMap = context.sourceMap;
         let sourceMap: string | object | undefined;
         let sourceMapParsed = false;
@@ -1064,6 +1082,23 @@ export async function runLoaders(
 
           if (currentLoaderObject.shouldYield()) break;
           if (currentLoaderObject.normalExecuted) {
+            loaderContext.loaderIndex--;
+            continue;
+          }
+
+          const cached: LoaderCacheEntry | null | undefined =
+            !parallelism && currentLoaderObject.loaderItem.cache && loaderCache
+              ? loaderCache.get(
+                  loaderContext.loaderIndex,
+                  content,
+                  additionalData,
+                )
+              : undefined;
+          if (cached) {
+            currentLoaderObject.normalExecuted = true;
+            content = cached.content;
+            sourceMap = JsSourceMap.__from_binding(cached.sourceMap);
+            sourceMapParsed = true;
             loaderContext.loaderIndex--;
             continue;
           }
@@ -1088,6 +1123,15 @@ export async function runLoaders(
             sourceMap,
             additionalData,
           ]);
+
+          if (cached === null) {
+            loaderCache?.store(
+              loaderContext.loaderIndex,
+              content,
+              JsSourceMap.__to_binding(sourceMap),
+              additionalData,
+            );
+          }
         }
 
         context.content = isNil(content) ? null : toBuffer(content);

--- a/packages/rspack/src/loader-runner/service.ts
+++ b/packages/rspack/src/loader-runner/service.ts
@@ -134,6 +134,8 @@ export enum RequestType {
   SetCacheable = 'SetCacheable',
   ImportModule = 'ImportModule',
   UpdateLoaderObjects = 'UpdateLoaderObjects',
+  LoaderCacheGet = 'LoaderCacheGet',
+  LoaderCacheStore = 'LoaderCacheStore',
   CompilationGetPath = 'CompilationGetPath',
   CompilationGetPathWithInfo = 'CompilationGetPathWithInfo',
   CompilationGetAssetPath = 'CompilationGetAssetPath',

--- a/packages/rspack/src/loader-runner/utils.ts
+++ b/packages/rspack/src/loader-runner/utils.ts
@@ -33,7 +33,11 @@ export function convertArgs(args: any[], raw: boolean) {
 
   // Ensure `Buffer` is used instead of `Uint8Array`
   if (raw && args[0] instanceof Uint8Array && !Buffer.isBuffer(args[0])) {
-    args[0] = Buffer.from(args[0].buffer);
+    args[0] = Buffer.from(
+      args[0].buffer,
+      args[0].byteOffset,
+      args[0].byteLength,
+    );
   }
 }
 

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -8,6 +8,7 @@ import type { LoaderContext } from '../config';
 import type { ResolveCallback } from '../config/adapterRuleUse';
 import type { ResolveRequest } from '../Resolver';
 import * as swc from '../swc';
+import { serializeObject, toObject } from '../util';
 import { cleverMerge } from '../util/cleverMerge';
 import { createHash } from '../util/createHash';
 import { absolutify, contextify } from '../util/identifier';
@@ -503,12 +504,43 @@ async function loaderImpl(
           continue;
         }
 
+        if (currentLoaderObject.loaderItem.cache) {
+          waitForPendingRequest(pendingDependencyRequest);
+          const hit = await sendRequest(
+            RequestType.LoaderCacheGet,
+            loaderContext.loaderIndex,
+            args[0],
+            args[2],
+          );
+          if (hit) {
+            currentLoaderObject.normalExecuted = true;
+            args = [
+              typeof hit.content === 'string'
+                ? hit.content
+                : hit.content && Buffer.from(hit.content),
+              hit.sourceMap ? toObject(Buffer.from(hit.sourceMap)) : undefined,
+              undefined,
+            ];
+            continue;
+          }
+        }
+
         await loadLoaderAsync(currentLoaderObject, loaderContext._compiler);
         const fn = currentLoaderObject.normal;
         currentLoaderObject.normalExecuted = true;
         if (!fn) continue;
         convertArgs(args, !!currentLoaderObject.raw);
         args = (await runSyncOrAsync(fn, loaderContext, args)) || [];
+        if (currentLoaderObject.loaderItem.cache) {
+          waitForPendingRequest(pendingDependencyRequest);
+          await sendRequest(
+            RequestType.LoaderCacheStore,
+            loaderContext.loaderIndex,
+            args[0],
+            serializeObject(args[1]),
+            args[2],
+          );
+        }
       }
     }
   }

--- a/packages/rspack/src/util/index.ts
+++ b/packages/rspack/src/util/index.ts
@@ -1,5 +1,7 @@
 import type { LoaderObject } from '../loader-runner';
 
+const decoder = new TextDecoder();
+
 export function isNil(value: unknown): value is null | undefined {
   return value === null || value === undefined;
 }
@@ -12,16 +14,20 @@ export const toBuffer = (bufLike: string | Buffer | Uint8Array): Buffer => {
     return Buffer.from(bufLike);
   }
   if (bufLike instanceof Uint8Array) {
-    return Buffer.from(bufLike.buffer);
+    return Buffer.from(bufLike.buffer, bufLike.byteOffset, bufLike.byteLength);
   }
 
   throw new Error('Buffer, Uint8Array or string expected');
 };
 
-export const toObject = (input: string | Buffer | object): object => {
+export const toObject = (
+  input: string | Buffer | Uint8Array | object,
+): object => {
   let s: string;
   if (Buffer.isBuffer(input)) {
     s = input.toString('utf8');
+  } else if (input instanceof Uint8Array) {
+    s = decoder.decode(input);
   } else if (input && typeof input === 'object') {
     return input;
   } else if (typeof input === 'string') {

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/bom.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/bom.js
@@ -1,0 +1,5 @@
+module.exports = {
+	hasBom: __HAS_BOM__,
+	producerRuns: __BOM_PRODUCER__,
+	consumerRuns: __BOM_CONSUMER__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/index.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/index.js
@@ -1,0 +1,27 @@
+const value = require("./value");
+const moduleA = require("./module-a");
+const moduleB = require("./module-b");
+const bom = require("./bom");
+
+// Cached loaders run initially, then run again when their input content
+// changes at steps 2 and 4.
+const CACHED_LOADER_RUNS_BY_STEP = [1, 1, 2, 2, 3];
+
+it("should cache each opted-in loader until its input changes", () => {
+	const step = +WATCH_STEP;
+	const cachedRuns = CACHED_LOADER_RUNS_BY_STEP[step];
+	expect(value).toEqual({
+		value: step < 2 ? "initial" : step < 4 ? "changed-2" : "changed-4",
+		leftRuns: step + 1,
+		markedRuns: cachedRuns,
+		rightRuns: cachedRuns,
+		sourceMap: true
+	});
+	expect(moduleA).toBe("module-a.js");
+	expect(moduleB).toBe("module-b.js");
+	expect(bom).toEqual({
+		hasBom: true,
+		producerRuns: 1,
+		consumerRuns: step + 1
+	});
+});

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/module-a.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/module-a.js
@@ -1,0 +1,1 @@
+module.exports = "__MODULE_ID__";

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/module-b.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/module-b.js
@@ -1,0 +1,1 @@
+module.exports = "__MODULE_ID__";

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/value.js
@@ -1,0 +1,7 @@
+module.exports = {
+	value: "initial",
+	leftRuns: __LEFT__,
+	markedRuns: __MARKED__,
+	rightRuns: __RIGHT__,
+	sourceMap: __SOURCE_MAP__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/1/module-a.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/1/module-a.js
@@ -1,0 +1,1 @@
+module.exports = "__MODULE_ID__";

--- a/tests/rspack-test/watchCases/loaders/loader-cache/1/module-b.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/1/module-b.js
@@ -1,0 +1,1 @@
+module.exports = "__MODULE_ID__";

--- a/tests/rspack-test/watchCases/loaders/loader-cache/1/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/1/value.js
@@ -1,0 +1,7 @@
+module.exports = {
+	value: "initial",
+	leftRuns: __LEFT__,
+	markedRuns: __MARKED__,
+	rightRuns: __RIGHT__,
+	sourceMap: __SOURCE_MAP__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/2/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/2/value.js
@@ -1,0 +1,7 @@
+module.exports = {
+	value: "changed-2",
+	leftRuns: __LEFT__,
+	markedRuns: __MARKED__,
+	rightRuns: __RIGHT__,
+	sourceMap: __SOURCE_MAP__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/3/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/3/value.js
@@ -1,0 +1,7 @@
+module.exports = {
+	value: "changed-2",
+	leftRuns: __LEFT__,
+	markedRuns: __MARKED__,
+	rightRuns: __RIGHT__,
+	sourceMap: __SOURCE_MAP__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/4/value.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/4/value.js
@@ -1,0 +1,7 @@
+module.exports = {
+	value: "changed-4",
+	leftRuns: __LEFT__,
+	markedRuns: __MARKED__,
+	rightRuns: __RIGHT__,
+	sourceMap: __SOURCE_MAP__
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/loader.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/loader.js
@@ -1,0 +1,49 @@
+const path = require("path");
+
+const loaderRuns = {
+	left: 0,
+	marked: 0,
+	right: 0,
+	"bom-consumer": 0,
+	"bom-producer": 0
+};
+
+module.exports = function (source, sourceMap) {
+	const { name } = this.getOptions();
+	if (name === "module-id") {
+		return source.replace("__MODULE_ID__", path.basename(this.resourcePath));
+	}
+	if (name === "bom-producer") {
+		loaderRuns[name]++;
+		return `\uFEFF${source.replace("__BOM_PRODUCER__", loaderRuns[name])}`;
+	}
+	if (name === "bom-consumer") {
+		loaderRuns[name]++;
+		this.addDependency(path.join(path.dirname(this.resourcePath), "value.js"));
+		return source
+			.replace("__HAS_BOM__", source.charCodeAt(0) === 0xfeff)
+			.replace("__BOM_CONSUMER__", loaderRuns[name]);
+	}
+	loaderRuns[name]++;
+	source = source.replace(`__${name.toUpperCase()}__`, loaderRuns[name]);
+
+	if (name === "right") {
+		this.callback(
+			null,
+			source,
+			{
+				version: 3,
+				sources: ["value.js"],
+				names: [],
+				mappings: ""
+			}
+		);
+		return;
+	}
+	if (name === "marked") {
+		this.callback(null, source, sourceMap);
+		return;
+	}
+
+	return source.replace("__SOURCE_MAP__", sourceMap?.version === 3);
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/marked-loader.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/marked-loader.js
@@ -1,0 +1,1 @@
+module.exports = require('./loader');

--- a/tests/rspack-test/watchCases/loaders/loader-cache/right-loader.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/right-loader.js
@@ -1,0 +1,1 @@
+module.exports = require('./loader');

--- a/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
@@ -1,0 +1,63 @@
+const path = require('path');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  cache: { type: 'memory' },
+  experiments: {
+    newCache: {
+      codeGeneration: false,
+      loader: true,
+      minimize: false,
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /value\.js$/,
+        use: [
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'left' },
+          },
+          {
+            loader: path.resolve(__dirname, 'marked-loader.js'),
+            options: { name: 'marked' },
+            parallel: { maxWorkers: 1 },
+            cache: true,
+          },
+          {
+            loader: path.resolve(__dirname, 'right-loader.js'),
+            options: { name: 'right' },
+            parallel: { maxWorkers: 1 },
+            cache: true,
+          },
+        ],
+      },
+      {
+        test: /bom\.js$/,
+        use: [
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'bom-consumer' },
+          },
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'bom-producer' },
+            cache: true,
+          },
+        ],
+      },
+      {
+        test: /module-[ab]\.js$/,
+        use: [
+          {
+            loader: path.resolve(__dirname, 'loader.js'),
+            options: { name: 'module-id' },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/test.filter.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/test.filter.js
@@ -1,0 +1,1 @@
+module.exports = () => !process.env.WASM;

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -754,7 +754,6 @@ type RuleSetLoaderWithOptions = {
   ident?: string;
   loader: string;
   options?: string | Record<string, any>;
-  cache?: boolean;
   parallel?: boolean | { maxWorkers?: number };
 };
 ```
@@ -838,61 +837,6 @@ export default {
   },
 };
 ```
-
-## rules[].use.cache
-
-<ApiMeta stability={Stability.Experimental} />
-
-- **Type:** `boolean`
-- **Default:** `false`
-
-Enables caching for an individual loader. This option only takes effect when `experiments.newCache.loader` is enabled.
-
-Rspack invalidates a loader cache entry when any of the following changes:
-
-- the input content passed to the loader;
-- the loader options after JSON serialization;
-- the loader implementation identity. Rspack hashes the resolved entry file for JavaScript loaders and uses the declared cache version for native loaders;
-- the Rspack version.
-
-On a cache hit, Rspack restores the transformed content and source map without executing the loader again.
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    newCache: {
-      loader: true,
-    },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        use: [
-          {
-            loader: './loaders/expensive-loader.js',
-            options: {
-              mode: 'transform',
-            },
-            cache: true,
-          },
-        ],
-      },
-    ],
-  },
-};
-```
-
-:::warning
-
-This experimental cache is intended for pure loaders whose observable result is limited to transformed content and an optional source map.
-
-- Dependencies added dynamically through the loader context are not included in cache validation and are not restored on a cache hit.
-- Transitive files imported by a JavaScript loader and its package metadata are not included in the loader implementation fingerprint.
-- Incoming source maps do not participate in cache validation. Only enable caching when the loader output does not depend on its input source map.
-- Results involving unsupported state such as `additionalData` or parse metadata are not cached. Loader side effects are not replayed on a cache hit.
-
-:::
 
 ## rules[].use.parallel
 

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -851,9 +851,9 @@ Enables caching for an individual loader. This option only takes effect when `ex
 Rspack invalidates a loader cache entry when any of the following changes:
 
 - the input content passed to the loader;
-- the input source map passed to the loader;
 - the loader options after JSON serialization;
-- the loader implementation version. For a JavaScript package loader, Rspack uses its package name and version. For a local JavaScript loader, Rspack hashes its resolved entry file.
+- the loader implementation identity. Rspack hashes the resolved entry file for JavaScript loaders and uses the declared cache version for native loaders;
+- the Rspack version.
 
 On a cache hit, Rspack restores the transformed content and source map without executing the loader again.
 
@@ -888,6 +888,8 @@ export default {
 This experimental cache is intended for pure loaders whose observable result is limited to transformed content and an optional source map.
 
 - Dependencies added dynamically through the loader context are not included in cache validation and are not restored on a cache hit.
+- Transitive files imported by a JavaScript loader and its package metadata are not included in the loader implementation fingerprint.
+- Incoming source maps do not participate in cache validation. Only enable caching when the loader output does not depend on its input source map.
 - Results involving unsupported state such as `additionalData` or parse metadata are not cached. Loader side effects are not replayed on a cache hit.
 
 :::

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -754,6 +754,7 @@ type RuleSetLoaderWithOptions = {
   ident?: string;
   loader: string;
   options?: string | Record<string, any>;
+  cache?: boolean;
   parallel?: boolean | { maxWorkers?: number };
 };
 ```
@@ -837,6 +838,59 @@ export default {
   },
 };
 ```
+
+## rules[].use.cache
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Enables caching for an individual loader. This option only takes effect when `experiments.newCache.loader` is enabled.
+
+Rspack invalidates a loader cache entry when any of the following changes:
+
+- the input content passed to the loader;
+- the input source map passed to the loader;
+- the loader options after JSON serialization;
+- the loader implementation version. For a JavaScript package loader, Rspack uses its package name and version. For a local JavaScript loader, Rspack hashes its resolved entry file.
+
+On a cache hit, Rspack restores the transformed content and source map without executing the loader again.
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    newCache: {
+      loader: true,
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: './loaders/expensive-loader.js',
+            options: {
+              mode: 'transform',
+            },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+:::warning
+
+This experimental cache is intended for pure loaders whose observable result is limited to transformed content and an optional source map.
+
+- Dependencies added dynamically through the loader context are not included in cache validation and are not restored on a cache hit.
+- Results involving unsupported state such as `additionalData` or parse metadata are not cached. Loader side effects are not replayed on a cache hit.
+
+:::
 
 ## rules[].use.parallel
 

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -849,9 +849,9 @@ export default {
 以下任一内容变化时，Rspack 会使对应的 loader 缓存失效：
 
 - 传给 loader 的输入内容；
-- 传给 loader 的输入 source map；
 - JSON 序列化后的 loader options；
-- loader 实现版本。对于 JavaScript 包形式的 loader，Rspack 使用其包名和版本；对于本地 JavaScript loader，Rspack 会计算解析后入口文件的哈希。
+- loader 实现标识。对于 JavaScript loader，Rspack 会计算解析后入口文件的哈希；对于 native loader，Rspack 使用其声明的缓存版本；
+- Rspack 版本。
 
 缓存命中时，Rspack 会直接恢复转换后的内容和 source map，不再执行 loader。
 
@@ -886,6 +886,8 @@ export default {
 该实验性缓存适用于可观测结果仅包含转换后内容和可选 source map 的纯 loader。
 
 - 通过 loader context 动态添加的依赖不会参与缓存校验，缓存命中时也不会恢复这些依赖。
+- JavaScript loader 间接导入的文件及其包元数据不会参与 loader 实现指纹的计算。
+- 输入 source map 不参与缓存校验。仅当 loader 输出不依赖输入 source map 时才应启用缓存。
 - 涉及 `additionalData`、parse metadata 等暂不支持状态的结果不会被缓存。缓存命中时也不会重放 loader 的副作用。
 
 :::

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -753,6 +753,7 @@ type RuleSetLoaderWithOptions = {
   ident?: string;
   loader: string;
   options?: string | Record<string, any>;
+  cache?: boolean;
   parallel?: boolean | { maxWorkers?: number };
 };
 ```
@@ -835,6 +836,59 @@ export default {
   },
 };
 ```
+
+## rules[].use.cache
+
+<ApiMeta stability={Stability.Experimental} />
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+为单个 loader 启用缓存。该选项仅在启用 `experiments.newCache.loader` 时生效。
+
+以下任一内容变化时，Rspack 会使对应的 loader 缓存失效：
+
+- 传给 loader 的输入内容；
+- 传给 loader 的输入 source map；
+- JSON 序列化后的 loader options；
+- loader 实现版本。对于 JavaScript 包形式的 loader，Rspack 使用其包名和版本；对于本地 JavaScript loader，Rspack 会计算解析后入口文件的哈希。
+
+缓存命中时，Rspack 会直接恢复转换后的内容和 source map，不再执行 loader。
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    newCache: {
+      loader: true,
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        use: [
+          {
+            loader: './loaders/expensive-loader.js',
+            options: {
+              mode: 'transform',
+            },
+            cache: true,
+          },
+        ],
+      },
+    ],
+  },
+};
+```
+
+:::warning
+
+该实验性缓存适用于可观测结果仅包含转换后内容和可选 source map 的纯 loader。
+
+- 通过 loader context 动态添加的依赖不会参与缓存校验，缓存命中时也不会恢复这些依赖。
+- 涉及 `additionalData`、parse metadata 等暂不支持状态的结果不会被缓存。缓存命中时也不会重放 loader 的副作用。
+
+:::
 
 ## rules[].use.parallel
 

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -753,7 +753,6 @@ type RuleSetLoaderWithOptions = {
   ident?: string;
   loader: string;
   options?: string | Record<string, any>;
-  cache?: boolean;
   parallel?: boolean | { maxWorkers?: number };
 };
 ```
@@ -836,61 +835,6 @@ export default {
   },
 };
 ```
-
-## rules[].use.cache
-
-<ApiMeta stability={Stability.Experimental} />
-
-- **类型：** `boolean`
-- **默认值：** `false`
-
-为单个 loader 启用缓存。该选项仅在启用 `experiments.newCache.loader` 时生效。
-
-以下任一内容变化时，Rspack 会使对应的 loader 缓存失效：
-
-- 传给 loader 的输入内容；
-- JSON 序列化后的 loader options；
-- loader 实现标识。对于 JavaScript loader，Rspack 会计算解析后入口文件的哈希；对于 native loader，Rspack 使用其声明的缓存版本；
-- Rspack 版本。
-
-缓存命中时，Rspack 会直接恢复转换后的内容和 source map，不再执行 loader。
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    newCache: {
-      loader: true,
-    },
-  },
-  module: {
-    rules: [
-      {
-        test: /\.js$/,
-        use: [
-          {
-            loader: './loaders/expensive-loader.js',
-            options: {
-              mode: 'transform',
-            },
-            cache: true,
-          },
-        ],
-      },
-    ],
-  },
-};
-```
-
-:::warning
-
-该实验性缓存适用于可观测结果仅包含转换后内容和可选 source map 的纯 loader。
-
-- 通过 loader context 动态添加的依赖不会参与缓存校验，缓存命中时也不会恢复这些依赖。
-- JavaScript loader 间接导入的文件及其包元数据不会参与 loader 实现指纹的计算。
-- 输入 source map 不参与缓存校验。仅当 loader 输出不依赖输入 source map 时才应启用缓存。
-- 涉及 `additionalData`、parse metadata 等暂不支持状态的结果不会被缓存。缓存命中时也不会重放 loader 的副作用。
-
-:::
 
 ## rules[].use.parallel
 

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -342,6 +342,8 @@ fn configure_swc_loader(builder: &mut CompilerBuilder) {
             })
             .to_string(),
           ),
+          cache: false,
+          options_cache_key: String::new(),
         }]),
         ..Default::default()
       },

--- a/xtask/benchmark/benches/groups/bundle/util.rs
+++ b/xtask/benchmark/benches/groups/bundle/util.rs
@@ -77,6 +77,8 @@ pub fn basic_compiler_builder(options: BuilderOptions) -> CompilerBuilder {
               })
               .to_string(),
             ),
+            cache: false,
+            options_cache_key: String::new(),
           }]),
           ..Default::default()
         },


### PR DESCRIPTION
## Summary

- add opt-in per-loader caching for native and JavaScript loaders when `experiments.newCache` is enabled
- store loader entries in the `loader` namespace of the compiler's existing new-cache storage, so memory and persistent behavior remain owned by the storage layer
- derive the cache key from the module identifier and loader name, and derive the etag from the input content, JSON-serialized loader options, and loader version
- preserve transformed content and source maps on cache hits, including JavaScript loaders running in workers
- keep the default `cache: false` path lightweight by skipping cache identity/version work, cache option propagation, cache object creation, and cache lookup

A loader can opt in with:

```js
module.exports = {
  experiments: {
    newCache: {
      loader: true,
    },
  },
  module: {
    rules: [
      {
        test: /\.js$/,
        use: [
          {
            loader: require.resolve("./expensive-loader"),
            options: { mode: "transform" },
            cache: true,
          },
        ],
      },
    ],
  },
};
```

For example, during watch mode, if an upstream loader produces the same code for a module, an opted-in expensive loader can reuse its previous transformed content and source map. Changing the input code, loader options, or loader implementation version invalidates that entry.

This is intentionally a minimal implementation. Loader-context dependencies added dynamically by a loader are not part of the cache identity and are not replayed. Entries involving unsupported observable state such as `additionalData`, parse metadata, diagnostics, emitted assets, or module extras are not stored.

## Performance
Benchmark runs in a simulated 10000 modules [code base](https://github.com/hardfist/mock-oai), with slow babel loaders, including server bundle and client bundle.
Runs on M5Pro with 48G memory. `mode = development`

| Variant | Profile | Median Cold (s)  | Median Warm (s) |
| --- | --- | ---: | ---: |
| disabled | `parallel = false` | 53.59 | 56.99 |
| disabled | `parallel = true` | 28.96 | 30 |
| babel enabled | `parallel = false` | 59.71 | 17.07 |
| swc enabled | `parallel = false` | 59.41 | 56.91 |
| babel + swc enabled | `parallel = false` | 61.35 | 17.80 |
| babel enabled | `parallel = true` | 32.62 | 24.48 |


## Related links

- CodSpeed identified `rust@build_swc-loader` as the main `cache: false` regression, which motivated the disabled-cache fast paths.

## Checklist

- [x] Tests updated.
- [x] Documentation not required beyond the experimental configuration type documentation.

## Validation

- `pnpm run build:cli:dev`
- `cargo check -p rspack_binding_api -p rspack_core -p rspack_loader_runner`
- `cargo test -p rspack_loader_runner`
- focused `watchCases/loaders/loader-cache` test
- Rust formatting/clippy and JavaScript lint/format

---
_by OpenAI Codex_