### PR TITLE
fix(ids): make compare_modules_by_pre_order_index_or_identifier a total order

### DIFF
--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -223,13 +223,35 @@ pub fn compare_modules_by_pre_order_index_or_identifier(
   a: &Identifier,
   b: &Identifier,
 ) -> std::cmp::Ordering {
-  if let Some(a) = module_graph.get_pre_order_index(a)
-    && let Some(b) = module_graph.get_pre_order_index(b)
-  {
-    compare_numbers(a, b)
-  } else {
-    compare_ids(a, b)
-  }
+  compare_by_pre_order_index_or_id(
+    module_graph.get_pre_order_index(a),
+    a,
+    module_graph.get_pre_order_index(b),
+    b,
+  )
+}
+
+/// Ordering logic for [`compare_modules_by_pre_order_index_or_identifier`], split
+/// out as a pure function so its total-order property is unit-testable without a
+/// `ModuleGraph`.
+///
+/// Must be a *strict total order*: Rust's `sort_unstable_by` aborts the process
+/// ("comparison function does not correctly implement a total order") once it
+/// detects a violation. The previous form — compare by pre-order index only when
+/// BOTH modules have one, else fall back to identifier — is not transitive when
+/// the set mixes modules with and without a pre-order index (e.g. under
+/// splitChunks / `experiments.layers`, where `get_pre_order_index` is `None` for
+/// some modules): a numeric edge and an identifier edge can disagree. Use a single
+/// key — pre-order index (missing sorts last via `u32::MAX`) — with the identifier
+/// as a deterministic tiebreak.
+fn compare_by_pre_order_index_or_id(
+  a_index: Option<u32>,
+  a_id: &str,
+  b_index: Option<u32>,
+  b_id: &str,
+) -> std::cmp::Ordering {
+  compare_numbers(a_index.unwrap_or(u32::MAX), b_index.unwrap_or(u32::MAX))
+    .then_with(|| compare_ids(a_id, b_id))
 }
 
 #[cfg(test)]
@@ -241,7 +263,59 @@ mod tests {
   };
   use rustc_hash::FxHashMap;
 
-  use super::{NaturalChunkCompareCache, assign_deterministic_ids, compare_chunks_natural};
+  use super::{
+    NaturalChunkCompareCache, assign_deterministic_ids, compare_by_pre_order_index_or_id,
+    compare_chunks_natural,
+  };
+
+  #[test]
+  fn compare_by_pre_order_index_or_id_is_a_total_order() {
+    // (pre_order_index, identifier) — a mix of Some/None. Includes the triple that
+    // made the old "compare by index only when BOTH present, else by identifier"
+    // logic non-transitive: A(Some(5),"z"), B(None,"m"), C(Some(10),"a") gives
+    // A<C and C<B (so transitively A<B) yet A>B — the violation that aborted
+    // `sort_unstable_by`.
+    let items: &[(Option<u32>, &str)] = &[
+      (Some(5), "z"),
+      (None, "m"),
+      (Some(10), "a"),
+      (Some(0), "b"),
+      (None, "a"),
+      (Some(5), "a"),
+      (None, "z"),
+    ];
+    let cmp = |x: &(Option<u32>, &str), y: &(Option<u32>, &str)| {
+      compare_by_pre_order_index_or_id(x.0, x.1, y.0, y.1)
+    };
+
+    // reflexive + antisymmetric: cmp(a,a) == Equal, and cmp(a,b) reverses cmp(b,a).
+    for a in items {
+      assert_eq!(cmp(a, a), Ordering::Equal);
+      for b in items {
+        assert_eq!(cmp(a, b), cmp(b, a).reverse());
+      }
+    }
+
+    // transitive: a <= b && b <= c  =>  a <= c.
+    let le = |a: &(Option<u32>, &str), b: &(Option<u32>, &str)| cmp(a, b) != Ordering::Greater;
+    for a in items {
+      for b in items {
+        for c in items {
+          if le(a, b) && le(b, c) {
+            assert!(
+              le(a, c),
+              "transitivity violated: {a:?} <= {b:?} <= {c:?} but {a:?} > {c:?}"
+            );
+          }
+        }
+      }
+    }
+
+    // the sort the plugin performs must not panic on this set.
+    let mut sorted = items.to_vec();
+    sorted.sort_unstable_by(|x, y| compare_by_pre_order_index_or_id(x.0, x.1, y.0, y.1));
+    assert_eq!(sorted.len(), items.len());
+  }
 
   #[test]
   fn assign_deterministic_ids_accepts_borrowed_names() {


### PR DESCRIPTION
`compare_modules_by_pre_order_index_or_identifier` compared by pre-order index
only when BOTH modules had one, and fell back to identifier otherwise. When the
sorted set mixes modules with and without a pre-order index (e.g. under
splitChunks / experiments.layers — `get_pre_order_index` returns `Option<u32>`),
this is not transitive: a numeric edge and an identifier edge can disagree, e.g.

  A(idx=5,id="z"), B(no idx,id="m"), C(idx=10,id="a")
  A<C (5<10), C<B ("a"<"m")  =>  A<B, but A>B ("z">"m")   x

`sort_unstable_by` aborts the process ("comparison function does not correctly
implement a total order") once it detects this (Rust >= 1.81); the failure is
non-deterministic because FxHashMap iteration order decides whether the violating
triple is visited. webpack's Array.sort runs the same logic but only yields an
unspecified order, so the port went unnoticed.

Use a single sort key: pre-order index (missing sorts last via u32::MAX) with the
identifier as a deterministic tiebreak. Preserves the intended index ordering for
the common case and is a strict total order.

Repro + verification (debug binding, same window): stock 6/6 panics, patched 0/20.
Closes #15259.