### PR TITLE
fix: preserve reexport call context in concatenation

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -3319,6 +3319,8 @@ impl ConcatenatedModule {
             let referenced_info_id = reference.module;
             let mut referenced_export_name = reference.options.ids.clone();
             referenced_export_name.extend(export_name.iter().skip(1).cloned());
+            // Call and ASI semantics belong to the consuming import expression,
+            // not to the re-export edge being followed here.
             return Self::get_final_binding(
               mg,
               mg_cache,
@@ -3327,10 +3329,10 @@ impl ConcatenatedModule {
               referenced_export_name,
               module_to_info_map,
               runtime,
-              reference.options.call,
+              as_call,
               reference.options.deferred_import,
               module.build_meta().strict_esm_module(),
-              reference.options.asi_safe,
+              asi_safe,
               already_visited,
             );
           }

--- a/tests/rspack-test/configCases/concatenate-modules/interop/module-normal.cjs
+++ b/tests/rspack-test/configCases/concatenate-modules/interop/module-normal.cjs
@@ -2,7 +2,10 @@ function exportValue(exports) {
   module.exports = function () { return 42 }
 
   module.exports.__esModule = true
-  module.exports.default = () => { return 24 }
+  module.exports.default = function () {
+    "use strict"
+    return this === undefined ? 24 : -1
+  }
 }
 
 exportValue(exports)


### PR DESCRIPTION
## Summary

- Preserve the consuming import expression's call and ASI semantics while faster module concatenation follows a structured direct re-export.
- Strengthen the existing CommonJS interop case with a strict, `this`-sensitive default export.

Faster module concatenation previously used the re-export edge's fixed `call` and `asi_safe` metadata when resolving the final binding. This discarded the consuming import's context and could render a CommonJS default call as `getter.a(...)` instead of `getter()(...)`, changing the function's `this` value.

After this fix, enabling or disabling `experiments.fasterModuleConcatenation` produces byte-for-byte identical output across all five projects in `rstackjs/build-tools-performance` (`react-1k`, `react-5k`, `react-10k`, `popular-libs`, and `ui-components`).

## Related links

- Follow-up to #14852

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test:unit` (9208 passed, 4 skipped)
- `cargo fmt --all --check`
- Cold-cache faster on/off output comparison for all `rstackjs/build-tools-performance` projects; the full output tree is byte-for-byte identical

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
