### PR TITLE
fix(cache): validate minimize persistent cache entries against asset identity

### DIFF
--- a/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
+++ b/crates/rspack_core/src/cache/persistent/occasion/minimize/mod.rs
@@ -14,8 +14,23 @@ use crate::RayonConsumer;
 
 pub const SCOPE: &str = "occasion_minimize";
 
+/// Identity of the asset that produced a cached minimize entry.
+///
+/// `MinimizeCacheKey` folds these values into a single `u64`, which is lossy:
+/// a key that has been swapped, truncated, or collided still parses into a
+/// well-formed key. Persisting the identity beside the value lets recovery
+/// reject an entry that does not belong to the asset that requested it.
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct EntryIdentity {
+  pub filename: String,
+  pub options_hash: u64,
+  pub is_module: Option<bool>,
+}
+
 #[cacheable]
 struct Entry {
+  pub identity: EntryIdentity,
   #[cacheable(with=AsPreset)]
   pub source: BoxSource,
   pub extracted_comments: Option<ExtractedCommentsEntry>,
@@ -49,7 +64,7 @@ impl MinimizeCacheKey {
 
 #[derive(Debug, Default)]
 pub struct MinimizePersistentCache {
-  entries: FxHashMap<MinimizeCacheKey, CachedMinimizeEntry>,
+  entries: FxHashMap<MinimizeCacheKey, (EntryIdentity, CachedMinimizeEntry)>,
   /// Keys of entries that were added during this build and need to be persisted.
   dirty_keys: Vec<MinimizeCacheKey>,
 }
@@ -71,13 +86,40 @@ pub struct CachedExtractedComments {
 }
 
 impl MinimizePersistentCache {
-  pub fn get(&self, key: MinimizeCacheKey) -> Option<&CachedMinimizeEntry> {
-    self.entries.get(&key)
+  /// Look up a cached minimize result.
+  ///
+  /// The stored identity is compared against the asset that is asking for it.
+  /// A mismatch means the key/value association in storage is not trustworthy,
+  /// so the entry is treated as a miss and the asset is minimized again.
+  pub fn get(
+    &self,
+    key: MinimizeCacheKey,
+    filename: &str,
+    options_hash: u64,
+    is_module: Option<bool>,
+  ) -> Option<&CachedMinimizeEntry> {
+    let (identity, entry) = self.entries.get(&key)?;
+    if identity.filename != filename
+      || identity.options_hash != options_hash
+      || identity.is_module != is_module
+    {
+      tracing::warn!(
+        "minimize persistent cache entry does not belong to {}; treating as a miss",
+        filename
+      );
+      return None;
+    }
+    Some(entry)
   }
 
-  pub fn insert(&mut self, key: MinimizeCacheKey, entry: CachedMinimizeEntry) {
+  pub fn insert(
+    &mut self,
+    key: MinimizeCacheKey,
+    identity: EntryIdentity,
+    entry: CachedMinimizeEntry,
+  ) {
     self.dirty_keys.push(key);
-    self.entries.insert(key, entry);
+    self.entries.insert(key, (identity, entry));
   }
 }
 
@@ -111,8 +153,9 @@ impl Occasion for MinimizeOccasion {
       .dirty_keys
       .par_iter()
       .filter_map(|key| {
-        let entry = cache_item.entries.get(key)?;
+        let (identity, entry) = cache_item.entries.get(key)?;
         let storage_entry = Entry {
+          identity: identity.clone(),
           source: entry.source.clone(),
           extracted_comments: entry
             .extracted_comments
@@ -155,13 +198,16 @@ impl Occasion for MinimizeOccasion {
         Ok(entry) => {
           entries.insert(
             key,
-            CachedMinimizeEntry {
-              source: entry.source,
-              extracted_comments: entry.extracted_comments.map(|ec| CachedExtractedComments {
-                source: ec.source,
-                comments_file_name: ec.comments_file_name,
-              }),
-            },
+            (
+              entry.identity,
+              CachedMinimizeEntry {
+                source: entry.source,
+                extracted_comments: entry.extracted_comments.map(|ec| CachedExtractedComments {
+                  source: ec.source,
+                  comments_file_name: ec.comments_file_name,
+                }),
+              },
+            ),
           );
         }
         Err(err) => {
@@ -178,5 +224,96 @@ impl Occasion for MinimizeOccasion {
       entries,
       dirty_keys: Vec::new(),
     })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_sources::{RawStringSource, SourceExt};
+
+  use super::*;
+  use crate::cache::persistent::storage::MemoryStorage;
+
+  const OPTIONS_HASH: u64 = 7;
+
+  fn entry(filename: &str, body: &str) -> Entry {
+    Entry {
+      identity: EntryIdentity {
+        filename: filename.to_string(),
+        options_hash: OPTIONS_HASH,
+        is_module: Some(false),
+      },
+      source: RawStringSource::from(body.to_string()).boxed(),
+      extracted_comments: None,
+    }
+  }
+
+  /// Storage verifies pack integrity, not the key/value association inside a
+  /// pack. A recovered entry whose identity does not match the asset asking
+  /// for it must be discarded rather than returned as that asset's output.
+  #[tokio::test]
+  async fn recovery_should_reject_cross_wired_entries() -> Result<()> {
+    let codec = Arc::new(CacheCodec::new(None));
+    let occasion = MinimizeOccasion::new(codec.clone());
+    let mut storage = MemoryStorage::default();
+
+    let key_a = MinimizeCacheKey::new(1);
+    let key_b = MinimizeCacheKey::new(2);
+
+    // Swap the two keys, as a truncated write or a partially restored cache can.
+    storage.set(SCOPE, key_b.to_bytes(), codec.encode(&entry("a.js", "A"))?);
+    storage.set(SCOPE, key_a.to_bytes(), codec.encode(&entry("b.js", "B"))?);
+
+    let cache = occasion.recovery(&storage).await?;
+    assert!(
+      cache
+        .get(key_a, "a.js", OPTIONS_HASH, Some(false))
+        .is_none()
+    );
+    assert!(
+      cache
+        .get(key_b, "b.js", OPTIONS_HASH, Some(false))
+        .is_none()
+    );
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn recovery_should_keep_matching_entries() -> Result<()> {
+    let codec = Arc::new(CacheCodec::new(None));
+    let occasion = MinimizeOccasion::new(codec.clone());
+    let mut storage = MemoryStorage::default();
+
+    let key_a = MinimizeCacheKey::new(1);
+    storage.set(SCOPE, key_a.to_bytes(), codec.encode(&entry("a.js", "A"))?);
+
+    let cache = occasion.recovery(&storage).await?;
+    let cached = cache
+      .get(key_a, "a.js", OPTIONS_HASH, Some(false))
+      .expect("matching entry should be a cache hit");
+    assert_eq!(cached.source.source().into_string_lossy(), "A");
+
+    Ok(())
+  }
+
+  #[tokio::test]
+  async fn recovery_should_reject_entries_with_stale_options() -> Result<()> {
+    let codec = Arc::new(CacheCodec::new(None));
+    let occasion = MinimizeOccasion::new(codec.clone());
+    let mut storage = MemoryStorage::default();
+
+    let key_a = MinimizeCacheKey::new(1);
+    storage.set(SCOPE, key_a.to_bytes(), codec.encode(&entry("a.js", "A"))?);
+
+    let cache = occasion.recovery(&storage).await?;
+    assert!(
+      cache
+        .get(key_a, "a.js", OPTIONS_HASH + 1, Some(false))
+        .is_none()
+    );
+    assert!(cache.get(key_a, "a.js", OPTIONS_HASH, Some(true)).is_none());
+
+    Ok(())
   }
 }

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -13,7 +13,7 @@ use rspack_core::{
   AssetInfo, CacheOptions, CacheValue, ChunkUkey, Compilation, CompilationAsset, CompilationParams,
   CompilationProcessAssets, CompilerCompilation, Etag, Logger, Plugin,
   cache::persistent::occasion::minimize::{
-    CachedExtractedComments, CachedMinimizeEntry, MinimizeCacheKey,
+    CachedExtractedComments, CachedMinimizeEntry, EntryIdentity, MinimizeCacheKey,
   },
   diagnostics::MinifyError,
   rspack_sources::{
@@ -230,7 +230,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
     && !matches!(&compilation.options.cache, CacheOptions::Disabled))
   .then(|| compilation.get_cache(PLUGIN_NAME));
   let minimize_persistent_cache = compilation.minimize_persistent_cache.take();
-  let legacy_cache_entries: Mutex<Vec<(MinimizeCacheKey, CachedMinimizeEntry)>> =
+  let legacy_cache_entries: Mutex<Vec<(MinimizeCacheKey, EntryIdentity, CachedMinimizeEntry)>> =
     Mutex::new(Vec::new());
   let logger = compilation.get_logger(PLUGIN_NAME);
   let minimize_cache_counter = (new_cache.is_some() || minimize_persistent_cache.is_some())
@@ -295,7 +295,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             is_module,
           ));
           cache_key = Some(key);
-          cache.get(key)
+          cache.get(key, filename, self.options_hash, is_module)
         } else {
           None
         };
@@ -528,7 +528,15 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             legacy_cache_entries
               .lock()
               .expect("legacy_cache_entries lock failed")
-              .push((cache_key, entry));
+              .push((
+                cache_key,
+                EntryIdentity {
+                  filename: filename.to_string(),
+                  options_hash: self.options_hash,
+                  is_module,
+                },
+                entry,
+              ));
           }
         }
 
@@ -540,11 +548,11 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   })?;
 
   if let Some(mut cache) = minimize_persistent_cache {
-    for (key, entry) in legacy_cache_entries
+    for (key, identity, entry) in legacy_cache_entries
       .into_inner()
       .expect("legacy_cache_entries lock failed")
     {
-      cache.insert(key, entry);
+      cache.insert(key, identity, entry);
     }
     compilation.minimize_persistent_cache = Some(cache);
   }


### PR DESCRIPTION
## Summary

`occasion_minimize` persists entries keyed only by `MinimizeCacheKey`, an 8-byte
`FxHasher` digest of `(source, options_hash, filename, is_module)`. The stored
value carries no identity of its own, and `MinimizeCacheKey::from_bytes`
validates only length — any 8 bytes parse into a well-formed key.

`MinimizeOccasion::recovery` therefore accepts whatever decodes and inserts it
under whatever key it arrived with. Nothing asks whether the value belongs to
the asset requesting it, so a key/value association that is wrong in storage
propagates into `original.set_source(...)`, and the asset is emitted with
another asset's minimized body, marked `minimized = true`, with no error.

Pack integrity hashing proves a pack was not corrupted. It cannot prove that a
given key still maps to the value written under it. Since this cache is a file
on disk that outlives the process — partially written on crash, copied between
branches, restored from CI artifacts — that gap is reachable in practice.

Strengthening the key does not close it: the association is what is wrong, not
the key, so a swap defeats any key scheme. This adds
`EntryIdentity { filename, options_hash, is_module }` to the persisted entry and
compares it on read; a mismatch is treated as a cache miss and the asset is
minimized again.

Note the `new_cache` path twenty lines above in the same function is not
affected — it keys on `asset_filename` with the hash as a separate etag, so a
bad etag is already a miss. But `experiments.newCache` defaults to `false`
(`defaults.ts:282`, asserted in `defaultsCases/default/base.js:27`), so the
unvalidated legacy path is the one that ships by default. `CachedMinimizeEntry`
is unchanged, so the `new_cache` path is untouched here.

## Verification

Against the reporter's repro, on a local build of `main`.

Before:

    dist/a.js contains A: false; contains B: true
    dist/b.js contains A: true; contains B: false
    BUG REPRODUCED: minimize recovery returned another asset's cached output.

After:

    dist/a.js contains A: true; contains B: false
    dist/b.js contains A: false; contains B: true
    Bug not reproduced: minimized outputs remained associated with their assets.

Three unit tests added, covering the cross-wired case, the matching case (cache
still hits), and stale `options_hash` / `is_module`.

### Cache compatibility

`Entry` gains a field, so packs written by an older rspack no longer decode.
`recovery` already handles decode failure by warning and skipping, so a
pre-upgrade cache degrades to a miss and rebuilds rather than erroring.

## Related links

Fixes #14862

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
