### PR TITLE
fix(esm): make module codegen cache scope-aware

### DIFF
--- a/crates/rspack_core/src/artifacts/cgm_hash_artifact.rs
+++ b/crates/rspack_core/src/artifacts/cgm_hash_artifact.rs
@@ -8,6 +8,7 @@ use crate::{
 #[derive(Debug, Default)]
 pub struct CgmHashArtifact {
   module_to_hashes: IdentifierMap<RuntimeSpecMap<RspackHashDigest>>,
+  module_to_code_generation_hash: IdentifierMap<RspackHashDigest>,
 }
 
 impl ArtifactExt for CgmHashArtifact {
@@ -20,6 +21,7 @@ impl FromIterator<(ModuleIdentifier, RuntimeSpecMap<RspackHashDigest>)> for CgmH
   ) -> Self {
     Self {
       module_to_hashes: IdentifierMap::from_iter(iter),
+      module_to_code_generation_hash: Default::default(),
     }
   }
 }
@@ -35,11 +37,21 @@ impl CgmHashArtifact {
     self.module_to_hashes.iter()
   }
 
+  pub fn code_generation_hashes_iter(
+    &self,
+  ) -> impl Iterator<Item = (&ModuleIdentifier, &RspackHashDigest)> {
+    self.module_to_code_generation_hash.iter()
+  }
+
   pub fn get_runtime_map(
     &self,
     module: &ModuleIdentifier,
   ) -> Option<&RuntimeSpecMap<RspackHashDigest>> {
     self.module_to_hashes.get(module)
+  }
+
+  pub fn get_code_generation_hash(&self, module: &ModuleIdentifier) -> Option<&RspackHashDigest> {
+    self.module_to_code_generation_hash.get(module)
   }
 
   pub fn get(&self, module: &ModuleIdentifier, runtime: &RuntimeSpec) -> Option<&RspackHashDigest> {
@@ -51,22 +63,40 @@ impl CgmHashArtifact {
     &mut self,
     module: ModuleIdentifier,
     hashes: RuntimeSpecMap<RspackHashDigest>,
+    code_generation_hash: Option<RspackHashDigest>,
   ) -> bool {
-    if let Some(old) = self.module_to_hashes.get(&module)
-      && old == &hashes
-    {
+    let hashes_unchanged = self
+      .module_to_hashes
+      .get(&module)
+      .is_some_and(|old| old == &hashes);
+    let code_generation_hash_unchanged =
+      self.module_to_code_generation_hash.get(&module) == code_generation_hash.as_ref();
+    if hashes_unchanged && code_generation_hash_unchanged {
       false
     } else {
       self.module_to_hashes.insert(module, hashes);
+      if let Some(code_generation_hash) = code_generation_hash {
+        self
+          .module_to_code_generation_hash
+          .insert(module, code_generation_hash);
+      } else {
+        self.module_to_code_generation_hash.remove(&module);
+      }
       true
     }
   }
 
+  pub fn set_code_generation_hash(&mut self, module: ModuleIdentifier, hash: RspackHashDigest) {
+    self.module_to_code_generation_hash.insert(module, hash);
+  }
+
   pub fn remove(&mut self, module: &ModuleIdentifier) -> Option<RuntimeSpecMap<RspackHashDigest>> {
+    self.module_to_code_generation_hash.remove(module);
     self.module_to_hashes.remove(module)
   }
 
   pub fn clear(&mut self) {
     self.module_to_hashes.clear();
+    self.module_to_code_generation_hash.clear();
   }
 }

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -3,7 +3,7 @@ use std::{collections::hash_map::Entry, fmt::Debug};
 use dyn_clone::{DynClone, clone_trait_object};
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
-  with::{AsCacheable, AsInner, AsMap, AsOption, AsPreset, AsVec, Unsupported},
+  with::{AsCacheable, AsInner, AsMap, AsPreset, AsVec},
 };
 use rspack_collections::IdentifierMap;
 use rspack_hash::{HashDigest, HashFunction, HashSalt, RspackHash, RspackHashDigest, RspackHasher};
@@ -17,8 +17,9 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet};
 use serde::Serialize;
 
 use crate::{
-  ArtifactExt, AssetInfo, BindingCell, ChunkInitFragments, ConcatenationScope, ModuleIdentifier,
-  RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, SourceType, incremental::IncrementalPasses,
+  ArtifactExt, AssetInfo, BindingCell, ChunkInitFragments, ConcatenationCodeGenerationData,
+  ConcatenationScope, ModuleIdentifier, RuntimeGlobals, RuntimeSpec, RuntimeSpecMap, SourceType,
+  incremental::IncrementalPasses,
 };
 
 #[cacheable]
@@ -228,8 +229,7 @@ pub struct CodeGenerationResult {
   pub runtime_requirements: RuntimeGlobals,
   pub hash: Option<RspackHashDigest>,
   pub id: CodeGenResultId,
-  #[cacheable(with=AsOption<Unsupported>)]
-  pub concatenation_scope: Option<ConcatenationScope>,
+  pub concatenation_data: Option<ConcatenationCodeGenerationData>,
 }
 
 impl CodeGenerationResult {

--- a/crates/rspack_core/src/cache/persistent/occasion/module_hashes/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/module_hashes/mod.rs
@@ -12,6 +12,7 @@ use super::{
 use crate::{CgmHashArtifact, ModuleIdentifier, RayonConsumer, RuntimeSpecMap};
 
 pub const SCOPE: &str = "occasion_module_hashes";
+const CODE_GENERATION_SCOPE: &str = "occasion_module_code_generation_hashes";
 
 #[derive(Debug)]
 pub struct ModuleHashesOccasion {
@@ -34,11 +35,13 @@ impl Occasion for ModuleHashesOccasion {
   #[tracing::instrument(name = "Cache::Occasion::ModuleHashes::reset", skip_all)]
   fn reset(&self, storage: &mut dyn Storage) {
     storage.reset(SCOPE);
+    storage.reset(CODE_GENERATION_SCOPE);
   }
 
   #[tracing::instrument(name = "Cache::Occasion::ModuleHashes::save", skip_all)]
   fn save(&self, storage: &mut dyn Storage, artifact: &CgmHashArtifact) {
     storage.reset(SCOPE);
+    storage.reset(CODE_GENERATION_SCOPE);
 
     let saved_count = std::sync::atomic::AtomicUsize::new(0);
     artifact
@@ -72,6 +75,42 @@ impl Occasion for ModuleHashesOccasion {
       "saved {} module hashes persistent cache entries",
       saved_count.load(std::sync::atomic::Ordering::Relaxed)
     );
+
+    let saved_code_generation_hash_count = std::sync::atomic::AtomicUsize::new(0);
+    artifact
+      .code_generation_hashes_iter()
+      .par_bridge()
+      .filter_map(|(module, hash)| {
+        let key = match self.codec.encode(module) {
+          Ok(bytes) => bytes,
+          Err(err) => {
+            tracing::warn!(
+              "module code generation hash persistent cache key encode failed: {:?}",
+              err
+            );
+            return None;
+          }
+        };
+        match self.codec.encode(hash) {
+          Ok(bytes) => Some((key, bytes)),
+          Err(err) => {
+            tracing::warn!(
+              "module code generation hash persistent cache encode failed: {:?}",
+              err
+            );
+            None
+          }
+        }
+      })
+      .consume(|(key, bytes)| {
+        storage.set(CODE_GENERATION_SCOPE, key, bytes);
+        saved_code_generation_hash_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+      });
+
+    tracing::debug!(
+      "saved {} module code generation hashes persistent cache entries",
+      saved_code_generation_hash_count.load(std::sync::atomic::Ordering::Relaxed)
+    );
   }
 
   #[tracing::instrument(name = "Cache::Occasion::ModuleHashes::recovery", skip_all)]
@@ -97,6 +136,37 @@ impl Occasion for ModuleHashesOccasion {
       "recovered {} module hashes persistent cache entries",
       entries.len()
     );
-    Ok(entries.into_iter().collect())
+    let mut artifact: CgmHashArtifact = entries.into_iter().collect();
+
+    let code_generation_hash_items = storage.load(CODE_GENERATION_SCOPE).await?;
+    let code_generation_hashes = code_generation_hash_items
+      .into_par_iter()
+      .map(|(key, value)| {
+        let module = self.codec.decode::<ModuleIdentifier>(&key).map_err(|err| {
+          rspack_error::error!(
+            "module code generation hash persistent cache key decode failed: {err}"
+          )
+        })?;
+        let hash = self
+          .codec
+          .decode::<RspackHashDigest>(&value)
+          .map_err(|err| {
+            rspack_error::error!(
+              "module code generation hash persistent cache decode failed: {err}"
+            )
+          })?;
+        Ok((module, hash))
+      })
+      .collect::<Result<IdentifierMap<RspackHashDigest>>>()?;
+    let code_generation_hash_count = code_generation_hashes.len();
+    for (module, hash) in code_generation_hashes {
+      artifact.set_code_generation_hash(module, hash);
+    }
+    tracing::debug!(
+      "recovered {} module code generation hashes persistent cache entries",
+      code_generation_hash_count
+    );
+
+    Ok(artifact)
   }
 }

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -304,10 +304,11 @@ impl ChunkGraph {
     compilation: &mut Compilation,
     module_identifier: ModuleIdentifier,
     hashes: RuntimeSpecMap<RspackHashDigest>,
+    code_generation_hash: Option<RspackHashDigest>,
   ) -> bool {
     compilation
       .cgm_hash_artifact
-      .set_hashes(module_identifier, hashes)
+      .set_hashes(module_identifier, hashes, code_generation_hash)
   }
 
   pub fn try_get_module_chunks(

--- a/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_hashes/mod.rs
@@ -33,6 +33,29 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
     compilation.cgm_hash_artifact.clear();
   }
 
+  let all_modules_for_code_generation_hashes = if compilation
+    .plugin_driver
+    .compilation_hooks
+    .concatenation_scope
+    .is_empty()
+  {
+    None
+  } else {
+    Some(
+      compilation
+        .get_module_graph()
+        .modules_keys()
+        .copied()
+        .collect::<IdentifierSet>(),
+    )
+  };
+  let has_code_generation_hashes = all_modules_for_code_generation_hashes.is_some();
+  let code_generation_hashes = if let Some(modules) = &all_modules_for_code_generation_hashes {
+    collect_code_generation_hashes(compilation, modules).await?
+  } else {
+    Default::default()
+  };
+
   let create_module_hashes_modules = if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::MODULES_HASHES)
@@ -48,6 +71,13 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
     let mut modules = mutations.get_affected_modules_with_chunk_graph(compilation);
 
     add_modules_with_changed_runtimes(compilation, &mut modules);
+    if has_code_generation_hashes {
+      add_modules_with_changed_code_generation_hashes(
+        compilation,
+        &code_generation_hashes,
+        &mut modules,
+      );
+    }
 
     tracing::debug!(target: incremental::TRACING_TARGET, passes = %IncrementalPasses::MODULES_HASHES, %mutations, ?modules);
     let logger = compilation.get_logger("rspack.incremental.modulesHashes");
@@ -59,13 +89,20 @@ async fn create_module_hashes_pass_impl(compilation: &mut Compilation) -> Result
 
     modules
   } else {
-    compilation
-      .get_module_graph()
-      .modules_keys()
-      .copied()
-      .collect()
+    all_modules_for_code_generation_hashes.unwrap_or_else(|| {
+      compilation
+        .get_module_graph()
+        .modules_keys()
+        .copied()
+        .collect()
+    })
   };
-  create_module_hashes(compilation, create_module_hashes_modules).await
+  create_module_hashes_with_code_generation_hashes(
+    compilation,
+    create_module_hashes_modules,
+    &code_generation_hashes,
+  )
+  .await
 }
 
 fn add_modules_with_changed_runtimes(compilation: &Compilation, modules: &mut IdentifierSet) {
@@ -123,10 +160,74 @@ fn add_modules_with_changed_runtimes(compilation: &Compilation, modules: &mut Id
   }
 }
 
+fn add_modules_with_changed_code_generation_hashes(
+  compilation: &Compilation,
+  code_generation_hashes: &IdentifierMap<RspackHashDigest>,
+  modules: &mut IdentifierSet,
+) {
+  for module in compilation.get_module_graph().modules_keys() {
+    if compilation
+      .cgm_hash_artifact
+      .get_code_generation_hash(module)
+      != code_generation_hashes.get(module)
+    {
+      modules.insert(*module);
+    }
+  }
+}
+
+async fn collect_code_generation_hashes(
+  compilation: &Compilation,
+  modules: &IdentifierSet,
+) -> Result<IdentifierMap<RspackHashDigest>> {
+  let hook = &compilation
+    .plugin_driver
+    .compilation_hooks
+    .concatenation_scope;
+  if hook.is_empty() {
+    return Ok(Default::default());
+  }
+
+  let mut hashes = IdentifierMap::default();
+  for module in modules {
+    let scope = hook.call(compilation, *module).await?;
+    if let Some(hash) = scope.and_then(|scope| scope.code_generation_hash) {
+      hashes.insert(*module, hash);
+    }
+  }
+  Ok(hashes)
+}
+
+fn merge_code_generation_hash(
+  compilation: &Compilation,
+  module_hash: RspackHashDigest,
+  code_generation_hash: Option<&RspackHashDigest>,
+) -> RspackHashDigest {
+  let Some(code_generation_hash) = code_generation_hash else {
+    return module_hash;
+  };
+
+  let mut hasher = RspackHasher::from(&compilation.options.output);
+  rspack_hash::RspackHash::hash("module-code-generation-v1", &mut hasher);
+  rspack_hash::RspackHash::hash(&module_hash, &mut hasher);
+  rspack_hash::RspackHash::hash(code_generation_hash, &mut hasher);
+  hasher.digest(&compilation.options.output.hash_digest)
+}
+
 #[instrument("Compilation:create_module_hashes", skip_all)]
 pub async fn create_module_hashes(
   compilation: &mut Compilation,
   modules: IdentifierSet,
+) -> Result<()> {
+  let code_generation_hashes = collect_code_generation_hashes(compilation, &modules).await?;
+  create_module_hashes_with_code_generation_hashes(compilation, modules, &code_generation_hashes)
+    .await
+}
+
+async fn create_module_hashes_with_code_generation_hashes(
+  compilation: &mut Compilation,
+  modules: IdentifierSet,
+  code_generation_hashes: &IdentifierMap<RspackHashDigest>,
 ) -> Result<()> {
   let mg = compilation.get_module_graph();
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
@@ -135,18 +236,31 @@ pub async fn create_module_hashes(
 
   let results = rspack_parallel::scope::<_, Result<_>>(|token| {
     for module_identifier in modules {
-      let s = unsafe { token.used((compilation_ref, &mg, chunk_graph, chunk_by_ukey)) };
+      let s = unsafe {
+        token.used((
+          compilation_ref,
+          &mg,
+          chunk_graph,
+          chunk_by_ukey,
+          code_generation_hashes,
+        ))
+      };
       s.spawn(
-        move |(compilation, mg, chunk_graph, chunk_by_ukey)| async move {
+        move |(compilation, mg, chunk_graph, chunk_by_ukey, code_generation_hashes)| async move {
           let mut hashes = RuntimeSpecMap::new();
+          let code_generation_hash = code_generation_hashes.get(&module_identifier).cloned();
           let module = mg
             .module_by_identifier(&module_identifier)
             .expect("should have module");
           for runtime in chunk_graph.get_module_runtimes_iter(module_identifier, chunk_by_ukey) {
-            let hash = module.get_runtime_hash(compilation, Some(runtime)).await?;
+            let hash = merge_code_generation_hash(
+              compilation,
+              module.get_runtime_hash(compilation, Some(runtime)).await?,
+              code_generation_hash.as_ref(),
+            );
             hashes.set(runtime.clone(), hash);
           }
-          Ok((module_identifier, hashes))
+          Ok((module_identifier, hashes, code_generation_hash))
         },
       );
     }
@@ -157,8 +271,8 @@ pub async fn create_module_hashes(
   .collect::<Result<Vec<_>>>()?;
 
   for result in results {
-    let (module, hashes) = result?;
-    if ChunkGraph::set_module_hashes(compilation, module, hashes)
+    let (module, hashes, code_generation_hash) = result?;
+    if ChunkGraph::set_module_hashes(compilation, module, hashes, code_generation_hash)
       && let Some(mut mutations) = compilation.incremental.mutations_write()
     {
       mutations.add(Mutation::ModuleSetHashes { module });

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -8,7 +8,10 @@ use std::{
 
 use rayon::prelude::*;
 use regex::Regex;
-use rspack_cacheable::{cacheable, cacheable_dyn, with::As};
+use rspack_cacheable::{
+  cacheable, cacheable_dyn,
+  with::{As, AsOption, AsPreset, AsVec},
+};
 use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
@@ -278,9 +281,12 @@ impl ConcatenationEntryExternal {
   }
 }
 
+#[cacheable]
 #[derive(Clone, Debug, Default)]
 pub struct ConcatenatedImportMapItem {
+  #[cacheable(with=AsVec<AsPreset>)]
   pub specifiers: HashSet<Atom>,
+  #[cacheable(with=AsOption<AsPreset>)]
   pub namespace: Option<Atom>,
 }
 
@@ -2586,7 +2592,7 @@ impl ConcatenatedModule {
         mut inner,
         mut data,
         mut runtime_requirements,
-        concatenation_scope,
+        concatenation_data,
         ..
       } = codegen_res;
 
@@ -2596,12 +2602,13 @@ impl ConcatenatedModule {
         .map(|fragments| mem::take(fragments.inner_mut()))
         .unwrap_or_default();
 
-      let concatenation_scope = concatenation_scope.expect("should have concatenation_scope");
+      let concatenation_data =
+        concatenation_data.expect("should have concatenation code generation data");
       let source = inner
         .remove(&SourceType::JavaScript)
         .expect("should have javascript source");
       let source_code = source.source().into_string_lossy();
-      let mut module_info = concatenation_scope.current_module;
+      let mut module_info = concatenation_data.into_module_info(info.clone());
 
       let jsx = module
         .as_ref()

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1242,7 +1242,8 @@ impl Module for ExternalModule {
         }
       }
     };
-    cgr.concatenation_scope = std::mem::take(concatenation_scope);
+    cgr.concatenation_data =
+      std::mem::take(concatenation_scope).map(ConcatenationScope::into_code_generation_data);
     Ok(cgr)
   }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -28,12 +28,13 @@ use tracing::{Instrument, info_span};
 use crate::{
   AsyncDependenciesBlockIdentifier, BoxDependencyTemplate, BoxLoader, BoxModule,
   BoxModuleDependency, BuildContext, BuildInfo, BuildMeta, BuildResult, ChunkGraph,
-  CodeGenerationResult, Compilation, ConnectionState, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult,
-  ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin,
-  RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, contextify,
+  CodeGenerationResult, Compilation, ConcatenationScope, ConnectionState, Context,
+  DependenciesBlock, DependencyId, FactoryMeta, GenerateContext, GeneratorOptions, ImportPhase,
+  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem, OutputOptions, ParseContext,
+  ParseResult, ParserAndGenerator, ParserOptions, Resolve, ResolvedModuleOptions,
+  RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact,
+  SourceType, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
@@ -639,7 +640,8 @@ impl Module for NormalModule {
           SourceType::JavaScript,
           RawStringSource::from(format!("throw new Error({});\n", json!(error))).boxed(),
         );
-        code_generation_result.concatenation_scope = std::mem::take(concatenation_scope);
+        code_generation_result.concatenation_data =
+          std::mem::take(concatenation_scope).map(ConcatenationScope::into_code_generation_data);
       }
       return Ok(code_generation_result);
     }
@@ -683,7 +685,8 @@ impl Module for NormalModule {
         code_generation_result.add(*source_type, CachedSource::new(generation_result).boxed());
       }
     }
-    code_generation_result.concatenation_scope = std::mem::take(concatenation_scope);
+    code_generation_result.concatenation_data =
+      std::mem::take(concatenation_scope).map(ConcatenationScope::into_code_generation_data);
     Ok(code_generation_result)
   }
 

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -1,16 +1,22 @@
 use std::sync::{Arc, LazyLock};
 
 use anymap::CloneAny;
+use rspack_cacheable::{
+  cacheable,
+  with::{AsCacheable, AsMap, AsOption, AsPreset, AsVec},
+};
 use rspack_collections::IdentifierIndexMap;
+use rspack_hash::RspackHashDigest;
 use rspack_util::{
   fx_hash::{FxIndexMap, FxIndexSet},
   itoa,
 };
+use rustc_hash::FxHashMap as HashMap;
 use swc_core::atoms::Atom;
 
 use crate::{
   ExportMode, ModuleIdentifier,
-  concatenated_module::{ConcatenatedModuleInfo, ModuleInfo},
+  concatenated_module::{ConcatenatedImportMap, ConcatenatedModuleInfo, ModuleInfo},
 };
 
 pub static DEFAULT_EXPORT_ATOM: LazyLock<Atom> = LazyLock::new(|| "__rspack_default_export".into());
@@ -19,8 +25,10 @@ pub const DEFAULT_EXPORT: &str = "__rspack_default_export";
 const MODULE_REFERENCE_PREFIX: &str = "__rspack_module_ref";
 const MODULE_REFERENCE_PROPERTY_ACCESS_SUFFIX: &str = "._";
 
+#[cacheable]
 #[derive(Default, Debug, Clone)]
 pub struct ModuleReferenceOptions {
+  #[cacheable(with=AsVec<AsPreset>)]
   pub ids: Vec<Atom>,
   pub call: bool,
   pub direct_import: bool,
@@ -29,11 +37,54 @@ pub struct ModuleReferenceOptions {
   pub index: usize,
 }
 
+/// Module-local data produced while generating code in a concatenation scope.
+///
+/// The scope also contains compilation-local inputs such as `modules_map` and
+/// type-erased scratch data. Only this output is needed after code generation
+/// and is safe to persist with the generated source.
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub struct ConcatenationCodeGenerationData {
+  #[cacheable(with=AsOption<AsPreset>)]
+  pub namespace_export_symbol: Option<Atom>,
+  #[cacheable(with=AsOption<AsMap<AsPreset>>)]
+  pub export_map: Option<HashMap<Atom, String>>,
+  #[cacheable(with=AsOption<AsMap<AsPreset>>)]
+  pub raw_export_map: Option<HashMap<Atom, String>>,
+  #[cacheable(with=AsOption<AsMap>)]
+  pub import_map: ConcatenatedImportMap,
+  #[cacheable(with=AsMap<AsCacheable, AsMap>)]
+  pub refs: IdentifierIndexMap<FxIndexMap<String, ModuleReferenceOptions>>,
+}
+
+impl ConcatenationCodeGenerationData {
+  pub fn apply_to(&self, info: &mut ConcatenatedModuleInfo) {
+    info.namespace_export_symbol = self.namespace_export_symbol.clone();
+    info.export_map = self.export_map.clone();
+    info.raw_export_map = self.raw_export_map.clone();
+    info.import_map = self.import_map.clone();
+  }
+
+  pub fn into_module_info(self, mut info: ConcatenatedModuleInfo) -> ConcatenatedModuleInfo {
+    info.namespace_export_symbol = self.namespace_export_symbol;
+    info.export_map = self.export_map;
+    info.raw_export_map = self.raw_export_map;
+    info.import_map = self.import_map;
+    info
+  }
+}
+
 #[derive(Debug, Clone)]
 pub struct ConcatenationScope {
   pub concat_module_id: ModuleIdentifier,
   pub current_module: ConcatenatedModuleInfo,
   pub modules_map: Arc<IdentifierIndexMap<ModuleInfo>>,
+  /// A stable fingerprint of the compilation-local inputs that can affect code generation.
+  ///
+  /// Scope providers may set this when their scope contains inputs that are not already covered by
+  /// the module runtime hash. The fingerprint is persisted alongside module hashes, while the scope
+  /// itself remains compilation-local.
+  pub code_generation_hash: Option<RspackHashDigest>,
   pub data: anymap::Map<dyn CloneAny + Send + Sync>,
   pub refs: IdentifierIndexMap<FxIndexMap<String, ModuleReferenceOptions>>,
   pub dyn_refs: IdentifierIndexMap<FxIndexSet<(String, Atom)>>,
@@ -51,6 +102,7 @@ impl ConcatenationScope {
       concat_module_id,
       current_module,
       modules_map,
+      code_generation_hash: None,
       data: Default::default(),
       refs: IdentifierIndexMap::default(),
       dyn_refs: Default::default(),
@@ -60,6 +112,21 @@ impl ConcatenationScope {
 
   pub fn is_module_in_scope(&self, module: &ModuleIdentifier) -> bool {
     self.modules_map.contains_key(module)
+  }
+
+  pub fn with_code_generation_hash(mut self, hash: RspackHashDigest) -> Self {
+    self.code_generation_hash = Some(hash);
+    self
+  }
+
+  pub fn into_code_generation_data(self) -> ConcatenationCodeGenerationData {
+    ConcatenationCodeGenerationData {
+      namespace_export_symbol: self.current_module.namespace_export_symbol,
+      export_map: self.current_module.export_map,
+      raw_export_map: self.current_module.raw_export_map,
+      import_map: self.current_module.import_map,
+      refs: self.refs,
+    }
   }
 
   /**

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1510,12 +1510,11 @@ var {} = {{}};
                     runtime_template,
                   )
                   .await?;
-                *concate_info = codegen_res
-                  .concatenation_scope
+                codegen_res
+                  .concatenation_data
                   .as_ref()
-                  .expect("should have concatenation scope")
-                  .current_module
-                  .clone();
+                  .expect("should have concatenation code generation data")
+                  .apply_to(&mut concate_info);
 
                 let m = module_graph
                   .module_by_identifier(&id)
@@ -2727,12 +2726,12 @@ var {} = {{}};
         }
 
         let codegen_res = compilation.code_generation_results.get(&m, None);
-        let concatenation_scope = codegen_res
-          .concatenation_scope
+        let concatenation_data = codegen_res
+          .concatenation_data
           .as_ref()
-          .expect("should have concatenation scope for scope hoisted module");
+          .expect("should have concatenation code generation data for scope hoisted module");
 
-        for (ref_module, all_refs) in &concatenation_scope.refs {
+        for (ref_module, all_refs) in &concatenation_data.refs {
           // import all atoms from ref_module
           for (ref_string, options) in all_refs.iter() {
             if refs.contains_key(ref_string) {

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -24,6 +24,7 @@ use rspack_core::{
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
+use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::{plugin, plugin_hook};
 use rspack_plugin_javascript::{
   JavascriptModulesRenderChunkContent, JsPlugin, RenderSource,
@@ -66,6 +67,8 @@ pub struct EsmLibraryPlugin {
   // and read-only access the map, so it receives the map as an Arc
   pub(crate) concatenated_modules_map_for_codegen:
     AtomicRefCell<Arc<IdentifierIndexMap<ModuleInfo>>>,
+  pub(crate) concatenation_scope_code_generation_hashes:
+    AtomicRefCell<IdentifierMap<RspackHashDigest>>,
   pub(crate) concatenated_modules_map: RwLock<IdentifierIndexMap<ModuleInfo>>,
   pub(crate) links: AtomicRefCell<FxHashMap<ChunkUkey, ChunkLinkContext>>,
   pub(crate) chunk_ids_to_ukey: AtomicRefCell<FxHashMap<String, ChunkUkey>>,
@@ -82,6 +85,7 @@ impl EsmLibraryPlugin {
     Self::new_inner(
       preserve_modules,
       split_chunks,
+      Default::default(),
       Default::default(),
       Default::default(),
       Default::default(),
@@ -245,6 +249,10 @@ impl EsmLibraryPlugin {
         }
       }
     }
+
+    let code_generation_hashes =
+      get_concatenation_scope_code_generation_hashes(compilation, module_graph, &modules_map);
+    *self.concatenation_scope_code_generation_hashes.borrow_mut() = code_generation_hashes;
 
     // only used for scope
     // we mutably modify data in `self.concatenated_modules_map`
@@ -420,6 +428,10 @@ async fn finish_modules(
     }
   }
 
+  let code_generation_hashes =
+    get_concatenation_scope_code_generation_hashes(compilation, module_graph, &modules_map);
+  *self.concatenation_scope_code_generation_hashes.borrow_mut() = code_generation_hashes;
+
   // only used for scope
   // we mutably modify data in `self.concatenated_modules_map`
   let mut map = self.concatenated_modules_map_for_codegen.borrow_mut();
@@ -461,12 +473,77 @@ async fn concatenation_scope(
   let ModuleInfo::Concatenated(current_module) = current_module else {
     return Ok(None);
   };
+  let code_generation_hash = self
+    .concatenation_scope_code_generation_hashes
+    .borrow()
+    .get(&module)
+    .cloned()
+    .expect("concatenated module should have a code generation hash");
   let scope = ConcatenationScope::new(
     current_module.module,
     modules_map.clone(),
     current_module.as_ref().clone(),
-  );
+  )
+  .with_code_generation_hash(code_generation_hash);
   Ok(Some(scope))
+}
+
+fn get_concatenation_scope_code_generation_hashes(
+  compilation: &Compilation,
+  module_graph: &ModuleGraph,
+  modules_map: &IdentifierIndexMap<ModuleInfo>,
+) -> IdentifierMap<RspackHashDigest> {
+  modules_map
+    .iter()
+    .filter(|(_, info)| matches!(info, ModuleInfo::Concatenated(_)))
+    .map(|(module, _)| {
+      (
+        *module,
+        get_concatenation_scope_code_generation_hash(
+          compilation,
+          module_graph,
+          *module,
+          modules_map,
+        ),
+      )
+    })
+    .collect()
+}
+
+fn get_concatenation_scope_code_generation_hash(
+  compilation: &Compilation,
+  module_graph: &ModuleGraph,
+  module: ModuleIdentifier,
+  modules_map: &IdentifierIndexMap<ModuleInfo>,
+) -> RspackHashDigest {
+  let mut hasher = RspackHasher::from(&compilation.options.output);
+  "esm-library-concatenation-scope-v1".hash(&mut hasher);
+
+  // Code generation only looks up dependency targets in `modules_map`, and observes their
+  // membership, kind, and index. Target identity and the rest of the module graph are already
+  // covered by the module runtime hash, so hashing this projection keeps the fingerprint portable.
+  for dependency in module_graph.get_outgoing_deps_in_order(&module) {
+    "dependency".hash(&mut hasher);
+    let Some(referenced_module) = module_graph.module_identifier_by_dependency_id(dependency)
+    else {
+      "unresolved".hash(&mut hasher);
+      continue;
+    };
+
+    match modules_map.get(referenced_module) {
+      Some(ModuleInfo::Concatenated(info)) => {
+        "concatenated".hash(&mut hasher);
+        info.index.hash(&mut hasher);
+      }
+      Some(ModuleInfo::External(info)) => {
+        "external".hash(&mut hasher);
+        info.index.hash(&mut hasher);
+      }
+      None => "out-of-scope".hash(&mut hasher),
+    }
+  }
+
+  hasher.digest(&compilation.options.output.hash_digest)
 }
 
 #[plugin_hook(CompilationAfterCodeGeneration for EsmLibraryPlugin)]

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-0.txt
@@ -1,0 +1,23 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> module hashes persistent cache recovery succeeded
+<t> read module hashes from persistent cache: xx ms
+<t> write module hashes to persistent cache: xx ms
+<i> modules codegen persistent cache recovery succeeded
+<t> read modules codegen from persistent cache: xx ms
+<t> write modules codegen to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-1.txt
@@ -1,0 +1,24 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> snapshot restored with no changed dependencies
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> module hashes persistent cache recovery succeeded
+<t> read module hashes from persistent cache: xx ms
+<t> write module hashes to persistent cache: xx ms
+<i> modules codegen persistent cache recovery succeeded
+<t> read modules codegen from persistent cache: xx ms
+<t> write modules codegen to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/__snapshots__/stats-2.txt
@@ -1,0 +1,27 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> snapshot restored with detected changed dependencies:
+<i> modified paths (2):
+<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/module-codegen-cache-modern-module/bridge.js
+<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/module-codegen-cache-modern-module/index.js
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> module hashes persistent cache recovery succeeded
+<t> read module hashes from persistent cache: xx ms
+<t> write module hashes to persistent cache: xx ms
+<i> modules codegen persistent cache recovery succeeded
+<t> read modules codegen from persistent cache: xx ms
+<t> write modules codegen to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/async-module.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/async-module.js
@@ -1,0 +1,5 @@
+export const value = 42;
+---
+export const value = 42;
+---
+export const value = 42;

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/bridge.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/bridge.js
@@ -1,0 +1,13 @@
+import value from "./file";
+
+export const bridge = value;
+---
+import value from "./file";
+
+export const bridge = value;
+---
+import value from "./file";
+
+eval("");
+
+export const bridge = value;

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/file.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/file.js
@@ -1,0 +1,5 @@
+export default 1;
+---
+export default 1;
+---
+export default 1;

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/index.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/index.js
@@ -1,0 +1,42 @@
+import { bridge } from "./bridge";
+import { stable } from "./stable";
+
+export { bridge, stable };
+
+it("should reuse and invalidate modern-module codegen metadata", async () => {
+	const asyncMod = await import("./async-module");
+
+	expect(bridge).toBe(1);
+	expect(stable).toBe("stable");
+	expect(asyncMod.value).toBe(42);
+
+	await NEXT_START();
+});
+---
+import { bridge } from "./bridge";
+import { stable } from "./stable";
+
+export { bridge, stable };
+
+it("should reuse and invalidate modern-module codegen metadata", async () => {
+	const asyncMod = await import("./async-module");
+
+	expect(bridge).toBe(1);
+	expect(stable).toBe("stable");
+	expect(asyncMod.value).toBe(42);
+
+	await NEXT_START();
+});
+---
+import { bridge } from "./bridge";
+import { stable } from "./stable";
+
+export { bridge, stable };
+
+it("should reuse and invalidate modern-module codegen metadata", async () => {
+	const asyncMod = await import("./async-module");
+
+	expect(bridge).toBe(1);
+	expect(stable).toBe("stable");
+	expect(asyncMod.value).toBe(42);
+});

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/rspack.config.js
@@ -1,0 +1,109 @@
+let updateIndex = 0;
+
+const MODULES_HASHES_LOGGER_NAME = 'rspack.incremental.modulesHashes';
+const MODULES_CODEGEN_LOGGER_NAME = 'rspack.incremental.modulesCodegen';
+
+function getAffectedLogEntry(logging, loggerName) {
+  return (logging?.[loggerName]?.entries ?? []).find(
+    (e) =>
+      e.type === 'log' &&
+      typeof e.message === 'string' &&
+      e.message.includes('modules are affected'),
+  );
+}
+
+function parseAffectedLogEntry(entry) {
+  const match = entry?.message.match(
+    /(\d+) modules are affected, (\d+) in total/,
+  );
+  expect(match).toBeTruthy();
+  return {
+    affected: Number(match[1]),
+    total: Number(match[2]),
+  };
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  cache: {
+    type: 'persistent',
+  },
+  incremental: {
+    buildModuleGraph: true,
+    modulesHashes: true,
+    modulesCodegen: true,
+  },
+  optimization: {
+    concatenateModules: false,
+    innerGraph: false,
+    mangleExports: false,
+  },
+  output: {
+    filename: '[name].mjs',
+    chunkFilename: '[name].chunk.[fullhash].mjs',
+    module: true,
+    library: {
+      type: 'modern-module',
+    },
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.done.tap(
+          'ModernModuleCodegenPersistentCacheTest',
+          (stats) => {
+            const s = stats.toJson({
+              all: false,
+              logging: 'verbose',
+            });
+            const modulesCodegenAffectedLogEntry = getAffectedLogEntry(
+              s.logging,
+              MODULES_CODEGEN_LOGGER_NAME,
+            );
+
+            if (updateIndex === 0) {
+              expect(modulesCodegenAffectedLogEntry).toBeUndefined();
+            }
+
+            if (updateIndex === 1) {
+              expect(modulesCodegenAffectedLogEntry).toBeTruthy();
+              const modulesCodegen = parseAffectedLogEntry(
+                modulesCodegenAffectedLogEntry,
+              );
+              expect(modulesCodegen.affected).toBe(0);
+              expect(modulesCodegen.total).toBeGreaterThan(0);
+            }
+
+            if (updateIndex === 2) {
+              expect(modulesCodegenAffectedLogEntry).toBeTruthy();
+              const modulesHashesAffectedLogEntry = getAffectedLogEntry(
+                s.logging,
+                MODULES_HASHES_LOGGER_NAME,
+              );
+              expect(modulesHashesAffectedLogEntry).toBeTruthy();
+              const modulesCodegen = parseAffectedLogEntry(
+                modulesCodegenAffectedLogEntry,
+              );
+              expect(modulesCodegen.affected).toBeGreaterThan(0);
+              expect(modulesCodegen.affected).toBeGreaterThan(2);
+              expect(modulesCodegen.total).toBeGreaterThan(0);
+              if (modulesCodegen.affected >= modulesCodegen.total) {
+                throw new Error(
+                  [
+                    `Expected module codegen affected modules to be less than total modules.`,
+                    `modulesHashes: ${modulesHashesAffectedLogEntry?.message}`,
+                    `modulesCodegen: ${modulesCodegenAffectedLogEntry.message}`,
+                  ].join('\n'),
+                );
+              }
+            }
+
+            updateIndex++;
+          },
+        );
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/stable.js
+++ b/tests/rspack-test/cacheCases/common/module-codegen-cache-modern-module/stable.js
@@ -1,0 +1,5 @@
+export const stable = "stable";
+---
+export const stable = "stable";
+---
+export const stable = "stable";


### PR DESCRIPTION
## Summary

- split compilation-local `ConcatenationScope` inputs from persistable `ConcatenationCodeGenerationData`
- fingerprint the per-module `modules_map` projection used by modern-module code generation and carry it through the existing concatenation-scope hook
- persist the sparse fingerprint alongside module hashes, compare it during incremental invalidation, and mix it into the effective module runtime hash
- keep the ordinary compilation path unchanged when no concatenation-scope hook is registered
- add a persistent-cache regression covering cache reuse and partial invalidation when a module changes concatenation status

The root cause is that ESM library code generation reads compilation-local `modules_map` state, while the generated result must remain persistable. Persisting only the generated metadata without representing that input could reuse stale codegen results; persisting the complete scope would duplicate non-portable graph state. This change persists only a compact fingerprint of the observable projection.

This is a stacked follow-up to #14731 and targets its head branch so the diff contains only the ESM cache changes.

## Related links

- #14731

## Validation

- `pnpm run build:binding:dev`
- `cargo test -p rspack_core -p rspack_plugin_esm_library --lib` (140 passed)
- `pnpm exec rstest Cache.test.js` (36 passed)
- `pnpm exec rstest EsmOutput.test.js` (456 passed)
- `pnpm exec rstest Normal.test.js -t "scope-hoisting"` (46 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- Prettier check for the new cache case

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required; internal cache behavior only).
