### PR TITLE
docs: improve lazy compilation documentation

### DIFF
--- a/website/docs/en/config/lazy-compilation.mdx
+++ b/website/docs/en/config/lazy-compilation.mdx
@@ -15,10 +15,11 @@ Lazy Compilation is an optimization technique that delays the compilation of mod
 
 Enable lazy compilation, which can greatly improve the dev startup performance of multi-page applications (MPA) or large single-page applications (SPA).
 
-## **lazyCompilation**
+:::tip
+Check out the [guide](/guide/features/lazy-compilation) for a quick start.
+:::
 
-- **Type:** `boolean | LazyCompilationOptions`
-- **Default:** `{ entries: false, imports: true }` when [`Target`](/config/target) is for `'web'` applications only, `false` for others.
+- **Type:**
 
 ```ts
 type LazyCompilationOptions =
@@ -55,13 +56,16 @@ type LazyCompilationOptions =
     };
 ```
 
-:::tip
-Check out the [guide](/guide/features/lazy-compilation) for a quick start.
-:::
+## Default behavior
+
+- **JavaScript API:** Lazy compilation is disabled by default. After enabling `lazyCompilation`, register the lazy compilation middleware with your development server. See [Integrating with custom server](/guide/features/lazy-compilation#integrating-with-custom-server).
+- **Rspack CLI:** `rspack dev` registers the middleware automatically. When [`target`](/config/target) is limited to a browser environment and `lazyCompilation` is not explicitly configured, it also uses `{ entries: false, imports: true }`. When the option is omitted in other cases, lazy compilation remains disabled.
+
+## Compilation scope
 
 If you have twenty entry points, only the accessed entry points will be built when you enable lazyCompilation. Or if there are many `import()` statements in the project, each module pointed to by `import()` will only be built when it is actually accessed.
 
-If set to `true`, lazy compilation will be applied by default to both entry modules and modules pointed to by `import()`. You can decide whether it applies only to entries or only to `import()` through a configuration object. The `entries` option determines whether it applies to entries, while the `import()` option determines whether it applies to `import()`.
+If set to `true`, lazy compilation will be applied by default to both entry modules and modules pointed to by `import()`. You can decide whether it applies only to entries or only to `import()` through a configuration object. The `entries` option determines whether it applies to entries, while the `imports` option determines whether it applies to `import()`.
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
@@ -74,6 +78,8 @@ export default {
 ```
 
 In addition, you can also configure a `test` parameter for more fine-grained control over which modules are lazily compiled. The `test` parameter can be a regular expression that matches only those modules that should be lazily compiled. It can also be a function where the input is of type 'Module' and returns a boolean value indicating whether it meets the criteria for lazy compilation logic.
+
+## Options
 
 ### lazyCompilation.client
 
@@ -121,32 +127,4 @@ export default {
     prefix: '/custom-lazy-endpoint-',
   },
 };
-```
-
-### Exclude HMR client
-
-If you do not use Rspack's own dev server and instead use your own server as the dev server, you generally need to add another client modules in the entry configuration to enable capabilities such as HMR. It is best to exclude these client module from lazy compilation by configuring `test`.
-
-If not excluded and lazy compilation of entry is enabled, this client will not be compiled when accessing the page for the first time, so an additional refresh is needed to make it take effect.
-
-For example:
-
-```js title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
-
-const options = {
-  lazyCompilation: {
-    test(module) {
-      const isMyClient = module.nameForCondition().endsWith('dev-client.js');
-      // make sure that dev-client.js won't be lazy compiled
-      return !isMyClient;
-    },
-  },
-};
-const compiler = rspack(options);
-
-new compiler.rspack.EntryPlugin(compiler.context, 'dev-client.js', {
-  // name: undefined means this is global entry
-  name: undefined,
-}).apply(compiler);
 ```

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -59,6 +59,14 @@ When lazy compilation is enabled for entries, entry modules will actually be asy
 
 Use the [dev.lazyCompilation](https://rsbuild.rs/config/dev/lazy-compilation) option to enable lazy compilation with Rsbuild.
 
+## Under the hood
+
+The principle of lazy compilation is to proxy the unexecuted entries and dynamically imported modules. When the module is executed during runtime it sends a request to the dev server, triggering rebuild by Compiler along with module hot updates.
+
+Only when corresponding entries and modules are executed will Rspack compile their respective entries and Modules along with all their dependencies.
+
+![image](https://assets.rspack.rs/rspack/assets/lazy-proxy-module.png)
+
 ## Filtering modules
 
 In addition to two options `entries` and `imports`, you can also use a `test` option to filter out certain modules for lazy compilation.
@@ -84,19 +92,37 @@ export default defineConfig({
 });
 ```
 
-## Under the hood
+### Exclude HMR client
 
-The principle of lazy compilation is to proxy the unexecuted entries and dynamically imported modules. When the module is executed during runtime it sends a request to the dev server, triggering rebuild by Compiler along with module hot updates.
+If you do not use Rspack's own dev server and instead use your own server as the dev server, you generally need to add another client modules in the entry configuration to enable capabilities such as HMR. It is best to exclude these client module from lazy compilation by configuring `test`.
 
-Only when corresponding entries and modules are executed will Rspack compile their respective entries and Modules along with all their dependencies.
+If not excluded and lazy compilation of entry is enabled, this client will not be compiled when accessing the page for the first time, so an additional refresh is needed to make it take effect.
 
-![image](https://assets.rspack.rs/rspack/assets/lazy-proxy-module.png)
+For example:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+const options = {
+  lazyCompilation: {
+    test(module) {
+      const isMyClient = module.nameForCondition().endsWith('dev-client.js');
+      // make sure that dev-client.js won't be lazy compiled
+      return !isMyClient;
+    },
+  },
+};
+const compiler = rspack(options);
+
+new compiler.rspack.EntryPlugin(compiler.context, 'dev-client.js', {
+  // name: undefined means this is global entry
+  name: undefined,
+}).apply(compiler);
+```
 
 ## Integrating with custom server
 
-When using Rspack CLI, the `lazyCompilation` option is actually processed by `@rspack/cli`. It adds an [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) to dev server to handle lazy compilation requests from client.
-
-If you are using a custom dev server, you will need to manually integrate `rspack.lazyCompilationMiddleware` into your dev server.
+If you are not using Rspack CLI or Rsbuild and are using your own development server, you need to manually integrate `rspack.lazyCompilationMiddleware` into your development server.
 
 ```js title="start.mjs"
 import { rspack } from '@rspack/core';

--- a/website/docs/zh/config/lazy-compilation.mdx
+++ b/website/docs/zh/config/lazy-compilation.mdx
@@ -15,10 +15,11 @@ import { ApiMeta } from '@components/ApiMeta';
 
 开启懒编译，对提高多入口应用（MPA）或大型单页面应用（SPA）的 dev 启动性能会非常有帮助。
 
-## lazyCompilation
+:::tip
+参考 [指南](/guide/features/lazy-compilation) 来快速上手。
+:::
 
-- **类型：** `boolean | LazyCompilationOptions`
-- **默认值：** 当 [`Target`](/config/target) 仅为 `'web'` 应用时 `{ entries: false, imports: true }`，其他情况 `false`.
+- **类型：**
 
 ```ts
 type LazyCompilationOptions =
@@ -54,13 +55,16 @@ type LazyCompilationOptions =
     };
 ```
 
-:::tip
-参考 [指南](/guide/features/lazy-compilation) 来快速上手。
-:::
+## 默认行为
+
+- **JavaScript API：** 默认关闭懒编译。启用 `lazyCompilation` 后，需要将 lazy compilation 中间件注册到开发服务器。参见[与自定义的服务器集成](/guide/features/lazy-compilation#与自定义的服务器集成)。
+- **Rspack CLI：** `rspack dev` 会自动注册中间件。当 [`target`](/config/target) 仅面向浏览器环境且未显式配置 `lazyCompilation` 时，还会默认使用 `{ entries: false, imports: true }`；其他情况下，未配置时保持关闭。
+
+## 编译范围
 
 如果你有二十个入口，当开启懒编译时，只有访问到的入口才会进行构建，或者如果项目中存在非常多的 `import()`，每一个 `import()` 所指向的模块都只有在被真正访问到时，才进行构建。
 
-如果设置为 `true`，则默认会对入口模块以及 `import()` 指向的模块进行懒编译。你可以通过配置对象形式，来决定是否只对入口或只对 `import()` 生效。`entries` 决定是否对入口生效，`import()` 决定是否对 `import()` 生效。
+如果设置为 `true`，则默认会对入口模块以及 `import()` 指向的模块进行懒编译。你可以通过配置对象形式，来决定是否只对入口或只对 `import()` 生效。`entries` 决定是否对入口生效，`imports` 决定是否对 `import()` 生效。
 
 ```js title="rspack.config.mjs"
 const isDev = process.env.NODE_ENV === 'development';
@@ -72,6 +76,8 @@ export default {
 ```
 
 除此以外你还可以配置 `test` 来更细粒度控制对哪些模块进行懒编译。`test` 可以是一个正则表达式，只对该正则匹配到的模块进行懒编译，`test` 也可以是一个函数，函数的输入是 `Module` 类型，返回 `boolean` 类型，表示是否命中懒编译逻辑。
+
+## 选项
 
 ### lazyCompilation.client
 
@@ -121,30 +127,4 @@ export default {
     prefix: '/custom-lazy-endpoint-',
   },
 };
-```
-
-### 排除 HMR client
-
-如果你未使用 Rspack 的 dev server，而是使用自己的 server 作为开发服务器，一般会在 entry 配置中加入另外的 client 代码来开启 HMR 等能力，那么最好通过配置 test 来将该 client 模块从懒编译模块中排除出去。
-
-如果不排除掉，并且开启 entry 的懒编译，该 client 在第一次访问页面时不会被编译，因此需要一次额外的刷新才能让其真正生效。
-
-```js title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
-
-const options = {
-  lazyCompilation: {
-    test(module) {
-      const isMyClient = module.nameForCondition().endsWith('dev-client.js');
-      // 让 dev-client.js 不被懒编译
-      return !isMyClient;
-    },
-  },
-};
-const compiler = rspack(options);
-
-new compiler.rspack.EntryPlugin(compiler.context, 'dev-client.js', {
-  // name: undefined 代表这是全局 entry，会插入到每一个 entry 前
-  name: undefined,
-}).apply(compiler);
 ```

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -59,6 +59,16 @@ export default defineConfig({
 
 使用 Rsbuild 的 [dev.lazyCompilation](https://rsbuild.rs/zh/config/dev/lazy-compilation) 选项开启。
 
+## 原理
+
+懒编译的原理是将未执行的入口和 Module 的内容改写，当该 Module 在运行时被执行时，会发送请求到开发服务器，随后开发服务器会触发对应 Compiler 的重编译以及模块热更新。
+
+如下图，左边是首次编译的 Home 入口 Module 内容，右图是触发重编译后对应 Module 的内容。
+
+![image](https://assets.rspack.rs/rspack/assets/lazy-proxy-module.png)
+
+只有当执行对应的入口和模块时，Rspack 才会编译对应的入口和 Module 以及他们的所有依赖。
+
 ## 筛选部分模块
 
 除了 `entries` 和 `imports` 两个选项以外，你也可以使用 `test` 选项来筛选部分模块开启懒编译。
@@ -84,21 +94,35 @@ export default defineConfig({
 });
 ```
 
-## 原理
+### 排除 HMR client
 
-懒编译的原理是将未执行的入口和 Module 的内容改写，当该 Module 在运行时被执行时，会发送请求到开发服务器，随后开发服务器会触发对应 Compiler 的重编译以及模块热更新。
+如果你未使用 Rspack 的 dev server，而是使用自己的 server 作为开发服务器，一般会在 entry 配置中加入另外的 client 代码来开启 HMR 等能力，那么最好通过配置 test 来将该 client 模块从懒编译模块中排除出去。
 
-如下图，左边是首次编译的 Home 入口 Module 内容，右图是触发重编译后对应 Module 的内容。
+如果不排除掉，并且开启 entry 的懒编译，该 client 在第一次访问页面时不会被编译，因此需要一次额外的刷新才能让其真正生效。
 
-![image](https://assets.rspack.rs/rspack/assets/lazy-proxy-module.png)
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 
-只有当执行对应的入口和模块时，Rspack 才会编译对应的入口和 Module 以及他们的所有依赖。
+const options = {
+  lazyCompilation: {
+    test(module) {
+      const isMyClient = module.nameForCondition().endsWith('dev-client.js');
+      // 让 dev-client.js 不被懒编译
+      return !isMyClient;
+    },
+  },
+};
+const compiler = rspack(options);
+
+new compiler.rspack.EntryPlugin(compiler.context, 'dev-client.js', {
+  // name: undefined 代表这是全局 entry，会插入到每一个 entry 前
+  name: undefined,
+}).apply(compiler);
+```
 
 ## 与自定义的服务器集成
 
-当你使用 Rspack CLI 时，`lazyCompilation` 选项实际上会由 `@rspack/cli` 消费，并向开发服务器中添加一个 [Express 风格的中间件](https://expressjs.com/en/guide/using-middleware.html)，来处理客户端发起的 lazy compilation 请求。
-
-如果你使用自己的开发服务器，你需要手动将 `rspack.lazyCompilationMiddleware` 集成到你的开发服务器中：
+如果你没有使用 Rspack CLI 或 Rsbuild，并且使用自己的开发服务器，你需要手动将 `rspack.lazyCompilationMiddleware` 集成到你的开发服务器中：
 
 ```js title="start.mjs"
 import { rspack } from '@rspack/core';


### PR DESCRIPTION
## Summary

This PR clarifies the default lazy compilation behavior for the JavaScript API and `rspack dev`.

It reorganizes the configuration reference and moves conceptual guidance about HMR client exclusion and custom server middleware into the guide. The English and Chinese documentation remain aligned.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).