### PR TITLE
chore: align agent guidance

### DIFF
--- a/.agents/CODE_STYLE.md
+++ b/.agents/CODE_STYLE.md
@@ -105,11 +105,10 @@ let result = str.cow_replace("old", "new");
 
 ### TS/JS Formatting
 
-- Use Prettier
+- Run `pnpm run format:js`
 - Use Rslint for linting
 - **Indentation**: Tabs
 - **Semicolons**: Use semicolons
-- **Quotes**: Double quotes
 
 ### TS/JS Naming Conventions
 
@@ -175,22 +174,10 @@ if (isNil(options.context)) {
 
 ### Rust Testing
 
-- Place in same file with `#[cfg(test)]` module
+- Do not add inline `#[test]` functions or crate-local unit tests in ordinary changes
+- Add Rust test cases only when they belong in a dedicated test crate
 - Use descriptive names: `test_<what>_<condition>_<expected>`
 - Use `assert_eq!`, `assert!`, etc.
-
-```rust
-#[cfg(test)]
-mod tests {
- use super::*;
-
- #[test]
- fn test_wrap_comment_single_line() {
-  let result = wrap_comment("test");
-  assert_eq!(result, "/*! test */");
- }
-}
-```
 
 ### JavaScript/TypeScript Testing
 
@@ -249,7 +236,7 @@ packages/xxx/
 
 - **Rust formatting**: `cargo fmt`
 - **Rust linting**: `cargo clippy`
-- **TypeScript formatting**: Prettier
+- **TypeScript formatting**: `pnpm run format:js`
 - **TypeScript linting**: Rslint
 - **Type checking**: TypeScript compiler
 

--- a/.agents/COMMON_PATTERNS.md
+++ b/.agents/COMMON_PATTERNS.md
@@ -191,24 +191,9 @@ async fn process_multiple(&self, items: Vec<Item>) -> Result<Vec<Result>>> {
 
 ## Testing Patterns
 
-### Rust Unit Test
+### Rust Tests
 
-```rust
-#[cfg(test)]
-mod tests {
- use super::*;
-
- #[test]
- fn test_plugin_creation() {
-  let options = MyPluginOptions {
-   option1: "test".to_string(),
-   option2: Some(true),
-  };
-  let plugin = MyPlugin::new(options);
-  assert_eq!(plugin.name(), "rspack.MyPlugin");
- }
-}
-```
+Do not add inline `#[test]` functions or crate-local unit tests in ordinary changes. Add Rust test cases only when they belong in a dedicated test crate.
 
 ### JavaScript Integration Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Rspack is a high-performance JavaScript bundler written in Rust that offers stro
 
 ## Setup
 
-- **Rust**: Latest stable (via [rustup](https://rustup.rs/))
+- **Rust**: Use the toolchain pinned by `rust-toolchain.toml`
 - **Node.js**: Latest LTS
 - **pnpm**: Version in `package.json`
 - Run `pnpm run setup` to install and build


### PR DESCRIPTION
## Summary

This PR aligns repository agent guidance after the testing-policy updates in #15105.
It makes setup defer to `rust-toolchain.toml`, removes conflicting inline Rust unit-test examples, and uses the configured JavaScript/TypeScript formatter command.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15105

## Checklist

- [x] Tests updated (not required; documentation-only changes).
- [x] Documentation updated.