### PR TITLE
chore(vscode): use Rstack extension as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
-    "rstack.rstest",
-    "rstack.rslint",
+    "rstack.rstack",
     "streetsidesoftware.code-spell-checker",
     "tamasfe.even-better-toml",
     "rust-lang.rust-analyzer",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,17 +12,15 @@
     "editor.formatOnSave": true
   },
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  // Temporary workaround until we switch to the Rstack VS Code extension.
-  "prettier.singleQuote": true,
+  "editor.defaultFormatter": "rstack.rstack",
   "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[json5]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "[jsonc]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rstack.rstack"
   },
   "git.ignoreLimitWarning": true,
   "eslint.enable": false,


### PR DESCRIPTION
## Summary

This aligns Rspack's recommended VS Code setup with the unified Rstack extension so contributors no longer need the standalone Rslint and Rstest extensions. It uses the Rstack formatter for the workspace default and JSON-family files, and removes the temporary Prettier workaround.

## Related links

- https://github.com/web-infra-dev/rsbuild/pull/8325
- https://github.com/rstackjs/rstack-cli/pull/378

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).