### PR TITLE
fix: preserve faster module concatenation semantics

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -315,7 +315,7 @@ pub struct GeneratedTopLevelSymbol {
   pub preferred_name: Atom,
   pub placeholder: Atom,
   pub target: GeneratedTopLevelSymbolTarget,
-  /// Make-time binding resolved from `original_range` for a rebound symbol.
+  /// Make-time binding resolved for a rebound symbol.
   pub resolved_binding: Option<Atom>,
 }
 
@@ -326,6 +326,9 @@ pub enum GeneratedTopLevelSymbolTarget {
   /// A declaration recreated during code generation that must stay bound to
   /// the original make-time binding.
   Rebind { original_range: DependencyRange },
+  /// A declaration injected during code generation that turns matching
+  /// make-time global references into references to the generated binding.
+  RebindGlobal,
 }
 
 /// Scope identifier supplied by dependency templates because it cannot be

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1112,7 +1112,7 @@ impl Module for ConcatenatedModule {
         s.spawn(|(module, compilation, runtime, id, info)| async move {
           let concatenation_scope = if let ModuleInfo::Concatenated(info) = info {
             let info = info.as_ref();
-            let mut scope = ConcatenationScope::new(
+            let scope = ConcatenationScope::new(
               module.id,
               module_to_info_map.expect("should have module_to_info_map for concatenated module"),
               ConcatenatedModuleInfo {
@@ -1121,9 +1121,6 @@ impl Module for ConcatenatedModule {
                 ..Default::default()
               },
             );
-            if compilation.options.experiments.faster_module_concatenation {
-              scope.enable_faster_module_concatenation();
-            }
             Some(scope)
           } else {
             None
@@ -2711,6 +2708,18 @@ impl ConcatenatedModule {
       let module = module_graph
         .module_by_identifier(&module_id)
         .unwrap_or_else(|| panic!("should have module {module_id}"));
+
+      if compilation.options.experiments.faster_module_concatenation
+        && !matches!(
+          module
+            .build_info()
+            .pending_concatenation_scope_info
+            .as_deref(),
+          Some(PendingConcatenationScopeInfo::CodegenAnalysisRequired)
+        )
+      {
+        concatenation_scope.enable_faster_module_concatenation();
+      }
 
       let mut runtime_template = compilation.runtime_template.create_module_code_template();
       let mut code_generation_context = ModuleCodeGenerationContext {

--- a/crates/rspack_core/src/concatenated_module/faster.rs
+++ b/crates/rspack_core/src/concatenated_module/faster.rs
@@ -107,7 +107,8 @@ impl PlaceholderReplacements<'_> {
       .filter(|symbol| symbol.placeholder == placeholder)?;
     let binding = match symbol.target {
       GeneratedTopLevelSymbolTarget::New => &symbol.placeholder,
-      GeneratedTopLevelSymbolTarget::Rebind { .. } => symbol.resolved_binding.as_ref()?,
+      GeneratedTopLevelSymbolTarget::Rebind { .. }
+      | GeneratedTopLevelSymbolTarget::RebindGlobal => symbol.resolved_binding.as_ref()?,
     };
     self.internal_names.get(binding).map(Atom::as_str)
   }
@@ -214,6 +215,12 @@ pub(crate) fn populate_info_from_pending(
   module_info.global_scope_ident.clear();
   module_info.binding_to_ref.clear();
   module_info.all_used_names.clear();
+  let rebound_global_names = module_info
+    .generated_top_level_symbols
+    .iter()
+    .filter(|symbol| symbol.target == GeneratedTopLevelSymbolTarget::RebindGlobal)
+    .map(|symbol| symbol.preferred_name.clone())
+    .collect::<SmallVec<[_; 4]>>();
   module_info.idents.reserve(
     pending_idents
       .len()
@@ -230,9 +237,12 @@ pub(crate) fn populate_info_from_pending(
       .len()
       .saturating_add(faster_info.added_used_names.len()),
   );
-  module_info
-    .all_used_names
-    .extend(faster_info.added_used_names.drain(..));
+  module_info.all_used_names.extend(
+    faster_info
+      .added_used_names
+      .drain(..)
+      .filter(|name| !rebound_global_names.contains(name)),
+  );
 
   let mut removed_ranges = SmallVec::<[DependencyRange; 4]>::new();
   let mut non_shorthand_ranges = SmallVec::<[DependencyRange; 4]>::new();
@@ -257,11 +267,13 @@ pub(crate) fn populate_info_from_pending(
       continue;
     }
 
+    let is_rebound_global = pending_ident.kind == ConcatenationScopeIdentKind::Global
+      && rebound_global_names.contains(&symbol);
     if removed_ranges
       .iter()
       .any(|range| range.start <= pending_ident.range.start && pending_ident.range.end <= range.end)
     {
-      if pending_ident.kind == ConcatenationScopeIdentKind::Global {
+      if pending_ident.kind == ConcatenationScopeIdentKind::Global && !is_rebound_global {
         module_info.all_used_names.insert(symbol);
       }
       continue;
@@ -269,6 +281,7 @@ pub(crate) fn populate_info_from_pending(
 
     let ctxt = match pending_ident.kind {
       ConcatenationScopeIdentKind::TopLevel => module_info.module_ctxt,
+      ConcatenationScopeIdentKind::Global if is_rebound_global => module_info.module_ctxt,
       ConcatenationScopeIdentKind::Global => module_info.global_ctxt,
       ConcatenationScopeIdentKind::UsedName => unreachable!(),
     };
@@ -331,6 +344,11 @@ pub(crate) fn populate_info_from_pending(
             || symbol_from_range(original_range),
             |canonical_name| canonical_name.name.clone(),
           );
+        symbol.resolved_binding = Some(binding.clone());
+        binding
+      }
+      GeneratedTopLevelSymbolTarget::RebindGlobal => {
+        let binding = symbol.preferred_name.clone();
         symbol.resolved_binding = Some(binding.clone());
         binding
       }

--- a/crates/rspack_core/src/concatenated_module/faster.rs
+++ b/crates/rspack_core/src/concatenated_module/faster.rs
@@ -187,6 +187,9 @@ pub(crate) fn populate_info_from_pending(
       info.canonical_names.as_slice(),
     ),
     PendingConcatenationScopeInfo::Generated => (0, 0, &[][..], &[][..]),
+    PendingConcatenationScopeInfo::CodegenAnalysisRequired => {
+      unreachable!("codegen analysis modules must not enter faster module concatenation")
+    }
   };
   let mut symbols = SmallVec::<[(&str, Atom); 8]>::new();
   let mut symbol_from_range = |range: DependencyRange| {

--- a/crates/rspack_core/src/dependency/dependency_template.rs
+++ b/crates/rspack_core/src/dependency/dependency_template.rs
@@ -102,6 +102,18 @@ impl<'a> TemplateReplaceSource<'a> {
     })
   }
 
+  pub fn rebind_generated_global_symbol(&mut self, preferred_name: impl Into<String>) -> String {
+    let preferred_name = preferred_name.into();
+    self
+      .faster_concatenation_scope()
+      .map(|scope| {
+        scope
+          .rebind_generated_global_symbol(&preferred_name)
+          .to_string()
+      })
+      .unwrap_or(preferred_name)
+  }
+
   #[inline]
   fn record_edit(
     &mut self,
@@ -208,6 +220,23 @@ impl<'a> TemplateReplaceSource<'a> {
 
   pub fn insert_static(&mut self, start: u32, content: &'static str, name: Option<&'static str>) {
     self.record_edit(start, start, content, GeneratedCodeUsedNames::Scan);
+    self.source.insert_static(start, content, name);
+  }
+
+  /// Inserts static code whose used names have already been recorded in the
+  /// concatenation scope.
+  pub fn insert_static_with_tracked_used_names(
+    &mut self,
+    start: u32,
+    content: &'static str,
+    name: Option<&'static str>,
+  ) {
+    self.record_edit(
+      start,
+      start,
+      content,
+      GeneratedCodeUsedNames::AlreadyTracked,
+    );
     self.source.insert_static(start, content, name);
   }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -749,6 +749,13 @@ impl ExternalModule {
         )
       ),
       "var" | "promise" | "const" | "let" | "assign" => {
+        if let Some(concatenation_scope) = concatenation_scope.as_deref_mut()
+          && let Some(request) = request
+        {
+          // The primary request is emitted as a free expression. Preserve its
+          // identifiers so concatenated bindings cannot capture the external.
+          concatenation_scope.register_used_names_from_generated_code(request.primary());
+        }
         let external_variable = if let Some(request) = request {
           get_request_string(request)
         } else {
@@ -1066,6 +1073,11 @@ if(typeof {global} !== "undefined") return resolve();
         )
       }
       _ => {
+        if let Some(concatenation_scope) = concatenation_scope.as_deref_mut()
+          && let Some(request) = request
+        {
+          concatenation_scope.register_used_names_from_generated_code(request.primary());
+        }
         let external_variable = if let Some(request) = request {
           get_request_string(request)
         } else {

--- a/crates/rspack_core/src/utils/concatenated_module_visitor.rs
+++ b/crates/rspack_core/src/utils/concatenated_module_visitor.rs
@@ -54,11 +54,15 @@ pub struct AnalyzedConcatenationScopeInfo {
 /// `Generated` is an explicit declaration that the module has no original
 /// JavaScript scope. Any bindings introduced by its generator must be
 /// registered through `ConcatenationScope` during code generation.
+///
+/// `CodegenAnalysisRequired` means make encountered user-provided generated
+/// code that needs the legacy codegen-time scope analysis.
 #[cacheable]
 #[derive(Clone, Debug)]
 pub enum PendingConcatenationScopeInfo {
   Analyzed(AnalyzedConcatenationScopeInfo),
   Generated,
+  CodegenAnalysisRequired,
 }
 
 #[derive(Default)]

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -519,6 +519,39 @@ impl ConcatenationScope {
     placeholder
   }
 
+  pub fn rebind_generated_global_symbol(&mut self, preferred_name: &str) -> Atom {
+    let preferred_name = Atom::from(preferred_name);
+    if !self.is_faster_module_concatenation() {
+      return preferred_name;
+    }
+    if let Some(existing) = self
+      .current_module
+      .generated_top_level_symbols
+      .iter()
+      .find(|symbol| {
+        symbol.target == GeneratedTopLevelSymbolTarget::RebindGlobal
+          && symbol.preferred_name == preferred_name
+      })
+    {
+      return existing.placeholder.clone();
+    }
+
+    let placeholder = Atom::from(format!(
+      "{GENERATED_TOP_LEVEL_SYMBOL_PREFIX}{}__",
+      self.current_module.generated_top_level_symbols.len()
+    ));
+    self
+      .current_module
+      .generated_top_level_symbols
+      .push(crate::GeneratedTopLevelSymbol {
+        preferred_name,
+        placeholder: placeholder.clone(),
+        target: GeneratedTopLevelSymbolTarget::RebindGlobal,
+        resolved_binding: None,
+      });
+    placeholder
+  }
+
   fn build_module_reference(
     &mut self,
     module: &ModuleIdentifier,

--- a/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/esm_export_imported_specifier_dependency.rs
@@ -65,6 +65,7 @@ pub struct ESMExportImportedSpecifierDependency {
   loc: Option<DependencyLocation>,
   factorize_info: FactorizeInfo,
   lazy_make: bool,
+  default_exported_namespace: bool,
 }
 
 impl ESMExportImportedSpecifierDependency {
@@ -98,7 +99,12 @@ impl ESMExportImportedSpecifierDependency {
       loc,
       factorize_info: Default::default(),
       lazy_make: false,
+      default_exported_namespace: false,
     }
+  }
+
+  pub fn set_default_exported_namespace(&mut self) {
+    self.default_exported_namespace = true;
   }
 
   // Because it is shared by multiply ESMExportImportedSpecifierDependency, so put it to `BuildInfo`
@@ -1778,13 +1784,10 @@ impl DependencyTemplate for ESMExportImportedSpecifierDependencyTemplate {
     ) || can_use_concatenated_reference;
 
     if can_handle_in_concatenation_scope && source.concatenation_scope().is_some() {
-      // `export default namespace` has a separate ConstDependency that removes the
-      // export prefix. Keep its unused expression so an overlapping
+      // `export default namespace` has a separate ConstDependency that removes
+      // the export prefix. Keep the expression so an overlapping
       // PureExpressionDependency still has an operand to wrap.
-      let keep_unused_default_namespace_expression = matches!(&mode, ExportMode::Unused(_))
-        && dep.name.as_ref().is_some_and(|name| name == "default")
-        && dep.get_ids(module_graph).is_empty();
-      if !keep_unused_default_namespace_expression {
+      if !dep.default_exported_namespace {
         source.replace(dep.range.start, dep.range.end, String::new(), None);
       } else {
         source.ignore_original_scope_range(dep.range);

--- a/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/provide_dependency.rs
@@ -159,7 +159,7 @@ impl DependencyTemplate for ProvideDependencyTemplate {
       .as_any()
       .downcast_ref::<ProvideDependency>()
       .expect("ProvideDependencyTemplate should only be used for ProvideDependency");
-    let rendered_identifier = source.ensure_generated_top_level_symbol(dep.identifier.clone());
+    let rendered_identifier = source.rebind_generated_global_symbol(dep.identifier.clone());
 
     let TemplateContext {
       compilation,

--- a/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/pure_expression_dependency.rs
@@ -144,14 +144,14 @@ impl DependencyTemplate for PureExpressionDependencyTemplate {
         format!("(/* runtime-dependent pure expression or super */ {condition} ? ("),
         None,
       );
-      source.insert_static(dep.range.end, ") : null)", None);
+      source.insert_static_with_tracked_used_names(dep.range.end, ") : null)", None);
     } else {
-      source.insert_static(
+      source.insert_static_with_tracked_used_names(
         dep.range.start,
         "(/* unused pure expression or super */ null && (",
         None,
       );
-      source.insert_static(dep.range.end, "))", None);
+      source.insert_static_with_tracked_used_names(dep.range.end, "))", None);
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -14,9 +14,9 @@ use rspack_core::{
   COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, ChunkGraph, CollectedTypeScriptInfo, Compilation,
   ConcatenationScope, ConcatenationScopeInfoMode, DependenciesBlock, DependencyId, GenerateContext,
   GeneratedSource, ImportMeta, Module, ModuleArgument, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  ParseContext, ParseResult, ParserAndGenerator, ResolvedModuleOptions, RuntimeGlobals,
-  RuntimeGlobalsRenderMode, RuntimeVariable, SideEffectsBailoutItem, SourceType, TemplateContext,
-  TemplateReplaceSource,
+  ParseContext, ParseResult, ParserAndGenerator, PendingConcatenationScopeInfo,
+  ResolvedModuleOptions, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeVariable,
+  SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
   diagnostics::map_box_diagnostics_to_module_parse_diagnostics,
   remove_bom, render_init_fragments, render_init_fragments_to_strings,
   rspack_sources::{BoxSource, ReplaceSource, Source, SourceExt},
@@ -385,6 +385,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       program: &program,
     };
     let parser_runtime_requirements = ParserRuntimeRequirementsData::new(runtime_template);
+    // `BuildInfo` can be reused by a watch rebuild. Clear the previous result
+    // before parser plugins use this field to request codegen-time analysis.
+    build_info.pending_concatenation_scope_info = None;
 
     let ScanDependenciesResult {
       dependencies,
@@ -419,13 +422,22 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     };
     diagnostics.append(&mut warning_diagnostics);
     let mut side_effects_bailout = None;
+    let codegen_analysis_required = build_info.pending_concatenation_scope_info.take();
 
     let pending_concatenation_scope_info = if build_meta.esm()
       && (uses_esm_library
         || (compiler_options.optimization.concatenate_modules
           && build_info.module_concatenation_bailout.is_none()))
     {
-      pending_concatenation_scope_info_visitor.map(|visitor| Box::new(visitor.into_info()))
+      if matches!(
+        codegen_analysis_required.as_deref(),
+        Some(PendingConcatenationScopeInfo::CodegenAnalysisRequired)
+      ) {
+        drop(pending_concatenation_scope_info_visitor);
+        codegen_analysis_required
+      } else {
+        pending_concatenation_scope_info_visitor.map(|visitor| Box::new(visitor.into_info()))
+      }
     } else {
       drop(pending_concatenation_scope_info_visitor);
       None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/utils.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/utils.rs
@@ -5,8 +5,73 @@ use rspack_core::{
   BoxDependencyTemplate, ConstDependency, RuntimeGlobals, RuntimeRequirementsDependency,
 };
 use serde_json::{Value, json};
+use swc_experimental_allocator::Allocator;
+use swc_experimental_ecma_ast::{EsVersion, Expr, Prop, PropName, PropOrSpread};
+use swc_experimental_ecma_parser::{EsSyntax, Syntax, parse_file_as_expr};
 
 use crate::visitors::{DestructuringAssignmentProperties, JavascriptParser};
+
+fn is_compile_time_expression(expr: &Expr<'_>) -> bool {
+  match expr {
+    Expr::Lit(_) => true,
+    Expr::Unary(expr) => is_compile_time_expression(&expr.arg),
+    Expr::Bin(expr) => {
+      is_compile_time_expression(&expr.left) && is_compile_time_expression(&expr.right)
+    }
+    Expr::Cond(expr) => {
+      is_compile_time_expression(&expr.test)
+        && is_compile_time_expression(&expr.cons)
+        && is_compile_time_expression(&expr.alt)
+    }
+    Expr::Array(expr) => expr.elems.iter().all(|element| {
+      element
+        .as_ref()
+        .is_none_or(|element| element.spread.is_none() && is_compile_time_expression(&element.expr))
+    }),
+    Expr::Object(expr) => expr.props.iter().all(|prop| match prop {
+      PropOrSpread::Prop(prop) => match &**prop {
+        Prop::KeyValue(prop) => {
+          let key_is_compile_time = match &prop.key {
+            PropName::Computed(computed) => is_compile_time_expression(&computed.expr),
+            PropName::Ident(_) | PropName::Str(_) | PropName::Num(_) | PropName::BigInt(_) => true,
+          };
+          key_is_compile_time && is_compile_time_expression(&prop.value)
+        }
+        Prop::Shorthand(_)
+        | Prop::Assign(_)
+        | Prop::Getter(_)
+        | Prop::Setter(_)
+        | Prop::Method(_) => false,
+      },
+      PropOrSpread::Spread(_) => false,
+    }),
+    Expr::Tpl(expr) => expr.exprs.iter().all(is_compile_time_expression),
+    Expr::Seq(expr) => expr.exprs.iter().all(is_compile_time_expression),
+    Expr::Paren(expr) => is_compile_time_expression(&expr.expr),
+    _ => false,
+  }
+}
+
+fn is_compile_time_source(source: &str) -> bool {
+  let allocator = Allocator::new();
+  parse_file_as_expr(
+    &allocator,
+    allocator.alloc_str(source),
+    Syntax::Es(EsSyntax::default()),
+    EsVersion::EsNext,
+    None,
+  )
+  .is_ok_and(|expr| is_compile_time_expression(&expr))
+}
+
+pub fn is_compile_time_define_value(code: &Value) -> bool {
+  match code {
+    Value::Array(items) => items.iter().all(is_compile_time_define_value),
+    Value::Object(object) => object.values().all(is_compile_time_define_value),
+    Value::String(source) => is_compile_time_source(source),
+    Value::Null | Value::Bool(_) | Value::Number(_) => true,
+  }
+}
 
 pub fn gen_const_dep(
   parser: &JavascriptParser,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/walk_data.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/define_plugin/walk_data.rs
@@ -5,6 +5,7 @@ use std::{
 
 use itertools::Itertools as _;
 use regex::Regex;
+use rspack_core::PendingConcatenationScopeInfo;
 use rspack_error::Diagnostic;
 use rustc_hash::FxHashMap;
 use serde_json::{Map, Value, json};
@@ -12,9 +13,22 @@ use swc_experimental_ecma_ast::Span;
 
 use super::{
   ConflictingValuesError, DefineValue,
-  utils::{code_to_string, gen_const_dep},
+  utils::{code_to_string, gen_const_dep, is_compile_time_define_value},
 };
 use crate::{utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser};
+
+fn check_concatenation_fallback(parser: &mut JavascriptParser, is_compile_time_value: bool) {
+  if parser
+    .compiler_options()
+    .experiments
+    .faster_module_concatenation
+    && !is_compile_time_value
+  {
+    parser.build_info.pending_concatenation_scope_info = Some(Box::new(
+      PendingConcatenationScopeInfo::CodegenAnalysisRequired,
+    ));
+  }
+}
 
 static TYPEOF_OPERATOR_REGEXP: LazyLock<Regex> =
   LazyLock::new(|| Regex::new("^typeof\\s+").expect("should init `TYPEOF_OPERATOR_REGEXP`"));
@@ -55,6 +69,7 @@ type OnTypeof = dyn Fn(&DefineRecord, &mut JavascriptParser, u32 /* start */, u3
 
 pub struct DefineRecord {
   code: Value,
+  is_compile_time_value: bool,
   pub on_evaluate_identifier: Option<Box<OnEvaluateIdentifier>>,
   pub on_evaluate_typeof: Option<Box<OnEvaluateTypeof>>,
   pub on_expression: Option<Box<OnExpression>>,
@@ -90,8 +105,10 @@ impl std::fmt::Debug for DefineRecord {
 
 impl DefineRecord {
   fn from_code(code: Value) -> DefineRecord {
+    let is_compile_time_value = is_compile_time_define_value(&code);
     Self {
       code,
+      is_compile_time_value,
       on_evaluate_identifier: None,
       on_evaluate_typeof: None,
       on_expression: None,
@@ -126,6 +143,7 @@ impl DefineRecord {
 #[derive(Default)]
 pub struct ObjectDefineRecord {
   object: Value,
+  is_compile_time_value: bool,
   pub on_evaluate_identifier: Option<Box<OnObjectEvaluateIdentifier>>,
   pub on_expression: Option<Box<OnObjectExpression>>,
 }
@@ -162,8 +180,10 @@ type OnObjectExpression = dyn Fn(
 impl ObjectDefineRecord {
   fn from_code(obj: Value) -> Self {
     assert!(matches!(obj, Value::Array(_) | Value::Object(_)));
+    let is_compile_time_value = is_compile_time_define_value(&obj);
     Self {
       object: obj,
+      is_compile_time_value,
       on_evaluate_identifier: None,
       on_expression: None,
     }
@@ -273,6 +293,7 @@ impl WalkData {
           }))
           .with_on_expression(Box::new(
             move |record, parser, span, start, end, for_name| {
+              check_concatenation_fallback(parser, record.is_compile_time_value);
               let code = code_to_string(
                 &record.code,
                 Some(!parser.is_asi_position(span.start)),
@@ -353,6 +374,7 @@ impl WalkData {
         }))
         .with_on_expression(Box::new(
           move |record, parser, span, start, end, for_name| {
+            check_concatenation_fallback(parser, record.is_compile_time_value);
             let code = code_to_string(
               &record.object,
               Some(!parser.is_asi_position(span.start)),
@@ -376,6 +398,7 @@ impl WalkData {
         }))
         .with_on_expression(Box::new(
           move |record, parser, span, start, end, for_name| {
+            check_concatenation_fallback(parser, record.is_compile_time_value);
             let code = code_to_string(
               &record.object,
               Some(!parser.is_asi_position(span.start)),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -61,6 +61,7 @@ fn create_default_exported_namespace_dependency(
   {
     dep.set_lazy();
   }
+  dep.set_default_exported_namespace();
   Some(dep)
 }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1086,7 +1086,10 @@ impl ModuleConcatenationPlugin {
           (mode, pending),
           (
             ConcatenationScopeInfoMode::AnalyzeAtMake,
-            Some(PendingConcatenationScopeInfo::Analyzed(_))
+            Some(
+              PendingConcatenationScopeInfo::Analyzed(_)
+                | PendingConcatenationScopeInfo::CodegenAnalysisRequired,
+            ),
           ) | (
             ConcatenationScopeInfoMode::GenerateAtCodegen,
             Some(PendingConcatenationScopeInfo::Generated)

--- a/crates/rspack_plugin_javascript/src/visitors/concatenate_scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/concatenate_scope_info.rs
@@ -6,7 +6,9 @@ use rspack_util::atom::Atom;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use swc_experimental_allocator::atom::Atom as AstAtom;
-use swc_experimental_ecma_ast::{ClassExpr, Ident, ObjectPatProp, Prop, Visit, VisitWith};
+use swc_experimental_ecma_ast::{
+  ClassExpr, ForHead, ForInStmt, ForOfStmt, Ident, ObjectPatProp, Prop, Visit, VisitWith,
+};
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
 #[derive(Clone, Copy)]
@@ -27,6 +29,13 @@ impl Default for UsedNames<'_> {
 }
 
 impl<'ast> UsedNames<'ast> {
+  fn contains(&self, name: &AstAtom<'ast>) -> bool {
+    match self {
+      Self::Inline(names) => names.contains(name),
+      Self::Heap(names) => names.contains(name),
+    }
+  }
+
   fn insert(&mut self, name: AstAtom<'ast>) -> bool {
     match self {
       Self::Inline(names) => {
@@ -53,9 +62,12 @@ impl<'ast> UsedNames<'ast> {
 pub(crate) struct PendingConcatenationScopeInfoVisitor<'semantic, 'ast> {
   semantic: &'semantic Semantic,
   top_level_idents: SmallVec<[PendingConcatenationScopeIdent; 8]>,
+  top_level_names: UsedNames<'ast>,
   global_idents: SmallVec<[PendingConcatenationScopeIdent; 4]>,
   used_name_set: UsedNames<'ast>,
   used_names: SmallVec<[(AstAtom<'ast>, DependencyRange); 8]>,
+  ambiguous_for_head_names: SmallVec<[AstAtom<'ast>; 1]>,
+  in_for_head_assignment: bool,
   canonical_names: SmallVec<[ConcatenationScopeCanonicalName; 1]>,
 }
 
@@ -64,9 +76,12 @@ impl<'semantic, 'ast> PendingConcatenationScopeInfoVisitor<'semantic, 'ast> {
     Self {
       semantic,
       top_level_idents: SmallVec::new(),
+      top_level_names: UsedNames::default(),
       global_idents: SmallVec::new(),
       used_name_set: UsedNames::default(),
       used_names: SmallVec::new(),
+      ambiguous_for_head_names: SmallVec::new(),
+      in_for_head_assignment: false,
       canonical_names: SmallVec::new(),
     }
   }
@@ -96,17 +111,29 @@ impl<'semantic, 'ast> PendingConcatenationScopeInfoVisitor<'semantic, 'ast> {
       self.add_canonical_name(ident, range);
       self.global_idents.push(pending_ident);
     } else if class_expr_with_ident || scope != self.semantic.top_level_scope_id() {
+      if self.in_for_head_assignment && !self.ambiguous_for_head_names.contains(&ident.sym) {
+        self.ambiguous_for_head_names.push(ident.sym);
+      }
       if self.used_name_set.insert(ident.sym) {
         self.add_canonical_name(ident, range);
         self.used_names.push((ident.sym, range));
       }
     } else {
       self.add_canonical_name(ident, range);
+      self.top_level_names.insert(ident.sym);
       self.top_level_idents.push(pending_ident);
     }
   }
 
   pub(crate) fn into_info(self) -> PendingConcatenationScopeInfo {
+    if self
+      .ambiguous_for_head_names
+      .iter()
+      .any(|name| self.top_level_names.contains(name))
+    {
+      return PendingConcatenationScopeInfo::CodegenAnalysisRequired;
+    }
+
     let mut idents = Vec::with_capacity(
       self.top_level_idents.len() + self.global_idents.len() + self.used_names.len(),
     );
@@ -181,5 +208,23 @@ impl<'ast> Visit<'ast> for PendingConcatenationScopeInfoVisitor<'_, 'ast> {
     } else {
       class_expr.visit_children_with(self);
     }
+  }
+
+  fn visit_for_in_stmt(&mut self, stmt: &ForInStmt<'ast>) {
+    let previous = self.in_for_head_assignment;
+    self.in_for_head_assignment = matches!(&stmt.left, ForHead::Pat(_));
+    stmt.left.visit_with(self);
+    self.in_for_head_assignment = previous;
+    stmt.right.visit_with(self);
+    stmt.body.visit_with(self);
+  }
+
+  fn visit_for_of_stmt(&mut self, stmt: &ForOfStmt<'ast>) {
+    let previous = self.in_for_head_assignment;
+    self.in_for_head_assignment = matches!(&stmt.left, ForHead::Pat(_));
+    stmt.left.visit_with(self);
+    self.in_for_head_assignment = previous;
+    stmt.right.visit_with(self);
+    stmt.body.visit_with(self);
   }
 }

--- a/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/expression.js
+++ b/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/expression.js
@@ -1,0 +1,9 @@
+const expressionValue = 40;
+
+function nested(expressionValue) {
+	return expressionValue;
+}
+
+export const expression = EXPRESSION_VALUE;
+
+nested(0);

--- a/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/identifier.js
+++ b/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/identifier.js
@@ -1,0 +1,9 @@
+const sourceValue = 40;
+
+function nested(sourceValue) {
+	return sourceValue;
+}
+
+export const identifier = IDENTIFIER_VALUE;
+
+nested(0);

--- a/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/index.js
@@ -1,0 +1,22 @@
+import { expression } from "./expression";
+import { identifier } from "./identifier";
+import { array, constant, literal, object } from "./literal";
+
+it("should analyze non-literal DefinePlugin code at codegen", () => {
+	expect(identifier).toBe(40);
+	expect(expression).toBe(42);
+	expect(literal).toBe("literal");
+	expect(constant).toBe(3);
+	expect(array).toEqual(["literal", false, 1]);
+	expect(object).toEqual({
+		MODE: "production",
+		DEV: false,
+		PROD: true,
+		SSR: false,
+		BASE_URL: "/",
+		ASSET_PREFIX: "",
+		NESTED: {
+			FLAGS: [true, false]
+		}
+	});
+});

--- a/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/literal.js
+++ b/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/literal.js
@@ -1,0 +1,4 @@
+export const literal = LITERAL_VALUE;
+export const constant = CONSTANT_VALUE;
+export const array = ARRAY_VALUE;
+export const object = OBJECT_VALUE;

--- a/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/define-plugin-codegen-analysis/rspack.config.js
@@ -1,0 +1,30 @@
+const { DefinePlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "development",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	},
+	plugins: [
+		new DefinePlugin({
+			IDENTIFIER_VALUE: "sourceValue",
+			EXPRESSION_VALUE: "expressionValue + 2",
+			LITERAL_VALUE: JSON.stringify("literal"),
+			CONSTANT_VALUE: "1 + 2",
+			ARRAY_VALUE: [JSON.stringify("literal"), false, 1],
+			OBJECT_VALUE: {
+				MODE: JSON.stringify("production"),
+				DEV: false,
+				PROD: true,
+				SSR: false,
+				BASE_URL: JSON.stringify("/"),
+				ASSET_PREFIX: JSON.stringify(""),
+				NESTED: {
+					FLAGS: [true, false]
+				}
+			}
+		})
+	]
+};

--- a/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/index.js
+++ b/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/index.js
@@ -1,0 +1,10 @@
+import { P, Q } from "./module";
+
+it("should preserve top-level bindings used as loop assignment targets", () => {
+	expect(P).toBe("expected");
+	expect(Q).toBe("expected");
+
+	const source = require("fs").readFileSync(__filename, "utf-8");
+	expect(source).toContain('var P = "initial"');
+	expect(source).toContain('var Q = "initial"');
+});

--- a/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/module.js
+++ b/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/module.js
@@ -1,0 +1,6 @@
+var P = "initial";
+for (P in { expected: true });
+var Q = "initial";
+for (Q of ["expected"]);
+
+export { P, Q };

--- a/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/rspack.config.js
+++ b/tests/rspack-test/configCases/concatenate-modules/for-in-assignment-scope/rspack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	target: "node",
+	optimization: {
+		concatenateModules: true,
+		minimize: false
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/base.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/base.js
@@ -1,0 +1,7 @@
+export function parse(value) {
+	return value;
+}
+
+export function stringify(value) {
+	return value;
+}

--- a/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/index.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/index.js
@@ -1,0 +1,5 @@
+import queryString from "./query-string";
+
+it("should keep an operand for a pure default-exported namespace", () => {
+	expect(queryString.parse("value")).toBe("value");
+});

--- a/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/query-string.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/query-string.js
@@ -1,0 +1,3 @@
+import * as queryString from "./base";
+
+export default queryString;

--- a/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/default-exported-namespace/test.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@rspack/cli").Configuration} */
+module.exports = {
+	mode: "production",
+	optimization: {
+		concatenateModules: true,
+		minimize: false,
+	},
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/index.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/index.js
@@ -1,0 +1,7 @@
+import externalReact from "react";
+import { React as localReact } from "./local";
+
+it("should keep generated external globals out of the concatenated local scope", () => {
+	expect(externalReact.version).toBe("global");
+	expect(localReact.version).toBe("local");
+});

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/local.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/local.js
@@ -1,0 +1,1 @@
+export const React = { version: "local" };

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/rspack.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	externals: {
+		react: "var React"
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	moduleScope(scope) {
+		scope.React = { version: "global" };
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/collision.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/collision.js
@@ -1,0 +1,1 @@
+export const process = "collision";

--- a/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/index.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/index.js
@@ -1,0 +1,7 @@
+import { value } from "./provided-value";
+import { process as collision } from "./collision";
+
+it("should bind untransformed global references to the provided declaration", () => {
+	expect(value).toBe("provided");
+	expect(collision).toBe("collision");
+});

--- a/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/process.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/process.js
@@ -1,0 +1,5 @@
+module.exports = {
+	env: {
+		PROVIDED_VALUE: "provided"
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/provided-value.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/provided-value.js
@@ -1,0 +1,8 @@
+var _a;
+
+export const value =
+	process.env.INLINED_VALUE === "inlined" && typeof process !== "undefined"
+		? (_a = process.env) === null || _a === void 0
+			? void 0
+			: _a.PROVIDED_VALUE
+		: "missing";

--- a/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/provide-global-rebinding/test.config.js
@@ -1,0 +1,17 @@
+const path = require("path");
+const { DefinePlugin, ProvidePlugin } = require("@rspack/core");
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	optimization: {
+		concatenateModules: true
+	},
+	plugins: [
+		new DefinePlugin({
+			"process.env.INLINED_VALUE": JSON.stringify("inlined")
+		}),
+		new ProvidePlugin({
+			process: path.resolve(__dirname, "process.js")
+		})
+	]
+};


### PR DESCRIPTION
## Summary

- Fall back to legacy codegen-time scope analysis when non-compile-time DefinePlugin replacements or ambiguous top-level `for-in`/`for-of` assignment heads cannot be represented safely by make-time scope metadata.
- Preserve binding relationships for globals materialized by ProvidePlugin, and keep default-exported namespace expressions intact when dependency templates overlap.
- Keep faster-concatenation used-name metadata accurate without treating static PureExpression wrapper code as generated identifiers.

## Related links

- Follow-up to #14852
- Supports #15081

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test:unit` (9224 passed, 4 skipped)
- `cargo fmt --all --check`
- `cargo check -p rspack_core -p rspack_plugin_javascript`
- Faster on/off comparison for all five `rstackjs/build-tools-performance` projects; complete output trees are byte-for-byte identical
- Faster on/off Dreamina production builds; stable executable assets are identical, with only the previously confirmed dependency-order nondeterminism and its hash/manifest/source-map cascades excluded

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).