### PR TITLE
test: cover external global capture in faster concatenation

### DIFF
--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/index.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/index.js
@@ -1,0 +1,33 @@
+import externalJSON from "json";
+import externalPromise from "promise";
+import externalURL from "url";
+import externalURLSearchParams from "url-search-params";
+import externalSymbol from "symbol";
+import externalReflect from "reflect";
+import externalGlobalThis from "global-this";
+import {
+	JSON as localJSON,
+	Promise as localPromise,
+	URL as localURL,
+	URLSearchParams as localURLSearchParams,
+	Symbol as localSymbol,
+	Reflect as localReflect,
+	globalThis as localGlobalThis
+} from "./local";
+
+it("should keep generated external globals out of the concatenated local scope", () => {
+	expect(externalJSON.marker).toBe("global-json");
+	expect(localJSON.marker).toBe("local-json");
+	expect(externalPromise.marker).toBe("global-promise");
+	expect(localPromise.marker).toBe("local-promise");
+	expect(externalURL.marker).toBe("global-url");
+	expect(localURL.marker).toBe("local-url");
+	expect(externalURLSearchParams.marker).toBe("global-url-search-params");
+	expect(localURLSearchParams.marker).toBe("local-url-search-params");
+	expect(externalSymbol.marker).toBe("global-symbol");
+	expect(localSymbol.marker).toBe("local-symbol");
+	expect(externalReflect.marker).toBe("global-reflect");
+	expect(localReflect.marker).toBe("local-reflect");
+	expect(externalGlobalThis.marker).toBe("global-global-this");
+	expect(localGlobalThis.marker).toBe("local-global-this");
+});

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/local.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/local.js
@@ -1,0 +1,7 @@
+export const JSON = { marker: "local-json" };
+export const Promise = { marker: "local-promise" };
+export const URL = { marker: "local-url" };
+export const URLSearchParams = { marker: "local-url-search-params" };
+export const Symbol = { marker: "local-symbol" };
+export const Reflect = { marker: "local-reflect" };
+export const globalThis = { marker: "local-global-this" };

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/rspack.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/rspack.config.js
@@ -1,0 +1,12 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    json: 'var JSON',
+    promise: 'var Promise',
+    url: 'var URL',
+    'url-search-params': 'var URLSearchParams',
+    symbol: 'var Symbol',
+    reflect: 'var Reflect',
+    'global-this': 'var globalThis',
+  },
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture-builtins/test.config.js
@@ -1,0 +1,15 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	moduleScope(scope) {
+		scope.JSON = { marker: "global-json" };
+		scope.Promise = { marker: "global-promise" };
+		scope.URL = { marker: "global-url" };
+		scope.URLSearchParams = { marker: "global-url-search-params" };
+		scope.Symbol = { marker: "global-symbol" };
+		scope.Reflect = { marker: "global-reflect" };
+		scope.marker = "global-global-this";
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/index.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/index.js
@@ -1,0 +1,7 @@
+import externalReact from "react";
+import { React as localReact } from "./local";
+
+it("should keep generated external globals out of the concatenated local scope", () => {
+	expect(externalReact.version).toBe("global");
+	expect(localReact.version).toBe("local");
+});

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/local.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/local.js
@@ -1,0 +1,1 @@
+export const React = { version: "local" };

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/rspack.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/rspack.config.js
@@ -1,0 +1,6 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  externals: {
+    react: 'var React',
+  },
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
@@ -1,0 +1,12 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	moduleScope(scope) {
+		scope.React = { version: "global" };
+	},
+	externals: {
+		react: "var React"
+	},
+	optimization: {
+		concatenateModules: true
+	}
+};

--- a/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
+++ b/tests/rspack-test/normalCases/scope-hoisting/external-global-capture/test.config.js
@@ -3,9 +3,6 @@ module.exports = {
 	moduleScope(scope) {
 		scope.React = { version: "global" };
 	},
-	externals: {
-		react: "var React"
-	},
 	optimization: {
 		concatenateModules: true
 	}


### PR DESCRIPTION
## Summary

Add a faster module concatenation case where an external `var React` and a local `React` binding coexist.

## Failure reason

The generated `React` reference from the external module is not reserved by faster concatenation. The local `const React` is retained, so the external reference executes in its temporal dead zone and throws `ReferenceError: Cannot access 'React' before initialization`. Legacy concatenation renames the local binding and passes.