### PR TITLE
fix(cache): use storage location for new cache

### DIFF
--- a/crates/rspack_core/src/cache/persistent/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/mod.rs
@@ -6,10 +6,7 @@ pub mod snapshot;
 pub mod storage;
 pub mod validation;
 
-use std::{
-  hash::{DefaultHasher, Hash, Hasher},
-  sync::Arc,
-};
+use std::sync::Arc;
 
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem};
 use rspack_workspace::rspack_pkg_version;
@@ -20,7 +17,7 @@ use self::{
   context::CacheContext,
   occasion::{MakeOccasion, MinimizeOccasion, SourceMapDevToolPluginOccasion},
   snapshot::{Snapshot, SnapshotOptions},
-  storage::{CacheDirectory, StorageOptions, create_storage},
+  storage::{StorageOptions, compiler_cache_directory, create_storage},
   validation::CacheValidation,
 };
 use super::Cache;
@@ -70,11 +67,7 @@ impl PersistentCache {
     };
     let codec = Arc::new(CacheCodec::new(project_root));
     // Each compiler path owns exactly one storage directory.
-    let cache_directory = {
-      let mut hasher = DefaultHasher::new();
-      compiler_path.hash(&mut hasher);
-      CacheDirectory::new(hex::encode(hasher.finish().to_ne_bytes()))
-    };
+    let cache_directory = compiler_cache_directory(compiler_path);
     let storage = create_storage(
       option.storage.clone(),
       cache_directory,

--- a/crates/rspack_core/src/cache/persistent/storage/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/storage/mod.rs
@@ -1,10 +1,19 @@
-use std::sync::Arc;
+use std::{
+  hash::{DefaultHasher, Hash, Hasher},
+  sync::Arc,
+};
 
 use rspack_cacheable::{cacheable, utils::PortablePath, with::As};
 use rspack_fs::IntermediateFileSystem;
 use rspack_paths::Utf8PathBuf;
 pub use rspack_storage::{BoxStorage, CacheDirectory, MemoryStorage, Storage};
 use rspack_storage::{FileSystemOptions, FileSystemStorage};
+
+pub(crate) fn compiler_cache_directory(compiler_path: &str) -> CacheDirectory {
+  let mut hasher = DefaultHasher::new();
+  compiler_path.hash(&mut hasher);
+  CacheDirectory::new(hex::encode(hasher.finish().to_ne_bytes()))
+}
 
 /// Storage Options
 ///

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -24,7 +24,8 @@ use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::{BuildDeps, Snapshot};
 use crate::{
-  CompilationLogger, CompilationLogging, CompilerOptions, cache::persistent::codec::CacheCodec,
+  CompilationLogger, CompilationLogging, CompilerOptions,
+  cache::persistent::{codec::CacheCodec, storage::compiler_cache_directory},
 };
 
 pub fn create_cache(
@@ -59,14 +60,15 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let (base_path, database_path) = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
-      directory.clone(),
-      directory.join(rspack_workspace::rspack_pkg_version!()),
-    ),
+  // Raw storage.directory is the normalized cache.storage.location.
+  let storage_location = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
+      directory.clone()
+    }
   };
+  let database_path = storage_location.join(compiler_cache_directory(&compiler_path).as_str());
   let strategy = match FileCacheStrategy::new(
-    (base_path, database_path),
+    (storage_location, database_path),
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),

--- a/tests/rspack-test/compilerCases/persistent-cache-compiler-path.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-compiler-path.js
@@ -46,7 +46,7 @@ class ChildCompilersPlugin {
 	}
 }
 
-const runCompiler = (context, cacheDirectory, version) =>
+const runCompiler = (context, cacheDirectory, version, newCache) =>
 	new Promise((resolve, reject) => {
 		const compiler = rspack({
 			name: "root",
@@ -55,6 +55,9 @@ const runCompiler = (context, cacheDirectory, version) =>
 			mode: "development",
 			output: {
 				path: context.getDist(`output-${version}`)
+			},
+			experiments: {
+				newCache
 			},
 			cache: {
 				type: "persistent",
@@ -90,26 +93,40 @@ module.exports = {
 		};
 	},
 	async build(context) {
-		const cacheDirectory = context.getDist(
+		const legacyCacheDirectory = context.getDist(
 			"persistent-cache-compiler-path"
 		);
-		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+		const newCacheDirectory = context.getDist(
+			"persistent-new-cache-compiler-path"
+		);
+		fs.rmSync(legacyCacheDirectory, { recursive: true, force: true });
+		fs.rmSync(newCacheDirectory, { recursive: true, force: true });
 
-		await runCompiler(context, cacheDirectory, "v1");
-		await runCompiler(context, cacheDirectory, "v2");
+		await runCompiler(context, legacyCacheDirectory, "v1", false);
+		await runCompiler(context, legacyCacheDirectory, "v2", false);
+		await runCompiler(context, newCacheDirectory, "v1", true);
+		await runCompiler(context, newCacheDirectory, "v2", true);
 
 		context.setValue(
 			"cacheDirectories",
-			fs
-				.readdirSync(cacheDirectory)
-				.filter(name => CACHE_DIRECTORY_REGEXP.test(name))
-				.sort()
+			{
+				legacy: fs
+					.readdirSync(legacyCacheDirectory)
+					.filter(name => CACHE_DIRECTORY_REGEXP.test(name))
+					.sort(),
+				newCache: fs
+					.readdirSync(newCacheDirectory)
+					.filter(name => CACHE_DIRECTORY_REGEXP.test(name))
+					.sort()
+			}
 		);
 	},
 	check({ context }) {
 		const cacheDirectories = context.getValue("cacheDirectories");
 
-		expect(cacheDirectories).toHaveLength(1 + CHILD_COMPILER_NAMES.length);
-		expect(new Set(cacheDirectories).size).toBe(cacheDirectories.length);
+		for (const directories of [cacheDirectories.legacy, cacheDirectories.newCache]) {
+			expect(directories).toHaveLength(1 + CHILD_COMPILER_NAMES.length);
+			expect(new Set(directories).size).toBe(directories.length);
+		}
 	}
 };


### PR DESCRIPTION
Use the normalized `cache.storage.location` directly for new_cache instead of adding an Rspack package version subdirectory.