### PR TITLE
feat: analyze dynamic imports in Promise.all destructuring

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 use swc_atoms::Atom;
 use swc_experimental_allocator::CloneIn;
 use swc_experimental_ecma_ast::{
-  BlockStmtOrExpr, CallExpr, Expr, GetSpan, Ident, MemberExpr, Pat, Span, VarDeclarator,
+  BlockStmtOrExpr, CallExpr, Expr, GetSpan, Ident, MemberExpr, ObjectPat, Pat, Span, VarDeclarator,
 };
 
 use super::{JavascriptParserPlugin, import_phase::get_import_phase};
@@ -20,9 +20,10 @@ use crate::{
   magic_comment::try_extract_magic_comment,
   utils::object_properties::{get_attributes, get_value_by_obj_prop},
   visitors::{
-    ContextModuleScanResult, JavascriptParser, PatRef, Statement, TagInfoData, TopLevelScope,
-    VariableDeclaration, VariableDeclarationKind, context_reg_exp, create_context_dependency,
-    create_traceable_error, get_non_optional_part, parse_order_string,
+    ContextModuleScanResult, DestructuringAssignmentProperties, JavascriptParser, PatRef,
+    Statement, TagInfoData, TopLevelScope, VariableDeclaration, VariableDeclarationKind,
+    context_reg_exp, create_context_dependency, create_traceable_error, get_non_optional_part,
+    parse_order_string,
   },
 };
 
@@ -46,6 +47,123 @@ fn tag_dynamic_import_referenced(
   );
 }
 
+fn collect_destructuring_references(
+  properties: &DestructuringAssignmentProperties,
+) -> Vec<Vec<Atom>> {
+  let mut references = Vec::new();
+  properties.traverse_on_leaf(&mut |stack| {
+    references.push(stack.iter().map(|property| property.id.clone()).collect());
+  });
+  references
+}
+
+fn add_destructuring_import_references(
+  parser: &mut JavascriptParser,
+  import_call: &CallExpr,
+  pattern: &ObjectPat,
+) {
+  let Some(properties) =
+    parser.collect_destructuring_assignment_properties_from_object_pattern(pattern)
+  else {
+    return;
+  };
+  let references = collect_destructuring_references(&properties);
+  let import_span = import_call.span();
+  parser.dynamic_import_references.add_import(import_span);
+  let import_references = parser
+    .dynamic_import_references
+    .get_import_mut_expect(&import_span);
+  for reference in references {
+    import_references.add_reference(reference);
+  }
+}
+
+fn is_unbound_promise_all(parser: &mut JavascriptParser, call: &CallExpr) -> bool {
+  let Some(callee) = call.callee.as_expr() else {
+    return false;
+  };
+  let Some(member) = callee.as_member() else {
+    return false;
+  };
+  member
+    .obj
+    .as_ident()
+    .is_some_and(|ident| ident.sym.as_str() == "Promise")
+    && member
+      .prop
+      .as_ident()
+      .is_some_and(|ident| ident.sym.as_str() == "all")
+    && parser.get_variable_info(&Atom::from("Promise")).is_none()
+}
+
+fn track_dynamic_import_pattern(
+  parser: &mut JavascriptParser,
+  import_call: &CallExpr,
+  pattern: &Pat,
+) {
+  match pattern {
+    Pat::Ident(binding) => {
+      let name = Atom::from(binding.id.sym.as_str());
+      parser.define_variable(name.clone());
+      tag_dynamic_import_referenced(parser, import_call, name);
+    }
+    Pat::Object(pattern) => {
+      add_destructuring_import_references(parser, import_call, pattern);
+    }
+    Pat::Assign(pattern) => {
+      track_dynamic_import_pattern(parser, import_call, &pattern.left);
+    }
+    _ => {}
+  }
+}
+
+fn track_dynamic_imports_in_promise_all(parser: &mut JavascriptParser, declarator: &VarDeclarator) {
+  let Some(pattern) = declarator.name.as_array() else {
+    return;
+  };
+  let Some(init) = &declarator.init else {
+    return;
+  };
+  let Some(await_expr) = init.as_await() else {
+    return;
+  };
+  let Some(promise_all) = await_expr.arg.as_call() else {
+    return;
+  };
+  if !is_unbound_promise_all(parser, promise_all) {
+    return;
+  }
+  let [argument] = promise_all.args.as_slice() else {
+    return;
+  };
+  if argument.spread.is_some() {
+    return;
+  }
+  let Some(imports) = argument.expr.as_array() else {
+    return;
+  };
+  if imports
+    .elems
+    .iter()
+    .flatten()
+    .any(|element| element.spread.is_some())
+  {
+    return;
+  }
+
+  for (pattern, import) in pattern.elems.iter().zip(&imports.elems) {
+    let (Some(pattern), Some(import)) = (pattern, import) else {
+      continue;
+    };
+    let Some(import_call) = import.expr.as_call() else {
+      continue;
+    };
+    if import_call.callee.is_import() {
+      track_dynamic_import_pattern(parser, import_call, pattern);
+    }
+  }
+}
+
 #[derive(Debug, Default)]
 pub struct ImportsReferencesState {
   inner: FxHashMap<Span, ImportReferences>,
@@ -53,7 +171,7 @@ pub struct ImportsReferencesState {
 
 impl ImportsReferencesState {
   pub fn add_import(&mut self, import: Span) {
-    self.inner.insert(import, ImportReferences::default());
+    self.inner.entry(import).or_default();
   }
 
   fn get_import(&self, import: &Span) -> Option<&ImportReferences> {
@@ -151,16 +269,18 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
     declarator: &VarDeclarator,
     declaration: VariableDeclaration<'_>,
   ) -> Option<bool> {
-    if declaration.kind() != VariableDeclarationKind::Var
-      && let Some(init) = &declarator.init
-      && let Some(expr) = init.as_await()
-      && let Some(call) = expr.arg.as_call()
-      && call.callee.is_import()
-      && let Some(binding) = declarator.name.as_ident()
-    {
-      let name = Atom::from(binding.id.sym.as_str());
-      parser.define_variable(name.clone());
-      tag_dynamic_import_referenced(parser, call, name);
+    if declaration.kind() != VariableDeclarationKind::Var {
+      if let Some(init) = &declarator.init
+        && let Some(expr) = init.as_await()
+        && let Some(call) = expr.arg.as_call()
+        && call.callee.is_import()
+        && let Some(binding) = declarator.name.as_ident()
+      {
+        let name = Atom::from(binding.id.sym.as_str());
+        parser.define_variable(name.clone());
+        tag_dynamic_import_referenced(parser, call, name);
+      }
+      track_dynamic_imports_in_promise_all(parser, declarator);
     }
     None
   }
@@ -182,11 +302,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
       .destructuring_assignment_properties
       .get(&ident.span())
     {
-      let mut refs = Vec::new();
-      keys.traverse_on_leaf(&mut |stack| {
-        refs.push(stack.iter().map(|p| p.id.clone()).collect::<Vec<Atom>>());
-      });
-      for ids in refs {
+      for ids in collect_destructuring_references(keys) {
         parser
           .dynamic_import_references
           .get_import_mut_expect(&data.import_span)
@@ -330,12 +446,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
     let referenced_fulfilled_ns_obj =
       import_then.and_then(|import_then| get_fulfilled_callback_namespace_obj(import_then));
     if let Some(keys) = referenced_in_destructuring {
-      let mut refs = Vec::new();
-      keys.traverse_on_leaf(&mut |stack| {
-        let names = stack.iter().map(|p| p.id.clone()).collect();
-        refs.push(ReferencedSpecifier::new(names));
-      });
-      exports = Some(refs);
+      exports = Some(
+        collect_destructuring_references(keys)
+          .into_iter()
+          .map(ReferencedSpecifier::new)
+          .collect(),
+      );
     }
     if let Some((referenced_in_members, is_call)) = referenced_in_members {
       let referenced = if is_call {
@@ -672,23 +788,7 @@ fn walk_import_then_fulfilled_callback(
       if let Some(ns_obj) = namespace_obj_arg.as_ident() {
         tag_dynamic_import_referenced(parser, import_call, Atom::from(ns_obj.id.sym.as_str()));
       } else if let Some(ns_obj) = namespace_obj_arg.as_object() {
-        if let Some(keys) =
-          parser.collect_destructuring_assignment_properties_from_object_pattern(ns_obj)
-        {
-          parser
-            .dynamic_import_references
-            .add_import(import_call.span);
-          let import_references = parser
-            .dynamic_import_references
-            .get_import_mut_expect(&import_call.span);
-          let mut refs = Vec::new();
-          keys.traverse_on_leaf(&mut |stack| {
-            refs.push(stack.iter().map(|p| p.id.clone()).collect::<Vec<Atom>>());
-          });
-          for ids in refs {
-            import_references.add_reference(ids);
-          }
-        }
+        add_destructuring_import_references(parser, import_call, ns_obj);
       } else {
         unreachable!()
       }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -377,7 +377,11 @@ impl DestructuringAssignmentProperties {
     for prop in &self.inner {
       stack.push(prop);
       on_enter_node(stack);
-      if let Some(pattern) = &prop.pattern {
+      // Empty nested patterns still access and coerce their parent value, so
+      // the parent property is a referenced leaf in that case.
+      if let Some(pattern) = &prop.pattern
+        && !pattern.inner.is_empty()
+      {
         pattern.traverse_impl(on_leaf_node, on_enter_node, stack);
       } else {
         on_leaf_node(stack);

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
@@ -77,3 +77,46 @@ it("should correctly analyze usage of variable for var declaration", async () =>
 	expect(m.a).toBe(1);
 	expect(m.usedExports).toEqual(true);
 });
+
+it("should analyze dynamic imports destructured from Promise.all", async () => {
+	const [namespace, { foo, usedExports: destructuredUsedExports }] = await Promise.all([
+		import("./promise-all/a"),
+		import("./promise-all/b")
+	]);
+
+	expect(namespace.bar).toBe("bar");
+	expect(namespace.usedExports).toEqual(["bar", "usedExports"]);
+	expect(foo).toBe("foo");
+	expect(destructuredUsedExports).toEqual(["foo", "usedExports"]);
+});
+
+it("should not analyze Promise.all when Promise is shadowed", async () => {
+	await (async Promise => {
+		const [{ foo, usedExports: destructuredUsedExports }, namespace] = await Promise.all([
+			import("./promise-all/a?shadowed"),
+			import("./promise-all/b?shadowed")
+		]);
+
+		expect(foo).toBe("foo");
+		expect(destructuredUsedExports).toBe(true);
+		expect(namespace.bar).toBe("bar");
+		expect(namespace.usedExports).toBe(true);
+	})({
+		all(values) {
+			return globalThis.Promise.all(values).then(([a, b]) => [b, a]);
+		}
+	});
+});
+
+it("should not analyze Promise.all when its input contains a spread", async () => {
+	const imports = [import("./promise-all/a?spread")];
+	const [namespace, { foo, usedExports: destructuredUsedExports }] = await Promise.all([
+		...imports,
+		import("./promise-all/b?spread")
+	]);
+
+	expect(namespace.bar).toBe("bar");
+	expect(namespace.usedExports).toBe(true);
+	expect(foo).toBe("foo");
+	expect(destructuredUsedExports).toBe(true);
+});

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/index.js
@@ -90,6 +90,27 @@ it("should analyze dynamic imports destructured from Promise.all", async () => {
 	expect(destructuredUsedExports).toEqual(["foo", "usedExports"]);
 });
 
+it("should retain parent exports for empty nested patterns in Promise.all", async () => {
+	const [{ bar: {}, usedExports }] = await Promise.all([
+		import("./promise-all/a?empty-nested-pattern")
+	]);
+
+	expect(usedExports).toEqual(["bar", "usedExports"]);
+});
+
+it("should keep Promise.all imports without a matching pattern fully referenced", async () => {
+	const [namespace] = await Promise.all([
+		import("./promise-all/a?unmatched-pattern"),
+		import("./promise-all/b?unmatched-pattern")
+	]);
+
+	expect(namespace.bar).toBe("bar");
+	expect(namespace.usedExports).toEqual(["bar", "usedExports"]);
+
+	const unmatched = await import("./promise-all/b?unmatched-pattern");
+	expect(unmatched.usedExports).toBe(true);
+});
+
 it("should not analyze Promise.all when Promise is shadowed", async () => {
 	await (async Promise => {
 		const [{ foo, usedExports: destructuredUsedExports }, namespace] = await Promise.all([

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/promise-all/a.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/promise-all/a.js
@@ -1,0 +1,3 @@
+export const bar = "bar";
+export const unused = "unused";
+export const usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/chunks/statical-dynamic-import/promise-all/b.js
+++ b/tests/rspack-test/normalCases/chunks/statical-dynamic-import/promise-all/b.js
@@ -1,0 +1,3 @@
+export const foo = "foo";
+export const unused = "unused";
+export const usedExports = __webpack_exports_info__.usedExports;


### PR DESCRIPTION
## Summary

- analyze direct dynamic imports in array destructuring from `await Promise.all([...])`
- reuse the existing namespace/member and object-destructuring export tracking for each positional import
- conservatively bail out for shadowed `Promise` and spread inputs

## Why

Rspack already narrows exports for direct `await import()` destructuring, but `const [ns, { foo }] = await Promise.all([import(...), import(...)])` lost the per-import usage relationship and treated the imported namespaces as fully referenced.

## Impact

This static `Promise.all` form can now tree-shake unused dynamic-import exports without changing chunk loading or runtime behavior. Unsupported or ambiguous forms keep the existing conservative behavior.

## Testing

- `cargo check -p rspack_plugin_javascript`
- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `cd tests/rspack-test && pnpm run test -t "normalCases/chunks/statical-dynamic-import"` (4 files, 20 tests)
- `cargo fmt --all --check`
- `git diff --check`
