### PR TITLE
chore: remove unused files and exports

### DIFF
--- a/packages/rspack-cli/src/constants.ts
+++ b/packages/rspack-cli/src/constants.ts
@@ -1,5 +1,3 @@
-export const DEFAULT_CONFIG_NAME = 'rspack.config' as const;
-
 export const DEFAULT_EXTENSIONS = [
   '.ts',
   '.js',

--- a/packages/rspack-cli/src/utils/isTsFile.ts
+++ b/packages/rspack-cli/src/utils/isTsFile.ts
@@ -1,8 +1,0 @@
-import path from 'node:path';
-export const TS_EXTENSION = ['.ts', '.cts', '.mts'];
-const isTsFile = (configPath: string) => {
-  const ext = path.extname(configPath);
-  return TS_EXTENSION.includes(ext);
-};
-
-export default isTsFile;

--- a/packages/rspack-test-tools/src/case/serial.ts
+++ b/packages/rspack-test-tools/src/case/serial.ts
@@ -1,9 +1,6 @@
 import { BasicCaseCreator } from '../test/creator';
-import type { TTestConfig } from '../type';
 import { createConfigProcessor } from './config';
 import { createMultiCompilerRunner, getMultiCompilerRunnerKey } from './runner';
-
-export type TSerialCaseConfig = Omit<TTestConfig, 'validate'>;
 
 const creator = new BasicCaseCreator({
   clean: true,

--- a/packages/rspack/src/builtin-loader/swc/index.ts
+++ b/packages/rspack/src/builtin-loader/swc/index.ts
@@ -2,8 +2,6 @@ import type { GetLoaderOptions } from '../../config/adapterRuleUse';
 import { resolveCollectTypeScriptInfo } from './collectTypeScriptInfo';
 import { resolvePluginImport } from './pluginImport';
 
-export type { CollectTypeScriptInfoOptions } from './collectTypeScriptInfo';
-export type { PluginImportOptions } from './pluginImport';
 export type {
   SwcLoaderEnvConfig,
   SwcLoaderEsParserConfig,

--- a/packages/rspack/src/builtin-plugin/RslibPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RslibPlugin.ts
@@ -2,11 +2,6 @@ import { BuiltinPluginName, type RawRslibPluginOptions } from '@rspack/binding';
 
 import { create } from './base';
 
-export type RslibPluginArgument =
-  | Partial<Omit<RawRslibPluginOptions, 'handler'>>
-  | ((percentage: number, msg: string, ...args: string[]) => void)
-  | undefined;
-
 export const RslibPlugin = create(
   BuiltinPluginName.RslibPlugin,
   (rslib: RawRslibPluginOptions): RawRslibPluginOptions => {

--- a/packages/rspack/src/builtin-plugin/RstestPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/RstestPlugin.ts
@@ -5,11 +5,6 @@ import {
 
 import { create } from './base';
 
-export type RstestPluginArgument =
-  | Partial<Omit<RawRstestPluginOptions, 'handler'>>
-  | ((percentage: number, msg: string, ...args: string[]) => void)
-  | undefined;
-
 export const RstestPlugin = create(
   BuiltinPluginName.RstestPlugin,
   (rstest: RawRstestPluginOptions): RawRstestPluginOptions => {

--- a/packages/rspack/src/builtin-plugin/index.ts
+++ b/packages/rspack/src/builtin-plugin/index.ts
@@ -4,7 +4,7 @@ export * from './AssetModulesPlugin';
 export * from './AsyncWebAssemblyModulesPlugin';
 export * from './BannerPlugin';
 export * from './BundlerInfoRspackPlugin';
-export { createNativePlugin, RspackBuiltinPlugin } from './base';
+export { createNativePlugin } from './base';
 export * from './CaseSensitivePlugin';
 export * from './ChunkPrefetchPreloadPlugin';
 export * from './CircularModulesInfoPlugin';

--- a/packages/rspack/src/container/index.ts
+++ b/packages/rspack/src/container/index.ts
@@ -1,4 +1,0 @@
-export * from './ContainerPlugin';
-export * from './ContainerReferencePlugin';
-export * from './ModuleFederationPlugin';
-export * from './ModuleFederationPluginV1';


### PR DESCRIPTION
## Summary

Knip identified unreachable internal files and stale exports that add maintenance noise. This PR removes those unused files and declarations while keeping package exports, generated public declarations, and runtime behavior unchanged.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).