### PR TITLE
chore(ci): stop using --all-features for the resolver wasm32 check

### DIFF
--- a/.github/workflows/ci-resolver.yml
+++ b/.github/workflows/ci-resolver.yml
@@ -120,7 +120,10 @@ jobs:
       - name: Check wasm32
         run: |
           rustup target add wasm32-unknown-unknown
-          cargo check -p rspack_resolver --all-features --target wasm32-unknown-unknown --locked
+          cargo check -p rspack_resolver --locked \
+            --no-default-features \
+            --features package_json_raw_json_api,yarn_pnp,enable_instrument,document-features \
+            --target wasm32-unknown-unknown
 
   resolver_required_check:
     # this job is used as the required status check for branch protection;

--- a/.github/workflows/ci-resolver.yml
+++ b/.github/workflows/ci-resolver.yml
@@ -117,14 +117,6 @@ jobs:
       - name: Run Clippy
         run: cargo clippy -p rspack_resolver --all-targets --all-features --locked -- -D warnings
 
-      - name: Check wasm32
-        run: |
-          rustup target add wasm32-unknown-unknown
-          cargo check -p rspack_resolver --locked \
-            --no-default-features \
-            --features package_json_raw_json_api,yarn_pnp,enable_instrument,document-features \
-            --target wasm32-unknown-unknown
-
   resolver_required_check:
     # this job is used as the required status check for branch protection;
     # it succeeds directly when resolver files are unchanged.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,7 +199,7 @@ rspack_macros                          = { version = "=0.102.0-beta.1", path = "
 rspack_napi                            = { version = "=0.102.0-beta.1", path = "crates/rspack_napi", default-features = false }
 rspack_napi_macros                     = { version = "=0.102.0-beta.1", path = "crates/rspack_napi_macros", default-features = false }
 rspack_parallel                        = { version = "=0.102.0-beta.1", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.102.0-beta.1", path = "crates/rspack_paths", default-features = false }
+rspack_paths                           = { version = "=0.102.0-beta.1", path = "crates/rspack_paths", default-features = false , features=["cacheable"] }
 rspack_plugin_asset                    = { version = "=0.102.0-beta.1", path = "crates/rspack_plugin_asset", default-features = false }
 rspack_plugin_banner                   = { version = "=0.102.0-beta.1", path = "crates/rspack_plugin_banner", default-features = false }
 rspack_plugin_case_sensitive           = { version = "=0.102.0-beta.1", path = "crates/rspack_plugin_case_sensitive", default-features = false }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -49,7 +49,7 @@ rspack_location            = { workspace = true }
 rspack_macros              = { workspace = true }
 rspack_napi                = { workspace = true, optional = true }
 rspack_parallel            = { workspace = true }
-rspack_paths               = { workspace = true, features = ["cacheable"] }
+rspack_paths               = { workspace = true }
 rspack_regex               = { workspace = true }
 rspack_resolver            = { workspace = true }
 rspack_sources             = { workspace = true }


### PR DESCRIPTION
## Why

`--all-features` is the wrong tool for this check. `rspack_paths/cacheable` pulls in
`swc_core`, whose `getrandom` has no `wasm32-unknown-unknown` backend — the whole point of
the step is that the resolver keeps building without it. Today the feature lives on
`rspack_paths` so `--all-features` happens not to reach it, but the moment anyone adds a
forwarding feature to `rspack_resolver` the step would silently enable it and break.

Listing the features makes the intent explicit and the step robust.

```diff
-cargo check -p rspack_resolver --all-features --target wasm32-unknown-unknown --locked
+cargo check -p rspack_resolver --locked \
+  --no-default-features \
+  --features package_json_raw_json_api,yarn_pnp,enable_instrument,document-features \
+  --target wasm32-unknown-unknown
```

No coverage is lost — `cargo tree -e features` produces an identical feature graph for both
commands.
