### PR TITLE
fix(resolver): restore tsconfig files as file dependencies

### DIFF
--- a/crates/rspack_resolver/src/lib.rs
+++ b/crates/rspack_resolver/src/lib.rs
@@ -1516,13 +1516,9 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         &tsconfig_options.references,
       )
       .await?;
-    // TODO: restore once these can be reported without costing `module count * tsconfig count`.
-    // Temporarily disabled: a monorepo with project references bursts memory in the consumer,
-    // which keeps this set per module. Trade-off: tsconfig edits won't invalidate watch builds.
-    // See `tsconfig_file_as_file_dependencies`, ignored for now.
-    // for dependency in &tsconfig.file_dependencies {
-    //   ctx.add_file_dependency(dependency.as_path());
-    // }
+    for dependency in &tsconfig.file_dependencies {
+      ctx.add_file_dependency(dependency.as_path());
+    }
     let paths = tsconfig.resolve(cached_path.path(), specifier);
     for path in paths {
       let cached_path = self.cache.value(&path);

--- a/crates/rspack_resolver/src/lib.rs
+++ b/crates/rspack_resolver/src/lib.rs
@@ -1516,8 +1516,10 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
         &tsconfig_options.references,
       )
       .await?;
-    for dependency in &tsconfig.file_dependencies {
-      ctx.add_file_dependency(dependency.as_path());
+    if ctx.file_dependencies.is_some() {
+      for dependency in &tsconfig.file_dependencies {
+        ctx.add_file_dependency(dependency.as_path());
+      }
     }
     let paths = tsconfig.resolve(cached_path.path(), specifier);
     for path in paths {

--- a/crates/rspack_resolver/src/tests/tsconfig_project_references.rs
+++ b/crates/rspack_resolver/src/tests/tsconfig_project_references.rs
@@ -45,8 +45,6 @@ async fn auto() {
 }
 
 #[tokio::test]
-#[ignore = "temporary workaround: tsconfig and its references are no longer reported as file dependencies, \
-            because a monorepo with many project references bursts memory in the consumer"]
 async fn tsconfig_file_as_file_dependencies() {
   let f = super::fixture_root().join("tsconfig/cases/project_references");
 


### PR DESCRIPTION
## Why

Reverts the temporary workaround from [rspack-resolver#291](https://github.com/rstackjs/rspack-resolver/pull/291) inside the vendored `rspack_resolver` crate.

`ArcPath` is now an interned handle (#15205), so a reported path is a deduped 8-byte value instead of a full owned path per module — the reason the reporting was disabled no longer holds in the same form.

There will be about 10% memory cost in large scale project with lots tsconfig referenced files. 
<img width="1755" height="975" alt="mem-curve-internal-large-app-2x2" src="https://github.com/user-attachments/assets/74bb19e1-b074-41bf-afba-85e09a8405d0" />


## What

- restore the `tsconfig.file_dependencies` loop in `load_tsconfig_paths`
- un-ignore `tsconfig_file_as_file_dependencies`