### PR TITLE
test(copy-plugin): cover brace expansion in glob patterns

### DIFF
--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/index.js
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/index.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const path = require("path");
+
+const read = file =>
+	fs.readFileSync(path.join(__STATS__.outputPath, file), "utf-8").trim();
+const exists = file => fs.existsSync(path.join(__STATS__.outputPath, file));
+
+it("should copy files when a brace pattern is combined with a wildcard", () => {
+	expect(read("wildcard/foo.en.yml")).toBe("from foo");
+	expect(read("wildcard/bar.de.yml")).toBe("from bar");
+	expect(exists("wildcard/qux.en.yml")).toBe(false);
+});
+
+it("should copy files when a brace is the only glob character", () => {
+	expect(read("literal/alpha.txt")).toBe("from alpha");
+	expect(read("literal/beta.txt")).toBe("from beta");
+	expect(exists("literal/gamma.txt")).toBe(false);
+});
+
+it("should copy files when a brace pattern matches a directory segment", () => {
+	expect(read("nested/src/one/deep/x.txt")).toBe("from one");
+	expect(read("nested/src/two/y.txt")).toBe("from two");
+	expect(exists("nested/src/three/z.txt")).toBe(false);
+});

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/rspack.config.js
@@ -1,0 +1,27 @@
+const { CopyRspackPlugin } = require('@rspack/core');
+
+module.exports = {
+  entry: './index.js',
+  target: 'node',
+  plugins: [
+    new CopyRspackPlugin({
+      patterns: [
+        {
+          from: 'src/{foo,bar}.*.yml',
+          to: 'wildcard/[name][ext]',
+        },
+        {
+          from: 'src/{alpha,beta}.txt',
+          to: 'literal/[name][ext]',
+        },
+        {
+          from: 'src/{one,two}/**/*.txt',
+          to: 'nested/[path][name][ext]',
+        },
+      ],
+    }),
+  ],
+  output: {
+    clean: true,
+  },
+};

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/alpha.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/alpha.txt
@@ -1,0 +1,1 @@
+from alpha

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/bar.de.yml
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/bar.de.yml
@@ -1,0 +1,1 @@
+from bar

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/beta.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/beta.txt
@@ -1,0 +1,1 @@
+from beta

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/foo.en.yml
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/foo.en.yml
@@ -1,0 +1,1 @@
+from foo

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/gamma.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/gamma.txt
@@ -1,0 +1,1 @@
+from gamma

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/one/deep/x.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/one/deep/x.txt
@@ -1,0 +1,1 @@
+from one

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/qux.en.yml
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/qux.en.yml
@@ -1,0 +1,1 @@
+from qux

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/three/z.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/three/z.txt
@@ -1,0 +1,1 @@
+from three

--- a/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/two/y.txt
+++ b/tests/rspack-test/configCases/plugins/copy-plugin-braces/src/two/y.txt
@@ -1,0 +1,1 @@
+from two


### PR DESCRIPTION
## Summary

When #7778 was filed, `CopyRspackPlugin` could not expand brace patterns such as `{foo,bar,baz}.*.yml`, and the issue was answered with "the rust glob does not support this match pattern yet".

That is no longer true. The copy plugin now globs through `fast_glob::glob_match` (`crates/rspack_core/src/glob_utils.rs`, `crates/rspack_plugin_copy/src/lib.rs`), and `fast-glob` does support brace expansion. `{` is already treated as a glob metacharacter by `is_glob_metacharacter`/`glob_base_dir_end`, so base-directory extraction handles brace patterns correctly too.

I verified against `@rspack/core@2.1.10` that all of these work today and that non-matching files are correctly excluded:

| pattern | copied | not copied |
| --- | --- | --- |
| `src/{foo,bar}.*.yml` | `foo.en.yml`, `bar.de.yml` | `qux.en.yml` |
| `src/{alpha,beta}.txt` | `alpha.txt`, `beta.txt` | `gamma.txt` |
| `src/{one,two}/**/*.txt` | `one/deep/x.txt`, `two/y.txt` | `three/z.txt` |

So the feature works but nothing pins it. This PR adds a `configCases` case covering the three shapes above, including the negative cases, so a future change to the glob layer cannot silently regress it.

The middle row matters most: a pattern whose only metacharacter is `{` still has to be classified as a glob rather than as a literal path, which is a distinct code path from the other two.

No source changes — test only.

## Related links

- Closes #7778

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
