### PR TITLE
perf(split-chunks): reduce bundle splitting overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5423,6 +5423,7 @@ dependencies = [
  "rspack_regex",
  "rspack_util",
  "rustc-hash",
+ "smallvec",
  "tracing",
 ]
 

--- a/crates/rspack_plugin_split_chunks/Cargo.toml
+++ b/crates/rspack_plugin_split_chunks/Cargo.toml
@@ -23,6 +23,7 @@ rspack_parallel    = { workspace = true }
 rspack_regex       = { workspace = true }
 rspack_util        = { workspace = true }
 rustc-hash         = { workspace = true }
+smallvec           = { workspace = true }
 tracing            = { workspace = true }
 
 [lints]

--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -1,6 +1,6 @@
 use std::{
   ops::{Deref, DerefMut},
-  sync::Arc,
+  sync::{Arc, LazyLock},
 };
 
 use derive_more::Debug;
@@ -70,12 +70,26 @@ pub type ModuleTypeFilter = Arc<dyn Fn(&dyn Module) -> bool + Send + Sync>;
 pub type ModuleLayerFilter =
   Arc<dyn Fn(Option<String>) -> BoxFuture<'static, Result<bool>> + Send + Sync>;
 
+static DEFAULT_MODULE_TYPE_FILTER: LazyLock<ModuleTypeFilter> =
+  LazyLock::new(|| Arc::new(|_| true));
+static DEFAULT_MODULE_LAYER_FILTER: LazyLock<ModuleLayerFilter> = LazyLock::new(|| {
+  Arc::new(|_| -> BoxFuture<'static, Result<bool>> { Box::pin(async move { Ok(true) }) })
+});
+
 pub fn create_default_module_type_filter() -> ModuleTypeFilter {
-  Arc::new(|_| true)
+  DEFAULT_MODULE_TYPE_FILTER.clone()
 }
 
 pub fn create_default_module_layer_filter() -> ModuleLayerFilter {
-  Arc::new(|_| Box::pin(async move { Ok(true) }))
+  DEFAULT_MODULE_LAYER_FILTER.clone()
+}
+
+pub(crate) fn is_default_module_type_filter(filter: &ModuleTypeFilter) -> bool {
+  Arc::ptr_eq(filter, &DEFAULT_MODULE_TYPE_FILTER)
+}
+
+pub(crate) fn is_default_module_layer_filter(filter: &ModuleLayerFilter) -> bool {
+  Arc::ptr_eq(filter, &DEFAULT_MODULE_LAYER_FILTER)
 }
 
 pub fn create_async_chunk_filter() -> ChunkFilter {

--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -267,6 +267,21 @@ impl ModuleChunkMap {
     module_chunks.entry(module).or_default().insert(chunk);
   }
 
+  pub fn insert_shared_chunk(
+    &mut self,
+    expected_modules: &IdentifierSet,
+    chunk: ChunkUkey,
+  ) -> bool {
+    let Self::Shared { modules, chunks } = self else {
+      return false;
+    };
+    if modules != expected_modules {
+      return false;
+    }
+    chunks.insert(chunk);
+    true
+  }
+
   pub fn retain_modules(&mut self, modules_to_keep: &IdentifierSet) {
     match self {
       Self::Shared { modules, .. } => modules.retain(|module| modules_to_keep.contains(module)),

--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -248,6 +248,14 @@ pub struct FallbackCacheGroup {
 pub type ModuleSizes = IdentifierMap<FxHashMap<SourceType, f64>>;
 pub(crate) type ModuleChunks = Vec<FxHashSet<ChunkUkey>>;
 
+/// Returns a lossy mask for quickly proving that two chunk sets are disjoint. Chunk keys may
+/// collide in the mask, so overlapping masks must always fall back to an exact check.
+pub(crate) fn chunk_mask<'a>(chunks: impl Iterator<Item = &'a ChunkUkey>) -> u64 {
+  chunks.fold(0, |mask, chunk| {
+    mask | (1u64 << (chunk.as_u32() & (u64::BITS - 1)))
+  })
+}
+
 #[derive(Debug)]
 pub(crate) enum ModuleChunkMap {
   Shared {
@@ -258,6 +266,13 @@ pub(crate) enum ModuleChunkMap {
 }
 
 impl ModuleChunkMap {
+  pub fn chunk_mask(&self) -> u64 {
+    match self {
+      Self::Shared { chunks, .. } => chunk_mask(chunks.iter()),
+      Self::ByModule(module_chunks) => chunk_mask(module_chunks.values().flatten()),
+    }
+  }
+
   pub fn get(&self, module: &ModuleIdentifier) -> Option<&FxHashSet<ChunkUkey>> {
     match self {
       Self::Shared { modules, chunks } => modules.contains(module).then_some(chunks),

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fmt};
 use derive_more::Debug;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{ChunkUkey, ModuleIdentifier, SourceType};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 
 use crate::{
   CacheGroup,
@@ -131,7 +131,6 @@ pub(crate) struct ModuleGroup {
   /// A module
   pub chunk_name: Option<String>,
 
-  pub source_types_modules: FxHashMap<SourceType, IdentifierSet>,
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
@@ -155,7 +154,6 @@ impl ModuleGroup {
       cache_group_index,
       cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
       sizes: Default::default(),
-      source_types_modules: Default::default(),
       chunks: Default::default(),
       modules_for_compare: Default::default(),
       chunk_name,
@@ -170,28 +168,18 @@ impl ModuleGroup {
     ty: &[SourceType],
     module_sizes: &ModuleSizes,
   ) -> IdentifierSet {
-    // if there is only one source type, we can just use the `source_types_modules` directly
-    // instead of iterating over all modules
-    if ty.len() == 1 {
-      self
-        .source_types_modules
-        .get(ty.first().expect("should have at least one source type"))
-        .cloned()
-        .unwrap_or_default()
-    } else {
-      self
-        .modules
-        .iter()
-        .filter_map(|module| {
-          let sizes = module_sizes.get(module).expect("should have module size");
-          if ty.iter().any(|ty| sizes.contains_key(ty)) {
-            Some(*module)
-          } else {
-            None
-          }
-        })
-        .collect()
-    }
+    self
+      .modules
+      .iter()
+      .filter_map(|module| {
+        let sizes = module_sizes.get(module).expect("should have module size");
+        if ty.iter().any(|ty| sizes.contains_key(ty)) {
+          Some(*module)
+        } else {
+          None
+        }
+      })
+      .collect()
   }
 
   pub fn add_module(
@@ -322,11 +310,6 @@ impl ModuleGroup {
           let size = self.sizes.entry(*ty).or_default();
           *size += s;
           self.total_size += s;
-          self
-            .source_types_modules
-            .entry(*ty)
-            .or_default()
-            .insert(module);
         }
       }
     }
@@ -339,11 +322,6 @@ impl ModuleGroup {
           *size -= s;
           *size = size.max(0.0);
           self.total_size -= s;
-          self
-            .source_types_modules
-            .entry(*ty)
-            .or_default()
-            .remove(&module);
         }
       }
     }

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -213,27 +213,45 @@ impl ModuleGroup {
     self.remove_modules([module]);
   }
 
-  pub fn remove_shared_modules_in(&mut self, modules: &IdentifierSet) -> bool {
+  pub fn remove_shared_modules_in(
+    &mut self,
+    modules: &IdentifierSet,
+    module_sizes: &ModuleSizes,
+  ) -> bool {
     debug_assert!(matches!(self.module_chunks, ModuleGroupChunks::Shared(_)));
-    let removed_start = self.removed.len();
+    let sizes = &mut self.sizes;
+    let total_size = &mut self.total_size;
+    let mut removed_any = false;
+    let mut subtract_sizes = |module: &ModuleIdentifier| {
+      let module_sizes = module_sizes.get(module).expect("should have module size");
+      for (ty, module_size) in module_sizes {
+        let size = sizes
+          .get_mut(ty)
+          .expect("removed module source type should have group size");
+        *size -= module_size;
+        *size = size.max(0.0);
+        *total_size -= module_size;
+      }
+    };
     if self.modules.len() > modules.len() {
       for module in modules {
         if self.modules.remove(module) {
-          self.removed.push(*module);
+          subtract_sizes(module);
+          removed_any = true;
         }
       }
     } else {
-      let removed = &mut self.removed;
       self.modules.retain(|module| {
         if modules.contains(module) {
-          removed.push(*module);
+          subtract_sizes(module);
+          removed_any = true;
           false
         } else {
           true
         }
       });
     }
-    self.removed.len() != removed_start
+    removed_any
   }
 
   pub fn remove_modules(&mut self, modules: impl IntoIterator<Item = ModuleIdentifier>) {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -348,10 +348,10 @@ impl ModuleGroup {
   }
 }
 
-pub(crate) fn compare_entries(
+pub(crate) fn is_better_entry(
   (a_key, a): (&ModuleGroupKey, &mut ModuleGroup),
   (b_key, b): (&ModuleGroupKey, &mut ModuleGroup),
-) -> f64 {
+) -> bool {
   // 1. by priority
   // no need to compare priority anymore because we already pick all cache groups with same priority
   // let diff_priority = a.cache_group_priority - b.cache_group_priority;
@@ -361,9 +361,8 @@ pub(crate) fn compare_entries(
   // 2. by number of chunks
   let a_chunks_len = a.chunks.len();
   let b_chunks_len = b.chunks.len();
-  let diff_count = a_chunks_len as f64 - b_chunks_len as f64;
-  if diff_count != 0f64 {
-    return diff_count;
+  if a_chunks_len != b_chunks_len {
+    return a_chunks_len > b_chunks_len;
   }
 
   // 3. by size reduction
@@ -371,21 +370,19 @@ pub(crate) fn compare_entries(
   let b_size_reduce = b.get_total_size() * (b_chunks_len - 1) as f64;
   let diff_size_reduce = a_size_reduce - b_size_reduce;
   if diff_size_reduce != 0f64 {
-    return diff_size_reduce;
+    return diff_size_reduce > 0f64;
   }
 
   // 4. by cache group index
-  let index_diff = b.cache_group_index as f64 - a.cache_group_index as f64;
-  if index_diff != 0f64 {
-    return index_diff;
+  if a.cache_group_index != b.cache_group_index {
+    return a.cache_group_index < b.cache_group_index;
   }
 
   // 5. by number of modules (to be able to compare by identifier)
   let modules_a_len = a.modules.len();
   let modules_b_len = b.modules.len();
-  let diff = modules_a_len as f64 - modules_b_len as f64;
-  if diff != 0f64 {
-    return diff;
+  if modules_a_len != modules_b_len {
+    return modules_a_len > modules_b_len;
   }
 
   let mut modules_a = a.sorted_modules_for_compare().iter();
@@ -397,17 +394,13 @@ pub(crate) fn compare_entries(
       (Some(a), Some(b)) => {
         let res = a.cmp(b);
         if !res.is_eq() {
-          return res as i32 as f64;
+          return res.is_gt();
         }
       }
-      (None, Some(_)) => return -1.0,
-      (Some(_), None) => return 1.0,
+      (None, Some(_)) => return false,
+      (Some(_), None) => return true,
     }
   }
 
-  match a_key.cmp(b_key) {
-    Ordering::Less => -1.0,
-    Ordering::Equal => 0.0,
-    Ordering::Greater => 1.0,
-  }
+  a_key > b_key
 }

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -31,42 +31,6 @@ impl<'a> IndexedCacheGroup<'a> {
   }
 }
 
-#[derive(Debug)]
-enum ModulesForCompare {
-  Unsorted(Vec<ModuleIdentifier>),
-  Sorted(Vec<ModuleIdentifier>),
-}
-
-impl Default for ModulesForCompare {
-  fn default() -> Self {
-    Self::Unsorted(Default::default())
-  }
-}
-
-impl ModulesForCompare {
-  fn prepare(&mut self, modules: Vec<ModuleIdentifier>) {
-    if modules.is_empty() {
-      return;
-    }
-
-    if matches!(self, Self::Unsorted(modules_for_compare) if modules_for_compare.is_empty()) {
-      *self = Self::Unsorted(modules);
-    }
-  }
-
-  fn sorted(&mut self) -> &[ModuleIdentifier] {
-    if let Self::Unsorted(modules) = self {
-      modules.sort_unstable_by_key(|module| module.precomputed_hash());
-      *self = Self::Sorted(std::mem::take(modules));
-    }
-
-    let Self::Sorted(modules) = self else {
-      unreachable!("modules for compare should be sorted");
-    };
-    modules
-  }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub(crate) enum ModuleGroupKey {
   Named {
@@ -136,7 +100,7 @@ pub(crate) struct ModuleGroup {
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
-  modules_for_compare: ModulesForCompare,
+  modules_for_compare: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
   total_size: f64,
@@ -312,12 +276,13 @@ impl ModuleGroup {
         self.total_size += size;
       }
     }
-    self.modules_for_compare.prepare(modules);
+    modules.sort_unstable_by_key(|module| module.precomputed_hash());
+    self.modules_for_compare = modules;
     self.removed.reserve(self.modules.len());
   }
 
-  pub fn sorted_modules_for_compare(&mut self) -> &[ModuleIdentifier] {
-    self.modules_for_compare.sorted()
+  pub fn sorted_modules_for_compare(&self) -> &[ModuleIdentifier] {
+    &self.modules_for_compare
   }
 
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {
@@ -349,8 +314,8 @@ impl ModuleGroup {
 }
 
 pub(crate) fn is_better_entry(
-  (a_key, a): (&ModuleGroupKey, &mut ModuleGroup),
-  (b_key, b): (&ModuleGroupKey, &mut ModuleGroup),
+  (a_key, a): (&ModuleGroupKey, &ModuleGroup),
+  (b_key, b): (&ModuleGroupKey, &ModuleGroup),
 ) -> bool {
   // 1. by priority
   // no need to compare priority anymore because we already pick all cache groups with same priority

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -251,6 +251,29 @@ impl ModuleGroup {
     self.remove_modules([module]);
   }
 
+  pub fn remove_shared_modules_in(&mut self, modules: &IdentifierSet) -> bool {
+    debug_assert!(matches!(self.module_chunks, ModuleGroupChunks::Shared(_)));
+    let removed_start = self.removed.len();
+    if self.modules.len() > modules.len() {
+      for module in modules {
+        if self.modules.remove(module) {
+          self.removed.push(*module);
+        }
+      }
+    } else {
+      let removed = &mut self.removed;
+      self.modules.retain(|module| {
+        if modules.contains(module) {
+          removed.push(*module);
+          false
+        } else {
+          true
+        }
+      });
+    }
+    self.removed.len() != removed_start
+  }
+
   pub fn remove_modules(&mut self, modules: impl IntoIterator<Item = ModuleIdentifier>) {
     match &mut self.module_chunks {
       ModuleGroupChunks::Shared(_) => {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -13,6 +13,8 @@ use crate::{
 pub(crate) struct IndexedCacheGroup<'a> {
   pub cache_group_index: u32,
   pub cache_group: &'a CacheGroup,
+  pub has_default_type_filter: bool,
+  pub has_default_layer_filter: bool,
 }
 
 impl<'a> IndexedCacheGroup<'a> {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -7,7 +7,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
   CacheGroup,
-  common::{ModuleSizes, SplitChunkSizes},
+  common::{ModuleSizes, SplitChunkSizes, chunk_mask},
 };
 
 pub(crate) struct IndexedCacheGroup<'a> {
@@ -100,6 +100,10 @@ pub(crate) struct ModuleGroup {
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
+  /// A conservative snapshot of the group's chunks before selection starts. Later operations only
+  /// remove chunks, so retaining the original bits can add false positives but never false
+  /// negatives to cleanup filtering.
+  chunk_mask: u64,
   modules_for_compare: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
@@ -120,6 +124,7 @@ impl ModuleGroup {
       cache_group_reuse_existing_chunk: cache_group.reuse_existing_chunk,
       sizes: Default::default(),
       chunks: Default::default(),
+      chunk_mask: 0,
       modules_for_compare: Default::default(),
       chunk_name,
       removed: Default::default(),
@@ -285,6 +290,7 @@ impl ModuleGroup {
   }
 
   pub fn prepare_modules_for_sizes_and_compare(&mut self, module_sizes: &ModuleSizes) {
+    self.chunk_mask = chunk_mask(self.chunks.iter());
     let mut modules = Vec::with_capacity(self.modules.len());
     for module in &self.modules {
       modules.push(*module);
@@ -301,6 +307,10 @@ impl ModuleGroup {
 
   pub fn sorted_modules_for_compare(&self) -> &[ModuleIdentifier] {
     &self.modules_for_compare
+  }
+
+  pub fn may_have_chunks_in_mask(&self, mask: u64) -> bool {
+    self.chunk_mask & mask != 0
   }
 
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -301,7 +301,10 @@ impl ModuleGroup {
       for module in self.removed.drain(..) {
         let module_sizes = module_sizes.get(&module).expect("should have module size");
         for (ty, s) in module_sizes.iter() {
-          let size = self.sizes.entry(*ty).or_default();
+          let size = self
+            .sizes
+            .get_mut(ty)
+            .expect("removed module source type should have group size");
           *size -= s;
           *size = size.max(0.0);
           self.total_size -= s;

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -339,8 +339,7 @@ impl ModuleGroup {
       }
     }
     if !self.removed.is_empty() {
-      let removed = std::mem::take(&mut self.removed);
-      for module in removed {
+      for module in self.removed.drain(..) {
         let module_sizes = module_sizes.get(&module).expect("should have module size");
         for (ty, s) in module_sizes.iter() {
           let size = self.sizes.entry(*ty).or_default();

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -137,7 +137,6 @@ pub(crate) struct ModuleGroup {
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
   modules_for_compare: ModulesForCompare,
-  added: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
   sizes: SplitChunkSizes,
   total_size: f64,
@@ -159,7 +158,6 @@ impl ModuleGroup {
       chunks: Default::default(),
       modules_for_compare: Default::default(),
       chunk_name,
-      added: Default::default(),
       removed: Default::default(),
       total_size: 0.0,
     }
@@ -304,9 +302,16 @@ impl ModuleGroup {
       .extend(module_chunks.values().flatten().copied());
   }
 
-  pub fn prepare_modules_for_sizes_and_compare(&mut self) {
-    let modules = self.modules.iter().copied().collect::<Vec<_>>();
-    self.added = modules.clone();
+  pub fn prepare_modules_for_sizes_and_compare(&mut self, module_sizes: &ModuleSizes) {
+    let mut modules = Vec::with_capacity(self.modules.len());
+    for module in &self.modules {
+      modules.push(*module);
+      let module_sizes = module_sizes.get(module).expect("should have module size");
+      for (ty, size) in module_sizes {
+        *self.sizes.entry(*ty).or_default() += size;
+        self.total_size += size;
+      }
+    }
     self.modules_for_compare.prepare(modules);
     self.removed.reserve(self.modules.len());
   }
@@ -320,24 +325,13 @@ impl ModuleGroup {
   }
 
   pub fn get_total_size(&self) -> f64 {
-    if !self.added.is_empty() || !self.removed.is_empty() {
+    if !self.removed.is_empty() {
       unreachable!("should update sizes before get total size");
     }
     self.total_size
   }
 
   pub fn get_sizes(&mut self, module_sizes: &ModuleSizes) -> &SplitChunkSizes {
-    if !self.added.is_empty() {
-      let added = std::mem::take(&mut self.added);
-      for module in added {
-        let module_sizes = module_sizes.get(&module).expect("should have module size");
-        for (ty, s) in module_sizes.iter() {
-          let size = self.sizes.entry(*ty).or_default();
-          *size += s;
-          self.total_size += s;
-        }
-      }
-    }
     if !self.removed.is_empty() {
       for module in self.removed.drain(..) {
         let module_sizes = module_sizes.get(&module).expect("should have module size");

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -209,7 +209,8 @@ impl SplitChunksPlugin {
     if item.uses_shared_module_chunks() {
       debug_assert!(original_chunks.is_subset(&item.chunks));
       let chunks = original_chunks.clone();
-      let mut modules = IdentifierSet::default();
+      let mut modules =
+        IdentifierSet::with_capacity_and_hasher(item.modules.len(), Default::default());
       for mid in &item.modules {
         if let Some(module) = compilation.module_by_identifier(mid)
           && module_chunk_condition(module.as_ref(), &new_chunk, compilation)

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -260,6 +260,7 @@ impl SplitChunksPlugin {
     &self,
     placed_module_chunks: &ModuleChunkMap,
     new_chunk: ChunkUkey,
+    destination_has_all_modules: bool,
     compilation: &mut Compilation,
   ) {
     let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
@@ -272,7 +273,9 @@ impl SplitChunksPlugin {
         .collect::<Vec<_>>();
       if !chunks.is_empty() {
         chunk_graph.disconnect_chunks_and_modules(&chunks, &modules);
-        chunk_graph.connect_chunk_and_modules(new_chunk, &modules);
+        if !destination_has_all_modules {
+          chunk_graph.connect_chunk_and_modules(new_chunk, &modules);
+        }
       }
       return;
     }
@@ -299,7 +302,9 @@ impl SplitChunksPlugin {
       move_module(module, chunks);
     }
 
-    chunk_graph.connect_chunk_and_modules(new_chunk, &module_identifiers);
+    if !destination_has_all_modules {
+      chunk_graph.connect_chunk_and_modules(new_chunk, &module_identifiers);
+    }
   }
 
   /// Since the modules are moved into the `new_chunk`, we should

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -14,19 +14,23 @@ use crate::{
 };
 
 fn put_split_chunk_reason(
-  chunk_reason: &mut Option<String>,
+  reason_slot: &mut Option<String>,
   is_reuse_existing_chunk_with_all_modules: bool,
+  additional_capacity: usize,
 ) {
   let reason = if is_reuse_existing_chunk_with_all_modules {
-    "reused as split chunk".to_string()
+    "reused as split chunk"
   } else {
-    "split chunk".to_string()
+    "split chunk"
   };
-  if let Some(chunk_reason) = chunk_reason {
+  if let Some(chunk_reason) = reason_slot {
+    chunk_reason.reserve(1 + reason.len() + additional_capacity);
     chunk_reason.push(',');
-    chunk_reason.push_str(&reason);
+    chunk_reason.push_str(reason);
   } else {
-    *chunk_reason = Some(reason);
+    let mut chunk_reason = String::with_capacity(reason.len() + additional_capacity);
+    chunk_reason.push_str(reason);
+    *reason_slot = Some(chunk_reason);
   }
 }
 
@@ -129,6 +133,7 @@ impl SplitChunksPlugin {
     module_group: &mut ModuleGroup,
     is_reuse_existing_chunk: &mut bool,
     is_reuse_existing_chunk_with_all_modules: &mut bool,
+    reason_additional_capacity: usize,
   ) -> ChunkUkey {
     if let Some(chunk_name) = &module_group.chunk_name {
       if let Some(chunk) = compilation
@@ -157,6 +162,7 @@ impl SplitChunksPlugin {
         put_split_chunk_reason(
           new_chunk.chunk_reason_mut(),
           *is_reuse_existing_chunk_with_all_modules,
+          reason_additional_capacity,
         );
 
         compilation
@@ -187,6 +193,7 @@ impl SplitChunksPlugin {
       put_split_chunk_reason(
         new_chunk.chunk_reason_mut(),
         *is_reuse_existing_chunk_with_all_modules,
+        reason_additional_capacity,
       );
 
       compilation

--- a/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/chunk.rs
@@ -6,6 +6,7 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 
 use crate::{
   SplitChunksPlugin,
@@ -273,12 +274,15 @@ impl SplitChunksPlugin {
   ) {
     let chunk_graph = &mut compilation.build_chunk_graph_artifact.chunk_graph;
     if let ModuleChunkMap::Shared { modules, chunks } = placed_module_chunks {
-      let modules = modules.iter().copied().collect::<Vec<_>>();
+      let modules = modules
+        .iter()
+        .copied()
+        .collect::<SmallVec<[ModuleIdentifier; 8]>>();
       let chunks = chunks
         .iter()
         .filter(|chunk| **chunk != new_chunk)
         .copied()
-        .collect::<Vec<_>>();
+        .collect::<SmallVec<[ChunkUkey; 8]>>();
       if !chunks.is_empty() {
         chunk_graph.disconnect_chunks_and_modules(&chunks, &modules);
         if !destination_has_all_modules {

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_request.rs
@@ -15,6 +15,12 @@ impl SplitChunksPlugin {
     cache_group: &CacheGroup,
     used_chunks: &mut Cow<FxHashSet<ChunkUkey>>,
   ) {
+    if cache_group.max_initial_requests == f64::INFINITY
+      && cache_group.max_async_requests == f64::INFINITY
+    {
+      return;
+    }
+
     let chunk_db = &compilation.build_chunk_graph_artifact.chunk_by_ukey;
     let chunk_group_db = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
     let invalided_chunks = used_chunks

--- a/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/max_size.rs
@@ -480,6 +480,14 @@ impl SplitChunksPlugin {
     max_size_setting_map: &FxHashMap<ChunkUkey, MaxSizeSetting>,
   ) -> Result<()> {
     let fallback_cache_group = &self.fallback_cache_group;
+    if max_size_setting_map.is_empty()
+      && !fallback_cache_group.chunks_filter.is_func()
+      && fallback_cache_group.max_async_size.is_empty()
+      && fallback_cache_group.max_initial_size.is_empty()
+    {
+      return Ok(());
+    }
+
     let chunk_group_db = &compilation.build_chunk_graph_artifact.chunk_group_by_ukey;
     let compilation_ref = &*compilation;
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/min_size.rs
@@ -185,14 +185,24 @@ impl SplitChunksPlugin {
       .filter_map(|(module_group_key, module_group)| {
         let cache_group = module_group.get_cache_group(&self.cache_groups);
         // Fast path
-        if cache_group.min_size.is_empty() {
-          let _ = module_group.get_sizes(module_sizes);
+        if cache_group.min_size.values().all(|size| *size == 0.0) {
+          let chunks_len = module_group.chunks.len();
+          let sizes = module_group.get_sizes(module_sizes);
           tracing::debug!(
-            "ModuleGroup({}) skips `minSize` checking. Reason: min_size of CacheGroup({}) is empty",
+            "ModuleGroup({}) skips `minSize` checking. Reason: min_size of CacheGroup({}) has no non-zero values",
             module_group_key,
             cache_group.key,
           );
-          return None;
+          if cache_group.min_size.is_empty()
+            || cache_group
+              .min_size_reduction
+              .values()
+              .all(|size| *size == 0.0)
+            || Self::check_min_size_reduction(sizes, &cache_group.min_size_reduction, chunks_len)
+          {
+            return None;
+          }
+          return Some(module_group_key.clone());
         }
 
         if remove_min_size_violating_modules(

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -247,7 +247,9 @@ impl SplitChunksPlugin {
 
       module_group_map
         .par_iter_mut()
-        .for_each(|(_, module_group)| module_group.prepare_modules_for_sizes_and_compare());
+        .for_each(|(_, module_group)| {
+          module_group.prepare_modules_for_sizes_and_compare(&module_sizes)
+        });
       self.ensure_min_size_fit(&mut module_group_map, &module_sizes);
 
       while !module_group_map.is_empty() {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -265,11 +265,18 @@ impl SplitChunksPlugin {
 
         let mut is_reuse_existing_chunk = false;
         let mut is_reuse_existing_chunk_with_all_modules = false;
+        let reason_additional_capacity = 16
+          + cache_group.key.len()
+          + module_group
+            .chunk_name
+            .as_ref()
+            .map_or(0, |chunk_name| 9 + chunk_name.len());
         let new_chunk = self.get_corresponding_chunk(
           compilation,
           &mut module_group,
           &mut is_reuse_existing_chunk,
           &mut is_reuse_existing_chunk_with_all_modules,
+          reason_additional_capacity,
         );
 
         tracing::trace!(
@@ -458,13 +465,7 @@ impl SplitChunksPlugin {
           .chunk_by_ukey
           .expect_get_mut(&new_chunk);
         if let Some(chunk_reason) = new_chunk_mut.chunk_reason_mut() {
-          chunk_reason.reserve(
-            16 + cache_group.key.len()
-              + module_group
-                .chunk_name
-                .as_ref()
-                .map_or(0, |chunk_name| 9 + chunk_name.len()),
-          );
+          chunk_reason.reserve(reason_additional_capacity);
           chunk_reason.push_str(" (cache group: ");
           chunk_reason.push_str(cache_group.key.as_str());
           chunk_reason.push(')');

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -458,9 +458,13 @@ impl SplitChunksPlugin {
           .chunk_by_ukey
           .expect_get_mut(&new_chunk);
         if let Some(chunk_reason) = new_chunk_mut.chunk_reason_mut() {
-          chunk_reason.push_str(&format!(" (cache group: {})", cache_group.key.as_str()));
+          chunk_reason.push_str(" (cache group: ");
+          chunk_reason.push_str(cache_group.key.as_str());
+          chunk_reason.push(')');
           if let Some(chunk_name) = &module_group.chunk_name {
-            chunk_reason.push_str(&format!(" (name: {chunk_name})"));
+            chunk_reason.push_str(" (name: ");
+            chunk_reason.push_str(chunk_name);
+            chunk_reason.push(')');
           }
         }
         if let Some(filename) = &cache_group.filename {

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -473,6 +473,7 @@ impl SplitChunksPlugin {
         self.move_modules_to_new_chunk_and_remove_from_old_chunks(
           &placed_module_chunks,
           new_chunk,
+          is_reuse_existing_chunk_with_all_modules,
           compilation,
         );
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -21,7 +21,10 @@ use tracing::instrument;
 
 use crate::{
   CacheGroup, SplitChunkSizes,
-  common::{FallbackCacheGroup, ModuleChunkMap},
+  common::{
+    FallbackCacheGroup, ModuleChunkMap, is_default_module_layer_filter,
+    is_default_module_type_filter,
+  },
   get_module_sizes,
   module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey},
   options::chunk_name::ChunkNameGetterFnCtx,
@@ -152,6 +155,8 @@ impl SplitChunksPlugin {
       .map(|v| IndexedCacheGroup {
         cache_group_index: u32::try_from(v.0).expect("cache group index should fit in u32"),
         cache_group: v.1,
+        has_default_type_filter: is_default_module_type_filter(&v.1.r#type),
+        has_default_layer_filter: is_default_module_layer_filter(&v.1.layer),
       })
       .sorted_by(|a, b| match b.compare_by_priority(a) {
         Ordering::Equal => a.compare_by_index(b),

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -211,9 +211,11 @@ impl SplitChunksPlugin {
         );
       }
 
-      if cache_groups
+      if let Some(min_chunks) = cache_groups
         .iter()
-        .any(|cache_group| cache_group.cache_group.used_exports)
+        .filter(|cache_group| cache_group.cache_group.used_exports)
+        .map(|cache_group| cache_group.cache_group.min_chunks as usize)
+        .min()
       {
         combinator.prepare_group_by_used_exports(
           &all_modules,
@@ -221,6 +223,7 @@ impl SplitChunksPlugin {
           &compilation.build_chunk_graph_artifact.chunk_by_ukey,
           available_module_chunks.as_ref(),
           &chunk_index_map,
+          min_chunks,
         );
       }
 

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -458,6 +458,13 @@ impl SplitChunksPlugin {
           .chunk_by_ukey
           .expect_get_mut(&new_chunk);
         if let Some(chunk_reason) = new_chunk_mut.chunk_reason_mut() {
+          chunk_reason.reserve(
+            16 + cache_group.key.len()
+              + module_group
+                .chunk_name
+                .as_ref()
+                .map_or(0, |chunk_name| 9 + chunk_name.len()),
+          );
           chunk_reason.push_str(" (cache group: ");
           chunk_reason.push_str(cache_group.key.as_str());
           chunk_reason.push(')');

--- a/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/mod.rs
@@ -299,7 +299,13 @@ impl SplitChunksPlugin {
           .await?;
         {
           let chunk_graph = &compilation.build_chunk_graph_artifact.chunk_graph;
-          if is_reuse_existing_chunk {
+          // `reuseExistingChunk` can select a chunk that already contains the complete module
+          // group. Keep the shared representation in that common case instead of expanding one
+          // identical chunk set per module. If a chunk condition excluded any module, the sets no
+          // longer match and we deliberately fall back to the per-module representation below.
+          let inserted_shared_destination = is_reuse_existing_chunk_with_all_modules
+            && placed_module_chunks.insert_shared_chunk(&module_group.modules, new_chunk);
+          if is_reuse_existing_chunk && !inserted_shared_destination {
             // A module already in the reused destination does not need to move, but that original
             // placement still belongs to the winning group and must be unavailable to competing
             // groups at this and lower priorities.

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -902,7 +902,7 @@ impl SplitChunksPlugin {
     let keys_of_invalid_group = module_group_map
       .par_iter_mut()
       .filter_map(|(key, other_module_group)| {
-        let duplicated_modules = match (
+        let removed_modules = match (
           placed_module_chunks,
           other_module_group.shared_module_chunks(),
         ) {
@@ -914,40 +914,35 @@ impl SplitChunksPlugin {
             Some(other_chunks),
           ) => {
             other_chunks.intersection(placed_chunks).next()?;
-            if other_module_group.modules.len() > modules.len() {
-              modules
-                .intersection(&other_module_group.modules)
-                .copied()
-                .collect::<Vec<_>>()
+            other_module_group.remove_shared_modules_in(modules)
+          }
+          _ => {
+            let duplicated_modules = other_module_group
+              .modules
+              .iter()
+              .filter(|module| {
+                let Some(placed_chunks) = placed_module_chunks.get(module) else {
+                  return false;
+                };
+                let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
+                  return false;
+                };
+                placed_chunks.intersection(other_chunks).next().is_some()
+              })
+              .copied()
+              .collect::<Vec<_>>();
+            if duplicated_modules.is_empty() {
+              false
             } else {
-              other_module_group
-                .modules
-                .intersection(modules)
-                .copied()
-                .collect::<Vec<_>>()
+              other_module_group.remove_modules(duplicated_modules);
+              true
             }
           }
-          _ => other_module_group
-            .modules
-            .iter()
-            .filter(|module| {
-              let Some(placed_chunks) = placed_module_chunks.get(module) else {
-                return false;
-              };
-              let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
-                return false;
-              };
-              placed_chunks.intersection(other_chunks).next().is_some()
-            })
-            .copied()
-            .collect::<Vec<_>>(),
         };
 
-        if duplicated_modules.is_empty() {
+        if !removed_modules {
           return None;
         }
-
-        other_module_group.remove_modules(duplicated_modules);
 
         if other_module_group.modules.is_empty() {
           tracing::trace!(

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -914,7 +914,7 @@ impl SplitChunksPlugin {
           Some(other_chunks),
         ) => {
           other_chunks.intersection(placed_chunks).next()?;
-          other_module_group.remove_shared_modules_in(modules)
+          other_module_group.remove_shared_modules_in(modules, module_sizes)
         }
         _ => {
           let duplicated_modules = other_module_group

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -302,6 +302,20 @@ impl Combinator {
       }];
     }
 
+    let mut chunks = module_chunks.iter();
+    if let Some(first_chunk) = chunks.next() {
+      let first_runtime_key = get_runtime_key(chunk_by_ukey.expect_get(first_chunk).runtime());
+      // Chunks with the same runtime always have the same usage key for a module.
+      if chunks.all(|chunk_ukey| {
+        get_runtime_key(chunk_by_ukey.expect_get(chunk_ukey).runtime()) == first_runtime_key
+      }) {
+        return vec![ChunkCombination {
+          key: get_key(module_chunks.iter().copied(), chunk_index_map),
+          chunks: Arc::new(module_chunks.clone()),
+        }];
+      }
+    }
+
     let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
     let mut runtime_key_map = RuntimeKeyMap::default();

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -901,7 +901,11 @@ impl SplitChunksPlugin {
     module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
+    let placed_chunk_mask = placed_module_chunks.chunk_mask();
     let process_module_group = |(key, other_module_group): (&ModuleGroupKey, &mut ModuleGroup)| {
+      if !other_module_group.may_have_chunks_in_mask(placed_chunk_mask) {
+        return None;
+      }
       let (removed_modules, updated_shared_group) = match (
         placed_module_chunks,
         other_module_group.shared_module_chunks(),

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -899,103 +899,109 @@ impl SplitChunksPlugin {
     module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
-    let keys_of_invalid_group = module_group_map
-      .par_iter_mut()
-      .filter_map(|(key, other_module_group)| {
-        let removed_modules = match (
-          placed_module_chunks,
-          other_module_group.shared_module_chunks(),
-        ) {
-          (
-            ModuleChunkMap::Shared {
-              modules,
-              chunks: placed_chunks,
-            },
-            Some(other_chunks),
-          ) => {
-            other_chunks.intersection(placed_chunks).next()?;
-            other_module_group.remove_shared_modules_in(modules)
+    let process_module_group = |(key, other_module_group): (&ModuleGroupKey, &mut ModuleGroup)| {
+      let removed_modules = match (
+        placed_module_chunks,
+        other_module_group.shared_module_chunks(),
+      ) {
+        (
+          ModuleChunkMap::Shared {
+            modules,
+            chunks: placed_chunks,
+          },
+          Some(other_chunks),
+        ) => {
+          other_chunks.intersection(placed_chunks).next()?;
+          other_module_group.remove_shared_modules_in(modules)
+        }
+        _ => {
+          let duplicated_modules = other_module_group
+            .modules
+            .iter()
+            .filter(|module| {
+              let Some(placed_chunks) = placed_module_chunks.get(module) else {
+                return false;
+              };
+              let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
+                return false;
+              };
+              placed_chunks.intersection(other_chunks).next().is_some()
+            })
+            .copied()
+            .collect::<Vec<_>>();
+          if duplicated_modules.is_empty() {
+            false
+          } else {
+            other_module_group.remove_modules(duplicated_modules);
+            true
           }
-          _ => {
-            let duplicated_modules = other_module_group
-              .modules
-              .iter()
-              .filter(|module| {
-                let Some(placed_chunks) = placed_module_chunks.get(module) else {
-                  return false;
-                };
-                let Some(other_chunks) = other_module_group.get_module_chunks(module) else {
-                  return false;
-                };
-                placed_chunks.intersection(other_chunks).next().is_some()
-              })
-              .copied()
-              .collect::<Vec<_>>();
-            if duplicated_modules.is_empty() {
-              false
-            } else {
-              other_module_group.remove_modules(duplicated_modules);
-              true
-            }
-          }
-        };
-
-        if !removed_modules {
-          return None;
         }
+      };
 
-        if other_module_group.modules.is_empty() {
-          tracing::trace!(
-            "{key} is deleted for having empty modules",
-          );
-          return Some(key.clone());
-        }
+      if !removed_modules {
+        return None;
+      }
 
-        tracing::trace!("other_module_group: {other_module_group:#?}");
-        tracing::trace!("placed_module_chunks: {placed_module_chunks:#?}");
+      if other_module_group.modules.is_empty() {
+        tracing::trace!("{key} is deleted for having empty modules",);
+        return Some(key.clone());
+      }
 
-        let cache_group = other_module_group.get_cache_group(&self.cache_groups);
+      tracing::trace!("other_module_group: {other_module_group:#?}");
+      tracing::trace!("placed_module_chunks: {placed_module_chunks:#?}");
 
-        // Since we removed some modules and chunks from the `other_module_group`. There are chances
-        // that the `min_chunks` and `min_size` validation is not satisfied anymore.
+      let cache_group = other_module_group.get_cache_group(&self.cache_groups);
 
-        // Validate `min_size` again
-        if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
-          tracing::trace!(
-            "{key} is deleted for violating min_size {:#?}",
-            cache_group.min_size,
-          );
-          return Some(key.clone());
-        }
+      // Since we removed some modules and chunks from the `other_module_group`. There are chances
+      // that the `min_chunks` and `min_size` validation is not satisfied anymore.
 
-        other_module_group.rebuild_chunks();
+      // Validate `min_size` again
+      if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
+        tracing::trace!(
+          "{key} is deleted for violating min_size {:#?}",
+          cache_group.min_size,
+        );
+        return Some(key.clone());
+      }
 
-        // Validate `min_chunks` again
-        if other_module_group.chunks.len() < cache_group.min_chunks as usize {
-          tracing::trace!(
-            "{key} is deleted for each_module_group.chunks.len()({:?}) < cache_group.min_chunks({:?})",
-            other_module_group.chunks.len(),
-            cache_group.min_chunks
-          );
-          return Some(key.clone());
-        }
+      other_module_group.rebuild_chunks();
 
-        let chunks_len = other_module_group.chunks.len();
-        if !Self::check_min_size_reduction(
-          other_module_group.get_sizes(module_sizes),
-          &cache_group.min_size_reduction,
-          chunks_len,
-        ) {
-          tracing::trace!(
-            "{key} is deleted for violating min_size {:#?}",
-            cache_group.min_size,
-          );
-          return Some(key.clone());
-        }
+      // Validate `min_chunks` again
+      if other_module_group.chunks.len() < cache_group.min_chunks as usize {
+        tracing::trace!(
+          "{key} is deleted for each_module_group.chunks.len()({:?}) < cache_group.min_chunks({:?})",
+          other_module_group.chunks.len(),
+          cache_group.min_chunks
+        );
+        return Some(key.clone());
+      }
 
-        None
-      })
-      .collect::<Vec<_>>();
+      let chunks_len = other_module_group.chunks.len();
+      if !Self::check_min_size_reduction(
+        other_module_group.get_sizes(module_sizes),
+        &cache_group.min_size_reduction,
+        chunks_len,
+      ) {
+        tracing::trace!(
+          "{key} is deleted for violating min_size {:#?}",
+          cache_group.min_size,
+        );
+        return Some(key.clone());
+      }
+
+      None
+    };
+    let keys_of_invalid_group = if rayon::current_num_threads() == 1 {
+      module_group_map
+        .iter_mut()
+        .filter_map(&process_module_group)
+        .collect::<Vec<_>>()
+    } else {
+      module_group_map
+        .par_iter_mut()
+        .filter_map(&process_module_group)
+        .collect::<Vec<_>>()
+    };
 
     keys_of_invalid_group.into_iter().for_each(|key| {
       module_group_map.swap_remove(&key);

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -210,12 +210,50 @@ pub(crate) struct Combinator {
 
 enum ChunkCombinations<'a> {
   Slice(&'a [ChunkCombination]),
-  UsedExports(Vec<&'a ChunkCombination>),
+  UsedExports {
+    chunk_keys: &'a [ChunksKey],
+    combinations: &'a FxHashMap<ChunksKey, Vec<ChunkCombination>>,
+  },
+}
+
+struct UsedExportsCombinationsIter<'a> {
+  chunk_keys: std::slice::Iter<'a, ChunksKey>,
+  combinations: &'a FxHashMap<ChunksKey, Vec<ChunkCombination>>,
+  current: Option<std::slice::Iter<'a, ChunkCombination>>,
 }
 
 enum ChunkCombinationsIter<'a> {
   Slice(std::slice::Iter<'a, ChunkCombination>),
-  UsedExports(std::iter::Copied<std::slice::Iter<'a, &'a ChunkCombination>>),
+  UsedExports(UsedExportsCombinationsIter<'a>),
+}
+
+impl<'a> Iterator for UsedExportsCombinationsIter<'a> {
+  type Item = &'a ChunkCombination;
+
+  fn next(&mut self) -> Option<Self::Item> {
+    loop {
+      if let Some(current) = &mut self.current
+        && let Some(combination) = current.next()
+      {
+        return Some(combination);
+      }
+      let chunk_key = self.chunk_keys.next()?;
+      self.current = Some(
+        self
+          .combinations
+          .get(chunk_key)
+          .expect("should have combinations")
+          .iter(),
+      );
+    }
+  }
+
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    (
+      self.current.as_ref().map_or(0, ExactSizeIterator::len),
+      None,
+    )
+  }
 }
 
 impl<'a> Iterator for ChunkCombinationsIter<'a> {
@@ -243,9 +281,14 @@ impl<'a> IntoIterator for &'a ChunkCombinations<'a> {
   fn into_iter(self) -> Self::IntoIter {
     match self {
       ChunkCombinations::Slice(combs) => ChunkCombinationsIter::Slice(combs.iter()),
-      ChunkCombinations::UsedExports(combs) => {
-        ChunkCombinationsIter::UsedExports(combs.iter().copied())
-      }
+      ChunkCombinations::UsedExports {
+        chunk_keys,
+        combinations,
+      } => ChunkCombinationsIter::UsedExports(UsedExportsCombinationsIter {
+        chunk_keys: chunk_keys.iter(),
+        combinations,
+        current: None,
+      }),
     }
   }
 }
@@ -269,24 +312,6 @@ impl Combinator {
       .combinations
       .get(&chunks_key)
       .expect("should have combinations")
-  }
-
-  fn get_used_exports_combs(&self, module_index: usize) -> Vec<&ChunkCombination> {
-    let mut result = vec![];
-    let chunks_by_module_used = self
-      .grouped_by_exports
-      .get(module_index)
-      .expect("should have exports for module");
-
-    for chunks_key in chunks_by_module_used.iter() {
-      let combs = self
-        .used_exports_combinations
-        .get(chunks_key)
-        .expect("should have combinations");
-      result.extend(combs.iter());
-    }
-
-    result
   }
 
   fn group_chunks_by_exports(
@@ -352,7 +377,13 @@ impl Combinator {
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> ChunkCombinations<'_> {
     if used_exports {
-      ChunkCombinations::UsedExports(self.get_used_exports_combs(module_index))
+      ChunkCombinations::UsedExports {
+        chunk_keys: self
+          .grouped_by_exports
+          .get(module_index)
+          .expect("should have exports for module"),
+        combinations: &self.used_exports_combinations,
+      }
     } else {
       ChunkCombinations::Slice(self.get_non_used_exports_combs(
         module_index,

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -643,8 +643,11 @@ impl SplitChunksPlugin {
                         .get(indexed_cache_group.cache_group_index as usize)
                         .is_some_and(Option::is_some)
                     });
-                    if !(cache_group.r#type)(module)
-                      || !(cache_group.layer)(module.get_layer().map(ToString::to_string)).await?
+                    if (!indexed_cache_group.has_default_type_filter
+                      && !(cache_group.r#type)(module))
+                      || (!indexed_cache_group.has_default_layer_filter
+                        && !(cache_group.layer)(module.get_layer().map(ToString::to_string))
+                          .await?)
                     {
                       continue;
                     }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -658,6 +658,15 @@ impl SplitChunksPlugin {
                   if belong_to_chunks.is_empty() {
                     return Ok(());
                   }
+                  if cache_groups.iter().all(|indexed_cache_group| {
+                    let cache_group = indexed_cache_group.cache_group;
+                    indexed_cache_group.has_default_type_filter
+                      && indexed_cache_group.has_default_layer_filter
+                      && !matches!(&cache_group.test, CacheGroupTest::Fn(_))
+                      && belong_to_chunks.len() < cache_group.min_chunks as usize
+                  }) {
+                    return Ok(());
+                  }
 
                   let module = module_graph
                     .module_by_identifier(module_identifier)
@@ -674,6 +683,15 @@ impl SplitChunksPlugin {
                         .get(indexed_cache_group.cache_group_index as usize)
                         .is_some_and(Option::is_some)
                     });
+                    let can_check_min_chunks_before_filters = indexed_cache_group
+                      .has_default_type_filter
+                      && indexed_cache_group.has_default_layer_filter
+                      && !matches!(&cache_group.test, CacheGroupTest::Fn(_));
+                    if can_check_min_chunks_before_filters
+                      && belong_to_chunks.len() < cache_group.min_chunks as usize
+                    {
+                      continue;
+                    }
                     if (!indexed_cache_group.has_default_type_filter
                       && !(cache_group.r#type)(module))
                       || (!indexed_cache_group.has_default_layer_filter

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -25,7 +25,7 @@ use crate::{
   SplitChunksNameBatchFn, SplitChunksPlugin,
   common::{ChunkFilter, ModuleChunkMap, ModuleChunks, ModuleSizes},
   min_size::remove_min_size_violating_modules,
-  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, compare_entries},
+  module_group::{IndexedCacheGroup, ModuleGroup, ModuleGroupKey, is_better_entry},
   options::{
     cache_group::CacheGroup,
     cache_group_test::{CacheGroupTest, CacheGroupTestFnCtx},
@@ -551,8 +551,7 @@ impl SplitChunksPlugin {
       let [(entry_key, entry), (best_entry_key, best_entry)] = module_group_map
         .get_disjoint_indices_mut([entry_index, best_entry_index])
         .expect("entry indices should be valid and unique");
-      let result = compare_entries((entry_key, entry), (best_entry_key, best_entry));
-      if result > 0f64 {
+      if is_better_entry((entry_key, entry), (best_entry_key, best_entry)) {
         best_entry_index = entry_index;
       }
     }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -445,16 +445,23 @@ impl Combinator {
     chunk_by_ukey: &ChunkByUkey,
     module_chunks: &ModuleChunks,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
+    min_chunks: usize,
   ) {
     let (grouped_by_exports, used_exports_chunks): (Vec<_>, Vec<_>) = all_modules
       .par_iter()
       .enumerate()
       .map(|(module_index, module)| {
+        let module_chunks = module_chunks
+          .get(module_index)
+          .expect("should have module chunks");
+        // Usage grouping only partitions this module's chunks, so none of the resulting groups can
+        // satisfy the smallest used-exports cache group when the original set is already smaller.
+        if module_chunks.len() < min_chunks {
+          return (Vec::new(), Vec::new());
+        }
         let grouped_chunks = Self::group_chunks_by_exports(
           module,
-          module_chunks
-            .get(module_index)
-            .expect("should have module chunks"),
+          module_chunks,
           exports_info_artifact,
           chunk_by_ukey,
           chunk_index_map,

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -117,6 +117,8 @@ struct PendingNameRequest {
 
 // Keep each N-API payload bounded while amortizing the fixed cost of crossing into JavaScript.
 const JS_CHUNK_NAME_BATCH_SIZE: usize = 128;
+const MAX_MODULE_GROUP_TASK_BATCH_SIZE: usize = 64;
+const MIN_MODULE_GROUP_TASKS: usize = 256;
 
 async fn process_name_requests(
   mut receiver: mpsc::UnboundedReceiver<PendingNameRequest>,
@@ -574,16 +576,23 @@ impl SplitChunksPlugin {
         );
       }
 
+      // Keep enough tasks to run async cache group callbacks concurrently while avoiding one
+      // Tokio task allocation for every module in large compilations.
+      let module_group_task_batch_size = all_modules
+        .len()
+        .div_ceil(MIN_MODULE_GROUP_TASKS)
+        .clamp(1, MAX_MODULE_GROUP_TASK_BATCH_SIZE);
       all_modules
-        .iter()
+        .chunks(module_group_task_batch_size)
         .enumerate()
-        .for_each(|(module_index, module_identifier)| {
+        .for_each(|(batch_index, modules)| {
+          let module_index_start = batch_index * module_group_task_batch_size;
           let name_sender = name_sender.clone();
           let s = unsafe {
             token.used((
               &cache_groups,
-              module_index,
-              module_identifier,
+              module_index_start,
+              modules,
               &module_graph,
               compilation,
               &module_group_map,
@@ -597,8 +606,8 @@ impl SplitChunksPlugin {
           s.spawn(
             |(
               cache_groups,
-              module_index,
-              module_identifier,
+              module_index_start,
+              modules,
               module_graph,
               compilation,
               module_group_map,
@@ -608,183 +617,200 @@ impl SplitChunksPlugin {
               name_sender,
               name_batch_getters,
             )| async move {
-              let belong_to_chunks = module_chunks
-                .get(module_index)
-                .expect("should have module chunks");
-              if belong_to_chunks.is_empty() {
-                return Ok(());
-              }
-
-              let module = module_graph
-                .module_by_identifier(module_identifier)
-                .expect("should have module")
-                .as_ref();
-              let mut used_exports_combinations = None;
-              let mut non_used_exports_combinations = None;
-
-              for (cache_group_position, indexed_cache_group) in cache_groups.iter().enumerate() {
-                let cache_group = indexed_cache_group.cache_group;
-                let has_name_batch_getter = name_batch_getters.is_some_and(|getters| {
-                  getters
-                    .get(indexed_cache_group.cache_group_index as usize)
-                    .is_some_and(Option::is_some)
-                });
-                if !(cache_group.r#type)(module)
-                  || !(cache_group.layer)(module.get_layer().map(ToString::to_string)).await?
-                {
-                  continue;
-                }
-
-                let is_match = match &cache_group.test {
-                  CacheGroupTest::String(test) => module
-                    .name_for_condition()
-                    .is_some_and(|name| name.starts_with(test)),
-                  CacheGroupTest::RegExp(test) => module
-                    .name_for_condition()
-                    .is_some_and(|name| test.test(&name)),
-                  CacheGroupTest::Fn(test) => test(CacheGroupTestFnCtx {
-                    compilation,
-                    module,
-                  })
-                  .await?
-                  .unwrap_or_default(),
-                  CacheGroupTest::Enabled => true,
-                };
-                if !is_match || belong_to_chunks.len() < cache_group.min_chunks as usize {
-                  continue;
-                }
-
-                let combinations = if cache_group.used_exports {
-                  if used_exports_combinations.is_none() {
-                    used_exports_combinations = Some(combinator.get_combs(
-                      module_index,
-                      true,
-                      module_chunks,
-                      chunk_index_map,
-                    ));
+              let name_sender = name_sender.as_ref();
+              let module_results: Vec<Result<()>> = join_all(modules.iter().enumerate().map(
+                |(module_offset, module_identifier)| async move {
+                  let module_index = module_index_start + module_offset;
+                  let belong_to_chunks = module_chunks
+                    .get(module_index)
+                    .expect("should have module chunks");
+                  if belong_to_chunks.is_empty() {
+                    return Ok(());
                   }
-                  used_exports_combinations
-                    .as_ref()
-                    .expect("should have used exports combinations")
-                } else {
-                  if non_used_exports_combinations.is_none() {
-                    non_used_exports_combinations = Some(combinator.get_combs(
-                      module_index,
-                      false,
-                      module_chunks,
-                      chunk_index_map,
-                    ));
-                  }
-                  non_used_exports_combinations
-                    .as_ref()
-                    .expect("should have non-used exports combinations")
-                };
 
-                for chunk_combination in combinations {
-                  if chunk_combination.is_empty()
-                    || chunk_combination.len() < cache_group.min_chunks as usize
+                  let module = module_graph
+                    .module_by_identifier(module_identifier)
+                    .expect("should have module")
+                    .as_ref();
+                  let mut used_exports_combinations = None;
+                  let mut non_used_exports_combinations = None;
+
+                  for (cache_group_position, indexed_cache_group) in cache_groups.iter().enumerate()
                   {
-                    continue;
-                  }
-
-                  if matches!(&cache_group.chunk_filter, ChunkFilter::All)
-                    && matches!(&cache_group.name, ChunkNameGetter::Disabled)
-                    && !has_name_batch_getter
-                  {
-                    let mut module_group = module_group_map
-                      .entry(ModuleGroupKey::Anonymous {
-                        cache_group_index: indexed_cache_group.cache_group_index,
-                        chunks_key: chunk_combination.key,
-                      })
-                      .or_insert_with(|| {
-                        ModuleGroup::new(None, indexed_cache_group.cache_group_index, cache_group)
-                      });
-                    module_group.add_module_with_shared_chunks(
-                      module.identifier(),
-                      chunk_combination.iter().copied(),
-                    );
-                    continue;
-                  }
-
-                  let selected_chunks = match &cache_group.chunk_filter {
-                    ChunkFilter::All => SelectedChunks::All(chunk_combination),
-                    ChunkFilter::Func(_) => SelectedChunks::Filtered(
-                      join_all(chunk_combination.iter().map(|chunk| async move {
-                        cache_group
-                          .chunk_filter
-                          .test_func(chunk, compilation)
-                          .await
-                          .map(|matched| (chunk, matched))
-                      }))
-                      .await
-                      .into_iter()
-                      .collect::<Result<Vec<_>>>()?
-                      .into_iter()
-                      .filter_map(|(chunk, matched)| matched.then_some(*chunk))
-                      .collect(),
-                    ),
-                    _ => SelectedChunks::Filtered(
-                      chunk_combination
-                        .iter()
-                        .filter(|chunk| cache_group.chunk_filter.test_internal(chunk, compilation))
-                        .copied()
-                        .collect(),
-                    ),
-                  };
-
-                  if selected_chunks.len() < cache_group.min_chunks as usize {
-                    continue;
-                  }
-
-                  let chunk_name = if has_name_batch_getter {
-                    let name_sender = name_sender
-                      .as_ref()
-                      .expect("name callback should have a batch coordinator");
-                    let (response, response_receiver) = oneshot::channel();
-                    if name_sender
-                      .unbounded_send(PendingNameRequest {
-                        module: module.identifier(),
-                        chunks: selected_chunks.iter().copied().collect(),
-                        cache_group_position,
-                        response: Some(response),
-                      })
-                      .is_err()
+                    let cache_group = indexed_cache_group.cache_group;
+                    let has_name_batch_getter = name_batch_getters.is_some_and(|getters| {
+                      getters
+                        .get(indexed_cache_group.cache_group_index as usize)
+                        .is_some_and(Option::is_some)
+                    });
+                    if !(cache_group.r#type)(module)
+                      || !(cache_group.layer)(module.get_layer().map(ToString::to_string)).await?
                     {
-                      return Ok(());
+                      continue;
                     }
-                    let Ok(chunk_name) = response_receiver.await else {
-                      return Ok(());
-                    };
-                    chunk_name
-                  } else {
-                    match &cache_group.name {
-                      ChunkNameGetter::String(name) => Some(name.clone()),
-                      ChunkNameGetter::Disabled => None,
-                      ChunkNameGetter::Fn(get_name) => {
-                        let chunks = selected_chunks.iter().copied().collect::<Vec<_>>();
-                        get_name(ChunkNameGetterFnCtx {
-                          module,
-                          compilation,
-                          chunks: &chunks,
-                          cache_group_key: &cache_group.key,
-                        })
-                        .await?
-                      }
-                    }
-                  };
 
-                  merge_matched_item_into_module_group_map(
-                    MatchedItem {
-                      module,
-                      cache_group,
-                      cache_group_index: indexed_cache_group.cache_group_index,
-                      selected_chunks,
-                    },
-                    chunk_name,
-                    module_group_map,
-                    chunk_index_map,
-                  );
-                }
+                    let is_match = match &cache_group.test {
+                      CacheGroupTest::String(test) => module
+                        .name_for_condition()
+                        .is_some_and(|name| name.starts_with(test)),
+                      CacheGroupTest::RegExp(test) => module
+                        .name_for_condition()
+                        .is_some_and(|name| test.test(&name)),
+                      CacheGroupTest::Fn(test) => test(CacheGroupTestFnCtx {
+                        compilation,
+                        module,
+                      })
+                      .await?
+                      .unwrap_or_default(),
+                      CacheGroupTest::Enabled => true,
+                    };
+                    if !is_match || belong_to_chunks.len() < cache_group.min_chunks as usize {
+                      continue;
+                    }
+
+                    let combinations = if cache_group.used_exports {
+                      if used_exports_combinations.is_none() {
+                        used_exports_combinations = Some(combinator.get_combs(
+                          module_index,
+                          true,
+                          module_chunks,
+                          chunk_index_map,
+                        ));
+                      }
+                      used_exports_combinations
+                        .as_ref()
+                        .expect("should have used exports combinations")
+                    } else {
+                      if non_used_exports_combinations.is_none() {
+                        non_used_exports_combinations = Some(combinator.get_combs(
+                          module_index,
+                          false,
+                          module_chunks,
+                          chunk_index_map,
+                        ));
+                      }
+                      non_used_exports_combinations
+                        .as_ref()
+                        .expect("should have non-used exports combinations")
+                    };
+
+                    for chunk_combination in combinations {
+                      if chunk_combination.is_empty()
+                        || chunk_combination.len() < cache_group.min_chunks as usize
+                      {
+                        continue;
+                      }
+
+                      if matches!(&cache_group.chunk_filter, ChunkFilter::All)
+                        && matches!(&cache_group.name, ChunkNameGetter::Disabled)
+                        && !has_name_batch_getter
+                      {
+                        let mut module_group = module_group_map
+                          .entry(ModuleGroupKey::Anonymous {
+                            cache_group_index: indexed_cache_group.cache_group_index,
+                            chunks_key: chunk_combination.key,
+                          })
+                          .or_insert_with(|| {
+                            ModuleGroup::new(
+                              None,
+                              indexed_cache_group.cache_group_index,
+                              cache_group,
+                            )
+                          });
+                        module_group.add_module_with_shared_chunks(
+                          module.identifier(),
+                          chunk_combination.iter().copied(),
+                        );
+                        continue;
+                      }
+
+                      let selected_chunks = match &cache_group.chunk_filter {
+                        ChunkFilter::All => SelectedChunks::All(chunk_combination),
+                        ChunkFilter::Func(_) => SelectedChunks::Filtered(
+                          join_all(chunk_combination.iter().map(|chunk| async move {
+                            cache_group
+                              .chunk_filter
+                              .test_func(chunk, compilation)
+                              .await
+                              .map(|matched| (chunk, matched))
+                          }))
+                          .await
+                          .into_iter()
+                          .collect::<Result<Vec<_>>>()?
+                          .into_iter()
+                          .filter_map(|(chunk, matched)| matched.then_some(*chunk))
+                          .collect(),
+                        ),
+                        _ => SelectedChunks::Filtered(
+                          chunk_combination
+                            .iter()
+                            .filter(|chunk| {
+                              cache_group.chunk_filter.test_internal(chunk, compilation)
+                            })
+                            .copied()
+                            .collect(),
+                        ),
+                      };
+
+                      if selected_chunks.len() < cache_group.min_chunks as usize {
+                        continue;
+                      }
+
+                      let chunk_name = if has_name_batch_getter {
+                        let name_sender =
+                          name_sender.expect("name callback should have a batch coordinator");
+                        let (response, response_receiver) = oneshot::channel();
+                        if name_sender
+                          .unbounded_send(PendingNameRequest {
+                            module: module.identifier(),
+                            chunks: selected_chunks.iter().copied().collect(),
+                            cache_group_position,
+                            response: Some(response),
+                          })
+                          .is_err()
+                        {
+                          return Ok(());
+                        }
+                        let Ok(chunk_name) = response_receiver.await else {
+                          return Ok(());
+                        };
+                        chunk_name
+                      } else {
+                        match &cache_group.name {
+                          ChunkNameGetter::String(name) => Some(name.clone()),
+                          ChunkNameGetter::Disabled => None,
+                          ChunkNameGetter::Fn(get_name) => {
+                            let chunks = selected_chunks.iter().copied().collect::<Vec<_>>();
+                            get_name(ChunkNameGetterFnCtx {
+                              module,
+                              compilation,
+                              chunks: &chunks,
+                              cache_group_key: &cache_group.key,
+                            })
+                            .await?
+                          }
+                        }
+                      };
+
+                      merge_matched_item_into_module_group_map(
+                        MatchedItem {
+                          module,
+                          cache_group,
+                          cache_group_index: indexed_cache_group.cache_group_index,
+                          selected_chunks,
+                        },
+                        chunk_name,
+                        module_group_map,
+                        chunk_index_map,
+                      );
+                    }
+                  }
+                  Ok(())
+                },
+              ))
+              .await;
+              for module_result in module_results {
+                module_result?;
               }
               Ok(())
             },

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -902,7 +902,7 @@ impl SplitChunksPlugin {
   ) {
     // remove all modules from other entries and update size
     let process_module_group = |(key, other_module_group): (&ModuleGroupKey, &mut ModuleGroup)| {
-      let removed_modules = match (
+      let (removed_modules, updated_shared_group) = match (
         placed_module_chunks,
         other_module_group.shared_module_chunks(),
       ) {
@@ -914,7 +914,10 @@ impl SplitChunksPlugin {
           Some(other_chunks),
         ) => {
           other_chunks.intersection(placed_chunks).next()?;
-          other_module_group.remove_shared_modules_in(modules, module_sizes)
+          (
+            other_module_group.remove_shared_modules_in(modules, module_sizes),
+            true,
+          )
         }
         _ => {
           let duplicated_modules = other_module_group
@@ -932,10 +935,10 @@ impl SplitChunksPlugin {
             .copied()
             .collect::<Vec<_>>();
           if duplicated_modules.is_empty() {
-            false
+            (false, false)
           } else {
             other_module_group.remove_modules(duplicated_modules);
-            true
+            (true, false)
           }
         }
       };
@@ -953,6 +956,17 @@ impl SplitChunksPlugin {
       tracing::trace!("placed_module_chunks: {placed_module_chunks:#?}");
 
       let cache_group = other_module_group.get_cache_group(&self.cache_groups);
+
+      if updated_shared_group
+        && cache_group.min_size.values().all(|size| *size == 0.0)
+        && cache_group
+          .min_size_reduction
+          .values()
+          .all(|size| *size == 0.0)
+      {
+        debug_assert!(other_module_group.chunks.len() >= cache_group.min_chunks as usize);
+        return None;
+      }
 
       // Since we removed some modules and chunks from the `other_module_group`. There are chances
       // that the `min_chunks` and `min_size` validation is not satisfied anymore.

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -294,17 +294,12 @@ impl Combinator {
     chunk_by_ukey: &ChunkByUkey,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<ChunkCombination> {
-    if let Some(first_chunk) = module_chunks.iter().next() {
-      let first_runtime_key = get_runtime_key(chunk_by_ukey.expect_get(first_chunk).runtime());
-      // Chunks with the same runtime always have the same usage key for a module.
-      if module_chunks.iter().skip(1).all(|chunk_ukey| {
-        get_runtime_key(chunk_by_ukey.expect_get(chunk_ukey).runtime()) == first_runtime_key
-      }) {
-        return vec![ChunkCombination {
-          key: get_key(module_chunks.iter().copied(), chunk_index_map),
-          chunks: Arc::new(module_chunks.clone()),
-        }];
-      }
+    // A single chunk cannot produce runtime-dependent usage groups.
+    if module_chunks.len() == 1 {
+      return vec![ChunkCombination {
+        key: get_key(module_chunks.iter().copied(), chunk_index_map),
+        chunks: Arc::new(module_chunks.clone()),
+      }];
     }
 
     let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -289,15 +289,28 @@ impl Combinator {
 
   fn group_chunks_by_exports(
     module_identifier: &ModuleIdentifier,
-    module_chunks: impl Iterator<Item = ChunkUkey>,
+    module_chunks: &FxHashSet<ChunkUkey>,
     exports_info_artifact: &ExportsInfoArtifact,
     chunk_by_ukey: &ChunkByUkey,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<ChunkCombination> {
+    if let Some(first_chunk) = module_chunks.iter().next() {
+      let first_runtime_key = get_runtime_key(chunk_by_ukey.expect_get(first_chunk).runtime());
+      // Chunks with the same runtime always have the same usage key for a module.
+      if module_chunks.iter().skip(1).all(|chunk_ukey| {
+        get_runtime_key(chunk_by_ukey.expect_get(chunk_ukey).runtime()) == first_runtime_key
+      }) {
+        return vec![ChunkCombination {
+          key: get_key(module_chunks.iter().copied(), chunk_index_map),
+          chunks: Arc::new(module_chunks.clone()),
+        }];
+      }
+    }
+
     let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
     let mut runtime_key_map = RuntimeKeyMap::default();
-    for chunk_ukey in module_chunks {
+    for chunk_ukey in module_chunks.iter().copied() {
       let chunk = chunk_by_ukey.expect_get(&chunk_ukey);
       let runtime = chunk.runtime();
       let usage_key = runtime_key_map
@@ -432,9 +445,7 @@ impl Combinator {
           module,
           module_chunks
             .get(module_index)
-            .expect("should have module chunks")
-            .iter()
-            .copied(),
+            .expect("should have module chunks"),
           exports_info_artifact,
           chunk_by_ukey,
           chunk_index_map,

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -17,6 +17,7 @@ use rspack_core::{
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 use rspack_util::{fx_hash::FxDashMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use smallvec::SmallVec;
 use tracing::instrument;
 
 use super::ModuleGroupMap;
@@ -191,7 +192,7 @@ fn get_key<I: Iterator<Item = ChunkUkey>>(
         .get(&chunk)
         .expect("should already have index for chunk ukey")
     })
-    .collect::<Vec<_>>();
+    .collect::<SmallVec<[u32; 16]>>();
   sorted_chunk_ukeys.sort_unstable();
   let mut hasher = FxHasher::default();
   for chunk_ukey in sorted_chunk_ukeys {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -548,9 +548,12 @@ impl SplitChunksPlugin {
 
     let mut best_entry_index = 0;
     for entry_index in 1..module_group_map.len() {
-      let [(entry_key, entry), (best_entry_key, best_entry)] = module_group_map
-        .get_disjoint_indices_mut([entry_index, best_entry_index])
-        .expect("entry indices should be valid and unique");
+      let (entry_key, entry) = module_group_map
+        .get_index(entry_index)
+        .expect("entry index should be valid");
+      let (best_entry_key, best_entry) = module_group_map
+        .get_index(best_entry_index)
+        .expect("best entry index should be valid");
       if is_better_entry((entry_key, entry), (best_entry_key, best_entry)) {
         best_entry_index = entry_index;
       }

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -955,8 +955,15 @@ impl SplitChunksPlugin {
       // Since we removed some modules and chunks from the `other_module_group`. There are chances
       // that the `min_chunks` and `min_size` validation is not satisfied anymore.
 
-      // Validate `min_size` again
-      if remove_min_size_violating_modules(key, other_module_group, cache_group, module_sizes) {
+      // Validate `min_size` again and always flush the pending size updates before comparisons.
+      if cache_group.min_size.values().all(|size| *size == 0.0) {
+        let _ = other_module_group.get_sizes(module_sizes);
+      } else if remove_min_size_violating_modules(
+        key,
+        other_module_group,
+        cache_group,
+        module_sizes,
+      ) {
         tracing::trace!(
           "{key} is deleted for violating min_size {:#?}",
           cache_group.min_size,
@@ -977,11 +984,16 @@ impl SplitChunksPlugin {
       }
 
       let chunks_len = other_module_group.chunks.len();
-      if !Self::check_min_size_reduction(
-        other_module_group.get_sizes(module_sizes),
-        &cache_group.min_size_reduction,
-        chunks_len,
-      ) {
+      if cache_group
+        .min_size_reduction
+        .values()
+        .any(|size| *size != 0.0)
+        && !Self::check_min_size_reduction(
+          other_module_group.get_sizes(module_sizes),
+          &cache_group.min_size_reduction,
+          chunks_len,
+        )
+      {
         tracing::trace!(
           "{key} is deleted for violating min_size {:#?}",
           cache_group.min_size,


### PR DESCRIPTION
## Summary

- Reduce `splitChunks` combination construction, module-group scheduling, serial selection/cleanup, and size bookkeeping overhead.
- Keep runtime-dependent `usedExports`, JS callback ordering/concurrency, chunk conditions, request limits, size constraints, and residual priority behavior unchanged.
- Preserve compact shared module/chunk representations when reusing an existing destination.

## Commit breakdown

- `021ac3a8ef` — Prepare only the used-exports/non-used-exports combinators requested by the cache groups at the current priority.
- `816ffc0d5e` — Keep the constant-time used-exports fast path for modules that belong to exactly one chunk.
- `815409771d` — Reuse one chunk combination when every participating chunk has the same runtime key; mixed runtimes still use export-usage grouping.
- `7df39e57da` — Add a reused destination directly to `ModuleChunkMap::Shared` when every module passed its chunk condition, avoiding shared-to-per-module expansion.
- `0e0af1724c` — Skip reconnecting modules to a reused destination that already contains the complete module group.
- `98e25bc20e` — Skip used-exports grouping when the module's original chunk count is already below the minimum `minChunks`; partitioning cannot create a qualifying group.
- `9ddcda596e` — Stop maintaining source-type membership sets eagerly; build the violating-module set only on the uncommon `minSize` failure path.
- `eb2c86516b` — Batch large module-group workloads into at least 256 Tokio tasks with a maximum batch size of 64, while polling every module future in a batch with `join_all` so async callbacks remain concurrent.
- `1bbba4fb5e` — Reuse stable default type/layer filters and skip invoking those no-op filters per module.
- `27392ea07c` — Iterate used-export combinations lazily instead of allocating a temporary `Vec<&ChunkCombination>` per module.
- `9397e7230e` — Reject modules below `minChunks` before module lookup/filtering only when all relevant filters are built-in and side-effect-free; user callbacks retain their previous invocation order.
- `282710fad7` — Store up to 16 chunk indices inline while sorting/hashing a combination key, avoiding the common temporary heap allocation.
- `2b30f0af2e` — Skip chunk-group request counting when both initial and async request limits are unbounded.
- `4f7f11299a` — Remove overlapping modules directly from shared anonymous groups, avoiding a temporary intersection vector and a second hash removal pass.
- `3b00146d2f` — Skip max-size task scheduling when neither cache groups nor the non-callback fallback configure max sizes.
- `bec8b28055` — Run module-group cleanup directly when Rayon has one worker; retain parallel cleanup when multiple workers are available.
- `12eb40773e` — Skip module scans for zero-valued `minSize`/`minSizeReduction` constraints while keeping size state synchronized.
- `e94a3c8ee9` — Drain pending module removals without replacing their vector, retaining capacity across repeated cleanup rounds.
- `2ed755cbac` — Initialize group sizes while preparing comparison modules and remove the duplicate deferred-added module list.
- `5bb278fcac` — Compare module groups with direct integer/boolean ordering while preserving the existing floating size-reduction and identifier tie-break semantics.
- `35a8ae7dfe` — Preallocate the placed-module set from the winning group size.
- `3608164df3` — Append chunk reasons directly instead of allocating temporary formatted strings.
- `6bab34e4bb` — Reserve the cache-group/name suffix capacity before appending a chunk reason.
- `c4f7362073` — Sort the existing comparison snapshot during parallel preparation so serial best-group selection can use read-only indexed access.
- `82a486cd54` — Allocate the initial split-chunk reason with enough capacity for its later cache-group/name suffix.
- `7371b210c1` — Keep the small temporary module/chunk slices used by batched chunk-graph moves inline.
- `73c8a47e3b` — Update already initialized group source-type sizes directly instead of entering the hash map again.
- `5124b55238` — Subtract shared-group module sizes during removal instead of queueing and draining a second pass.
- `01608ad77f` — Skip shared-group chunk/minChunks revalidation when module removal cannot change its common chunk set and both size constraints are zero.
- `877bae88ce` — Use a conservative 64-bit chunk mask to skip exact cleanup for module groups whose chunk sets are provably disjoint.

## Performance

### Official CodSpeed split-chunks workload

The latest completed CodSpeed result at `7371b210c1` for `rust@split_chunks` is 2.1 ms to 1.8 ms (**+22.29%**), up from +17.19% at `12eb40773e` and +5.9% at the earlier PR head. The run for the current head `877bae88ce` is pending. CodSpeed flags different runtime environments for the completed comparison and falls back to `main` commit `ddaed17` because the latest base commit did not have a successful run, so the local same-environment Callgrind result below is included as a cross-check. This workload has 240 modules, 125 output chunks, one cache group, `usedExports: false`, unbounded request limits, and no max-size constraints, so several earlier runtime/grouping optimizations are intentionally not exercised.

The eighteen follow-up commits target the serial work that this case does exercise. Local Callgrind results for the same workload are:

| Instrumented SplitChunks stages | IR | Change vs `origin/main` |
| --- | ---: | ---: |
| `origin/main` | 5,379,674 | — |
| previous PR head (`282710fad7`) | 4,999,066 | -7.1% |
| completed CodSpeed head (`12eb40773e`) | 4,465,969 | -17.0% |
| previous pushed head (`7371b210c1`) | 4,298,145 | -20.1% |
| current head (`877bae88ce`) | 3,931,090 | -26.9% |

The follow-up commits reduce another 1,067,976 IR (-21.4%) from the previous PR head. The thirteen commits after `12eb40773e` account for 534,879 IR (-12.0%). The four newest commits reduce 367,055 IR (-8.54%) from `7371b210c1`. Output remains 240 modules and 125 chunks.

Sequential Callgrind deltas for the follow-up commits:

- Skip unbounded request checks: -81,887 IR (-1.63%).
- Remove shared modules in place: -122,037 IR (-2.47%).
- Avoid Rayon for single-worker cleanup: -54,271 IR (-1.13%).
- Skip the unused max-size pass: -243,693 IR (-5.11%).
- Skip zero-valued size constraints: -31,209 IR (-0.69%).
- Retain removed-module capacity: -13,661 IR (-0.30%).
- Initialize group sizes eagerly: -25,371 IR (-0.57%).
- Compare module groups directly: -23,702 IR (-0.53%).
- Preallocate placed modules: -13,366 IR (-0.30%).
- Append chunk reasons directly: -3,941 IR (-0.09%).
- Reserve chunk-reason suffix capacity: -24,763 IR (-0.56%).
- Prepare comparison order eagerly: -25,147 IR (-0.57%).
- Preallocate complete split-chunk reasons: -12,725 IR (-0.29%).
- Keep small move sets inline: -25,148 IR (-0.58%).
- Update initialized source-type sizes directly: -26,994 IR (-0.63%).
- Update shared-group sizes during removal: -15,236 IR (-0.36%).
- Skip unchanged shared-group revalidation: -4,574 IR (-0.11%).
- Skip cleanup for disjoint chunk masks: -320,251 IR (-7.53%).

The current instrumented stage distribution is 248,906 IR preparing modules, 16,952 indexing chunks, 2,061 preparing cache groups, 1,160 preparing available module chunks, 329,683 preparing combinations, 1,340,948 preparing module groups, 306,740 preparing group sizes (including comparison order and chunk-mask preparation), 1,682,788 selecting/splitting groups, and 1,852 checking max size. The chunk-mask commit alone reduces selection/splitting by 392,594 IR (-18.9%) while preserving exact checks for every possible overlap.

### React-10k production workload

Callgrind was also run on the complete React-10k production build with cache and minification disabled. At the `282710fad7` checkpoint, output remained 19,027 modules, 17 chunks, and 18 assets:

| SplitChunks stages | `origin/main` IR | `282710fad7` IR | Change |
| --- | ---: | ---: | ---: |
| prepare combinations (both priorities) | 90.149M | 4.269M | -95.3% |
| prepare module groups (both priorities) | 112.471M | 68.067M | -39.5% |
| prepare module-group sizes | 2.092M | 0.852M | -59.3% |
| select and split groups | 9.329M | 9.318M | -0.1% |
| all instrumented SplitChunks stages | 237.765M | 106.253M | -55.3% |

The React-10k configuration sets `usedExports` to false and does not select a reusable winner, so the reused-destination and used-exports-only commits are correctness/overhead improvements for other configurations and are not credited with React-10k gains.

## Correctness notes

- The same-runtime shortcut compares runtime keys and falls back to the existing export-usage path on the first mismatch.
- Shared reused placement is retained only when the placed module set exactly equals the winning group; partial chunk-condition results use the existing per-module representation.
- Batched module futures are polled concurrently, while each module still visits cache groups in order. Existing callback-order, batch callback, and output-order cases pass.
- Early `minChunks` rejection is disabled for custom type/layer filters and function tests, preserving observable callback invocation semantics.
- Request counting is skipped only when both request limits are positive infinity.
- Shared in-place removal is used only when both the placed group and candidate group have shared chunk sets; named/per-module groups retain the existing path.
- The max-size pass is skipped only when no per-cache-group max size exists, the fallback chunk filter is not a user callback, and fallback max sizes are empty. Callback invocation and error behavior are preserved.
- Single-worker cleanup uses the same closure and removal order as the Rayon path; multi-worker builds remain parallel.
- Empty `minSize` retains its previous special behavior. Non-empty zero-valued `minSize` still validates a non-zero `minSizeReduction`, and pending size updates are flushed before later comparisons.
- Eager size initialization uses the same per-module source sizes, and retained removal capacity changes only allocation reuse.
- Direct comparison preserves the existing size-reduction subtraction (including unordered floating values), cache-group, module-count, identifier, and key ordering.
- Eager comparison sorting uses the same initial module snapshot and precomputed-hash key; it only moves sorting into the parallel preparation stage and makes serial selection read-only.
- Chunk-reason changes preserve the exact text and append order; only temporary allocation and capacity growth differ.
- Inline move sets still expose ordinary slices to chunk-graph mutation and spill to heap storage automatically when a group exceeds the inline capacity.
- Direct size updates rely on source-type totals initialized during group preparation and keep the existing assertion when that invariant is violated.
- Shared groups subtract sizes in the same module traversal that removes modules; named/per-module groups keep deferred size updates.
- Removing modules from a shared anonymous group cannot change its common chunk set, so an already valid `minChunks` remains valid. Non-zero `minSize` or `minSizeReduction` still takes the full validation path.
- Chunk masks are snapshots of each group's original chunk union. Cleanup only removes chunks afterward, so the mask remains a conservative superset; collisions fall back to the existing exact set/module intersection and cannot change output.

## Validation

- `pnpm run build:binding:dev`
- split-chunks filtered suite: 2 files passed, 200 tests passed, 8,472 skipped
- `pnpm run test:unit`: Rspack tests 46 files passed, 9,114 passed / 4 skipped; CLI 89 passed / 1 skipped; binding type test passed
- `cargo check -p rspack_plugin_split_chunks -p rspack_binding_api`
- `cargo clippy -p rspack_plugin_split_chunks -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

No benchmark, Callgrind, or CodSpeed-only files are included in this PR.

## Related links

N/A

## Checklist

- [x] Tests updated (not required; covered by existing split-chunks, callback-order, used-exports, request-limit, size-limit, and reuse/residual cases).
- [x] Documentation updated (not required; no user-facing behavior changes).
