### PR TITLE
fix(cache): use storage location for new cache

### DIFF
--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -61,8 +61,8 @@ pub fn create_cache(
   );
   let (base_path, database_path) = match &options.storage {
     crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
+      directory.parent().unwrap_or(directory).to_path_buf(),
       directory.clone(),
-      directory.join(rspack_workspace::rspack_pkg_version!()),
     ),
   };
   let strategy = match FileCacheStrategy::new(

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -59,21 +59,23 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let (base_path, database_path) = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => (
-      directory.parent().unwrap_or(directory).to_path_buf(),
-      directory.clone(),
-    ),
+  let database_paths = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => directory
+      .parent()
+      .map(|base_path| (base_path.to_path_buf(), directory.clone()))
+      .ok_or_else(|| rspack_error::error!("Persistent cache path has no parent: {directory}")),
   };
-  let strategy = match FileCacheStrategy::new(
-    (base_path, database_path),
-    options.readonly,
-    rspack_workspace::rspack_pkg_version!().to_string(),
-    options.version.clone(),
-    codec,
-    snapshot,
-    build_deps,
-  ) {
+  let strategy = match database_paths.and_then(|database_paths| {
+    FileCacheStrategy::new(
+      database_paths,
+      options.readonly,
+      rspack_workspace::rspack_pkg_version!().to_string(),
+      options.version.clone(),
+      codec,
+      snapshot,
+      build_deps,
+    )
+  }) {
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -59,25 +59,26 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
-  let database_paths = match &options.storage {
-    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => directory
-      .parent()
-      .map(|base_path| (base_path.to_path_buf(), directory.clone()))
-      .ok_or_else(|| {
-        rspack_error::error!("Persistent cache directory must have a parent directory: {directory}")
-      }),
+  let (base_path, database_path) = match &options.storage {
+    crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
+      let Some(base_path) = directory.parent() else {
+        tracing::warn!(
+          "Opening persistent cache database failed: Persistent cache directory must have a parent directory: {directory}"
+        );
+        return Cache::new(compiler_path, MemoryCache::default(), None);
+      };
+      (base_path.to_path_buf(), directory.clone())
+    }
   };
-  let strategy = match database_paths.and_then(|database_paths| {
-    FileCacheStrategy::new(
-      database_paths,
-      options.readonly,
-      rspack_workspace::rspack_pkg_version!().to_string(),
-      options.version.clone(),
-      codec,
-      snapshot,
-      build_deps,
-    )
-  }) {
+  let strategy = match FileCacheStrategy::new(
+    (base_path, database_path),
+    options.readonly,
+    rspack_workspace::rspack_pkg_version!().to_string(),
+    options.version.clone(),
+    codec,
+    snapshot,
+    build_deps,
+  ) {
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -63,7 +63,9 @@ pub fn create_cache(
     crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => directory
       .parent()
       .map(|base_path| (base_path.to_path_buf(), directory.clone()))
-      .ok_or_else(|| rspack_error::error!("Persistent cache path has no parent: {directory}")),
+      .ok_or_else(|| {
+        rspack_error::error!("Persistent cache directory must have a parent directory: {directory}")
+      }),
   };
   let strategy = match database_paths.and_then(|database_paths| {
     FileCacheStrategy::new(

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -61,12 +61,9 @@ pub fn create_cache(
   );
   let (base_path, database_path) = match &options.storage {
     crate::cache::persistent::storage::StorageOptions::FileSystem { directory } => {
-      let Some(base_path) = directory.parent() else {
-        tracing::warn!(
-          "Opening persistent cache database failed: Persistent cache directory must have a parent directory: {directory}"
-        );
-        return Cache::new(compiler_path, MemoryCache::default(), None);
-      };
+      let base_path = directory.parent().unwrap_or_else(|| {
+        panic!("Persistent cache directory must have a parent directory: {directory}")
+      });
       (base_path.to_path_buf(), directory.clone())
     }
   };


### PR DESCRIPTION
Use the normalized `cache.storage.location` directly for new_cache instead of adding an Rspack package version subdirectory. Cache compatibility remains enforced by validator metadata.