### PR TITLE
fix(cache): validate new cache version

### DIFF
--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -14,7 +14,7 @@ pub struct Database {
 }
 
 impl Database {
-  pub fn open(_base_path: Utf8PathBuf, _path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
+  pub fn open(_path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
     Ok(Self::default())
   }
 

--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -14,7 +14,7 @@ pub struct Database {
 }
 
 impl Database {
-  pub fn open(_path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
+  pub fn open(_base_path: Utf8PathBuf, _path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
     Ok(Self::default())
   }
 

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -11,7 +11,7 @@ pub use turbo::{Database, DatabaseValue};
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseFamily {
   Cache,
-  Snapshot,
+  Meta,
 }
 
 impl DatabaseFamily {
@@ -20,7 +20,7 @@ impl DatabaseFamily {
   pub const fn index(self) -> usize {
     match self {
       Self::Cache => 0,
-      Self::Snapshot => 1,
+      Self::Meta => 1,
     }
   }
 }

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -11,7 +11,7 @@ pub use turbo::Database;
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseFamily {
   Cache,
-  Meta,
+  Validator,
 }
 
 impl DatabaseFamily {
@@ -20,7 +20,7 @@ impl DatabaseFamily {
   pub const fn index(self) -> usize {
     match self {
       Self::Cache => 0,
-      Self::Meta => 1,
+      Self::Validator => 1,
     }
   }
 }

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -4,9 +4,9 @@ mod memory;
 mod turbo;
 
 #[cfg(target_family = "wasm")]
-pub use memory::Database;
+pub use memory::{Database, DatabaseValue};
 #[cfg(not(target_family = "wasm"))]
-pub use turbo::Database;
+pub use turbo::{Database, DatabaseValue};
 
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseFamily {

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -4,9 +4,9 @@ mod memory;
 mod turbo;
 
 #[cfg(target_family = "wasm")]
-pub use memory::{Database, DatabaseValue};
+pub use memory::Database;
 #[cfg(not(target_family = "wasm"))]
-pub use turbo::{Database, DatabaseValue};
+pub use turbo::Database;
 
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseFamily {

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -194,7 +194,7 @@ fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
         kind: FamilyKind::SingleValue,
       },
       FamilyConfig {
-        name: "meta",
+        name: "validator",
         kind: FamilyKind::SingleValue,
       },
     ],

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -194,7 +194,7 @@ fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
         kind: FamilyKind::SingleValue,
       },
       FamilyConfig {
-        name: "snapshot",
+        name: "meta",
         kind: FamilyKind::SingleValue,
       },
     ],

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -33,6 +33,7 @@ pub type DatabaseValue = turbo_persistence::ArcBytes;
 
 pub struct Database {
   inner: Inner,
+  base_path: Utf8PathBuf,
   path: Utf8PathBuf,
   readonly: bool,
 }
@@ -48,10 +49,11 @@ impl fmt::Debug for Database {
 }
 
 impl Database {
-  pub fn open(path: Utf8PathBuf, readonly: bool) -> Result<Self> {
+  pub fn open(base_path: Utf8PathBuf, path: Utf8PathBuf, readonly: bool) -> Result<Self> {
     let inner = open_database(&path, readonly)?;
     Ok(Self {
       inner,
+      base_path,
       path,
       readonly,
     })
@@ -161,11 +163,7 @@ impl Database {
   }
 
   fn stale_directory(&self) -> Utf8PathBuf {
-    self
-      .path
-      .parent()
-      .map_or_else(|| Utf8PathBuf::from("."), |parent| parent.to_path_buf())
-      .join(STALE_DIRECTORY)
+    self.base_path.join(STALE_DIRECTORY)
   }
 }
 

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -33,7 +33,6 @@ pub type DatabaseValue = turbo_persistence::ArcBytes;
 
 pub struct Database {
   inner: Inner,
-  base_path: Utf8PathBuf,
   path: Utf8PathBuf,
   readonly: bool,
 }
@@ -49,11 +48,10 @@ impl fmt::Debug for Database {
 }
 
 impl Database {
-  pub fn open(base_path: Utf8PathBuf, path: Utf8PathBuf, readonly: bool) -> Result<Self> {
+  pub fn open(path: Utf8PathBuf, readonly: bool) -> Result<Self> {
     let inner = open_database(&path, readonly)?;
     Ok(Self {
       inner,
-      base_path,
       path,
       readonly,
     })
@@ -163,7 +161,11 @@ impl Database {
   }
 
   fn stale_directory(&self) -> Utf8PathBuf {
-    self.base_path.join(STALE_DIRECTORY)
+    self
+      .path
+      .parent()
+      .map_or_else(|| Utf8PathBuf::from("."), |parent| parent.to_path_buf())
+      .join(STALE_DIRECTORY)
   }
 }
 

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -28,6 +28,8 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
+  rspack_pkg_version: String,
+  cache_version: String,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
@@ -50,12 +52,16 @@ impl FileCacheStrategy {
   pub fn new(
     database_path: Utf8PathBuf,
     readonly: bool,
+    rspack_pkg_version: String,
+    cache_version: String,
     codec: Arc<CacheCodec>,
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
     let database = Database::open(database_path, readonly)?;
     Ok(Self {
+      rspack_pkg_version,
+      cache_version,
       codec,
       snapshot,
       build_deps,
@@ -72,7 +78,13 @@ impl FileCacheStrategy {
       let meta: Option<DatabaseValue> = self.database.get(DatabaseFamily::Meta, META_KEY)?;
       self
         .build_deps
-        .validate_snapshot(&self.codec, &self.snapshot, meta.as_deref())
+        .validate_snapshot(
+          &self.codec,
+          &self.snapshot,
+          meta.as_deref(),
+          &self.rspack_pkg_version,
+          &self.cache_version,
+        )
         .await
     };
     match validation {
@@ -169,7 +181,13 @@ impl FileCacheStrategy {
         Some(
           self
             .build_deps
-            .create_snapshot(&self.codec, &self.snapshot, dependencies.iter().cloned())
+            .create_snapshot(
+              &self.codec,
+              &self.snapshot,
+              dependencies.iter().cloned(),
+              &self.rspack_pkg_version,
+              &self.cache_version,
+            )
             .await?,
         )
       } else {

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -13,17 +13,17 @@ use super::{
 };
 use crate::cache::persistent::codec::CacheCodec;
 
-const META_KEY: &[u8] = b"meta";
+const VALIDATOR_KEY: &[u8] = b"validator";
 
 #[cacheable]
 #[derive(Debug)]
-struct CacheMeta {
+struct CacheValidator {
   rspack_pkg_version: String,
   cache_version: String,
   build_dependencies: BuildDependenciesSnapshot,
 }
 
-impl CacheMeta {
+impl CacheValidator {
   fn new(rspack_pkg_version: String, cache_version: String) -> Self {
     Self {
       rspack_pkg_version,
@@ -37,10 +37,10 @@ impl CacheMeta {
   }
 }
 
-enum CacheMetaValidationResult {
+enum CacheValidatorResult {
   InvalidVersion,
   Valid {
-    meta: CacheMeta,
+    validator: CacheValidator,
     tracked_files: usize,
   },
   InvalidBuildDependencies {
@@ -63,7 +63,7 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
-  meta: CacheMeta,
+  validator: CacheValidator,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
@@ -95,7 +95,7 @@ impl FileCacheStrategy {
   ) -> Result<Self> {
     let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
-      meta: CacheMeta::new(rspack_pkg_version, cache_version),
+      validator: CacheValidator::new(rspack_pkg_version, cache_version),
       codec,
       snapshot,
       build_deps,
@@ -108,21 +108,23 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let data = self.database.get(DatabaseFamily::Meta, META_KEY)?;
-    let validation = self.validate_meta(data.as_deref()).await;
+    let data = self
+      .database
+      .get(DatabaseFamily::Validator, VALIDATOR_KEY)?;
+    let validation = self.validate_cache(data.as_deref()).await;
     match validation {
-      Ok(CacheMetaValidationResult::InvalidVersion) => {
+      Ok(CacheValidatorResult::InvalidVersion) => {
         tracing::info!("Resetting persistent cache database because cache version changed");
         self.database.reset()?;
       }
-      Ok(CacheMetaValidationResult::Valid {
-        meta,
+      Ok(CacheValidatorResult::Valid {
+        validator,
         tracked_files,
       }) => {
-        self.meta = meta;
+        self.validator = validator;
         tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
       }
-      Ok(CacheMetaValidationResult::InvalidBuildDependencies {
+      Ok(CacheValidatorResult::InvalidBuildDependencies {
         modified_files,
         removed_files,
       }) => {
@@ -143,27 +145,27 @@ impl FileCacheStrategy {
     Ok(())
   }
 
-  async fn validate_meta(&self, data: Option<&[u8]>) -> Result<CacheMetaValidationResult> {
+  async fn validate_cache(&self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
     let Some(data) = data else {
-      return Ok(CacheMetaValidationResult::InvalidVersion);
+      return Ok(CacheValidatorResult::InvalidVersion);
     };
-    let meta = self.codec.decode::<CacheMeta>(data)?;
-    if !meta.has_same_version(&self.meta) {
-      return Ok(CacheMetaValidationResult::InvalidVersion);
+    let validator = self.codec.decode::<CacheValidator>(data)?;
+    if !validator.has_same_version(&self.validator) {
+      return Ok(CacheValidatorResult::InvalidVersion);
     }
     let validation = self
       .build_deps
-      .validate_snapshot(&self.snapshot, &meta.build_dependencies)
+      .validate_snapshot(&self.snapshot, &validator.build_dependencies)
       .await;
     Ok(match validation {
-      BuildDepsValidationResult::Valid { tracked_files } => CacheMetaValidationResult::Valid {
-        meta,
+      BuildDepsValidationResult::Valid { tracked_files } => CacheValidatorResult::Valid {
+        validator,
         tracked_files,
       },
       BuildDepsValidationResult::Invalid {
         modified_files,
         removed_files,
-      } => CacheMetaValidationResult::InvalidBuildDependencies {
+      } => CacheValidatorResult::InvalidBuildDependencies {
         modified_files,
         removed_files,
       },
@@ -231,16 +233,16 @@ impl FileCacheStrategy {
     }
 
     if self.has_pending_writes() {
-      let encoded_meta = if let Some(dependencies) = &self.pending_writes.build_dependencies {
+      let encoded_validator = if let Some(dependencies) = &self.pending_writes.build_dependencies {
         self
           .build_deps
           .update_snapshot(
             &self.snapshot,
-            &mut self.meta.build_dependencies,
+            &mut self.validator.build_dependencies,
             dependencies.iter().cloned(),
           )
           .await;
-        Some(self.codec.encode(&self.meta)?)
+        Some(self.codec.encode(&self.validator)?)
       } else {
         None
       };
@@ -257,11 +259,11 @@ impl FileCacheStrategy {
           DatabaseWrite::new(DatabaseFamily::Cache, key.as_bytes(), value.as_slice())
         })
         .collect::<Vec<_>>();
-      if let Some(meta) = &encoded_meta {
+      if let Some(validator) = &encoded_validator {
         writes.push(DatabaseWrite::new(
-          DatabaseFamily::Meta,
-          META_KEY,
-          meta.as_slice(),
+          DatabaseFamily::Validator,
+          VALIDATOR_KEY,
+          validator.as_slice(),
         ));
       }
       self.database.write_batch(writes)?;

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,5 +1,6 @@
 use std::{fmt, sync::Arc};
 
+use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rustc_hash::FxHashMap;
@@ -7,12 +8,46 @@ use rustc_hash::FxHashMap;
 use super::{
   CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
-  db::{Database, DatabaseFamily, DatabaseValue, DatabaseWrite},
-  snapshot::{BuildDeps, BuildDepsValidationResult, Snapshot},
+  db::{Database, DatabaseFamily, DatabaseWrite},
+  snapshot::{BuildDependenciesSnapshot, BuildDeps, BuildDepsValidationResult, Snapshot},
 };
 use crate::cache::persistent::codec::CacheCodec;
 
 const META_KEY: &[u8] = b"meta";
+
+#[cacheable]
+#[derive(Debug)]
+struct CacheMeta {
+  rspack_pkg_version: String,
+  cache_version: String,
+  build_dependencies: BuildDependenciesSnapshot,
+}
+
+impl CacheMeta {
+  fn new(rspack_pkg_version: String, cache_version: String) -> Self {
+    Self {
+      rspack_pkg_version,
+      cache_version,
+      build_dependencies: Default::default(),
+    }
+  }
+
+  fn has_same_version(&self, other: &Self) -> bool {
+    self.rspack_pkg_version == other.rspack_pkg_version && self.cache_version == other.cache_version
+  }
+}
+
+enum CacheMetaValidationResult {
+  InvalidVersion,
+  Valid {
+    meta: CacheMeta,
+    tracked_files: usize,
+  },
+  InvalidBuildDependencies {
+    modified_files: ArcPathSet,
+    removed_files: ArcPathSet,
+  },
+}
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -28,8 +63,7 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
-  rspack_pkg_version: String,
-  cache_version: String,
+  meta: CacheMeta,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
@@ -61,8 +95,7 @@ impl FileCacheStrategy {
   ) -> Result<Self> {
     let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
-      rspack_pkg_version,
-      cache_version,
+      meta: CacheMeta::new(rspack_pkg_version, cache_version),
       codec,
       snapshot,
       build_deps,
@@ -75,28 +108,21 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let validation = {
-      let meta: Option<DatabaseValue> = self.database.get(DatabaseFamily::Meta, META_KEY)?;
-      self
-        .build_deps
-        .validate_snapshot(
-          &self.codec,
-          &self.snapshot,
-          meta.as_deref(),
-          &self.rspack_pkg_version,
-          &self.cache_version,
-        )
-        .await
-    };
+    let data = self.database.get(DatabaseFamily::Meta, META_KEY)?;
+    let validation = self.validate_meta(data.as_deref()).await;
     match validation {
-      Ok(BuildDepsValidationResult::InvalidVersion) => {
+      Ok(CacheMetaValidationResult::InvalidVersion) => {
         tracing::info!("Resetting persistent cache database because cache version changed");
         self.database.reset()?;
       }
-      Ok(BuildDepsValidationResult::Valid { tracked_files }) => {
+      Ok(CacheMetaValidationResult::Valid {
+        meta,
+        tracked_files,
+      }) => {
+        self.meta = meta;
         tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
       }
-      Ok(BuildDepsValidationResult::Invalid {
+      Ok(CacheMetaValidationResult::InvalidBuildDependencies {
         modified_files,
         removed_files,
       }) => {
@@ -115,6 +141,33 @@ impl FileCacheStrategy {
       }
     }
     Ok(())
+  }
+
+  async fn validate_meta(&self, data: Option<&[u8]>) -> Result<CacheMetaValidationResult> {
+    let Some(data) = data else {
+      return Ok(CacheMetaValidationResult::InvalidVersion);
+    };
+    let meta = self.codec.decode::<CacheMeta>(data)?;
+    if !meta.has_same_version(&self.meta) {
+      return Ok(CacheMetaValidationResult::InvalidVersion);
+    }
+    let validation = self
+      .build_deps
+      .validate_snapshot(&self.snapshot, &meta.build_dependencies)
+      .await;
+    Ok(match validation {
+      BuildDepsValidationResult::Valid { tracked_files } => CacheMetaValidationResult::Valid {
+        meta,
+        tracked_files,
+      },
+      BuildDepsValidationResult::Invalid {
+        modified_files,
+        removed_files,
+      } => CacheMetaValidationResult::InvalidBuildDependencies {
+        modified_files,
+        removed_files,
+      },
+    })
   }
 
   pub(super) fn store(
@@ -178,19 +231,16 @@ impl FileCacheStrategy {
     }
 
     if self.has_pending_writes() {
-      let build_snapshot = if let Some(dependencies) = &self.pending_writes.build_dependencies {
-        Some(
-          self
-            .build_deps
-            .create_snapshot(
-              &self.codec,
-              &self.snapshot,
-              dependencies.iter().cloned(),
-              &self.rspack_pkg_version,
-              &self.cache_version,
-            )
-            .await?,
-        )
+      let encoded_meta = if let Some(dependencies) = &self.pending_writes.build_dependencies {
+        self
+          .build_deps
+          .update_snapshot(
+            &self.snapshot,
+            &mut self.meta.build_dependencies,
+            dependencies.iter().cloned(),
+          )
+          .await;
+        Some(self.codec.encode(&self.meta)?)
       } else {
         None
       };
@@ -207,11 +257,11 @@ impl FileCacheStrategy {
           DatabaseWrite::new(DatabaseFamily::Cache, key.as_bytes(), value.as_slice())
         })
         .collect::<Vec<_>>();
-      if let Some(snapshot) = &build_snapshot {
+      if let Some(meta) = &encoded_meta {
         writes.push(DatabaseWrite::new(
           DatabaseFamily::Meta,
           META_KEY,
-          snapshot.as_slice(),
+          meta.as_slice(),
         ));
       }
       self.database.write_batch(writes)?;

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -15,6 +15,7 @@ use crate::cache::persistent::codec::CacheCodec;
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
 // The cache version and build dependency snapshot share the metadata family.
 const CACHE_VERSION_KEY: &[u8] = b"cache-version";
+const RSPACK_PKG_VERSION_KEY: &[u8] = b"rspack-pkg-version";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -30,6 +31,7 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
+  rspack_pkg_version: String,
   version: String,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
@@ -51,16 +53,17 @@ impl fmt::Debug for FileCacheStrategy {
 
 impl FileCacheStrategy {
   pub fn new(
-    base_path: Utf8PathBuf,
     database_path: Utf8PathBuf,
     readonly: bool,
+    rspack_pkg_version: String,
     version: String,
     codec: Arc<CacheCodec>,
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
-    let database = Database::open(base_path, database_path, readonly)?;
+    let database = Database::open(database_path, readonly)?;
     Ok(Self {
+      rspack_pkg_version,
       version,
       codec,
       snapshot,
@@ -74,11 +77,16 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
+    let rspack_pkg_version = self
+      .database
+      .get(DatabaseFamily::Meta, RSPACK_PKG_VERSION_KEY)?;
     let cache_version = self.database.get(DatabaseFamily::Meta, CACHE_VERSION_KEY)?;
-    if cache_version.as_deref() != Some(self.version.as_bytes()) {
+    if rspack_pkg_version.as_deref() != Some(self.rspack_pkg_version.as_bytes())
+      || cache_version.as_deref() != Some(self.version.as_bytes())
+    {
       tracing::info!("Resetting persistent cache database because cache version changed");
       self.database.reset()?;
-      self.store_version()?;
+      self.store_meta()?;
       return Ok(());
     }
 
@@ -105,28 +113,35 @@ impl FileCacheStrategy {
           "Resetting persistent cache database because build dependencies changed"
         );
         self.database.reset()?;
-        self.store_version()?;
+        self.store_meta()?;
       }
       Err(error) => {
         tracing::warn!(
           "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
         self.database.reset()?;
-        self.store_version()?;
+        self.store_meta()?;
       }
     }
     Ok(())
   }
 
-  fn store_version(&mut self) -> Result<()> {
+  fn store_meta(&mut self) -> Result<()> {
     if self.readonly {
       return Ok(());
     }
-    self.database.write_batch([DatabaseWrite::new(
-      DatabaseFamily::Meta,
-      CACHE_VERSION_KEY,
-      self.version.as_bytes(),
-    )])
+    self.database.write_batch([
+      DatabaseWrite::new(
+        DatabaseFamily::Meta,
+        RSPACK_PKG_VERSION_KEY,
+        self.rspack_pkg_version.as_bytes(),
+      ),
+      DatabaseWrite::new(
+        DatabaseFamily::Meta,
+        CACHE_VERSION_KEY,
+        self.version.as_bytes(),
+      ),
+    ])
   }
 
   pub(super) fn store(

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -12,16 +12,12 @@ use super::{
 };
 use crate::cache::persistent::codec::CacheCodec;
 
-const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
-// The cache version and build dependency snapshot share the metadata family.
-const CACHE_VERSION_KEY: &[u8] = b"cache-version";
-const RSPACK_PKG_VERSION_KEY: &[u8] = b"rspack-pkg-version";
+const META_KEY: &[u8] = b"meta";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: Option<ArcPathSet>,
-  store_meta: bool,
 }
 
 #[derive(Debug)]
@@ -32,8 +28,6 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
-  rspack_pkg_version: String,
-  version: String,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
@@ -56,16 +50,12 @@ impl FileCacheStrategy {
   pub fn new(
     database_path: Utf8PathBuf,
     readonly: bool,
-    rspack_pkg_version: String,
-    version: String,
     codec: Arc<CacheCodec>,
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
     let database = Database::open(database_path, readonly)?;
     Ok(Self {
-      rspack_pkg_version,
-      version,
       codec,
       snapshot,
       build_deps,
@@ -78,29 +68,18 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let rspack_pkg_version = self
-      .database
-      .get(DatabaseFamily::Meta, RSPACK_PKG_VERSION_KEY)?;
-    let cache_version = self.database.get(DatabaseFamily::Meta, CACHE_VERSION_KEY)?;
-    if rspack_pkg_version.as_deref() != Some(self.rspack_pkg_version.as_bytes())
-      || cache_version.as_deref() != Some(self.version.as_bytes())
-    {
-      tracing::info!("Resetting persistent cache database because cache version changed");
-      self.database.reset()?;
-      self.pending_writes.store_meta = true;
-      return Ok(());
-    }
-
     let validation = {
-      let build_snapshot: Option<DatabaseValue> = self
-        .database
-        .get(DatabaseFamily::Meta, BUILD_DEPENDENCIES_KEY)?;
+      let meta: Option<DatabaseValue> = self.database.get(DatabaseFamily::Meta, META_KEY)?;
       self
         .build_deps
-        .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
+        .validate_snapshot(&self.codec, &self.snapshot, meta.as_deref())
         .await
     };
     match validation {
+      Ok(BuildDepsValidationResult::InvalidVersion) => {
+        tracing::info!("Resetting persistent cache database because cache version changed");
+        self.database.reset()?;
+      }
       Ok(BuildDepsValidationResult::Valid { tracked_files }) => {
         tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
       }
@@ -114,14 +93,12 @@ impl FileCacheStrategy {
           "Resetting persistent cache database because build dependencies changed"
         );
         self.database.reset()?;
-        self.pending_writes.store_meta = true;
       }
       Err(error) => {
         tracing::warn!(
           "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
         self.database.reset()?;
-        self.pending_writes.store_meta = true;
       }
     }
     Ok(())
@@ -214,32 +191,14 @@ impl FileCacheStrategy {
       if let Some(snapshot) = &build_snapshot {
         writes.push(DatabaseWrite::new(
           DatabaseFamily::Meta,
-          BUILD_DEPENDENCIES_KEY,
+          META_KEY,
           snapshot.as_slice(),
         ));
-      }
-      let store_meta = self.pending_writes.store_meta && build_snapshot.is_some();
-      if store_meta {
-        writes.extend([
-          DatabaseWrite::new(
-            DatabaseFamily::Meta,
-            RSPACK_PKG_VERSION_KEY,
-            self.rspack_pkg_version.as_bytes(),
-          ),
-          DatabaseWrite::new(
-            DatabaseFamily::Meta,
-            CACHE_VERSION_KEY,
-            self.version.as_bytes(),
-          ),
-        ]);
       }
       self.database.write_batch(writes)?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
-      if store_meta {
-        self.pending_writes.store_meta = false;
-      }
     }
 
     for _ in 0..max_compaction_passes {

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -48,8 +48,7 @@ impl fmt::Debug for FileCacheStrategy {
 
 impl FileCacheStrategy {
   pub fn new(
-    base_path: Utf8PathBuf,
-    database_path: Utf8PathBuf,
+    database_paths: (Utf8PathBuf, Utf8PathBuf),
     readonly: bool,
     rspack_pkg_version: String,
     cache_version: String,
@@ -57,6 +56,7 @@ impl FileCacheStrategy {
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
+    let (base_path, database_path) = database_paths;
     let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
       validator: CacheValidator::new(

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -50,6 +50,7 @@ impl fmt::Debug for FileCacheStrategy {
 
 impl FileCacheStrategy {
   pub fn new(
+    base_path: Utf8PathBuf,
     database_path: Utf8PathBuf,
     readonly: bool,
     rspack_pkg_version: String,
@@ -58,7 +59,7 @@ impl FileCacheStrategy {
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
-    let database = Database::open(database_path, readonly)?;
+    let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
       rspack_pkg_version,
       cache_version,

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -13,6 +13,9 @@ use super::{
 use crate::cache::persistent::codec::CacheCodec;
 
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
+// Stored in the snapshot family because the database schema is shared by all
+// cache entries and build dependency snapshots.
+const CACHE_VERSION_KEY: &[u8] = b"cache-version";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -28,6 +31,7 @@ struct PendingWrite {
 
 /// Filesystem cache implementation scheduled by [`super::IdleFileCache`].
 pub struct FileCacheStrategy {
+  version: String,
   codec: Arc<CacheCodec>,
   snapshot: Snapshot,
   build_deps: BuildDeps,
@@ -51,12 +55,14 @@ impl FileCacheStrategy {
     base_path: Utf8PathBuf,
     database_path: Utf8PathBuf,
     readonly: bool,
+    version: String,
     codec: Arc<CacheCodec>,
     snapshot: Snapshot,
     build_deps: BuildDeps,
   ) -> Result<Self> {
     let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
+      version,
       codec,
       snapshot,
       build_deps,
@@ -69,6 +75,16 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
+    let cache_version = self
+      .database
+      .get(DatabaseFamily::Snapshot, CACHE_VERSION_KEY)?;
+    if cache_version.as_deref() != Some(self.version.as_bytes()) {
+      tracing::info!("Resetting persistent cache database because cache version changed");
+      self.database.reset()?;
+      self.store_version()?;
+      return Ok(());
+    }
+
     let validation = {
       let build_snapshot: Option<DatabaseValue> = self
         .database
@@ -92,15 +108,28 @@ impl FileCacheStrategy {
           "Resetting persistent cache database because build dependencies changed"
         );
         self.database.reset()?;
+        self.store_version()?;
       }
       Err(error) => {
         tracing::warn!(
           "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
         self.database.reset()?;
+        self.store_version()?;
       }
     }
     Ok(())
+  }
+
+  fn store_version(&mut self) -> Result<()> {
+    if self.readonly {
+      return Ok(());
+    }
+    self.database.write_batch([DatabaseWrite::new(
+      DatabaseFamily::Snapshot,
+      CACHE_VERSION_KEY,
+      self.version.as_bytes(),
+    )])
   }
 
   pub(super) fn store(

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,6 +1,5 @@
 use std::{fmt, sync::Arc};
 
-use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_paths::{ArcPathSet, Utf8PathBuf};
 use rustc_hash::FxHashMap;
@@ -8,46 +7,13 @@ use rustc_hash::FxHashMap;
 use super::{
   CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
-  db::{Database, DatabaseFamily, DatabaseWrite},
-  snapshot::{BuildDependenciesSnapshot, BuildDeps, BuildDepsValidationResult, Snapshot},
+  db::{Database, DatabaseFamily, DatabaseValue, DatabaseWrite},
+  snapshot::{BuildDeps, Snapshot},
+  validator::{CacheValidator, CacheValidatorResult},
 };
 use crate::cache::persistent::codec::CacheCodec;
 
 const VALIDATOR_KEY: &[u8] = b"validator";
-
-#[cacheable]
-#[derive(Debug)]
-struct CacheValidator {
-  rspack_pkg_version: String,
-  cache_version: String,
-  build_dependencies: BuildDependenciesSnapshot,
-}
-
-impl CacheValidator {
-  fn new(rspack_pkg_version: String, cache_version: String) -> Self {
-    Self {
-      rspack_pkg_version,
-      cache_version,
-      build_dependencies: Default::default(),
-    }
-  }
-
-  fn has_same_version(&self, other: &Self) -> bool {
-    self.rspack_pkg_version == other.rspack_pkg_version && self.cache_version == other.cache_version
-  }
-}
-
-enum CacheValidatorResult {
-  InvalidVersion,
-  Valid {
-    validator: CacheValidator,
-    tracked_files: usize,
-  },
-  InvalidBuildDependencies {
-    modified_files: ArcPathSet,
-    removed_files: ArcPathSet,
-  },
-}
 
 #[derive(Debug, Default)]
 struct PendingWrites {
@@ -65,8 +31,6 @@ struct PendingWrite {
 pub struct FileCacheStrategy {
   validator: CacheValidator,
   codec: Arc<CacheCodec>,
-  snapshot: Snapshot,
-  build_deps: BuildDeps,
   database: Database,
   pending_writes: PendingWrites,
   readonly: bool,
@@ -95,10 +59,14 @@ impl FileCacheStrategy {
   ) -> Result<Self> {
     let database = Database::open(base_path, database_path, readonly)?;
     Ok(Self {
-      validator: CacheValidator::new(rspack_pkg_version, cache_version),
+      validator: CacheValidator::new(
+        rspack_pkg_version,
+        cache_version,
+        codec.clone(),
+        snapshot,
+        build_deps,
+      ),
       codec,
-      snapshot,
-      build_deps,
       database,
       pending_writes: PendingWrites::default(),
       readonly,
@@ -108,20 +76,16 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let data = self
+    let data: Option<DatabaseValue> = self
       .database
       .get(DatabaseFamily::Validator, VALIDATOR_KEY)?;
-    let validation = self.validate_cache(data.as_deref()).await;
+    let validation = self.validator.validate(data.as_deref()).await;
     match validation {
       Ok(CacheValidatorResult::InvalidVersion) => {
         tracing::info!("Resetting persistent cache database because cache version changed");
         self.database.reset()?;
       }
-      Ok(CacheValidatorResult::Valid {
-        validator,
-        tracked_files,
-      }) => {
-        self.validator = validator;
+      Ok(CacheValidatorResult::Valid { tracked_files }) => {
         tracing::debug!(tracked_files, "Build dependencies snapshot is valid");
       }
       Ok(CacheValidatorResult::InvalidBuildDependencies {
@@ -143,33 +107,6 @@ impl FileCacheStrategy {
       }
     }
     Ok(())
-  }
-
-  async fn validate_cache(&self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
-    let Some(data) = data else {
-      return Ok(CacheValidatorResult::InvalidVersion);
-    };
-    let validator = self.codec.decode::<CacheValidator>(data)?;
-    if !validator.has_same_version(&self.validator) {
-      return Ok(CacheValidatorResult::InvalidVersion);
-    }
-    let validation = self
-      .build_deps
-      .validate_snapshot(&self.snapshot, &validator.build_dependencies)
-      .await;
-    Ok(match validation {
-      BuildDepsValidationResult::Valid { tracked_files } => CacheValidatorResult::Valid {
-        validator,
-        tracked_files,
-      },
-      BuildDepsValidationResult::Invalid {
-        modified_files,
-        removed_files,
-      } => CacheValidatorResult::InvalidBuildDependencies {
-        modified_files,
-        removed_files,
-      },
-    })
   }
 
   pub(super) fn store(
@@ -234,15 +171,7 @@ impl FileCacheStrategy {
 
     if self.has_pending_writes() {
       let encoded_validator = if let Some(dependencies) = &self.pending_writes.build_dependencies {
-        self
-          .build_deps
-          .update_snapshot(
-            &self.snapshot,
-            &mut self.validator.build_dependencies,
-            dependencies.iter().cloned(),
-          )
-          .await;
-        Some(self.codec.encode(&self.validator)?)
+        Some(self.validator.update(dependencies.iter().cloned()).await?)
       } else {
         None
       };

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -13,8 +13,7 @@ use super::{
 use crate::cache::persistent::codec::CacheCodec;
 
 const BUILD_DEPENDENCIES_KEY: &[u8] = b"build-dependencies";
-// Stored in the snapshot family because the database schema is shared by all
-// cache entries and build dependency snapshots.
+// The cache version and build dependency snapshot share the metadata family.
 const CACHE_VERSION_KEY: &[u8] = b"cache-version";
 
 #[derive(Debug, Default)]
@@ -75,9 +74,7 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let cache_version = self
-      .database
-      .get(DatabaseFamily::Snapshot, CACHE_VERSION_KEY)?;
+    let cache_version = self.database.get(DatabaseFamily::Meta, CACHE_VERSION_KEY)?;
     if cache_version.as_deref() != Some(self.version.as_bytes()) {
       tracing::info!("Resetting persistent cache database because cache version changed");
       self.database.reset()?;
@@ -88,7 +85,7 @@ impl FileCacheStrategy {
     let validation = {
       let build_snapshot: Option<DatabaseValue> = self
         .database
-        .get(DatabaseFamily::Snapshot, BUILD_DEPENDENCIES_KEY)?;
+        .get(DatabaseFamily::Meta, BUILD_DEPENDENCIES_KEY)?;
       self
         .build_deps
         .validate_snapshot(&self.codec, &self.snapshot, build_snapshot.as_deref())
@@ -126,7 +123,7 @@ impl FileCacheStrategy {
       return Ok(());
     }
     self.database.write_batch([DatabaseWrite::new(
-      DatabaseFamily::Snapshot,
+      DatabaseFamily::Meta,
       CACHE_VERSION_KEY,
       self.version.as_bytes(),
     )])
@@ -217,7 +214,7 @@ impl FileCacheStrategy {
         })
         .chain(build_snapshot.iter().map(|snapshot| {
           DatabaseWrite::new(
-            DatabaseFamily::Snapshot,
+            DatabaseFamily::Meta,
             BUILD_DEPENDENCIES_KEY,
             snapshot.as_slice(),
           )

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -21,6 +21,7 @@ const RSPACK_PKG_VERSION_KEY: &[u8] = b"rspack-pkg-version";
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: Option<ArcPathSet>,
+  store_meta: bool,
 }
 
 #[derive(Debug)]
@@ -86,7 +87,7 @@ impl FileCacheStrategy {
     {
       tracing::info!("Resetting persistent cache database because cache version changed");
       self.database.reset()?;
-      self.store_meta()?;
+      self.pending_writes.store_meta = true;
       return Ok(());
     }
 
@@ -113,35 +114,17 @@ impl FileCacheStrategy {
           "Resetting persistent cache database because build dependencies changed"
         );
         self.database.reset()?;
-        self.store_meta()?;
+        self.pending_writes.store_meta = true;
       }
       Err(error) => {
         tracing::warn!(
           "Resetting persistent cache database because build dependencies validation failed: {error}"
         );
         self.database.reset()?;
-        self.store_meta()?;
+        self.pending_writes.store_meta = true;
       }
     }
     Ok(())
-  }
-
-  fn store_meta(&mut self) -> Result<()> {
-    if self.readonly {
-      return Ok(());
-    }
-    self.database.write_batch([
-      DatabaseWrite::new(
-        DatabaseFamily::Meta,
-        RSPACK_PKG_VERSION_KEY,
-        self.rspack_pkg_version.as_bytes(),
-      ),
-      DatabaseWrite::new(
-        DatabaseFamily::Meta,
-        CACHE_VERSION_KEY,
-        self.version.as_bytes(),
-      ),
-    ])
   }
 
   pub(super) fn store(
@@ -222,22 +205,41 @@ impl FileCacheStrategy {
         .map(|(key, pending)| Ok((key, (pending.encoder)(&pending.entry, &self.codec)?)))
         .collect::<Result<Vec<_>>>()?;
 
-      let writes = cache_entries
+      let mut writes = cache_entries
         .iter()
         .map(|(key, value)| {
           DatabaseWrite::new(DatabaseFamily::Cache, key.as_bytes(), value.as_slice())
         })
-        .chain(build_snapshot.iter().map(|snapshot| {
+        .collect::<Vec<_>>();
+      if let Some(snapshot) = &build_snapshot {
+        writes.push(DatabaseWrite::new(
+          DatabaseFamily::Meta,
+          BUILD_DEPENDENCIES_KEY,
+          snapshot.as_slice(),
+        ));
+      }
+      let store_meta = self.pending_writes.store_meta && build_snapshot.is_some();
+      if store_meta {
+        writes.extend([
           DatabaseWrite::new(
             DatabaseFamily::Meta,
-            BUILD_DEPENDENCIES_KEY,
-            snapshot.as_slice(),
-          )
-        }));
+            RSPACK_PKG_VERSION_KEY,
+            self.rspack_pkg_version.as_bytes(),
+          ),
+          DatabaseWrite::new(
+            DatabaseFamily::Meta,
+            CACHE_VERSION_KEY,
+            self.version.as_bytes(),
+          ),
+        ]);
+      }
       self.database.write_batch(writes)?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
+      if store_meta {
+        self.pending_writes.store_meta = false;
+      }
     }
 
     for _ in 0..max_compaction_passes {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -55,6 +55,8 @@ pub fn create_cache(
   let snapshot = Snapshot::new(options.snapshot.clone(), input_filesystem.clone());
   let build_deps = BuildDeps::new(
     &options.build_dependencies,
+    rspack_workspace::rspack_pkg_version!().to_string(),
+    options.version.clone(),
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
@@ -63,21 +65,14 @@ pub fn create_cache(
       directory.clone()
     }
   };
-  let strategy = match FileCacheStrategy::new(
-    database_path,
-    options.readonly,
-    rspack_workspace::rspack_pkg_version!().to_string(),
-    options.version.clone(),
-    codec,
-    snapshot,
-    build_deps,
-  ) {
-    Ok(strategy) => strategy,
-    Err(error) => {
-      tracing::warn!("Opening persistent cache database failed: {error}");
-      return Cache::new(compiler_path, MemoryCache::default(), None);
-    }
-  };
+  let strategy =
+    match FileCacheStrategy::new(database_path, options.readonly, codec, snapshot, build_deps) {
+      Ok(strategy) => strategy,
+      Err(error) => {
+        tracing::warn!("Opening persistent cache database failed: {error}");
+        return Cache::new(compiler_path, MemoryCache::default(), None);
+      }
+    };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
 
   Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -8,6 +8,7 @@ mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 mod snapshot;
+mod validator;
 
 use std::sync::Arc;
 

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -55,8 +55,6 @@ pub fn create_cache(
   let snapshot = Snapshot::new(options.snapshot.clone(), input_filesystem.clone());
   let build_deps = BuildDeps::new(
     &options.build_dependencies,
-    rspack_workspace::rspack_pkg_version!().to_string(),
-    options.version.clone(),
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
@@ -65,14 +63,21 @@ pub fn create_cache(
       directory.clone()
     }
   };
-  let strategy =
-    match FileCacheStrategy::new(database_path, options.readonly, codec, snapshot, build_deps) {
-      Ok(strategy) => strategy,
-      Err(error) => {
-        tracing::warn!("Opening persistent cache database failed: {error}");
-        return Cache::new(compiler_path, MemoryCache::default(), None);
-      }
-    };
+  let strategy = match FileCacheStrategy::new(
+    database_path,
+    options.readonly,
+    rspack_workspace::rspack_pkg_version!().to_string(),
+    options.version.clone(),
+    codec,
+    snapshot,
+    build_deps,
+  ) {
+    Ok(strategy) => strategy,
+    Err(error) => {
+      tracing::warn!("Opening persistent cache database failed: {error}");
+      return Cache::new(compiler_path, MemoryCache::default(), None);
+    }
+  };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
 
   Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -58,16 +58,15 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let (base_path, database_path) = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
-      directory.clone(),
-      directory.join(rspack_workspace::rspack_pkg_version!()),
-    ),
+  let database_path = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
+      directory.clone()
+    }
   };
   let strategy = match FileCacheStrategy::new(
-    base_path,
     database_path,
     options.readonly,
+    rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
     codec,
     snapshot,

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -66,8 +66,7 @@ pub fn create_cache(
     ),
   };
   let strategy = match FileCacheStrategy::new(
-    base_path,
-    database_path,
+    (base_path, database_path),
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -58,12 +58,14 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let database_path = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
-      directory.clone()
-    }
+  let (base_path, database_path) = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
+      directory.clone(),
+      directory.join(rspack_workspace::rspack_pkg_version!()),
+    ),
   };
   let strategy = match FileCacheStrategy::new(
+    base_path,
     database_path,
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -68,6 +68,7 @@ pub fn create_cache(
     base_path,
     database_path,
     options.readonly,
+    options.version.clone(),
     codec,
     snapshot,
     build_deps,

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -32,8 +32,6 @@ pub enum BuildDepsValidationResult {
 pub struct BuildDeps {
   /// Dependencies configured at startup and added on the next store.
   pending: ArcPathSet,
-  rspack_pkg_version: String,
-  cache_version: String,
   data: BuildDependenciesSnapshot,
   fs: Arc<dyn ReadableFileSystem>,
   logger: CompilationLogger,
@@ -42,8 +40,6 @@ pub struct BuildDeps {
 impl BuildDeps {
   pub fn new(
     options: &BuildDepsOptions,
-    rspack_pkg_version: String,
-    cache_version: String,
     fs: Arc<dyn ReadableFileSystem>,
     logger: CompilationLogger,
   ) -> Self {
@@ -52,8 +48,6 @@ impl BuildDeps {
         .iter()
         .map(|path| ArcPath::from(path.as_path()))
         .collect(),
-      rspack_pkg_version,
-      cache_version,
       data: Default::default(),
       fs,
       logger,
@@ -69,6 +63,8 @@ impl BuildDeps {
     codec: &CacheCodec,
     snapshot: &Snapshot,
     data: impl Iterator<Item = ArcPath>,
+    rspack_pkg_version: &str,
+    cache_version: &str,
   ) -> Result<Vec<u8>> {
     let mut helper = Helper::new(self.fs.clone(), self.logger.clone());
     let mut added = ArcPathSet::default();
@@ -97,8 +93,8 @@ impl BuildDeps {
     self.data.snapshots.extend(snapshots);
     self.pending.clear();
     let meta = CacheMeta {
-      rspack_pkg_version: self.rspack_pkg_version.clone(),
-      cache_version: self.cache_version.clone(),
+      rspack_pkg_version: rspack_pkg_version.to_string(),
+      cache_version: cache_version.to_string(),
       build_dependencies: std::mem::take(&mut self.data),
     };
     let result = codec.encode(&meta);
@@ -114,14 +110,14 @@ impl BuildDeps {
     codec: &CacheCodec,
     snapshot: &Snapshot,
     data: Option<&[u8]>,
+    rspack_pkg_version: &str,
+    cache_version: &str,
   ) -> Result<BuildDepsValidationResult> {
     let Some(data) = data else {
       return Ok(BuildDepsValidationResult::InvalidVersion);
     };
     let meta = codec.decode::<CacheMeta>(data)?;
-    if meta.rspack_pkg_version != self.rspack_pkg_version
-      || meta.cache_version != self.cache_version
-    {
+    if meta.rspack_pkg_version != rspack_pkg_version || meta.cache_version != cache_version {
       return Ok(BuildDepsValidationResult::InvalidVersion);
     }
     let (modified_files, removed_files) = snapshot

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -4,7 +4,7 @@ use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 
-use super::{BuildDependenciesSnapshot, Snapshot};
+use super::{BuildDependenciesSnapshot, CacheMeta, Snapshot};
 use crate::{
   CompilationLogger,
   cache::persistent::{
@@ -17,6 +17,7 @@ pub type BuildDepsOptions = Vec<PathBuf>;
 
 #[derive(Debug)]
 pub enum BuildDepsValidationResult {
+  InvalidVersion,
   Valid {
     tracked_files: usize,
   },
@@ -31,6 +32,8 @@ pub enum BuildDepsValidationResult {
 pub struct BuildDeps {
   /// Dependencies configured at startup and added on the next store.
   pending: ArcPathSet,
+  rspack_pkg_version: String,
+  cache_version: String,
   data: BuildDependenciesSnapshot,
   fs: Arc<dyn ReadableFileSystem>,
   logger: CompilationLogger,
@@ -39,6 +42,8 @@ pub struct BuildDeps {
 impl BuildDeps {
   pub fn new(
     options: &BuildDepsOptions,
+    rspack_pkg_version: String,
+    cache_version: String,
     fs: Arc<dyn ReadableFileSystem>,
     logger: CompilationLogger,
   ) -> Self {
@@ -47,6 +52,8 @@ impl BuildDeps {
         .iter()
         .map(|path| ArcPath::from(path.as_path()))
         .collect(),
+      rspack_pkg_version,
+      cache_version,
       data: Default::default(),
       fs,
       logger,
@@ -89,7 +96,14 @@ impl BuildDeps {
     self.data.dependencies.extend(added);
     self.data.snapshots.extend(snapshots);
     self.pending.clear();
-    codec.encode(&self.data)
+    let meta = CacheMeta {
+      rspack_pkg_version: self.rspack_pkg_version.clone(),
+      cache_version: self.cache_version.clone(),
+      build_dependencies: std::mem::take(&mut self.data),
+    };
+    let result = codec.encode(&meta);
+    self.data = meta.build_dependencies;
+    result
   }
 
   /// Validate build dependencies.
@@ -102,18 +116,25 @@ impl BuildDeps {
     data: Option<&[u8]>,
   ) -> Result<BuildDepsValidationResult> {
     let Some(data) = data else {
-      return Ok(BuildDepsValidationResult::Valid { tracked_files: 0 });
+      return Ok(BuildDepsValidationResult::InvalidVersion);
     };
-    let data = codec.decode::<BuildDependenciesSnapshot>(data)?;
-    let (modified_files, removed_files) = snapshot.calc_modified_paths(&data.snapshots).await;
+    let meta = codec.decode::<CacheMeta>(data)?;
+    if meta.rspack_pkg_version != self.rspack_pkg_version
+      || meta.cache_version != self.cache_version
+    {
+      return Ok(BuildDepsValidationResult::InvalidVersion);
+    }
+    let (modified_files, removed_files) = snapshot
+      .calc_modified_paths(&meta.build_dependencies.snapshots)
+      .await;
     if !modified_files.is_empty() || !removed_files.is_empty() {
       return Ok(BuildDepsValidationResult::Invalid {
         modified_files,
         removed_files,
       });
     }
-    let tracked_files = data.dependencies.len();
-    self.data = data;
+    let tracked_files = meta.build_dependencies.dependencies.len();
+    self.data = meta.build_dependencies;
     Ok(BuildDepsValidationResult::Valid { tracked_files })
   }
 }

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 
-use super::{BuildDependenciesSnapshot, Snapshot};
+use super::{Snapshot, SnapshotEntry};
 use crate::{
   CompilationLogger,
   cache::persistent::build_dependencies::{Helper, is_node_package_path},
@@ -47,16 +47,15 @@ impl BuildDeps {
     }
   }
 
-  /// Update the build dependencies snapshot.
+  /// Resolve build dependencies that are not in the current snapshot.
   ///
   /// For performance reasons, recursive searches stop at dependencies in
   /// `node_modules`.
-  pub(in crate::new_cache) async fn update_snapshot(
+  pub async fn resolve_dependencies(
     &mut self,
-    snapshot: &Snapshot,
-    build_dependencies: &mut BuildDependenciesSnapshot,
+    current: &ArcPathSet,
     paths: impl Iterator<Item = ArcPath>,
-  ) {
+  ) -> ArcPathSet {
     let mut helper = Helper::new(self.fs.clone(), self.logger.clone());
     let mut added = ArcPathSet::default();
     let mut queue = VecDeque::new();
@@ -64,8 +63,7 @@ impl BuildDeps {
     queue.extend(paths);
 
     while let Some(dependency) = queue.pop_front() {
-      if build_dependencies.dependencies.contains(&dependency) || !added.insert(dependency.clone())
-      {
+      if current.contains(&dependency) || !added.insert(dependency.clone()) {
         continue;
       }
       if is_node_package_path(&dependency) {
@@ -80,29 +78,26 @@ impl BuildDeps {
       }
     }
 
-    let snapshots = snapshot.add(added.iter().cloned()).await;
-    build_dependencies.dependencies.extend(added);
-    build_dependencies.snapshots.extend(snapshots);
     self.pending.clear();
+    added
   }
 
   /// Validate build dependencies.
   ///
   /// If any build dependency changed, this method returns an invalid result.
-  pub(in crate::new_cache) async fn validate_snapshot(
+  pub async fn validate_snapshot(
     &self,
     snapshot: &Snapshot,
-    data: &BuildDependenciesSnapshot,
+    entries: &[SnapshotEntry],
+    tracked_files: usize,
   ) -> BuildDepsValidationResult {
-    let (modified_files, removed_files) = snapshot.calc_modified_paths(&data.snapshots).await;
+    let (modified_files, removed_files) = snapshot.calc_modified_paths(entries).await;
     if !modified_files.is_empty() || !removed_files.is_empty() {
       return BuildDepsValidationResult::Invalid {
         modified_files,
         removed_files,
       };
     }
-    BuildDepsValidationResult::Valid {
-      tracked_files: data.dependencies.len(),
-    }
+    BuildDepsValidationResult::Valid { tracked_files }
   }
 }

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -1,23 +1,18 @@
 use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
-use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{ArcPath, ArcPathSet, AssertUtf8};
 
-use super::{BuildDependenciesSnapshot, CacheMeta, Snapshot};
+use super::{BuildDependenciesSnapshot, Snapshot};
 use crate::{
   CompilationLogger,
-  cache::persistent::{
-    build_dependencies::{Helper, is_node_package_path},
-    codec::CacheCodec,
-  },
+  cache::persistent::build_dependencies::{Helper, is_node_package_path},
 };
 
 pub type BuildDepsOptions = Vec<PathBuf>;
 
 #[derive(Debug)]
 pub enum BuildDepsValidationResult {
-  InvalidVersion,
   Valid {
     tracked_files: usize,
   },
@@ -32,7 +27,6 @@ pub enum BuildDepsValidationResult {
 pub struct BuildDeps {
   /// Dependencies configured at startup and added on the next store.
   pending: ArcPathSet,
-  data: BuildDependenciesSnapshot,
   fs: Arc<dyn ReadableFileSystem>,
   logger: CompilationLogger,
 }
@@ -48,38 +42,36 @@ impl BuildDeps {
         .iter()
         .map(|path| ArcPath::from(path.as_path()))
         .collect(),
-      data: Default::default(),
       fs,
       logger,
     }
   }
 
-  /// Update build dependencies and serialize the complete snapshot.
+  /// Update the build dependencies snapshot.
   ///
   /// For performance reasons, recursive searches stop at dependencies in
   /// `node_modules`.
-  pub async fn create_snapshot(
+  pub(in crate::new_cache) async fn update_snapshot(
     &mut self,
-    codec: &CacheCodec,
     snapshot: &Snapshot,
-    data: impl Iterator<Item = ArcPath>,
-    rspack_pkg_version: &str,
-    cache_version: &str,
-  ) -> Result<Vec<u8>> {
+    build_dependencies: &mut BuildDependenciesSnapshot,
+    paths: impl Iterator<Item = ArcPath>,
+  ) {
     let mut helper = Helper::new(self.fs.clone(), self.logger.clone());
     let mut added = ArcPathSet::default();
     let mut queue = VecDeque::new();
     queue.extend(self.pending.iter().cloned());
-    queue.extend(data);
+    queue.extend(paths);
 
-    while let Some(current) = queue.pop_front() {
-      if self.data.dependencies.contains(&current) || !added.insert(current.clone()) {
+    while let Some(dependency) = queue.pop_front() {
+      if build_dependencies.dependencies.contains(&dependency) || !added.insert(dependency.clone())
+      {
         continue;
       }
-      if is_node_package_path(&current) {
+      if is_node_package_path(&dependency) {
         continue;
       }
-      if let Some(children) = helper.resolve(current.assert_utf8()).await {
+      if let Some(children) = helper.resolve(dependency.assert_utf8()).await {
         queue.extend(
           children
             .into_iter()
@@ -89,48 +81,28 @@ impl BuildDeps {
     }
 
     let snapshots = snapshot.add(added.iter().cloned()).await;
-    self.data.dependencies.extend(added);
-    self.data.snapshots.extend(snapshots);
+    build_dependencies.dependencies.extend(added);
+    build_dependencies.snapshots.extend(snapshots);
     self.pending.clear();
-    let meta = CacheMeta {
-      rspack_pkg_version: rspack_pkg_version.to_string(),
-      cache_version: cache_version.to_string(),
-      build_dependencies: std::mem::take(&mut self.data),
-    };
-    let result = codec.encode(&meta);
-    self.data = meta.build_dependencies;
-    result
   }
 
   /// Validate build dependencies.
   ///
   /// If any build dependency changed, this method returns an invalid result.
-  pub async fn validate_snapshot(
-    &mut self,
-    codec: &CacheCodec,
+  pub(in crate::new_cache) async fn validate_snapshot(
+    &self,
     snapshot: &Snapshot,
-    data: Option<&[u8]>,
-    rspack_pkg_version: &str,
-    cache_version: &str,
-  ) -> Result<BuildDepsValidationResult> {
-    let Some(data) = data else {
-      return Ok(BuildDepsValidationResult::InvalidVersion);
-    };
-    let meta = codec.decode::<CacheMeta>(data)?;
-    if meta.rspack_pkg_version != rspack_pkg_version || meta.cache_version != cache_version {
-      return Ok(BuildDepsValidationResult::InvalidVersion);
-    }
-    let (modified_files, removed_files) = snapshot
-      .calc_modified_paths(&meta.build_dependencies.snapshots)
-      .await;
+    data: &BuildDependenciesSnapshot,
+  ) -> BuildDepsValidationResult {
+    let (modified_files, removed_files) = snapshot.calc_modified_paths(&data.snapshots).await;
     if !modified_files.is_empty() || !removed_files.is_empty() {
-      return Ok(BuildDepsValidationResult::Invalid {
+      return BuildDepsValidationResult::Invalid {
         modified_files,
         removed_files,
-      });
+      };
     }
-    let tracked_files = meta.build_dependencies.dependencies.len();
-    self.data = meta.build_dependencies;
-    Ok(BuildDepsValidationResult::Valid { tracked_files })
+    BuildDepsValidationResult::Valid {
+      tracked_files: data.dependencies.len(),
+    }
   }
 }

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -25,6 +25,14 @@ struct BuildDependenciesSnapshot {
   snapshots: Vec<SnapshotEntry>,
 }
 
+#[cacheable]
+#[derive(Debug, Default)]
+struct CacheMeta {
+  rspack_pkg_version: String,
+  cache_version: String,
+  build_dependencies: BuildDependenciesSnapshot,
+}
+
 /// Creates and validates filesystem snapshots stored by the new cache.
 #[derive(Debug)]
 pub struct Snapshot {

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -18,6 +18,39 @@ pub struct SnapshotEntry {
   strategy: Strategy,
 }
 
+#[cacheable]
+#[derive(Debug, Default)]
+pub(super) struct BuildDependenciesSnapshot {
+  dependencies: ArcPathSet,
+  snapshots: Vec<SnapshotEntry>,
+}
+
+impl BuildDependenciesSnapshot {
+  pub(super) async fn validate(
+    &self,
+    snapshot: &Snapshot,
+    build_deps: &BuildDeps,
+  ) -> BuildDepsValidationResult {
+    build_deps
+      .validate_snapshot(snapshot, &self.snapshots, self.dependencies.len())
+      .await
+  }
+
+  pub(super) async fn update(
+    &mut self,
+    snapshot: &Snapshot,
+    build_deps: &mut BuildDeps,
+    paths: impl Iterator<Item = ArcPath>,
+  ) {
+    let added = build_deps
+      .resolve_dependencies(&self.dependencies, paths)
+      .await;
+    let snapshots = snapshot.add(added.iter().cloned()).await;
+    self.dependencies.extend(added);
+    self.snapshots.extend(snapshots);
+  }
+}
+
 /// Creates and validates filesystem snapshots stored by the new cache.
 #[derive(Debug)]
 pub struct Snapshot {

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -20,17 +20,9 @@ pub struct SnapshotEntry {
 
 #[cacheable]
 #[derive(Debug, Default)]
-struct BuildDependenciesSnapshot {
+pub(super) struct BuildDependenciesSnapshot {
   dependencies: ArcPathSet,
   snapshots: Vec<SnapshotEntry>,
-}
-
-#[cacheable]
-#[derive(Debug, Default)]
-struct CacheMeta {
-  rspack_pkg_version: String,
-  cache_version: String,
-  build_dependencies: BuildDependenciesSnapshot,
 }
 
 /// Creates and validates filesystem snapshots stored by the new cache.

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -18,13 +18,6 @@ pub struct SnapshotEntry {
   strategy: Strategy,
 }
 
-#[cacheable]
-#[derive(Debug, Default)]
-pub(super) struct BuildDependenciesSnapshot {
-  dependencies: ArcPathSet,
-  snapshots: Vec<SnapshotEntry>,
-}
-
 /// Creates and validates filesystem snapshots stored by the new cache.
 #[derive(Debug)]
 pub struct Snapshot {

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -4,15 +4,8 @@ use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_paths::{ArcPath, ArcPathSet};
 
-use super::snapshot::{BuildDeps, BuildDepsValidationResult, Snapshot, SnapshotEntry};
+use super::snapshot::{BuildDependenciesSnapshot, BuildDeps, BuildDepsValidationResult, Snapshot};
 use crate::cache::persistent::codec::CacheCodec;
-
-#[cacheable]
-#[derive(Debug, Default)]
-struct BuildDependenciesSnapshot {
-  dependencies: ArcPathSet,
-  snapshots: Vec<SnapshotEntry>,
-}
 
 #[cacheable]
 #[derive(Debug)]
@@ -79,13 +72,9 @@ impl CacheValidator {
     if !validator.has_same_version(&self.data) {
       return Ok(CacheValidatorResult::InvalidVersion);
     }
-    let validation = self
-      .build_deps
-      .validate_snapshot(
-        &self.snapshot,
-        &validator.build_dependencies.snapshots,
-        validator.build_dependencies.dependencies.len(),
-      )
+    let validation = validator
+      .build_dependencies
+      .validate(&self.snapshot, &self.build_deps)
       .await;
     Ok(match validation {
       BuildDepsValidationResult::Valid { tracked_files } => {
@@ -103,13 +92,11 @@ impl CacheValidator {
   }
 
   pub(super) async fn update(&mut self, paths: impl Iterator<Item = ArcPath>) -> Result<Vec<u8>> {
-    let added = self
-      .build_deps
-      .resolve_dependencies(&self.data.build_dependencies.dependencies, paths)
+    self
+      .data
+      .build_dependencies
+      .update(&self.snapshot, &mut self.build_deps, paths)
       .await;
-    let snapshots = self.snapshot.add(added.iter().cloned()).await;
-    self.data.build_dependencies.dependencies.extend(added);
-    self.data.build_dependencies.snapshots.extend(snapshots);
     self.codec.encode(&self.data)
   }
 }

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use rspack_cacheable::cacheable;
+use rspack_error::Result;
+use rspack_paths::{ArcPath, ArcPathSet};
+
+use super::snapshot::{BuildDeps, BuildDepsValidationResult, Snapshot, SnapshotEntry};
+use crate::cache::persistent::codec::CacheCodec;
+
+#[cacheable]
+#[derive(Debug, Default)]
+struct BuildDependenciesSnapshot {
+  dependencies: ArcPathSet,
+  snapshots: Vec<SnapshotEntry>,
+}
+
+#[cacheable]
+#[derive(Debug)]
+struct CacheValidatorData {
+  rspack_pkg_version: String,
+  cache_version: String,
+  build_dependencies: BuildDependenciesSnapshot,
+}
+
+impl CacheValidatorData {
+  fn new(rspack_pkg_version: String, cache_version: String) -> Self {
+    Self {
+      rspack_pkg_version,
+      cache_version,
+      build_dependencies: Default::default(),
+    }
+  }
+
+  fn has_same_version(&self, other: &Self) -> bool {
+    self.rspack_pkg_version == other.rspack_pkg_version && self.cache_version == other.cache_version
+  }
+}
+
+pub(super) enum CacheValidatorResult {
+  InvalidVersion,
+  Valid {
+    tracked_files: usize,
+  },
+  InvalidBuildDependencies {
+    modified_files: ArcPathSet,
+    removed_files: ArcPathSet,
+  },
+}
+
+#[derive(Debug)]
+pub(super) struct CacheValidator {
+  data: CacheValidatorData,
+  codec: Arc<CacheCodec>,
+  snapshot: Snapshot,
+  build_deps: BuildDeps,
+}
+
+impl CacheValidator {
+  pub(super) fn new(
+    rspack_pkg_version: String,
+    cache_version: String,
+    codec: Arc<CacheCodec>,
+    snapshot: Snapshot,
+    build_deps: BuildDeps,
+  ) -> Self {
+    Self {
+      data: CacheValidatorData::new(rspack_pkg_version, cache_version),
+      codec,
+      snapshot,
+      build_deps,
+    }
+  }
+
+  pub(super) async fn validate(&mut self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
+    let Some(data) = data else {
+      return Ok(CacheValidatorResult::InvalidVersion);
+    };
+    let validator = self.codec.decode::<CacheValidatorData>(data)?;
+    if !validator.has_same_version(&self.data) {
+      return Ok(CacheValidatorResult::InvalidVersion);
+    }
+    let validation = self
+      .build_deps
+      .validate_snapshot(
+        &self.snapshot,
+        &validator.build_dependencies.snapshots,
+        validator.build_dependencies.dependencies.len(),
+      )
+      .await;
+    Ok(match validation {
+      BuildDepsValidationResult::Valid { tracked_files } => {
+        self.data = validator;
+        CacheValidatorResult::Valid { tracked_files }
+      }
+      BuildDepsValidationResult::Invalid {
+        modified_files,
+        removed_files,
+      } => CacheValidatorResult::InvalidBuildDependencies {
+        modified_files,
+        removed_files,
+      },
+    })
+  }
+
+  pub(super) async fn update(&mut self, paths: impl Iterator<Item = ArcPath>) -> Result<Vec<u8>> {
+    let added = self
+      .build_deps
+      .resolve_dependencies(&self.data.build_dependencies.dependencies, paths)
+      .await;
+    let snapshots = self.snapshot.add(added.iter().cloned()).await;
+    self.data.build_dependencies.dependencies.extend(added);
+    self.data.build_dependencies.snapshots.extend(snapshots);
+    self.codec.encode(&self.data)
+  }
+}


### PR DESCRIPTION
Persist the configured cache version in new_cache and reset the persistent database when the version is missing or changes, preventing incompatible cache entries from being restored.