### PR TITLE
fix: refine binding code generation result error handling

### DIFF
--- a/crates/rspack_binding_api/src/compilation/code_generation_results.rs
+++ b/crates/rspack_binding_api/src/compilation/code_generation_results.rs
@@ -114,7 +114,9 @@ impl CodeGenerationResults {
         Either::B(vec) => vec.into_iter().map(Into::into).collect(),
       });
 
-      let code_generation_result = code_generation_results.get(&module.identifier, rt.as_ref());
+      let code_generation_result = code_generation_results
+        .try_get(&module.identifier, rt.as_ref())
+        .map_err(|error| napi::Error::from_reason(error.to_string()))?;
       Ok(code_generation_result.reflector())
     })
   }

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -447,32 +447,44 @@ impl CodeGenerationResults {
     module_identifier: &ModuleIdentifier,
     runtime: Option<&RuntimeSpec>,
   ) -> &BindingCell<CodeGenerationResult> {
-    if let Some(entry) = self.map.get(module_identifier) {
-      if let Some(runtime) = runtime {
-        entry.get(runtime).unwrap_or_else(|| {
-          panic!(
-            "Failed to code generation result for {module_identifier} with runtime {runtime:?} \n {entry:?}"
-          )
-        })
-      } else {
-        let mut values = entry.values();
-        let result = values
-          .next()
-          .unwrap_or_else(|| panic!("Expected value exists"));
-        if values.any(|other| !result.has_same_value(other)) {
-          panic!(
-            "No unique code generation entry for unspecified runtime for {module_identifier} ",
-          );
-        }
-        result
-      }
-    } else {
-      panic!(
+    self
+      .try_get(module_identifier, runtime)
+      .unwrap_or_else(|error| {
+        panic!("{error}");
+      })
+  }
+
+  pub fn try_get(
+    &self,
+    module_identifier: &ModuleIdentifier,
+    runtime: Option<&RuntimeSpec>,
+  ) -> rspack_error::Result<&BindingCell<CodeGenerationResult>> {
+    let entry = self.map.get(module_identifier).ok_or_else(|| {
+      rspack_error::error!(
         "No code generation entry for {} (existing entries: {:?})",
         module_identifier,
         self.map.keys().collect::<Vec<_>>()
       )
+    })?;
+
+    if let Some(runtime) = runtime {
+      return entry.get(runtime).ok_or_else(|| {
+        rspack_error::error!(
+          "Failed to code generation result for {module_identifier} with runtime {runtime:?} \n {entry:?}"
+        )
+      });
     }
+
+    let mut values = entry.values();
+    let result = values
+      .next()
+      .ok_or_else(|| rspack_error::error!("Expected value exists"))?;
+    if values.any(|other| !result.has_same_value(other)) {
+      return Err(rspack_error::error!(
+        "No unique code generation entry for unspecified runtime for {module_identifier} "
+      ));
+    }
+    Ok(result)
   }
 
   /**

--- a/tests/rspack-test/configCases/issues/issue-15246/index.js
+++ b/tests/rspack-test/configCases/issues/issue-15246/index.js
@@ -1,0 +1,5 @@
+import { usedStyles } from 'components';
+
+it('should keep the used CSS module', () => {
+  expect(Boolean(usedStyles.used)).toBe(true);
+});

--- a/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/index.js
+++ b/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/index.js
@@ -1,0 +1,2 @@
+export { default as usedStyles } from './used.module.less';
+export { default as unusedStyles } from './unused.module.less';

--- a/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/package.json
+++ b/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "components",
+  "sideEffects": false
+}

--- a/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/unused.module.less
+++ b/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/unused.module.less
@@ -1,0 +1,3 @@
+.unused {
+  color: red;
+}

--- a/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/used.module.less
+++ b/tests/rspack-test/configCases/issues/issue-15246/node_modules/components/used.module.less
@@ -1,0 +1,3 @@
+.used {
+  color: green;
+}

--- a/tests/rspack-test/configCases/issues/issue-15246/rspack.config.js
+++ b/tests/rspack-test/configCases/issues/issue-15246/rspack.config.js
@@ -1,0 +1,60 @@
+const path = require('path');
+
+const PLUGIN_NAME = 'Issue15246Plugin';
+
+class Issue15246Plugin {
+  /**
+   * @param {import('@rspack/core').Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.afterProcessAssets.tap(PLUGIN_NAME, () => {
+        const chunklessModule = Array.from(compilation.modules).find(
+          (module) =>
+            module.resource ===
+            path.join(__dirname, 'node_modules/components/index.js'),
+        );
+
+        expect(chunklessModule).toBeDefined();
+        expect(compilation.chunkGraph.getModuleChunks(chunklessModule)).toEqual(
+          [],
+        );
+
+        expect(() =>
+          compilation.codeGenerationResults.get(chunklessModule, undefined),
+        ).toThrow('No code generation entry');
+      });
+    });
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  entry: {
+    main: {
+      import: './index.js',
+      layer: 'miniprogram',
+    },
+  },
+  optimization: {
+    concatenateModules: false,
+    minimize: false,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.less$/,
+        type: 'css/auto',
+        use: ['less-loader'],
+      },
+    ],
+    parser: {
+      'css/auto': {
+        namedExports: false,
+      },
+    },
+  },
+  plugins: [new Issue15246Plugin()],
+};


### PR DESCRIPTION
## Summary

- Add a fallible `CodeGenerationResults::try_get` API while preserving the existing internal `get` invariant.
- Use `try_get` in the JavaScript binding so invalid code generation result lookups throw a catchable JavaScript error instead of causing a Rust panic.

For example, when a plugin queries a chunkless ModuleGraph module that has no code generation result, the binding now reports an error to JavaScript rather than aborting the process.

## Related links

- Related to #15246

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_