### PR TITLE
docs: clarify resolve alias behavior

### DIFF
--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -691,18 +691,34 @@ export type Output = {
 
 //#region Resolve
 /**
- * Path alias
+ * Redirect module requests to other paths.
+ *
  * @example
+ * A regular alias also matches subpath requests:
+ *
  * ```js
  * {
- * 	"@": path.resolve(__dirname, './src'),
- * 	"abc$": path.resolve(__dirname, './node_modules/abc/index.js'),
+ *   '@': path.resolve(import.meta.dirname, './src'),
  * }
- * // - require("@/a") will attempt to resolve <root>/src/a.
- * // - require("abc") will attempt to resolve <root>/src/abc.
- * // - require("abc/file.js") will not match, and it will attempt to resolve node_modules/abc/file.js.
  * ```
- * */
+ *
+ * `import '@/a'` will attempt to resolve `<root>/src/a`.
+ *
+ * @example
+ * Add `$` to the end of an alias key to match only the complete module request.
+ * The `$` is a special `resolve.alias` marker and is not part of the module request:
+ *
+ * ```js
+ * {
+ *   abc$: path.resolve(import.meta.dirname, './src/abc'),
+ * }
+ * ```
+ *
+ * - `import 'abc'` will attempt to resolve `<root>/src/abc`.
+ * - `import 'abc/file.js'` will not match the alias and will continue through normal module resolution, which typically attempts to resolve `node_modules/abc/file.js`.
+ *
+ * Without the `$`, an `abc` alias would also match subpath requests such as `import 'abc/file.js'`.
+ */
 export type ResolveAlias =
   | {
       [x: string]: string | false | (string | false)[];

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -22,32 +22,59 @@ type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
 
 - **Default:** `{}`
 
-Path alias, e.g.
+Use `resolve.alias` to redirect module requests to other paths:
 
+```js title="rspack.config.mjs"
+import path from 'node:path';
+
+export default {
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname, './src'),
+    },
+  },
+};
 ```
-{
-  "@": path.resolve(__dirname, './src'),
-  "abc$": path.resolve(__dirname, './node_modules/abc/index.js'),
-}
+
+With this configuration, `import '@/a'` will attempt to resolve `<root>/src/a`.
+
+### Exact matching
+
+Add `$` to the end of an alias key to match only the complete module request. The `$` is a special `resolve.alias` marker and is not part of the module request:
+
+```js title="rspack.config.mjs"
+import path from 'node:path';
+
+export default {
+  resolve: {
+    alias: {
+      abc$: path.resolve(import.meta.dirname, './src/abc'),
+    },
+  },
+};
 ```
 
-At this point:
+With this configuration:
 
-- `require("@/a")` will attempt to resolve `<root>/src/a`.
-- `require("abc")` will attempt to resolve `<root>/src/abc`.
-- `require("abc/file.js")` will not match, and it will attempt to resolve `node_modules/abc/file.js`.
+- `import 'abc'` will attempt to resolve `<root>/src/abc`.
+- `import 'abc/file.js'` will not match the alias and will continue through normal module resolution, which typically attempts to resolve `node_modules/abc/file.js`.
+
+Without the `$`, an `abc` alias would also match subpath requests such as `import 'abc/file.js'`.
 
 ### Impact on package resolution
 
-When you use `resolve.alias` to redirect a package import (for example, `import 'lib'`) to a specific directory inside a monorepo or within `node_modules`, the module resolution behavior changes:
+Using `resolve.alias` to redirect a package request such as `import 'lib'` to a file system path within a monorepo or `node_modules` changes how Rspack resolves that request:
 
-- **Default behavior**: If the import is a package name, Rspack performs the full package resolution process: it reads the package's `package.json` and determines the entry file and subpath mappings according to the [`exports`](https://nodejs.org/api/packages.html#exports) field.
-- **When aliased**: When an alias resolves to a file system path — for example, `./node_modules/lib` — Rspack no longer treats it as a package name and resolves it as a regular path. This bypasses the standard package resolution logic, causing fields such as `exports` in `package.json` to no longer take effect. This is the intended and standard behavior of Node.js.
+- **Without an alias**: `lib` is treated as a package request. Rspack reads the package's `package.json` and applies package resolution rules such as [`exports`](https://nodejs.org/api/packages.html#exports) to select an entry point or subpath.
+- **With an alias**: Rspack first replaces `lib` with the configured file system path. For example, after mapping `lib` to `./node_modules/lib`, Rspack resolves the replacement as a regular path, so the `exports` mappings for the package name `lib` no longer apply.
+
+This behavior follows the semantics of the `exports` field: it controls how package names and package subpaths are resolved, but does not apply to direct file system paths.
 
 ### Monorepo usage
 
-If you want packages within a monorepo to retain the same resolution behavior as regular npm packages, avoid using `alias` to point a package name directly to its source directory.
-The recommended approach is to use your package manager's workspace feature to symlink sub-packages into `node_modules`, so they can be resolved just like normal dependencies.
+If you want packages in a monorepo to resolve like regular npm dependencies, including support for `exports`, avoid using `alias` to map package names directly to their source directories.
+
+Instead, use your package manager's workspace feature to link the packages into `node_modules`, and continue importing them by package name. Rspack can then treat each request as a package request and apply the corresponding `package.json` resolution rules.
 
 ### Disable aliases
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -22,32 +22,59 @@ type ResolveAlias = false | Record<string, false | string | (false | string)[]>;
 
 - **默认值：** `{}`
 
-路径别名，例如：
+使用 `resolve.alias` 可以将模块请求重定向到其他路径：
 
-```ts
-{
-  "@": path.resolve(__dirname, './src'),
-  "abc$": path.resolve(__dirname, './src/abc')
-}
+```js title="rspack.config.mjs"
+import path from 'node:path';
+
+export default {
+  resolve: {
+    alias: {
+      '@': path.resolve(import.meta.dirname, './src'),
+    },
+  },
+};
 ```
 
-此时：
+使用上述配置时，`import '@/a'` 会尝试解析 `<root>/src/a`。
 
-- `require("@/a")` 会尝试解析 `<root>/src/a`。
-- `require("abc")` 会尝试解析 `<root>/src/abc`。
-- `require("abc/file.js")` 不会命中匹配规则，它会尝试去解析 `node_modules/abc/file.js`。
+### 精确匹配
+
+在别名键的末尾添加 `$`，可以让该别名只匹配完整的模块请求。`$` 是 `resolve.alias` 的特殊标记，不属于实际的模块请求：
+
+```js title="rspack.config.mjs"
+import path from 'node:path';
+
+export default {
+  resolve: {
+    alias: {
+      abc$: path.resolve(import.meta.dirname, './src/abc'),
+    },
+  },
+};
+```
+
+使用上述配置时：
+
+- `import 'abc'` 会尝试解析 `<root>/src/abc`。
+- `import 'abc/file.js'` 不会命中该别名，而是继续按照常规模块解析规则查找，通常会尝试解析 `node_modules/abc/file.js`。
+
+如果不添加 `$`，别名 `abc` 也会匹配 `import 'abc/file.js'` 这样的子路径请求。
 
 ### 对包解析的影响
 
-当你使用 `resolve.alias` 将包名导入（例如 `import 'lib'`）重定向到 monorepo 或 `node_modules` 中的具体目录时，模块的解析方式会发生变化：
+使用 `resolve.alias` 将 `import 'lib'` 这样的包请求重定向到 monorepo 或 `node_modules` 中的文件系统路径时，会改变 Rspack 解析该请求的方式：
 
-- **默认情况**：如果导入的是包名，Rspack 会执行完整的包解析流程：读取该包的 `package.json`，并根据 `[exports](https://nodejs.org/api/packages.html#exports)` 字段决定入口文件和子路径映射。
-- **重定向后**：当别名被替换成实际的文件系统路径，例如 `./node_modules/lib`，Rspack 不再将其视为包名，而是按普通路径进行解析。这会跳过包的默认解析逻辑，导致 `package.json` 中的 `exports` 等字段不再生效。这是 Node.js 的标准解析行为。
+- **未配置别名时**：`lib` 会被视为包请求。Rspack 会读取该包的 `package.json`，并按照 [`exports`](https://nodejs.org/api/packages.html#exports) 等包解析规则选择入口文件或子路径。
+- **配置别名后**：Rspack 会先将 `lib` 替换为别名指定的文件系统路径。例如，将 `lib` 映射到 `./node_modules/lib` 后，Rspack 会把替换结果作为普通路径继续解析，因此针对包名 `lib` 的 `exports` 映射不再生效。
+
+这种行为符合 `exports` 字段的语义：它用于控制包名及包子路径的解析，不适用于直接指定的文件系统路径。
 
 ### Monorepo 场景
 
-如果希望 monorepo 中的各个包依然保持和正常 npm 包一致的解析方式，不建议通过 `alias` 将包名直接指向源码目录。
-推荐的做法是使用包管理器的工作区功能，将子包符号链接到 `node_modules` 中，让它们像普通依赖一样被解析。
+如果希望 monorepo 中的包与普通 npm 依赖采用相同的解析方式，包括支持 `exports`，请避免使用 `alias` 将包名直接映射到源码目录。
+
+推荐使用包管理器的工作区功能将这些包链接到 `node_modules`，并继续通过包名导入。这样，Rspack 仍会将其视为包请求，并应用相应的 `package.json` 解析规则。
 
 ### 禁用别名
 


### PR DESCRIPTION
## Summary

Clarify how `resolve.alias` handles regular and exact matches, including the meaning of a trailing `$`.
Update the English and Chinese documentation and `ResolveAlias` type comments with runnable ESM examples, and explain how path aliases affect package `exports` resolution.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).