### PR TITLE
docs: expand lazy compilation option reference

### DIFF
--- a/website/docs/en/config/lazy-compilation.mdx
+++ b/website/docs/en/config/lazy-compilation.mdx
@@ -27,12 +27,10 @@ type LazyCompilationOptions =
   | {
       /**
        * Enable lazy compilation for entries.
-       * @default true
        */
       entries?: boolean;
       /**
        * Enable lazy compilation for dynamic imports.
-       * @default true
        */
       imports?: boolean;
       /**
@@ -63,29 +61,88 @@ type LazyCompilationOptions =
 
 ## Compilation scope
 
-If you have twenty entry points, only the accessed entry points will be built when you enable lazyCompilation. Or if there are many `import()` statements in the project, each module pointed to by `import()` will only be built when it is actually accessed.
+Lazy compilation can be applied to two groups of modules: entry modules and modules loaded through dynamic `import()`. Once enabled, Rspack defers building these modules until they are actually accessed.
 
-If set to `true`, lazy compilation will be applied by default to both entry modules and modules pointed to by `import()`. You can decide whether it applies only to entries or only to `import()` through a configuration object. The `entries` option determines whether it applies to entries, while the `imports` option determines whether it applies to `import()`.
+For example, if an application has twenty entries, Rspack builds only the entries that are accessed. The remaining entries are built when they are accessed. Modules loaded through dynamic `import()` follow the same behavior.
+
+Setting `lazyCompilation` to `true` enables lazy compilation for both groups:
 
 ```js title="rspack.config.mjs"
-import path from 'node:path';
+export default {
+  lazyCompilation: true,
+};
+```
 
+This is equivalent to:
+
+```js title="rspack.config.mjs"
 export default {
   lazyCompilation: {
-    client: path.resolve('custom-client.js'),
+    entries: true,
+    imports: true,
   },
 };
 ```
 
-In addition, you can also configure a `test` parameter for more fine-grained control over which modules are lazily compiled. The `test` parameter can be a regular expression that matches only those modules that should be lazily compiled. It can also be a function where the input is of type 'Module' and returns a boolean value indicating whether it meets the criteria for lazy compilation logic.
+To enable lazy compilation for only one group, use an object and configure [`entries`](#entries) and [`imports`](#imports) separately. `entries` controls entry modules, while `imports` controls modules loaded through dynamic `import()`.
+
+To narrow the scope further, use [`test`](#test) to filter modules. It accepts a regular expression or a function that receives a `Module` and returns a `boolean`.
 
 ## Options
 
-### lazyCompilation.client
+### entries
+
+- **Type:** `boolean`
+- **Default:** See [Default behavior](#default-behavior).
+
+Controls whether entry modules are lazily compiled. When set to `false`, entry modules are built during the initial compilation. This does not affect modules loaded through `import()`.
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    entries: false,
+  },
+};
+```
+
+### imports
+
+- **Type:** `boolean`
+- **Default:** See [Default behavior](#default-behavior).
+
+Controls whether modules loaded through dynamic `import()` are lazily compiled. When set to `false`, dynamically imported modules are built during the initial compilation. This does not affect entry modules.
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    imports: false,
+  },
+};
+```
+
+### test
+
+- **Type:** `RegExp | ((module: Module) => boolean)`
+- **Default:** `undefined`
+
+Further filters the entry and dynamically imported modules selected by `entries` and `imports`. A regular expression is tested against `module.nameForCondition()`, while a function receives the `Module` instance directly. A match or a return value of `true` enables lazy compilation for the module; otherwise, the module is built normally.
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    test: /src/,
+  },
+};
+```
+
+See [Filtering modules](/guide/features/lazy-compilation#filtering-modules) for configuration examples.
+
+### client
 
 - **Type:** `string`
+- **Default:** Built-in web or Node.js client, selected automatically
 
-The path to a custom runtime code that overrides the default lazy compilation client. If you want to customize the logic of the client runtime, you can specify it through this option.
+The path to custom runtime code that overrides the default lazy compilation client. By default, Rspack uses the built-in Node.js client when [`externalsPresets.node`](/config/externals#externalspresetsnode) is enabled, and the built-in web client otherwise.
 
 - [Client for web](https://github.com/web-infra-dev/rspack/blob/699229b9e7c33b7db7968c2f803f750e0367fe8a/packages/rspack/hot/lazy-compilation-web.js)
 - [Client for node](https://github.com/web-infra-dev/rspack/blob/699229b9e7c33b7db7968c2f803f750e0367fe8a/packages/rspack/hot/lazy-compilation-node.js)
@@ -100,11 +157,12 @@ export default {
 };
 ```
 
-### lazyCompilation.serverUrl
+### serverUrl
 
 - **Type:** `string`
+- **Default:** `''`
 
-Tells the client the server path that needs to be requested. By default it is empty, in a browser environment it will find the server path where the page is located, but in a node environment you need to explicitly specify a specific path.
+Sets the base URL requested by the lazy compilation client. Rspack appends [`lazyCompilation.prefix`](#prefix) to this value. When omitted, the web client sends requests to the current origin; in a Node.js environment, specify the development server URL explicitly.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -114,7 +172,7 @@ export default {
 };
 ```
 
-### lazyCompilation.prefix
+### prefix
 
 - **Type:** `string`
 - **Default:** `'/_rspack/lazy/trigger'`

--- a/website/docs/en/config/lazy-compilation.mdx
+++ b/website/docs/en/config/lazy-compilation.mdx
@@ -58,7 +58,6 @@ type LazyCompilationOptions =
 
 - **JavaScript API:** Lazy compilation is disabled by default. After enabling `lazyCompilation`, register the lazy compilation middleware with your development server. See [Integrating with custom server](/guide/features/lazy-compilation#integrating-with-custom-server).
 - **Rspack CLI:** `rspack dev` registers the middleware automatically. When [`target`](/config/target) is limited to a browser environment and `lazyCompilation` is not explicitly configured, it also uses `{ entries: false, imports: true }`. When the option is omitted in other cases, lazy compilation remains disabled.
-- **Configuration object:** When `lazyCompilation` is enabled with an object, omitted `entries` and `imports` each default to `true`.
 
 ## Compilation scope
 
@@ -94,9 +93,11 @@ To narrow the scope further, use [`test`](#test) to filter modules. It accepts a
 ### entries
 
 - **Type:** `boolean`
-- **Default:** See [Default behavior](#default-behavior).
+- **Default:** When `entries` is omitted from the configuration object, it defaults to `true`.
 
-Controls whether entry modules are lazily compiled. When omitted from the object, this option defaults to `true`. When set to `false`, entry modules are built during the initial compilation. Modules loaded through `import()` remain lazily compiled unless `imports` is also set to `false`.
+Controls whether entry modules are lazily compiled.
+
+When set to `false`, entry modules are built during the initial compilation.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -109,9 +110,11 @@ export default {
 ### imports
 
 - **Type:** `boolean`
-- **Default:** See [Default behavior](#default-behavior).
+- **Default:** When `imports` is omitted from the configuration object, it defaults to `true`.
 
-Controls whether modules loaded through dynamic `import()` are lazily compiled. When omitted from the object, this option defaults to `true`. When set to `false`, dynamically imported modules are built during the initial compilation. Entry modules remain lazily compiled unless `entries` is also set to `false`.
+Controls whether modules loaded through dynamic `import()` are lazily compiled.
+
+When set to `false`, dynamically imported modules are built during the initial compilation.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/lazy-compilation.mdx
+++ b/website/docs/en/config/lazy-compilation.mdx
@@ -58,6 +58,7 @@ type LazyCompilationOptions =
 
 - **JavaScript API:** Lazy compilation is disabled by default. After enabling `lazyCompilation`, register the lazy compilation middleware with your development server. See [Integrating with custom server](/guide/features/lazy-compilation#integrating-with-custom-server).
 - **Rspack CLI:** `rspack dev` registers the middleware automatically. When [`target`](/config/target) is limited to a browser environment and `lazyCompilation` is not explicitly configured, it also uses `{ entries: false, imports: true }`. When the option is omitted in other cases, lazy compilation remains disabled.
+- **Configuration object:** When `lazyCompilation` is enabled with an object, omitted `entries` and `imports` each default to `true`.
 
 ## Compilation scope
 
@@ -95,7 +96,7 @@ To narrow the scope further, use [`test`](#test) to filter modules. It accepts a
 - **Type:** `boolean`
 - **Default:** See [Default behavior](#default-behavior).
 
-Controls whether entry modules are lazily compiled. When set to `false`, entry modules are built during the initial compilation. This does not affect modules loaded through `import()`.
+Controls whether entry modules are lazily compiled. When omitted from the object, this option defaults to `true`. When set to `false`, entry modules are built during the initial compilation. Modules loaded through `import()` remain lazily compiled unless `imports` is also set to `false`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -110,7 +111,7 @@ export default {
 - **Type:** `boolean`
 - **Default:** See [Default behavior](#default-behavior).
 
-Controls whether modules loaded through dynamic `import()` are lazily compiled. When set to `false`, dynamically imported modules are built during the initial compilation. This does not affect entry modules.
+Controls whether modules loaded through dynamic `import()` are lazily compiled. When omitted from the object, this option defaults to `true`. When set to `false`, dynamically imported modules are built during the initial compilation. Entry modules remain lazily compiled unless `entries` is also set to `false`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -125,7 +126,7 @@ export default {
 - **Type:** `RegExp | ((module: Module) => boolean)`
 - **Default:** `undefined`
 
-Further filters the entry and dynamically imported modules selected by `entries` and `imports`. A regular expression is tested against `module.nameForCondition()`, while a function receives the `Module` instance directly. A match or a return value of `true` enables lazy compilation for the module; otherwise, the module is built normally.
+Further filters the entry and dynamically imported modules selected by `entries` and `imports`. When neither option is specified, both default to `true`, so `test` filters both groups. A regular expression is tested against `module.nameForCondition()`, while a function receives the `Module` instance directly. A match or a return value of `true` enables lazy compilation for the module; otherwise, the module is built normally.
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/guide/features/lazy-compilation.mdx
+++ b/website/docs/en/guide/features/lazy-compilation.mdx
@@ -69,7 +69,7 @@ Only when corresponding entries and modules are executed will Rspack compile the
 
 ## Filtering modules
 
-In addition to two options `entries` and `imports`, you can also use a `test` option to filter out certain modules for lazy compilation.
+In addition to the [`entries`](/config/lazy-compilation#entries) and [`imports`](/config/lazy-compilation#imports) options, you can use [`test`](/config/lazy-compilation#test) to filter which modules are lazily compiled.
 
 For example, if you want to disable lazy compilation for the `About` entry point, you can refer to the following configuration:
 
@@ -152,7 +152,7 @@ server.start();
 
 ## Customizing lazy compilation endpoint
 
-By default, the lazy compilation middleware uses the `/_rspack/lazy/trigger` prefix for handling requests. If you need to customize this prefix, you can use the `prefix` option:
+By default, the lazy compilation middleware uses the `/_rspack/lazy/trigger` prefix for handling requests. If you need to customize this prefix, you can use the [`prefix`](/config/lazy-compilation#prefix) option:
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';

--- a/website/docs/zh/config/lazy-compilation.mdx
+++ b/website/docs/zh/config/lazy-compilation.mdx
@@ -57,6 +57,7 @@ type LazyCompilationOptions =
 
 - **JavaScript API：** 默认关闭懒编译。启用 `lazyCompilation` 后，需要将 lazy compilation 中间件注册到开发服务器。参见[与自定义的服务器集成](/guide/features/lazy-compilation#integrating-with-custom-server)。
 - **Rspack CLI：** `rspack dev` 会自动注册中间件。当 [`target`](/config/target) 仅面向浏览器环境且未显式配置 `lazyCompilation` 时，还会默认使用 `{ entries: false, imports: true }`；其他情况下，未配置时保持关闭。
+- **配置对象：** 使用对象形式启用 `lazyCompilation` 时，未设置的 `entries` 和 `imports` 均默认为 `true`。
 
 ## 编译范围
 
@@ -94,7 +95,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** 参考 [默认行为](#默认行为)
 
-控制是否对入口模块启用懒编译。设为 `false` 时，入口模块会在首次编译中完成构建，不影响通过 `import()` 加载的模块。
+控制是否对入口模块启用懒编译。在对象中省略 `entries` 时，该选项默认为 `true`。设为 `false` 时，入口模块会在首次编译中完成构建；除非同时将 `imports` 设为 `false`，否则通过 `import()` 加载的模块仍会进行懒编译。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -109,7 +110,7 @@ export default {
 - **类型：** `boolean`
 - **默认值：** 参考 [默认行为](#默认行为)
 
-控制是否对 `import()` 动态导入的模块启用懒编译。设为 `false` 时，动态导入的模块会在首次编译中完成构建，不影响入口模块。
+控制是否对 `import()` 动态导入的模块启用懒编译。在对象中省略 `imports` 时，该选项默认为 `true`。设为 `false` 时，动态导入的模块会在首次编译中完成构建；除非同时将 `entries` 设为 `false`，否则入口模块仍会进行懒编译。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -124,7 +125,7 @@ export default {
 - **类型：** `RegExp | ((module: Module) => boolean)`
 - **默认值：** `undefined`
 
-在 `entries` 和 `imports` 选出的入口模块及动态导入模块上进一步筛选。正则表达式会匹配 `module.nameForCondition()`，函数则直接接收 `Module` 实例。匹配成功或返回 `true` 时，该模块会进行懒编译；否则会正常构建。
+在 `entries` 和 `imports` 选出的入口模块及动态导入模块上进一步筛选。两者均未设置时，都会默认为 `true`，因此 `test` 会同时筛选这两类模块。正则表达式会匹配 `module.nameForCondition()`，函数则直接接收 `Module` 实例。匹配成功或返回 `true` 时，该模块会进行懒编译；否则会正常构建。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/lazy-compilation.mdx
+++ b/website/docs/zh/config/lazy-compilation.mdx
@@ -27,12 +27,10 @@ type LazyCompilationOptions =
   | {
       /**
        * 为 entries 启用 lazy compilation
-       * @default true
        */
       entries?: boolean;
       /**
        * 为 dynamic imports 启用 lazy compilation
-       * @default true
        */
       imports?: boolean;
       /**
@@ -57,33 +55,93 @@ type LazyCompilationOptions =
 
 ## 默认行为
 
-- **JavaScript API：** 默认关闭懒编译。启用 `lazyCompilation` 后，需要将 lazy compilation 中间件注册到开发服务器。参见[与自定义的服务器集成](/guide/features/lazy-compilation#与自定义的服务器集成)。
+- **JavaScript API：** 默认关闭懒编译。启用 `lazyCompilation` 后，需要将 lazy compilation 中间件注册到开发服务器。参见[与自定义的服务器集成](/guide/features/lazy-compilation#integrating-with-custom-server)。
 - **Rspack CLI：** `rspack dev` 会自动注册中间件。当 [`target`](/config/target) 仅面向浏览器环境且未显式配置 `lazyCompilation` 时，还会默认使用 `{ entries: false, imports: true }`；其他情况下，未配置时保持关闭。
 
 ## 编译范围
 
-如果你有二十个入口，当开启懒编译时，只有访问到的入口才会进行构建，或者如果项目中存在非常多的 `import()`，每一个 `import()` 所指向的模块都只有在被真正访问到时，才进行构建。
+懒编译可以作用于两类模块：入口模块，以及通过 `import()` 动态导入的模块。启用后，Rspack 会将这些模块的构建推迟到它们被实际访问时。
 
-如果设置为 `true`，则默认会对入口模块以及 `import()` 指向的模块进行懒编译。你可以通过配置对象形式，来决定是否只对入口或只对 `import()` 生效。`entries` 决定是否对入口生效，`imports` 决定是否对 `import()` 生效。
+例如，如果应用包含二十个入口，Rspack 只会构建实际访问到的入口，其余入口会等到被访问时再构建。通过 `import()` 动态导入的模块也是如此。
+
+将 `lazyCompilation` 设置为 `true`，会同时对这两类模块开启懒编译：
 
 ```js title="rspack.config.mjs"
-const isDev = process.env.NODE_ENV === 'development';
-
 export default {
-  // 仅在 dev 模式下开启
-  lazyCompilation: isDev,
+  lazyCompilation: true,
 };
 ```
 
-除此以外你还可以配置 `test` 来更细粒度控制对哪些模块进行懒编译。`test` 可以是一个正则表达式，只对该正则匹配到的模块进行懒编译，`test` 也可以是一个函数，函数的输入是 `Module` 类型，返回 `boolean` 类型，表示是否命中懒编译逻辑。
+这等价于：
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    entries: true,
+    imports: true,
+  },
+};
+```
+
+如果只想对其中一类模块开启懒编译，可以使用配置对象分别设置 [`entries`](#entries) 和 [`imports`](#imports)。`entries` 控制入口模块，`imports` 控制通过 `import()` 动态导入的模块。
+
+如果还需要进一步缩小懒编译范围，可以使用 [`test`](#test) 筛选模块。`test` 支持正则表达式，也支持接收 `Module` 并返回 `boolean` 的函数。
 
 ## 选项
 
-### lazyCompilation.client
+### entries
+
+- **类型：** `boolean`
+- **默认值：** 参考 [默认行为](#默认行为)
+
+控制是否对入口模块启用懒编译。设为 `false` 时，入口模块会在首次编译中完成构建，不影响通过 `import()` 加载的模块。
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    entries: false,
+  },
+};
+```
+
+### imports
+
+- **类型：** `boolean`
+- **默认值：** 参考 [默认行为](#默认行为)
+
+控制是否对 `import()` 动态导入的模块启用懒编译。设为 `false` 时，动态导入的模块会在首次编译中完成构建，不影响入口模块。
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    imports: false,
+  },
+};
+```
+
+### test
+
+- **类型：** `RegExp | ((module: Module) => boolean)`
+- **默认值：** `undefined`
+
+在 `entries` 和 `imports` 选出的入口模块及动态导入模块上进一步筛选。正则表达式会匹配 `module.nameForCondition()`，函数则直接接收 `Module` 实例。匹配成功或返回 `true` 时，该模块会进行懒编译；否则会正常构建。
+
+```js title="rspack.config.mjs"
+export default {
+  lazyCompilation: {
+    test: /src/,
+  },
+};
+```
+
+配置示例参见[筛选部分模块](/guide/features/lazy-compilation#filtering-modules)。
+
+### client
 
 - **类型：** `string`
+- **默认值：** 自动选择内置的 Web 或 Node.js 客户端
 
-用于覆盖默认 lazy compilation 的客户端运行时，如果你想要自定义客户端运行时的逻辑，可以通过该配置项来指定。
+用于指定自定义运行时代码路径，以覆盖默认的懒编译客户端。默认情况下，启用 [`externalsPresets.node`](/config/externals#externalspresetsnode) 时使用内置的 Node.js 客户端，否则使用内置的 Web 客户端。
 
 你可以参考默认实现：
 
@@ -100,11 +158,12 @@ export default {
 };
 ```
 
-### lazyCompilation.serverUrl
+### serverUrl
 
 - **类型：** `string`
+- **默认值：** `''`
 
-告诉客户端需要请求的服务端路径，默认为空，在浏览器环境会找到页面所在的服务端路径，但在 Node 环境下需要显式指定具体的路径。
+设置懒编译客户端请求的服务端基础 URL，Rspack 会在该值后拼接 [`lazyCompilation.prefix`](#prefix)。未设置时，Web 客户端会向当前页面所在的服务端发送请求；在 Node.js 环境中，需要显式指定开发服务器 URL。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -114,7 +173,7 @@ export default {
 };
 ```
 
-### lazyCompilation.prefix
+### prefix
 
 - **类型：** `string`
 - **默认值：** `'/_rspack/lazy/trigger'`

--- a/website/docs/zh/config/lazy-compilation.mdx
+++ b/website/docs/zh/config/lazy-compilation.mdx
@@ -57,7 +57,6 @@ type LazyCompilationOptions =
 
 - **JavaScript API：** 默认关闭懒编译。启用 `lazyCompilation` 后，需要将 lazy compilation 中间件注册到开发服务器。参见[与自定义的服务器集成](/guide/features/lazy-compilation#integrating-with-custom-server)。
 - **Rspack CLI：** `rspack dev` 会自动注册中间件。当 [`target`](/config/target) 仅面向浏览器环境且未显式配置 `lazyCompilation` 时，还会默认使用 `{ entries: false, imports: true }`；其他情况下，未配置时保持关闭。
-- **配置对象：** 使用对象形式启用 `lazyCompilation` 时，未设置的 `entries` 和 `imports` 均默认为 `true`。
 
 ## 编译范围
 
@@ -93,9 +92,11 @@ export default {
 ### entries
 
 - **类型：** `boolean`
-- **默认值：** 参考 [默认行为](#默认行为)
+- **默认值：** 在对象中省略 `entries` 时，该选项默认为 `true`
 
-控制是否对入口模块启用懒编译。在对象中省略 `entries` 时，该选项默认为 `true`。设为 `false` 时，入口模块会在首次编译中完成构建；除非同时将 `imports` 设为 `false`，否则通过 `import()` 加载的模块仍会进行懒编译。
+控制是否对入口模块启用懒编译。
+
+设为 `false` 时，入口模块会在首次编译中完成构建。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -108,9 +109,11 @@ export default {
 ### imports
 
 - **类型：** `boolean`
-- **默认值：** 参考 [默认行为](#默认行为)
+- **默认值：** 在对象中省略 `imports` 时，该选项默认为 `true`
 
-控制是否对 `import()` 动态导入的模块启用懒编译。在对象中省略 `imports` 时，该选项默认为 `true`。设为 `false` 时，动态导入的模块会在首次编译中完成构建；除非同时将 `entries` 设为 `false`，否则入口模块仍会进行懒编译。
+控制是否对 `import()` 动态导入的模块启用懒编译。
+
+设为 `false` 时，动态导入的模块会在首次编译中完成构建。
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/guide/features/lazy-compilation.mdx
+++ b/website/docs/zh/guide/features/lazy-compilation.mdx
@@ -2,7 +2,7 @@
 description: 'Lazy compilation 是一个提升开发阶段启动性能的有效手段，它采用按需编译模块的方式，而非在启动时编译全部模块。'
 ---
 
-# 按需编译
+# 按需编译 \{#lazy-compilation}
 
 Lazy compilation 是一个提升开发阶段启动性能的有效手段，它采用按需编译模块的方式，而非在启动时编译全部模块。这意味着开发者在启动 dev server 时，可以很快看到应用运行，并分次构建所需的模块。
 
@@ -12,7 +12,7 @@ Lazy compilation 是一个提升开发阶段启动性能的有效手段，它采
 Lazy compilation 仅在开发阶段有效，对于生产构建不会产生影响。
 :::
 
-## 如何使用
+## 如何使用 \{#how-to-use}
 
 ### Rspack CLI
 
@@ -59,7 +59,7 @@ export default defineConfig({
 
 使用 Rsbuild 的 [dev.lazyCompilation](https://rsbuild.rs/zh/config/dev/lazy-compilation) 选项开启。
 
-## 原理
+## 原理 \{#under-the-hood}
 
 懒编译的原理是将未执行的入口和 Module 的内容改写，当该 Module 在运行时被执行时，会发送请求到开发服务器，随后开发服务器会触发对应 Compiler 的重编译以及模块热更新。
 
@@ -69,9 +69,9 @@ export default defineConfig({
 
 只有当执行对应的入口和模块时，Rspack 才会编译对应的入口和 Module 以及他们的所有依赖。
 
-## 筛选部分模块
+## 筛选部分模块 \{#filtering-modules}
 
-除了 `entries` 和 `imports` 两个选项以外，你也可以使用 `test` 选项来筛选部分模块开启懒编译。
+除了 [`entries`](/config/lazy-compilation#entries) 和 [`imports`](/config/lazy-compilation#imports) 选项以外，你也可以使用 [`test`](/config/lazy-compilation#test) 来筛选哪些模块开启懒编译。
 
 例如，如果你想要避免懒编译 `About` 入口，可以参考如下配置：
 
@@ -94,7 +94,7 @@ export default defineConfig({
 });
 ```
 
-### 排除 HMR client
+### 排除 HMR client \{#exclude-hmr-client}
 
 如果你未使用 Rspack 的 dev server，而是使用自己的 server 作为开发服务器，一般会在 entry 配置中加入另外的 client 代码来开启 HMR 等能力，那么最好通过配置 test 来将该 client 模块从懒编译模块中排除出去。
 
@@ -120,7 +120,7 @@ new compiler.rspack.EntryPlugin(compiler.context, 'dev-client.js', {
 }).apply(compiler);
 ```
 
-## 与自定义的服务器集成
+## 与自定义的服务器集成 \{#integrating-with-custom-server}
 
 如果你没有使用 Rspack CLI 或 Rsbuild，并且使用自己的开发服务器，你需要手动将 `rspack.lazyCompilationMiddleware` 集成到你的开发服务器中：
 
@@ -150,9 +150,9 @@ server.start();
 
 - `compiler`: 当前的 [Compiler](/api/javascript-api/compiler)，使用该 Compiler 对应的 `lazyCompilation` 配置。
 
-## 自定义懒编译端点
+## 自定义懒编译端点 \{#customizing-lazy-compilation-endpoint}
 
-默认情况下，懒编译中间件使用 `/_rspack/lazy/trigger` 前缀来处理请求。如果你需要自定义这个前缀，可以使用 `prefix` 选项：
+默认情况下，懒编译中间件使用 `/_rspack/lazy/trigger` 前缀来处理请求。如果你需要自定义这个前缀，可以使用 [`prefix`](/config/lazy-compilation#prefix) 选项：
 
 ```js title="rspack.config.mjs"
 import { defineConfig } from '@rspack/cli';

--- a/website/docs/zh/guide/migration/rspack_1.x.mdx
+++ b/website/docs/zh/guide/migration/rspack_1.x.mdx
@@ -586,7 +586,7 @@ export default {
 - `experiments.layers`：已被移除；Layer 功能现在已稳定并默认可用，但仍需要在 `module.rules` 中配置 `layer`。
 - `experiments.topLevelAwait`：已被移除；Top-level await 现在已稳定并在 ESM 模块中默认启用。
 - `experiments.lazyCompilation`：已移动到顶层的 [lazyCompilation](/config/lazy-compilation)。
-- `experiments.lazyCompilationMiddleware`：已移动到顶层的 [lazyCompilationMiddleware](/guide/features/lazy-compilation#与自定义的服务器集成)。
+- `experiments.lazyCompilationMiddleware`：已移动到顶层的 [lazyCompilationMiddleware](/guide/features/lazy-compilation#integrating-with-custom-server)。
 - `experiments.lazyBarrel`：已被移除，[Lazy barrel](/guide/optimization/lazy-barrel) 优化现在默认启用。
 - `experiments.typeReexportsPresence`：已被移除，可使用 [module.parser.javascript.typeReexportsPresence](/config/module-parser#javascripttypereexportspresence) 直接控制类型重导出时的行为。
 - `experiments.inlineConst`：已被移除，可使用 [optimization.inlineExports](/config/optimization#optimizationinlineexports) 控制常量内联优化。


### PR DESCRIPTION
## Summary

The lazy compilation configuration reference did not document every sub-option or clearly explain how compilation scope is selected.

This PR adds defaults, descriptions, and minimal examples for each option, clarifies how `true`, `entries`, `imports`, and `test` interact, and keeps the English and Chinese docs aligned.

## Related links

- Follow-up to https://github.com/web-infra-dev/rspack/pull/15295

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).