### PR TITLE
fix: include factory-created server actions in RSC metadata

### DIFF
--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -1560,7 +1560,7 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
       }
     }
 
-    if in_action_file && !self.config.is_react_server_layer {
+    if in_action_file {
       self.reference_ids_by_export_name.extend(
         self
           .server_reference_exports

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/20/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/20/output.js
@@ -1,4 +1,10 @@
+import { registerServerReference } from "react-server-dom-rspack/server";
 /** @type {[any]} */ const [foo] = [
     null
 ];
 export default foo;
+import { ensureServerActions } from "react-server-dom-rspack/server";
+ensureServerActions([
+    foo
+]);
+registerServerReference(foo, "7f629c080094d3e42e3f04da3fc764e18c5905c42019036be89980b7d901dc746d", null);

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/20/output.meta.txt
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/20/output.meta.txt
@@ -1,1 +1,6 @@
-None
+module_type: Server
+server_refs: []
+client_refs: []
+import_meta_rsc: false
+is_cjs: false
+action_ids: [7f629c080094d3e42e3f04da3fc764e18c5905c42019036be89980b7d901dc746d:default]

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/22/output.meta.txt
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/22/output.meta.txt
@@ -3,4 +3,4 @@ server_refs: []
 client_refs: []
 import_meta_rsc: false
 is_cjs: false
-action_ids: [7f629c080094d3e42e3f04da3fc764e18c5905c42019036be89980b7d901dc746d:default]
+action_ids: [7f629c080094d3e42e3f04da3fc764e18c5905c42019036be89980b7d901dc746d:default,7fa2596154c7aa07f03b5ef8eaef000c8894b51876f19ae00d947fa104c0d5857e:action]

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/31/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/31/output.js
@@ -1,3 +1,4 @@
+import { registerServerReference } from "react-server-dom-rspack/server";
 export const action = {
     async f (x) {
         ;
@@ -14,3 +15,10 @@ export const action2 = new class X {
         })();
     }
 }().f;
+import { ensureServerActions } from "react-server-dom-rspack/server";
+ensureServerActions([
+    action,
+    action2
+]);
+registerServerReference(action, "7fa2596154c7aa07f03b5ef8eaef000c8894b51876f19ae00d947fa104c0d5857e", null);
+registerServerReference(action2, "7fdeb5c9c3cddb80b9a5f7fa2f260fb2133ea392a753d1ce445f92e037e2a22e69", null);

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/31/output.meta.txt
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/31/output.meta.txt
@@ -1,1 +1,6 @@
-None
+module_type: Server
+server_refs: []
+client_refs: []
+import_meta_rsc: false
+is_cjs: false
+action_ids: [7fa2596154c7aa07f03b5ef8eaef000c8894b51876f19ae00d947fa104c0d5857e:action,7fdeb5c9c3cddb80b9a5f7fa2f260fb2133ea392a753d1ce445f92e037e2a22e69:action2]

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/input.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/input.js
@@ -1,0 +1,5 @@
+'use server'
+
+import { validator } from 'auth'
+
+export const action = validator(async () => {})

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/output.js
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/output.js
@@ -1,0 +1,8 @@
+import { registerServerReference } from "react-server-dom-rspack/server";
+import { validator } from 'auth';
+export const action = validator(async ()=>{});
+import { ensureServerActions } from "react-server-dom-rspack/server";
+ensureServerActions([
+    action
+]);
+registerServerReference(action, "7fa2596154c7aa07f03b5ef8eaef000c8894b51876f19ae00d947fa104c0d5857e", null);

--- a/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/output.meta.txt
+++ b/crates/rspack_loader_swc/src/rsc_transforms/tests/fixture/fixture/server-actions/server-graph/73/output.meta.txt
@@ -1,0 +1,6 @@
+module_type: Server
+server_refs: []
+client_refs: []
+import_meta_rsc: false
+is_cjs: false
+action_ids: [7fa2596154c7aa07f03b5ef8eaef000c8894b51876f19ae00d947fa104c0d5857e:action]


### PR DESCRIPTION
## Summary

A `use server` module can export a Server Function through an expression whose result cannot be classified statically, for example:

```js
'use server'

import { validator } from 'auth'

export const action = validator(async () => {})
```

The server-actions post-pass already discovers these exports, but it only copied their reference IDs into `reference_ids_by_export_name` when compiling the client layer. On the server layer this caused `RscMeta.action_ids` to omit post-pass-discovered actions. If a module contained only those actions, `has_action` also remained false, so the server-reference imports, runtime validation, and registration annotations were not emitted.

Populate the reference map for `use server` files in both runtime layers. The existing `ensureServerActions` check continues to reject values that do not evaluate to functions at runtime.

The fixture updates cover a named-only factory export, bound method exports, and the runtime-validation path for a value whose type cannot be established statically.

## Related links

No issue filed.

## Testing

- `cargo test -p rspack_loader_swc`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
