### PR TITLE
feat(cache): add fine-grained new cache options

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2303,11 +2303,6 @@ export interface RawExperiments {
   runtimeMode?: "webpack" | "rspack"
 }
 
-export interface RawNewCache {
-  codeGeneration: boolean
-  minimize: boolean
-}
-
 export interface RawExposeOptions {
   key: string
   name?: string
@@ -2750,6 +2745,11 @@ export interface RawModuleRule {
 export interface RawModuleRuleUse {
   loader: string
   options?: string
+}
+
+export interface RawNewCache {
+  codeGeneration: boolean
+  minimize: boolean
 }
 
 export interface RawNodeOption {

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2295,12 +2295,17 @@ export interface RawEvalDevToolModulePluginOptions {
 export interface RawExperiments {
   useInputFileSystem?: false | Array<RegExp>
   css?: boolean
-  newCache: boolean
+  newCache: false | RawNewCache
   deferImport: boolean
   sourceImport: boolean
   fasterModuleConcatenation: boolean
   pureFunctions: boolean
   runtimeMode?: "webpack" | "rspack"
+}
+
+export interface RawNewCache {
+  codeGeneration: boolean
+  minimize: boolean
 }
 
 export interface RawExposeOptions {

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -51,10 +51,10 @@ use rspack_core::{
   JavascriptParserOrder, JavascriptParserUrl, JavascriptParserWorkerOptions, JsonGeneratorOptions,
   JsonParserOptions, LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType,
   MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions, ModuleRule, ModuleRuleEffect,
-  ModuleType, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption, Optimization,
-  OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo, PublicPath, Resolve,
-  RuleSetCondition, RuleSetLogicalConditions, SideEffectOption, StatsOptions, TrustedTypes,
-  UsedExportsOption, WasmLoading, WasmLoadingType, incremental::IncrementalOptions,
+  ModuleType, NewCacheOptions, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption,
+  Optimization, OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo, PublicPath,
+  Resolve, RuleSetCondition, RuleSetLogicalConditions, SideEffectOption, StatsOptions,
+  TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType, incremental::IncrementalOptions,
   runtime_mode::RuntimeMode,
 };
 use rspack_error::{Error, Result};
@@ -3677,7 +3677,7 @@ pub struct ExperimentsBuilder {
   /// Whether to enable css.
   css: Option<bool>,
   /// Whether to enable the new cache implementation.
-  new_cache: Option<bool>,
+  new_cache: Option<NewCacheOptions>,
   /// Whether to enable async web assembly.
   async_web_assembly: Option<bool>,
   /// Whether to enable defer import.
@@ -3738,7 +3738,11 @@ impl ExperimentsBuilder {
 
   /// Set whether to enable the new cache implementation.
   pub fn new_cache(&mut self, new_cache: bool) -> &mut Self {
-    self.new_cache = Some(new_cache);
+    self.new_cache = Some(if new_cache {
+      NewCacheOptions::all()
+    } else {
+      NewCacheOptions::default()
+    });
     self
   }
 
@@ -3782,7 +3786,7 @@ impl ExperimentsBuilder {
 
     Ok(Experiments {
       css: d!(self.css, false),
-      new_cache: d!(self.new_cache, false),
+      new_cache: d!(self.new_cache, NewCacheOptions::default()),
       defer_import: d!(self.defer_import, false),
       source_import: d!(self.source_import, false),
       faster_module_concatenation: d!(self.faster_module_concatenation, false),

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1748,7 +1748,10 @@ CompilerOptions {
     cache: Disabled,
     experiments: Experiments {
         css: false,
-        new_cache: false,
+        new_cache: NewCacheOptions {
+            code_generation: false,
+            minimize: false,
+        },
         defer_import: false,
         source_import: false,
         faster_module_concatenation: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -1,8 +1,10 @@
 mod raw_incremental;
+mod raw_new_cache;
 
 use napi_derive::napi;
 pub use raw_incremental::RawIncremental;
-use rspack_core::{Experiments, runtime_mode::RuntimeMode};
+pub use raw_new_cache::RawNewCache;
+use rspack_core::{Experiments, NewCacheOptions, runtime_mode::RuntimeMode};
 use rspack_regex::RspackRegex;
 
 use super::WithFalse;
@@ -13,7 +15,8 @@ pub struct RawExperiments {
   #[napi(ts_type = "false | Array<RegExp>")]
   pub use_input_file_system: Option<WithFalse<Vec<RspackRegex>>>,
   pub css: Option<bool>,
-  pub new_cache: bool,
+  #[napi(ts_type = "false | RawNewCache")]
+  pub new_cache: WithFalse<RawNewCache>,
   pub defer_import: bool,
   pub source_import: bool,
   pub faster_module_concatenation: bool,
@@ -32,7 +35,10 @@ impl From<RawExperiments> for Experiments {
 
     Self {
       css: value.css.unwrap_or(false),
-      new_cache: value.new_cache,
+      new_cache: match value.new_cache {
+        WithFalse::False => NewCacheOptions::default(),
+        WithFalse::True(value) => value.into(),
+      },
       defer_import: value.defer_import,
       source_import: value.source_import,
       faster_module_concatenation: value.faster_module_concatenation,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
@@ -1,0 +1,18 @@
+use napi_derive::napi;
+use rspack_core::NewCacheOptions;
+
+#[derive(Debug, Default)]
+#[napi(object)]
+pub struct RawNewCache {
+  pub code_generation: bool,
+  pub minimize: bool,
+}
+
+impl From<RawNewCache> for NewCacheOptions {
+  fn from(value: RawNewCache) -> Self {
+    Self {
+      code_generation: value.code_generation,
+      minimize: value.minimize,
+    }
+  }
+}

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -54,7 +54,7 @@ pub fn new_cache(
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Box<dyn Cache> {
-  if compiler_option.experiments.new_cache.is_fully_enabled() {
+  if compiler_option.experiments.new_cache.is_enabled() {
     return Box::new(DisableCache);
   }
 

--- a/crates/rspack_core/src/cache/mod.rs
+++ b/crates/rspack_core/src/cache/mod.rs
@@ -54,7 +54,7 @@ pub fn new_cache(
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Box<dyn Cache> {
-  if compiler_option.experiments.new_cache {
+  if compiler_option.experiments.new_cache.is_fully_enabled() {
     return Box::new(DisableCache);
   }
 

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -134,6 +134,7 @@ pub(crate) async fn code_generation_modules(
     .options
     .experiments
     .new_cache
+    .code_generation
     .then(|| compilation.get_cache(CODE_GENERATION_CACHE_NAME));
   let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
   let module_graph = compilation.get_module_graph();

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -33,7 +33,7 @@ pub fn create_cache(
   input_filesystem: Arc<dyn ReadableFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Cache {
-  if !compiler_options.experiments.new_cache {
+  if !compiler_options.experiments.new_cache.is_enabled() {
     return Cache::new_disabled(compiler_path);
   }
 

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -23,10 +23,33 @@ pub mod runtime_mode {
 
 use runtime_mode::RuntimeMode;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NewCacheOptions {
+  pub code_generation: bool,
+  pub minimize: bool,
+}
+
+impl NewCacheOptions {
+  pub const fn all() -> Self {
+    Self {
+      code_generation: true,
+      minimize: true,
+    }
+  }
+
+  pub const fn is_enabled(self) -> bool {
+    self.code_generation || self.minimize
+  }
+
+  pub const fn is_fully_enabled(self) -> bool {
+    self.code_generation && self.minimize
+  }
+}
+
 #[derive(Debug)]
 pub struct Experiments {
   pub css: bool,
-  pub new_cache: bool,
+  pub new_cache: NewCacheOptions,
   pub defer_import: bool,
   pub source_import: bool,
   pub faster_module_concatenation: bool,

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -40,10 +40,6 @@ impl NewCacheOptions {
   pub const fn is_enabled(self) -> bool {
     self.code_generation || self.minimize
   }
-
-  pub const fn is_fully_enabled(self) -> bool {
-    self.code_generation && self.minimize
-  }
 }
 
 #[derive(Debug)]

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -226,7 +226,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let options = &self.options;
   let minimizer_options = &self.options.minimizer_options;
 
-  let new_cache = (compilation.options.experiments.new_cache
+  let new_cache = (compilation.options.experiments.new_cache.minimize
     && !matches!(&compilation.options.cache, CacheOptions::Disabled))
   .then(|| compilation.get_cache(PLUGIN_NAME));
   let minimize_persistent_cache = compilation.minimize_persistent_cache.take();

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -62,6 +62,7 @@ import type {
   JavascriptParserOptions,
   JsonGeneratorOptions,
   JsonParserOptions,
+  NewCache,
   Node,
   Optimization,
   Output,
@@ -82,13 +83,20 @@ export type {
 
 const MAX_U32 = 0xffffffff;
 
+type ExperimentsWithDefaults = Omit<
+  Required<ExperimentsNormalized>,
+  'newCache'
+> & {
+  newCache: false | Required<NewCache>;
+};
+
 // invariant: `options` is normalized with default value applied
 export const getRawOptions = (
   options: RspackOptionsNormalized,
   compiler: Compiler,
 ): RawOptions => {
   const mode = options.mode;
-  const experiments = options.experiments as Required<ExperimentsNormalized>;
+  const experiments = options.experiments as ExperimentsWithDefaults;
   return {
     name: options.name,
     mode,

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -280,6 +280,10 @@ const applyExperimentsDefaults = (
 ) => {
   D(experiments, 'futureDefaults', false);
   D(experiments, 'newCache', false);
+  if (typeof experiments.newCache === 'object') {
+    D(experiments.newCache, 'codeGeneration', true);
+    D(experiments.newCache, 'minimize', true);
+  }
   D(experiments, 'asyncWebAssembly', true);
   D(experiments, 'deferImport', false);
   D(experiments, 'sourceImport', false);

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -61,6 +61,8 @@ import type {
   LibraryOptions,
   Loader,
   Mode,
+  NewCache,
+  NewCachePresets,
   Name,
   Node,
   NoParseOption,
@@ -376,6 +378,10 @@ export const getNormalizedRspackOptions = (
     experiments: nestedConfig(config.experiments, (experiments) => {
       return {
         ...experiments,
+        newCache:
+          experiments.newCache === undefined
+            ? undefined
+            : getNormalizedNewCacheOptions(experiments.newCache),
         buildHttp: experiments.buildHttp,
         useInputFileSystem: experiments.useInputFileSystem,
       };
@@ -492,6 +498,14 @@ const getNormalizedIncrementalOptions = (
     return { silent: false };
   }
   return incremental;
+};
+
+const getNormalizedNewCacheOptions = (
+  newCache: NewCachePresets | NewCache,
+): false | NewCache => {
+  if (newCache === false) return false;
+  if (newCache === true) return {};
+  return newCache;
 };
 
 const nestedConfig = <T, R>(value: T | undefined, fn: (value: T) => R) =>
@@ -648,7 +662,7 @@ export interface ExperimentsNormalized {
   asyncWebAssembly?: boolean;
   css?: boolean;
   futureDefaults?: boolean;
-  newCache?: boolean;
+  newCache?: false | NewCache;
   fasterModuleConcatenation?: boolean;
   buildHttp?: HttpUriPluginOptions;
   useInputFileSystem?: false | RegExp[];

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3082,6 +3082,16 @@ export type HttpUriOptions = HttpUriPluginOptions;
  */
 export type UseInputFileSystem = false | RegExp[];
 
+/** Fine-grained switches for the experimental new cache implementation. */
+export type NewCache = {
+  /** Enable the module code generation cache. @default true */
+  codeGeneration?: boolean;
+  /** Enable the asset minimization cache. @default true */
+  minimize?: boolean;
+};
+
+export type NewCachePresets = boolean;
+
 /**
  * Experimental features configuration.
  */
@@ -3122,7 +3132,7 @@ export type Experiments = {
    * Enable the experimental new cache implementation.
    * @default false
    */
-  newCache?: boolean;
+  newCache?: NewCachePresets | NewCache;
   /**
    * Enable the faster module concatenation implementation.
    * @default false


### PR DESCRIPTION
## Summary

- allow `experiments.newCache` to configure code generation and minimization caches independently
- preserve boolean compatibility, with `true` enabling all available new-cache implementations
- disable the legacy cache whenever any new-cache implementation is enabled