### PR TITLE
docs: improve watch options documentation

### DIFF
--- a/website/docs/en/config/watch.mdx
+++ b/website/docs/en/config/watch.mdx
@@ -62,21 +62,21 @@ export default {
 - **Type:** `RegExp | string | string[]`
 - **Default:** `/[\\/](?:\.git|node_modules)[\\/]/`
 
-The path that matches is excluded while watching. Watching many files can result in a lot of CPU or memory usage.
+Use `watchOptions.ignored` to exclude matching files and directories from watch mode. Ignoring directories that do not need to be watched can reduce CPU and memory usage.
 
-Since Rspack v1.2.0, `node_modules` and `.git` directories are excluded by default. This means that changes to files in these directories will not trigger a rebuild.
+Since Rspack v1.2.0, `.git` and `node_modules` directories are ignored by default, so changes inside them do not trigger rebuilds.
 
-If you want to watch the `node_modules` directory, you can set it to only exclude the `.git` directory:
+To watch files in `node_modules`, override the default value and ignore only the `.git` directory:
 
 ```js title="rspack.config.mjs"
 export default {
   watchOptions: {
-    ignored: /\.git/,
+    ignored: /[\\/]\.git[\\/]/,
   },
 };
 ```
 
-`ignored` can use glob matching:
+You can also use a glob pattern:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -86,7 +86,7 @@ export default {
 };
 ```
 
-It is also possible to use multiple glob patterns:
+To ignore multiple glob patterns, pass an array:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -96,19 +96,23 @@ export default {
 };
 ```
 
-In addition, you can specify one or more absolute paths:
+You can also specify one or more absolute paths. Because strings are interpreted as glob patterns, normalize path separators to forward slashes for consistent behavior across platforms:
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
 
+const ignoredDir = path
+  .resolve(import.meta.dirname, 'ignored-dir')
+  .replaceAll(path.sep, '/');
+
 export default {
   watchOptions: {
-    ignored: [path.posix.resolve(__dirname, './ignored-dir')],
+    ignored: [ignoredDir],
   },
 };
 ```
 
-When using glob patterns, Rspack convert them to regular expressions with [glob-to-regexp](https://github.com/fitzgen/glob-to-regexp), so make sure to get yourself familiar with it before you use glob patterns for watchOptions.ignored.
+The glob syntax used by `watchOptions.ignored` is based on [glob-to-regexp](https://github.com/fitzgen/glob-to-regexp). See its documentation for details about the supported pattern syntax.
 
 ### watchOptions.poll
 
@@ -117,7 +121,7 @@ When using glob patterns, Rspack convert them to regular expressions with [glob-
 
 Whether to watch by polling.
 
-When set to `true`, the default polling interval is 5007 milliseconds.
+When set to `true`, the default polling interval is 5007 milliseconds. This matches the default polling interval used by Node.js `fs.watchFile()`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -127,7 +131,7 @@ export default {
 };
 ```
 
-It can also set a custom polling interval:
+You can also set a custom polling interval. Note that shorter intervals can significantly increase CPU usage and file system I/O:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/watch.mdx
+++ b/website/docs/zh/config/watch.mdx
@@ -62,21 +62,21 @@ export default {
 - **类型：** `RegExp | string | string[]`
 - **默认值：** `/[\\/](?:\.git|node_modules)[\\/]/`
 
-监听时排除匹配到的路径。监听大量文件可能会导致 CPU 或内存使用率过高。
+使用 `watchOptions.ignored` 可以从监听范围中排除匹配的文件和目录。忽略不需要监听的目录有助于降低 CPU 和内存占用。
 
-Rspack 从 v1.2.0 开始，默认排除 `node_modules` 和 `.git` 目录下的文件。这意味着当这些目录下的文件发生变化时，不会触发重新构建。
+从 Rspack v1.2.0 开始，`.git` 和 `node_modules` 目录会被默认忽略，其中的文件发生变化时不会触发重新构建。
 
-如果你希望监听 `node_modules` 目录，可以设置为仅排除 `.git` 目录：
+如果需要监听 `node_modules` 中的文件，可以覆盖默认值，仅忽略 `.git` 目录：
 
 ```js title="rspack.config.mjs"
 export default {
   watchOptions: {
-    ignored: /\.git/,
+    ignored: /[\\/]\.git[\\/]/,
   },
 };
 ```
 
-`ignored` 可以使用 glob 匹配：
+也可以使用 glob 模式：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -86,7 +86,7 @@ export default {
 };
 ```
 
-还可以使用多个 glob 匹配：
+如需忽略多个 glob 模式，请传入一个数组：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -96,19 +96,23 @@ export default {
 };
 ```
 
-还可以指定为一个或多个绝对路径：
+还可以指定一个或多个绝对路径。由于字符串会按 glob 模式解析，请将路径分隔符统一为正斜杠，以确保在各平台上的行为一致：
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
 
+const ignoredDir = path
+  .resolve(import.meta.dirname, 'ignored-dir')
+  .replaceAll(path.sep, '/');
+
 export default {
   watchOptions: {
-    ignored: [path.posix.resolve(__dirname, './ignored-dir')],
+    ignored: [ignoredDir],
   },
 };
 ```
 
-当使用 glob 匹配时，Rspack 会将它们转换为正则表达式，因此在使用 glob 匹配之前，请确保你熟悉 [glob-to-regexp](https://github.com/fitzgen/glob-to-regexp)。
+`watchOptions.ignored` 的 glob 语法基于 [glob-to-regexp](https://github.com/fitzgen/glob-to-regexp)。有关支持的模式语法，请参阅其文档。
 
 ### watchOptions.poll
 
@@ -117,7 +121,7 @@ export default {
 
 是否通过轮询进行监听。
 
-当设置为 `true` 时，默认的轮询间隔为 5007 毫秒。
+当设置为 `true` 时，默认的轮询间隔为 5007 毫秒，这与 Node.js `fs.watchFile()` 的默认轮询间隔一致。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -127,7 +131,7 @@ export default {
 };
 ```
 
-还可以设置一个自定义的轮询间隔：
+还可以设置一个自定义的轮询间隔。注意，轮询间隔过短会显著增加 CPU 占用和文件系统 I/O 开销：
 
 ```js title="rspack.config.mjs"
 export default {


### PR DESCRIPTION
## Summary

This PR improves the `watchOptions.ignored` documentation with clearer glob guidance and a cross-platform absolute-path example. It also documents that the 5007 ms polling default matches Node.js `fs.watchFile()` and warns that shorter polling intervals can increase CPU usage and file system I/O.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).