### PR TITLE
feat: integrate new cache into source map devtool plugin 

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2749,6 +2749,7 @@ export interface RawModuleRuleUse {
 
 export interface RawNewCache {
   codeGeneration: boolean
+  devtool: boolean
   minimize: boolean
 }
 

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1750,6 +1750,7 @@ CompilerOptions {
         css: false,
         new_cache: NewCacheOptions {
             code_generation: false,
+            devtool: false,
             minimize: false,
         },
         defer_import: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
@@ -5,6 +5,7 @@ use rspack_core::NewCacheOptions;
 #[napi(object)]
 pub struct RawNewCache {
   pub code_generation: bool,
+  pub devtool: bool,
   pub minimize: bool,
 }
 
@@ -12,6 +13,7 @@ impl From<RawNewCache> for NewCacheOptions {
   fn from(value: RawNewCache) -> Self {
     Self {
       code_generation: value.code_generation,
+      devtool: value.devtool,
       minimize: value.minimize,
     }
   }

--- a/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/devtool/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rayon::prelude::*;
 use rspack_cacheable::{
   cacheable,
-  with::{AsPreset, AsVec},
+  with::{AsCacheable, AsOption, AsPreset, AsTuple2, AsVec},
 };
 use rspack_error::Result;
 use rspack_sources::{BoxSource, ConcatSource, SourceExt};
@@ -65,15 +65,67 @@ impl CacheKey {
 
 #[derive(Debug, Default)]
 pub struct SourceMapDevToolPluginCache {
-  entries: FxHashMap<CacheKey, Option<CacheEntry>>,
+  entries: FxHashMap<CacheKey, Option<CachedSourceMapDevToolPluginEntry>>,
   pending_writes: Vec<CacheKey>,
   pending_removes: Vec<CacheKey>,
 }
 
+#[cacheable]
 #[derive(Debug, Clone)]
-struct CacheEntry {
-  pub asset_append: Vec<BoxSource>,
-  pub source_map: Option<(String, BoxSource)>,
+pub struct CachedSourceMapDevToolPluginEntry {
+  #[cacheable(with=AsVec<AsPreset>)]
+  asset_append: Vec<BoxSource>,
+  #[cacheable(with=AsOption<AsTuple2<AsCacheable, AsPreset>>)]
+  source_map: Option<(String, BoxSource)>,
+}
+
+impl CachedSourceMapDevToolPluginEntry {
+  pub fn from_assets(
+    asset_append: &[BoxSource],
+    source_map: Option<(&str, &CompilationAsset)>,
+  ) -> Option<Self> {
+    let source_map = match source_map {
+      Some((filename, asset)) => Some((filename.to_string(), asset.get_source()?.clone())),
+      None => None,
+    };
+
+    Some(Self {
+      asset_append: asset_append.to_vec(),
+      source_map,
+    })
+  }
+
+  #[allow(clippy::type_complexity)]
+  pub fn restore(
+    &self,
+    asset: &CompilationAsset,
+  ) -> Option<(
+    CompilationAsset,
+    Option<(String, CompilationAsset)>,
+    Vec<BoxSource>,
+  )> {
+    let source = asset.get_source()?.clone();
+    let source = if self.asset_append.is_empty() {
+      source
+    } else {
+      let mut children = Vec::with_capacity(self.asset_append.len() + 1);
+      children.push(source);
+      children.extend(self.asset_append.iter().cloned());
+      ConcatSource::new(children).boxed()
+    };
+
+    let source_asset = CompilationAsset::new(Some(source), (*asset.info).clone());
+    let source_map = self.source_map.as_ref().map(|(filename, source)| {
+      let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
+      source_map_asset_info.version = asset.info.version.clone();
+      (
+        filename.clone(),
+        CompilationAsset::new(Some(source.clone()), source_map_asset_info),
+      )
+    });
+
+    Some((source_asset, source_map, self.asset_append.clone()))
+  }
 }
 
 impl SourceMapDevToolPluginCache {
@@ -94,32 +146,11 @@ impl SourceMapDevToolPluginCache {
   )> {
     let cache_key = Self::cache_key(filename, asset)?;
 
-    let CacheEntry {
-      asset_append,
-      source_map,
-    } = self.entries.get_mut(&cache_key).and_then(Option::take)?;
-
-    let source = asset.get_source()?.clone();
-    let source = if asset_append.is_empty() {
-      source
-    } else {
-      let mut children = Vec::with_capacity(asset_append.len() + 1);
-      children.push(source);
-      children.extend(asset_append.iter().cloned());
-      ConcatSource::new(children).boxed()
-    };
-
-    let source_asset = CompilationAsset::new(Some(source), (*asset.info).clone());
-    let source_map = source_map.map(|(filename, source)| {
-      let mut source_map_asset_info = AssetInfo::default().with_development(Some(true));
-      source_map_asset_info.version = asset.info.version.clone();
-      (
-        filename,
-        CompilationAsset::new(Some(source), source_map_asset_info),
-      )
-    });
-
-    Some((source_asset, source_map, asset_append))
+    self
+      .entries
+      .get_mut(&cache_key)
+      .and_then(Option::take)?
+      .restore(asset)
   }
 
   pub fn store<'a>(
@@ -181,24 +212,12 @@ impl SourceMapDevToolPluginCache {
       &[BoxSource],
       Option<(&str, &CompilationAsset)>,
     ),
-  ) -> Option<(CacheKey, CacheEntry)> {
+  ) -> Option<(CacheKey, CachedSourceMapDevToolPluginEntry)> {
     let (filename, asset, asset_append, source_map) = item;
     let cache_key = Self::cache_key(filename, asset)?;
-    let source_map = match source_map {
-      Some((filename, asset)) => {
-        let source = asset.get_source()?;
-        Some((filename.to_string(), source.clone()))
-      }
-      None => None,
-    };
+    let cache_entry = CachedSourceMapDevToolPluginEntry::from_assets(asset_append, source_map)?;
 
-    Some((
-      cache_key,
-      CacheEntry {
-        asset_append: asset_append.to_vec(),
-        source_map,
-      },
-    ))
+    Some((cache_key, cache_entry))
   }
 }
 
@@ -293,7 +312,7 @@ impl Occasion for SourceMapDevToolPluginOccasion {
         match self.codec.decode::<Entry>(&value) {
           Ok(entry) => Some((
             key,
-            Some(CacheEntry {
+            Some(CachedSourceMapDevToolPluginEntry {
               asset_append: entry.append,
               source_map: entry
                 .source_map
@@ -306,7 +325,7 @@ impl Occasion for SourceMapDevToolPluginOccasion {
           }
         }
       })
-      .collect::<FxHashMap<CacheKey, Option<CacheEntry>>>();
+      .collect::<FxHashMap<CacheKey, Option<CachedSourceMapDevToolPluginEntry>>>();
 
     tracing::debug!(
       "recovered {} source map persistent cache entries",

--- a/crates/rspack_core/src/cache/persistent/occasion/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/mod.rs
@@ -4,7 +4,9 @@ pub mod minimize;
 
 use std::future::Future;
 
-pub use devtool::{SourceMapDevToolPluginCache, SourceMapDevToolPluginOccasion};
+pub use devtool::{
+  CachedSourceMapDevToolPluginEntry, SourceMapDevToolPluginCache, SourceMapDevToolPluginOccasion,
+};
 pub use make::MakeOccasion;
 pub use minimize::{
   CachedExtractedComments, CachedMinimizeEntry, MinimizeOccasion, MinimizePersistentCache,

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -26,6 +26,7 @@ use runtime_mode::RuntimeMode;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct NewCacheOptions {
   pub code_generation: bool,
+  pub devtool: bool,
   pub minimize: bool,
 }
 
@@ -33,12 +34,13 @@ impl NewCacheOptions {
   pub const fn all() -> Self {
     Self {
       code_generation: true,
+      devtool: true,
       minimize: true,
     }
   }
 
   pub const fn is_enabled(self) -> bool {
-    self.code_generation || self.minimize
+    self.code_generation || self.devtool || self.minimize
   }
 }
 

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -10,10 +10,10 @@ use futures::future::BoxFuture;
 use itertools::Itertools;
 use regex::Regex;
 use rspack_core::{
-  AssetInfo, CacheCount, Chunk, ChunkUkey, Compilation, CompilationAsset, CompilationParams,
-  CompilationProcessAssets, CompilerCompilation, Filename, Logger, ModuleIdentifier, PathData,
-  Plugin,
-  cache::persistent::occasion::SourceMapDevToolPluginCache,
+  AssetInfo, CacheCount, CacheFacade, CacheOptions, CacheValue, Chunk, ChunkUkey, Compilation,
+  CompilationAsset, CompilationParams, CompilationProcessAssets, CompilerCompilation, Etag,
+  Filename, Logger, ModuleIdentifier, PathData, Plugin,
+  cache::persistent::occasion::{CachedSourceMapDevToolPluginEntry, SourceMapDevToolPluginCache},
   has_content_hash_placeholder,
   rspack_sources::{
     BoxSource, ConcatSource, MapOptions, ObjectPool, RawBufferSource, RawStringSource, Source,
@@ -147,6 +147,8 @@ fn compute_source_references(
 static URL_FORMATTING_REGEXP: LazyLock<Regex> = LazyLock::new(|| {
   Regex::new(r"^\n\/\/(.*)$").expect("failed to compile URL_FORMATTING_REGEXP regex")
 });
+
+const PLUGIN_NAME: &str = "rspack.SourceMapDevToolPlugin";
 
 #[derive(Clone)]
 pub enum ModuleFilenameTemplate {
@@ -436,7 +438,86 @@ impl SourceMapDevToolPlugin {
       .await
   }
 
-  async fn use_cache(
+  async fn use_new_cache(
+    &self,
+    compilation: &Compilation,
+    file_to_chunk: &HashMap<&str, &Chunk>,
+    output_path: &Utf8Path,
+    compilation_assets: Vec<(String, &CompilationAsset)>,
+    cache: &CacheFacade,
+    cache_counter: Option<&CacheCount>,
+  ) -> Result<Vec<MappedAsset>> {
+    let asset_count = compilation_assets.len();
+    let mut mapped_assets = Vec::with_capacity(asset_count);
+    let mut vanilla_assets = Vec::new();
+
+    for (index, (filename, asset)) in compilation_assets.into_iter().enumerate() {
+      let cached = if asset.get_source().is_some() && !asset.info.version.is_empty() {
+        cache.get::<CachedSourceMapDevToolPluginEntry>(
+          &filename,
+          Some(Etag::from(asset.info.version.clone())),
+        )?
+      } else {
+        None
+      };
+
+      if let Some(cached) = cached
+        && let Some((source_asset, source_map, asset_append)) = cached.restore(asset)
+      {
+        if let Some(counter) = cache_counter {
+          counter.hit();
+        }
+        mapped_assets.push(MappedAsset {
+          asset: (Arc::from(filename), source_asset),
+          asset_append,
+          source_map,
+        });
+        continue;
+      }
+
+      if let Some(counter) = cache_counter {
+        counter.miss();
+      }
+
+      if vanilla_assets.is_empty() {
+        vanilla_assets.reserve(asset_count - index);
+      }
+      vanilla_assets.push((filename, asset));
+    }
+
+    if !vanilla_assets.is_empty() {
+      let new_mapped_assets = self
+        .map_assets(compilation, file_to_chunk, output_path, vanilla_assets)
+        .await?;
+
+      for mapped_asset in &new_mapped_assets {
+        let asset = &mapped_asset.asset.1;
+        if asset.get_source().is_none() || asset.info.version.is_empty() {
+          continue;
+        }
+        let Some(cache_entry) = CachedSourceMapDevToolPluginEntry::from_assets(
+          mapped_asset.asset_append.as_slice(),
+          mapped_asset
+            .source_map
+            .as_ref()
+            .map(|(filename, asset)| (filename.as_str(), asset)),
+        ) else {
+          continue;
+        };
+        cache.store(
+          mapped_asset.asset.0.as_ref(),
+          Some(Etag::from(asset.info.version.clone())),
+          CacheValue::new(cache_entry),
+        )?;
+      }
+
+      mapped_assets.extend(new_mapped_assets);
+    }
+
+    Ok(mapped_assets)
+  }
+
+  async fn use_legacy_cache(
     &self,
     compilation: &Compilation,
     file_to_chunk: &HashMap<&str, &Chunk>,
@@ -1160,13 +1241,15 @@ async fn compilation(
   compilation: &mut Compilation,
   _params: &mut CompilationParams,
 ) -> Result<()> {
-  compilation.use_source_map_dev_tool_plugin_cache = true;
+  if !compilation.options.experiments.new_cache.devtool {
+    compilation.use_source_map_dev_tool_plugin_cache = true;
+  }
   Ok(())
 }
 
 #[plugin_hook(CompilationProcessAssets for SourceMapDevToolPlugin, stage = Compilation::PROCESS_ASSETS_STAGE_DEV_TOOLING)]
 async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
-  let logger = compilation.get_logger("rspack.SourceMapDevToolPlugin");
+  let logger = compilation.get_logger(PLUGIN_NAME);
 
   // use to read
   let mut file_to_chunk: HashMap<&str, &Chunk> = HashMap::default();
@@ -1198,12 +1281,16 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       .await?,
   );
 
-  let mut cache = compilation.source_map_dev_tool_plugin_cache.take();
-  let cache_counter = if cache.is_some() {
-    Some(logger.cache("source map persistent cache"))
-  } else {
+  let new_cache = (compilation.options.experiments.new_cache.devtool
+    && !matches!(&compilation.options.cache, CacheOptions::Disabled))
+  .then(|| compilation.get_cache(PLUGIN_NAME));
+  let mut legacy_cache = if new_cache.is_some() {
     None
+  } else {
+    compilation.source_map_dev_tool_plugin_cache.take()
   };
+  let cache_counter = (new_cache.is_some() || legacy_cache.is_some())
+    .then(|| logger.cache("source map persistent cache"));
 
   let start = logger.time("collect source maps");
   let compilation_assets = compilation
@@ -1212,19 +1299,32 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     .filter(|(_filename, asset)| asset.info.related.source_map.is_none())
     .map(|(filename, asset)| (filename.clone(), asset))
     .collect();
-  let mapped_assets = self
-    .use_cache(
-      compilation,
-      &file_to_chunk,
-      &output_path,
-      compilation_assets,
-      cache.as_mut(),
-      cache_counter.as_ref(),
-    )
-    .await?;
+  let mapped_assets = if let Some(cache) = &new_cache {
+    self
+      .use_new_cache(
+        compilation,
+        &file_to_chunk,
+        &output_path,
+        compilation_assets,
+        cache,
+        cache_counter.as_ref(),
+      )
+      .await?
+  } else {
+    self
+      .use_legacy_cache(
+        compilation,
+        &file_to_chunk,
+        &output_path,
+        compilation_assets,
+        legacy_cache.as_mut(),
+        cache_counter.as_ref(),
+      )
+      .await?
+  };
   logger.time_end(start);
 
-  if let Some(cache) = cache {
+  if let Some(cache) = legacy_cache {
     compilation.source_map_dev_tool_plugin_cache = Some(cache);
   }
   if let Some(counter) = cache_counter {
@@ -1268,7 +1368,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
 
 impl Plugin for SourceMapDevToolPlugin {
   fn name(&self) -> &'static str {
-    "rspack.SourceMapDevToolPlugin"
+    PLUGIN_NAME
   }
 
   fn apply(&self, ctx: &mut rspack_core::ApplyContext<'_>) -> Result<()> {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -282,6 +282,7 @@ const applyExperimentsDefaults = (
   D(experiments, 'newCache', false);
   if (typeof experiments.newCache === 'object') {
     D(experiments.newCache, 'codeGeneration', true);
+    D(experiments.newCache, 'devtool', true);
     D(experiments.newCache, 'minimize', true);
   }
   D(experiments, 'asyncWebAssembly', true);

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3086,6 +3086,8 @@ export type UseInputFileSystem = false | RegExp[];
 export type NewCache = {
   /** Enable the module code generation cache. @default true */
   codeGeneration?: boolean;
+  /** Enable the devtool asset cache. @default true */
+  devtool?: boolean;
   /** Enable the asset minimization cache. @default true */
   minimize?: boolean;
 };


### PR DESCRIPTION
## Summary

- Add the `experiments.newCache.devtool` option with a default of `true`.
- Implement persistent caching for `SourceMapDevToolPlugin` assets.
- Preserve legacy caching when the new cache is disabled.
- Update Rust and TypeScript option definitions and default snapshots.

## Testing

- Not run (not requested).