### PR TITLE
docs: clarify externals type defaults

### DIFF
--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -310,7 +310,7 @@ export default {
 
 Set `externalsType` explicitly when an external dependency needs a loading format different from the inferred value.
 
-## Default value
+### Default value
 
 The default value is inferred in this order:
 
@@ -318,9 +318,9 @@ The default value is inferred in this order:
 - Otherwise, if [`output.module`](/config/output#outputmodule) is `true`, it defaults to `'module-import'`.
 - Otherwise, it defaults to `'var'`.
 
-For backward compatibility, [`output.library.type: 'modern-module'`](#externalstypemodern-module) currently skips the first rule and falls through to the `output.module` rule. Set `externalsType: 'modern-module'` explicitly to opt in to modern module externals.
+For backward compatibility, [`output.library.type: 'modern-module'`](/config/output#outputlibrarytype) currently skips the first rule and falls through to the `output.module` rule. Set `externalsType: 'modern-module'` explicitly to opt in to modern module externals.
 
-## Supported values
+### Supported values
 
 The following types are supported:
 

--- a/website/docs/en/config/externals.mdx
+++ b/website/docs/en/config/externals.mdx
@@ -305,25 +305,32 @@ export default {
 ## externalsType
 
 - **Type:** `string`
-- **Default:** Depends on [`output.library.type`](/config/output#outputlibrarytype) and [`output.module`](/config/output#outputmodule)
 
-The default value is inferred as follows:
+`externalsType` determines how Rspack loads external dependencies by default. When using the `'amd'`, `'umd'`, `'system'`, or `'jsonp'` type, [`output.library.type`](/config/output#outputlibrarytype) must be set to the same value. For example, only an `'amd'` library can use an `'amd'` external.
 
-- When [`output.library`](/config/output#outputlibrary) is configured, it matches [`output.library.type`](/config/output#outputlibrarytype).
-- Otherwise, when [`output.module`](/config/output#outputmodule) is `true`, it is `'module-import'`.
-- Otherwise, it is `'var'`.
+Set `externalsType` explicitly when an external dependency needs a loading format different from the inferred value.
 
-Specify the default type of externals. `amd`, `umd`, `system` and `jsonp` externals **depend on the [`output.library.type`](/config/output#outputlibrarytype)** being set to the same value e.g. you can only consume `amd` externals within an `amd` library.
+## Default value
 
-Set `externalsType` explicitly when the external dependency should use a different loading format from the inferred default.
+The default value is inferred in this order:
 
-Supported types:
+- If [`output.library`](/config/output#outputlibrary) is configured with a type other than `'modern-module'`, `externalsType` defaults to [`output.library.type`](/config/output#outputlibrarytype).
+- Otherwise, if [`output.module`](/config/output#outputmodule) is `true`, it defaults to `'module-import'`.
+- Otherwise, it defaults to `'var'`.
+
+For backward compatibility, [`output.library.type: 'modern-module'`](#externalstypemodern-module) currently skips the first rule and falls through to the `output.module` rule. Set `externalsType: 'modern-module'` explicitly to opt in to modern module externals.
+
+## Supported values
+
+The following types are supported:
 
 - `'amd'`
 - `'amd-require'`
 - `'assign'` - same as `'var'`
 - [`'commonjs'`](#externalstypecommonjs)
+- `'commonjs2'`
 - `'commonjs-module'`
+- `'commonjs-static'`
 - [`'global'`](#externalstypeglobal)
 - [`'module'`](#externalstypemodule)
 - [`'import'`](#externalstypeimport) - uses `import()` to load a native ECMAScript module (async module)

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -310,7 +310,7 @@ export default {
 
 如果 external 依赖需要使用与推导结果不同的加载格式，请显式设置 `externalsType`。
 
-## 默认值
+### 默认值
 
 默认值按以下顺序推导：
 
@@ -318,9 +318,9 @@ export default {
 - 否则，如果 [`output.module`](/config/output#outputmodule) 为 `true`，则默认为 `'module-import'`。
 - 其他情况下默认为 `'var'`。
 
-出于向后兼容的考虑，[`output.library.type: 'modern-module'`](#externalstypemodern-module) 目前会跳过第一条规则，继续按照 `output.module` 推导默认值。如需使用 modern module externals，请显式设置 `externalsType: 'modern-module'`。
+出于向后兼容的考虑，[`output.library.type: 'modern-module'`](/config/output#outputlibrarytype) 目前会跳过第一条规则，继续按照 `output.module` 推导默认值。如需使用 modern module externals，请显式设置 `externalsType: 'modern-module'`。
 
-## 可选值
+### 可选值
 
 支持的类型如下：
 

--- a/website/docs/zh/config/externals.mdx
+++ b/website/docs/zh/config/externals.mdx
@@ -305,17 +305,22 @@ export default {
 ## externalsType
 
 - **类型：** `string`
-- **默认值：** 取决于 [`output.library.type`](/config/output#outputlibrarytype) 和 [`output.module`](/config/output#outputmodule)
 
-默认值的推导规则如下：
+`externalsType` 决定 Rspack 默认如何加载 external 依赖。使用 `'amd'`、`'umd'`、`'system'` 或 `'jsonp'` 类型时，[`output.library.type`](/config/output#outputlibrarytype) 必须设置为相同的值。例如，只有 `'amd'` 库才能使用 `'amd'` 类型的 external。
 
-- 配置了 [`output.library`](/config/output#outputlibrary) 时，与 [`output.library.type`](/config/output#outputlibrarytype) 保持一致。
-- 否则，如果 [`output.module`](/config/output#outputmodule) 为 `true`，则为 `'module-import'`。
-- 否则为 `'var'`。
+如果 external 依赖需要使用与推导结果不同的加载格式，请显式设置 `externalsType`。
 
-指定 externals 的默认类型。当 external 被设置为 `amd`，`umd`，`system` 以及 `jsonp` 时，[`output.library.type`](/config/output#outputlibrarytype) 的值也应相同。例如，你只能在 `amd` 库中使用 `amd` 的 externals。
+## 默认值
 
-如果 external 依赖需要使用不同于推导结果的加载格式，请显式设置 `externalsType`。
+默认值按以下顺序推导：
+
+- 如果配置了 [`output.library`](/config/output#outputlibrary)，且其类型不是 `'modern-module'`，则 `externalsType` 默认为 [`output.library.type`](/config/output#outputlibrarytype)。
+- 否则，如果 [`output.module`](/config/output#outputmodule) 为 `true`，则默认为 `'module-import'`。
+- 其他情况下默认为 `'var'`。
+
+出于向后兼容的考虑，[`output.library.type: 'modern-module'`](#externalstypemodern-module) 目前会跳过第一条规则，继续按照 `output.module` 推导默认值。如需使用 modern module externals，请显式设置 `externalsType: 'modern-module'`。
+
+## 可选值
 
 支持的类型如下：
 
@@ -323,7 +328,9 @@ export default {
 - `'amd-require'`
 - `'assign'` - 同 `'var'`
 - [`'commonjs'`](#externalstypecommonjs)
+- `'commonjs2'`
 - `'commonjs-module'`
+- `'commonjs-static'`
 - [`'global'`](#externalstypeglobal)
 - [`'module'`](#externalstypemodule)
 - [`'import'`](#externalstypeimport) - 使用 `import()` 加载一个原生的 ECMAScript 模块（异步模块）


### PR DESCRIPTION
## Summary

This PR clarifies the English and Chinese `externalsType` documentation so its inferred default matches the current behavior. It documents the `modern-module` compatibility exception, adds the missing `commonjs2` and `commonjs-static` values, and removes the oversimplified default summary.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).