### PR TITLE
feat(core): add compilation.runtimeTemplate

### DIFF
--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -47,6 +47,7 @@ import type { NormalModuleFactory } from './NormalModuleFactory';
 import type { ResolverFactory } from './ResolverFactory';
 import type { RspackError } from './RspackError';
 import { RuntimeModule } from './RuntimeModule';
+import { RuntimeTemplate } from './RuntimeTemplate';
 import {
   Stats,
   type StatsAsset,
@@ -314,6 +315,7 @@ export class Compilation {
   inputFileSystem: InputFileSystem | null;
   options: RspackOptionsNormalized;
   outputOptions: OutputNormalized;
+  runtimeTemplate: RuntimeTemplate;
   logging: Map<string, LogEntry[]>;
   childrenCounters: Record<string, number>;
   children: Compilation[];
@@ -461,6 +463,7 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
     this.inputFileSystem = compiler.inputFileSystem;
     this.options = compiler.options;
     this.outputOptions = compiler.options.output;
+    this.runtimeTemplate = new RuntimeTemplate(this, this.outputOptions);
     this.logging = new Map();
     this.childrenCounters = {};
     this.children = [];

--- a/packages/rspack/src/RuntimeTemplate.ts
+++ b/packages/rspack/src/RuntimeTemplate.ts
@@ -149,10 +149,13 @@ export class RuntimeTemplate {
     return this.outputOptions.module;
   }
 
+  /**
+   * Matches `CompilerPlatform::is_neutral` in
+   * `crates/rspack_core/src/options/platform.rs`.
+   */
   isNeutralPlatform(): boolean {
-    return (
-      !this.#environment.document && !this.compilation.compiler.platform.node
-    );
+    const { platform } = this.compilation.compiler;
+    return !platform.web && !platform.node;
   }
 
   supportsConst(): boolean {

--- a/packages/rspack/src/RuntimeTemplate.ts
+++ b/packages/rspack/src/RuntimeTemplate.ts
@@ -1,0 +1,406 @@
+/**
+ * The following code is modified based on
+ * https://github.com/webpack/webpack/blob/v5.101.0/lib/RuntimeTemplate.js
+ *
+ * MIT Licensed
+ * Author Tobias Koppers @sokra
+ * Copyright (c) JS Foundation and other contributors
+ * https://github.com/webpack/webpack/blob/main/LICENSE
+ */
+
+import type { Compilation } from './Compilation';
+import { Template } from './Template';
+import type { Environment, OutputNormalized } from './config';
+
+const SAFE_IDENTIFIER = /^[_a-zA-Z$][_a-zA-Z$0-9]*$/;
+const RESERVED_IDENTIFIER = new Set([
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'export',
+  'extends',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'enum',
+  // strict mode
+  'implements',
+  'interface',
+  'let',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'static',
+  'yield',
+  // module code
+  'await',
+  // skip future reserved keywords defined under ES1 till ES3
+  // additional
+  'null',
+  'true',
+  'false',
+]);
+
+const propertyAccess = (properties: string[], start = 0): string => {
+  let str = '';
+  for (let i = start; i < properties.length; i++) {
+    const p = properties[i];
+    if (`${+p}` === p) {
+      str += `[${p}]`;
+    } else if (SAFE_IDENTIFIER.test(p) && !RESERVED_IDENTIFIER.has(p)) {
+      str += `.${p}`;
+    } else {
+      str += `[${JSON.stringify(p)}]`;
+    }
+  }
+  return str;
+};
+
+const getGlobalObject = (
+  definition: string | undefined,
+): string | undefined => {
+  if (!definition) return definition;
+  const trimmed = definition.trim();
+
+  if (
+    // identifier, we do not need real identifier regarding ECMAScript/Unicode
+    /^[_\p{L}][_0-9\p{L}]*$/iu.test(trimmed) ||
+    // iife
+    // call expression
+    // expression in parentheses
+    /^([_\p{L}][_0-9\p{L}]*)?\(.*\)$/iu.test(trimmed)
+  ) {
+    return trimmed;
+  }
+
+  return `Object(${trimmed})`;
+};
+
+export type ConcatenationArg = string | { expr: string };
+
+/**
+ * Helpers to generate runtime code that matches the capabilities of the
+ * targeted environment, available as `compilation.runtimeTemplate`.
+ *
+ * Mirrors webpack's `RuntimeTemplate`, and the environment dependent branches
+ * behave the same as `RuntimeTemplate` in
+ * `crates/rspack_core/src/runtime_template.rs`.
+ *
+ * Note: the webpack methods that render references to other modules
+ * (`moduleId`, `moduleRaw`, `moduleExports`, `moduleNamespace`,
+ * `moduleNamespacePromise`, `importStatement`, `exportFromImport`,
+ * `blockPromise`, `asyncModuleFactory`, `syncModuleFactory`, `weakError`,
+ * `runtimeConditionExpression`) are not part of this class. They need read
+ * access to the module graph and the code generation results, which Rspack
+ * keeps on the Rust side. `comment()` is omitted because Rspack has no
+ * `compilation.requestShortener`, and `defineEsModuleFlagStatement()` because
+ * Rspack renders runtime globals from a numeric `RuntimeGlobals` enum whose
+ * final identifier depends on the runtime mode.
+ */
+export class RuntimeTemplate {
+  compilation: Compilation;
+  outputOptions: OutputNormalized;
+  globalObject: string | undefined;
+  contentHashReplacement: string;
+
+  constructor(compilation: Compilation, outputOptions: OutputNormalized) {
+    this.compilation = compilation;
+    this.outputOptions = outputOptions || {};
+    this.globalObject = getGlobalObject(this.outputOptions.globalObject);
+    this.contentHashReplacement = 'X'.repeat(
+      this.outputOptions.hashDigestLength ?? 0,
+    );
+  }
+
+  get #environment(): Environment {
+    return this.outputOptions.environment ?? {};
+  }
+
+  isIIFE(): boolean | undefined {
+    return this.outputOptions.iife;
+  }
+
+  isModule(): boolean | undefined {
+    return this.outputOptions.module;
+  }
+
+  isNeutralPlatform(): boolean {
+    return (
+      !this.#environment.document && !this.compilation.compiler.platform.node
+    );
+  }
+
+  supportsConst(): boolean {
+    return Boolean(this.#environment.const);
+  }
+
+  supportsArrowFunction(): boolean {
+    return Boolean(this.#environment.arrowFunction);
+  }
+
+  supportsAsyncFunction(): boolean {
+    return Boolean(this.#environment.asyncFunction);
+  }
+
+  supportsOptionalChaining(): boolean {
+    return Boolean(this.#environment.optionalChaining);
+  }
+
+  supportsForOf(): boolean {
+    return Boolean(this.#environment.forOf);
+  }
+
+  supportsDestructuring(): boolean {
+    return Boolean(this.#environment.destructuring);
+  }
+
+  supportsBigIntLiteral(): boolean {
+    return Boolean(this.#environment.bigIntLiteral);
+  }
+
+  supportsDynamicImport(): boolean {
+    return Boolean(this.#environment.dynamicImport);
+  }
+
+  supportsEcmaScriptModuleSyntax(): boolean {
+    return Boolean(this.#environment.module);
+  }
+
+  supportTemplateLiteral(): boolean {
+    return Boolean(this.#environment.templateLiteral);
+  }
+
+  supportNodePrefixForCoreModules(): boolean {
+    return Boolean(this.#environment.nodePrefixForCoreModules);
+  }
+
+  /**
+   * @param mod a module
+   * @returns a module with `node:` prefix when supported, otherwise an original name
+   */
+  renderNodePrefixForCoreModule(mod: string): string {
+    return this.supportNodePrefixForCoreModules()
+      ? `"node:${mod}"`
+      : `"${mod}"`;
+  }
+
+  /**
+   * @param returnValue return value
+   * @param args arguments
+   * @returns returning function
+   */
+  returningFunction(returnValue: string, args = ''): string {
+    return this.supportsArrowFunction()
+      ? `(${args}) => (${returnValue})`
+      : `function(${args}) { return ${returnValue}; }`;
+  }
+
+  /**
+   * @param args arguments
+   * @param body body
+   * @returns basic function
+   */
+  basicFunction(args: string, body: string | string[]): string {
+    return this.supportsArrowFunction()
+      ? `(${args}) => {\n${Template.indent(body)}\n}`
+      : `function(${args}) {\n${Template.indent(body)}\n}`;
+  }
+
+  /**
+   * @param args args
+   * @returns result expression
+   */
+  concatenation(...args: ConcatenationArg[]): string {
+    const len = args.length;
+
+    if (len === 2) return this.#es5Concatenation(args);
+    if (len === 0) return '""';
+    if (len === 1) {
+      return typeof args[0] === 'string'
+        ? JSON.stringify(args[0])
+        : `"" + ${args[0].expr}`;
+    }
+    if (!this.supportTemplateLiteral()) return this.#es5Concatenation(args);
+
+    // cost comparison between template literal and concatenation:
+    // both need equal surroundings: `xxx` vs "xxx"
+    // template literal has constant cost of 3 chars for each expression
+    // es5 concatenation has cost of 3 + n chars for n expressions in row
+    // when a es5 concatenation ends with an expression it reduces cost by 3
+    // when a es5 concatenation starts with an single expression it reduces cost by 3
+    // e. g. `${a}${b}${c}` (3*3 = 9) is longer than ""+a+b+c ((3+3)-3 = 3)
+    // e. g. `x${a}x${b}x${c}x` (3*3 = 9) is shorter than "x"+a+"x"+b+"x"+c+"x" (4+4+4 = 12)
+
+    let templateCost = 0;
+    let concatenationCost = 0;
+
+    let lastWasExpr = false;
+    for (const arg of args) {
+      const isExpr = typeof arg !== 'string';
+      if (isExpr) {
+        templateCost += 3;
+        concatenationCost += lastWasExpr ? 1 : 4;
+      }
+      lastWasExpr = isExpr;
+    }
+    if (lastWasExpr) concatenationCost -= 3;
+    if (typeof args[0] !== 'string' && typeof args[1] === 'string') {
+      concatenationCost -= 3;
+    }
+
+    if (concatenationCost <= templateCost) return this.#es5Concatenation(args);
+
+    return `\`${args
+      .map((arg) => (typeof arg === 'string' ? arg : `\${${arg.expr}}`))
+      .join('')}\``;
+  }
+
+  /**
+   * @param args args (len >= 2)
+   * @returns result expression
+   */
+  #es5Concatenation(args: ConcatenationArg[]): string {
+    const str = args
+      .map((arg) => (typeof arg === 'string' ? JSON.stringify(arg) : arg.expr))
+      .join(' + ');
+
+    // when the first two args are expression, we need to prepend "" + to force string
+    // concatenation instead of number addition.
+    return typeof args[0] !== 'string' && typeof args[1] !== 'string'
+      ? `"" + ${str}`
+      : str;
+  }
+
+  /**
+   * @param expression expression
+   * @param args arguments
+   * @returns expression function code
+   */
+  expressionFunction(expression: string, args = ''): string {
+    return this.supportsArrowFunction()
+      ? `(${args}) => (${expression})`
+      : `function(${args}) { ${expression}; }`;
+  }
+
+  /**
+   * @returns empty function code
+   */
+  emptyFunction(): string {
+    return this.supportsArrowFunction() ? 'x => {}' : 'function() {}';
+  }
+
+  /**
+   * @param items items
+   * @param value value
+   * @returns destructure array code
+   */
+  destructureArray(items: string[], value: string): string {
+    return this.supportsDestructuring()
+      ? `var [${items.join(', ')}] = ${value};`
+      : Template.asString(
+          items.map((item, i) => `var ${item} = ${value}[${i}];`),
+        );
+  }
+
+  /**
+   * @param items items
+   * @param value value
+   * @returns destructure object code
+   */
+  destructureObject(items: string[], value: string): string {
+    return this.supportsDestructuring()
+      ? `var {${items.join(', ')}} = ${value};`
+      : Template.asString(
+          items.map(
+            (item) => `var ${item} = ${value}${propertyAccess([item])};`,
+          ),
+        );
+  }
+
+  /**
+   * @param args arguments
+   * @param body body
+   * @returns IIFE code
+   */
+  iife(args: string, body: string | string[]): string {
+    return `(${this.basicFunction(args, body)})()`;
+  }
+
+  /**
+   * @param variable variable
+   * @param array array
+   * @param body body
+   * @returns for each code
+   */
+  forEach(variable: string, array: string, body: string | string[]): string {
+    return this.supportsForOf()
+      ? `for(const ${variable} of ${array}) {\n${Template.indent(body)}\n}`
+      : `${array}.forEach(function(${variable}) {\n${Template.indent(body)}\n});`;
+  }
+
+  /**
+   * @param options generation options
+   * @returns generated error block
+   */
+  throwMissingModuleErrorBlock({ request }: { request?: string }): string {
+    const err = `Cannot find module '${request}'`;
+    return `var e = new Error(${JSON.stringify(err)}); e.code = 'MODULE_NOT_FOUND'; throw e;`;
+  }
+
+  /**
+   * @param options generation options
+   * @returns generated error function
+   */
+  throwMissingModuleErrorFunction({ request }: { request?: string }): string {
+    return `function webpackMissingModule() { ${this.throwMissingModuleErrorBlock({ request })} }`;
+  }
+
+  /**
+   * @param options generation options
+   * @returns generated error IIFE
+   */
+  missingModule({ request }: { request?: string }): string {
+    return `Object(${this.throwMissingModuleErrorFunction({ request })}())`;
+  }
+
+  /**
+   * @param options generation options
+   * @returns generated error statement
+   */
+  missingModuleStatement({ request }: { request?: string }): string {
+    return `${this.missingModule({ request })};\n`;
+  }
+
+  /**
+   * @param options generation options
+   * @returns generated error code
+   */
+  missingModulePromise({ request }: { request?: string }): string {
+    return `Promise.resolve().then(${this.throwMissingModuleErrorFunction({ request })})`;
+  }
+}

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -65,6 +65,8 @@ import * as ModuleFilenameHelpers from './lib/ModuleFilenameHelpers';
 
 // API extractor not working with some re-exports, see: https://github.com/microsoft/fluentui/issues/20694
 export { Template } from './Template';
+export { RuntimeTemplate } from './RuntimeTemplate';
+export type { ConcatenationArg } from './RuntimeTemplate';
 export { ModuleFilenameHelpers };
 
 export const WebpackError = Error;

--- a/tests/rspack-test/compilerCases/runtime-template.js
+++ b/tests/rspack-test/compilerCases/runtime-template.js
@@ -1,0 +1,116 @@
+const { RuntimeTemplate } = require("@rspack/core");
+
+let runtimeTemplate;
+
+class MyPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Plugin", compilation => {
+			runtimeTemplate = compilation.runtimeTemplate;
+		});
+	}
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should expose compilation.runtimeTemplate",
+	options(context) {
+		return {
+			context: context.getSource(),
+			entry: "./d",
+			output: {
+				environment: {
+					arrowFunction: false,
+					destructuring: false,
+					forOf: false,
+					templateLiteral: false,
+					nodePrefixForCoreModules: false
+				}
+			},
+			plugins: [new MyPlugin()]
+		};
+	},
+	async build(_, compiler) {
+		await new Promise(resolve => {
+			compiler.run(() => {
+				resolve();
+			});
+		});
+	},
+	async check() {
+		expect(runtimeTemplate).toBeInstanceOf(RuntimeTemplate);
+
+		// the environment configured above, without any ES2015 feature
+		expect(runtimeTemplate.supportsArrowFunction()).toBe(false);
+		expect(runtimeTemplate.supportsDestructuring()).toBe(false);
+		expect(runtimeTemplate.supportsForOf()).toBe(false);
+		expect(runtimeTemplate.supportTemplateLiteral()).toBe(false);
+		expect(runtimeTemplate.returningFunction("a", "b")).toBe(
+			"function(b) { return a; }"
+		);
+		expect(runtimeTemplate.basicFunction("a", "return a;")).toBe(
+			"function(a) {\n\treturn a;\n}"
+		);
+		expect(runtimeTemplate.expressionFunction("a()")).toBe(
+			"function() { a(); }"
+		);
+		expect(runtimeTemplate.emptyFunction()).toBe("function() {}");
+		expect(runtimeTemplate.iife("", "a();")).toBe(
+			"(function() {\n\ta();\n})()"
+		);
+		expect(runtimeTemplate.destructureArray(["a", "b"], "c")).toBe(
+			"var a = c[0];\nvar b = c[1];"
+		);
+		expect(runtimeTemplate.destructureObject(["a", "b"], "c")).toBe(
+			"var a = c.a;\nvar b = c.b;"
+		);
+		expect(runtimeTemplate.forEach("a", "b", "c(a);")).toBe(
+			"b.forEach(function(a) {\n\tc(a);\n});"
+		);
+		expect(runtimeTemplate.concatenation("a", { expr: "b" }, "c")).toBe(
+			'"a" + b + "c"'
+		);
+		expect(runtimeTemplate.renderNodePrefixForCoreModule("fs")).toBe('"fs"');
+		expect(
+			runtimeTemplate.missingModuleStatement({ request: "./missing" })
+		).toBe(
+			`Object(function webpackMissingModule() { var e = new Error("Cannot find module './missing'"); e.code = 'MODULE_NOT_FOUND'; throw e; }());\n`
+		);
+
+		// the same helpers with every ES2015 feature enabled
+		const modern = new RuntimeTemplate(runtimeTemplate.compilation, {
+			...runtimeTemplate.outputOptions,
+			environment: {
+				...runtimeTemplate.outputOptions.environment,
+				arrowFunction: true,
+				destructuring: true,
+				forOf: true,
+				templateLiteral: true,
+				nodePrefixForCoreModules: true
+			}
+		});
+		expect(modern.returningFunction("a", "b")).toBe("(b) => (a)");
+		expect(modern.basicFunction("a", "return a;")).toBe(
+			"(a) => {\n\treturn a;\n}"
+		);
+		expect(modern.expressionFunction("a()")).toBe("() => (a())");
+		expect(modern.emptyFunction()).toBe("x => {}");
+		expect(modern.iife("", "a();")).toBe("(() => {\n\ta();\n})()");
+		expect(modern.destructureArray(["a", "b"], "c")).toBe("var [a, b] = c;");
+		expect(modern.destructureObject(["a", "b"], "c")).toBe("var {a, b} = c;");
+		expect(modern.forEach("a", "b", "c(a);")).toBe(
+			"for(const a of b) {\n\tc(a);\n}"
+		);
+		expect(
+			modern.concatenation(
+				"x",
+				{ expr: "a" },
+				"x",
+				{ expr: "b" },
+				"x",
+				{ expr: "c" },
+				"x"
+			)
+		).toBe("`x${a}x${b}x${c}x`");
+		expect(modern.renderNodePrefixForCoreModule("fs")).toBe('"node:fs"');
+	}
+};

--- a/tests/rspack-test/compilerCases/runtime-template.js
+++ b/tests/rspack-test/compilerCases/runtime-template.js
@@ -1,6 +1,7 @@
 const { RuntimeTemplate } = require("@rspack/core");
 
 let runtimeTemplate;
+let neutralPlatform;
 
 class MyPlugin {
 	apply(compiler) {
@@ -10,107 +11,159 @@ class MyPlugin {
 	}
 }
 
-/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
-module.exports = {
-	description: "should expose compilation.runtimeTemplate",
-	options(context) {
-		return {
-			context: context.getSource(),
-			entry: "./d",
-			output: {
-				environment: {
-					arrowFunction: false,
-					destructuring: false,
-					forOf: false,
-					templateLiteral: false,
-					nodePrefixForCoreModules: false
-				}
-			},
-			plugins: [new MyPlugin()]
-		};
-	},
-	async build(_, compiler) {
-		await new Promise(resolve => {
-			compiler.run(() => {
-				resolve();
-			});
+class PlatformPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap("Plugin", compilation => {
+			neutralPlatform = compilation.runtimeTemplate.isNeutralPlatform();
 		});
-	},
-	async check() {
-		expect(runtimeTemplate).toBeInstanceOf(RuntimeTemplate);
-
-		// the environment configured above, without any ES2015 feature
-		expect(runtimeTemplate.supportsArrowFunction()).toBe(false);
-		expect(runtimeTemplate.supportsDestructuring()).toBe(false);
-		expect(runtimeTemplate.supportsForOf()).toBe(false);
-		expect(runtimeTemplate.supportTemplateLiteral()).toBe(false);
-		expect(runtimeTemplate.returningFunction("a", "b")).toBe(
-			"function(b) { return a; }"
-		);
-		expect(runtimeTemplate.basicFunction("a", "return a;")).toBe(
-			"function(a) {\n\treturn a;\n}"
-		);
-		expect(runtimeTemplate.expressionFunction("a()")).toBe(
-			"function() { a(); }"
-		);
-		expect(runtimeTemplate.emptyFunction()).toBe("function() {}");
-		expect(runtimeTemplate.iife("", "a();")).toBe(
-			"(function() {\n\ta();\n})()"
-		);
-		expect(runtimeTemplate.destructureArray(["a", "b"], "c")).toBe(
-			"var a = c[0];\nvar b = c[1];"
-		);
-		expect(runtimeTemplate.destructureObject(["a", "b"], "c")).toBe(
-			"var a = c.a;\nvar b = c.b;"
-		);
-		expect(runtimeTemplate.forEach("a", "b", "c(a);")).toBe(
-			"b.forEach(function(a) {\n\tc(a);\n});"
-		);
-		expect(runtimeTemplate.concatenation("a", { expr: "b" }, "c")).toBe(
-			'"a" + b + "c"'
-		);
-		expect(runtimeTemplate.renderNodePrefixForCoreModule("fs")).toBe('"fs"');
-		expect(
-			runtimeTemplate.missingModuleStatement({ request: "./missing" })
-		).toBe(
-			`Object(function webpackMissingModule() { var e = new Error("Cannot find module './missing'"); e.code = 'MODULE_NOT_FOUND'; throw e; }());\n`
-		);
-
-		// the same helpers with every ES2015 feature enabled
-		const modern = new RuntimeTemplate(runtimeTemplate.compilation, {
-			...runtimeTemplate.outputOptions,
-			environment: {
-				...runtimeTemplate.outputOptions.environment,
-				arrowFunction: true,
-				destructuring: true,
-				forOf: true,
-				templateLiteral: true,
-				nodePrefixForCoreModules: true
-			}
-		});
-		expect(modern.returningFunction("a", "b")).toBe("(b) => (a)");
-		expect(modern.basicFunction("a", "return a;")).toBe(
-			"(a) => {\n\treturn a;\n}"
-		);
-		expect(modern.expressionFunction("a()")).toBe("() => (a())");
-		expect(modern.emptyFunction()).toBe("x => {}");
-		expect(modern.iife("", "a();")).toBe("(() => {\n\ta();\n})()");
-		expect(modern.destructureArray(["a", "b"], "c")).toBe("var [a, b] = c;");
-		expect(modern.destructureObject(["a", "b"], "c")).toBe("var {a, b} = c;");
-		expect(modern.forEach("a", "b", "c(a);")).toBe(
-			"for(const a of b) {\n\tc(a);\n}"
-		);
-		expect(
-			modern.concatenation(
-				"x",
-				{ expr: "a" },
-				"x",
-				{ expr: "b" },
-				"x",
-				{ expr: "c" },
-				"x"
-			)
-		).toBe("`x${a}x${b}x${c}x`");
-		expect(modern.renderNodePrefixForCoreModule("fs")).toBe('"node:fs"');
 	}
+}
+
+const build = async (_, compiler) => {
+	await new Promise(resolve => {
+		compiler.run(() => {
+			resolve();
+		});
+	});
 };
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+	{
+		description: "should expose compilation.runtimeTemplate",
+		options(context) {
+			return {
+				context: context.getSource(),
+				entry: "./d",
+				output: {
+					environment: {
+						arrowFunction: false,
+						destructuring: false,
+						forOf: false,
+						templateLiteral: false,
+						nodePrefixForCoreModules: false
+					}
+				},
+				plugins: [new MyPlugin()]
+			};
+		},
+		build,
+		async check() {
+			expect(runtimeTemplate).toBeInstanceOf(RuntimeTemplate);
+
+			// `target` defaults to `web`, so the platform is not neutral
+			expect(runtimeTemplate.isNeutralPlatform()).toBe(false);
+
+			// the environment configured above, without any ES2015 feature
+			expect(runtimeTemplate.supportsArrowFunction()).toBe(false);
+			expect(runtimeTemplate.supportsDestructuring()).toBe(false);
+			expect(runtimeTemplate.supportsForOf()).toBe(false);
+			expect(runtimeTemplate.supportTemplateLiteral()).toBe(false);
+			expect(runtimeTemplate.returningFunction("a", "b")).toBe(
+				"function(b) { return a; }"
+			);
+			expect(runtimeTemplate.basicFunction("a", "return a;")).toBe(
+				"function(a) {\n\treturn a;\n}"
+			);
+			expect(runtimeTemplate.expressionFunction("a()")).toBe(
+				"function() { a(); }"
+			);
+			expect(runtimeTemplate.emptyFunction()).toBe("function() {}");
+			expect(runtimeTemplate.iife("", "a();")).toBe(
+				"(function() {\n\ta();\n})()"
+			);
+			expect(runtimeTemplate.destructureArray(["a", "b"], "c")).toBe(
+				"var a = c[0];\nvar b = c[1];"
+			);
+			expect(runtimeTemplate.destructureObject(["a", "b"], "c")).toBe(
+				"var a = c.a;\nvar b = c.b;"
+			);
+			expect(runtimeTemplate.forEach("a", "b", "c(a);")).toBe(
+				"b.forEach(function(a) {\n\tc(a);\n});"
+			);
+			expect(runtimeTemplate.concatenation("a", { expr: "b" }, "c")).toBe(
+				'"a" + b + "c"'
+			);
+			expect(runtimeTemplate.renderNodePrefixForCoreModule("fs")).toBe('"fs"');
+			expect(
+				runtimeTemplate.missingModuleStatement({ request: "./missing" })
+			).toBe(
+				`Object(function webpackMissingModule() { var e = new Error("Cannot find module './missing'"); e.code = 'MODULE_NOT_FOUND'; throw e; }());\n`
+			);
+
+			// the same helpers with every ES2015 feature enabled
+			const modern = new RuntimeTemplate(runtimeTemplate.compilation, {
+				...runtimeTemplate.outputOptions,
+				environment: {
+					...runtimeTemplate.outputOptions.environment,
+					arrowFunction: true,
+					destructuring: true,
+					forOf: true,
+					templateLiteral: true,
+					nodePrefixForCoreModules: true
+				}
+			});
+			expect(modern.returningFunction("a", "b")).toBe("(b) => (a)");
+			expect(modern.basicFunction("a", "return a;")).toBe(
+				"(a) => {\n\treturn a;\n}"
+			);
+			expect(modern.expressionFunction("a()")).toBe("() => (a())");
+			expect(modern.emptyFunction()).toBe("x => {}");
+			expect(modern.iife("", "a();")).toBe("(() => {\n\ta();\n})()");
+			expect(modern.destructureArray(["a", "b"], "c")).toBe("var [a, b] = c;");
+			expect(modern.destructureObject(["a", "b"], "c")).toBe(
+				"var {a, b} = c;"
+			);
+			expect(modern.forEach("a", "b", "c(a);")).toBe(
+				"for(const a of b) {\n\tc(a);\n}"
+			);
+			expect(
+				modern.concatenation(
+					"x",
+					{ expr: "a" },
+					"x",
+					{ expr: "b" },
+					"x",
+					{ expr: "c" },
+					"x"
+				)
+			).toBe("`x${a}x${b}x${c}x`");
+			expect(modern.renderNodePrefixForCoreModule("fs")).toBe('"node:fs"');
+		}
+	},
+	{
+		description: "should not report a web worker as a neutral platform",
+		options(context) {
+			return {
+				context: context.getSource(),
+				entry: "./d",
+				target: "webworker",
+				plugins: [new PlatformPlugin()]
+			};
+		},
+		build,
+		async check() {
+			expect(neutralPlatform).toBe(false);
+		}
+	},
+	{
+		description: "should report a platform agnostic target as neutral",
+		options(context) {
+			return {
+				context: context.getSource(),
+				entry: "./d",
+				// without a target there is no platform to infer a chunk format from
+				target: false,
+				output: {
+					chunkFormat: "array-push",
+					chunkLoading: false
+				},
+				plugins: [new PlatformPlugin()]
+			};
+		},
+		build,
+		async check() {
+			expect(neutralPlatform).toBe(true);
+		}
+	}
+];

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -612,12 +612,6 @@ class MyPlugin {
 }
 ```
 
-The webpack methods that render references to other modules (`moduleId`, `moduleRaw`,
-`moduleExports`, `moduleNamespace`, `moduleNamespacePromise`, `importStatement`,
-`exportFromImport`, `blockPromise`, `asyncModuleFactory`, `syncModuleFactory`, `weakError`,
-`runtimeConditionExpression`) are not available, because Rspack keeps the module graph and the
-code generation results on the Rust side.
-
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -15,6 +15,7 @@ import StatsType from '../../types/stats.mdx';
 import LoggerType from '../../types/logger.mdx';
 import CacheType from '../../types/cache.mdx';
 import CompilerType from '../../types/compiler.mdx';
+import RuntimeTemplateType from '../../types/runtime-template.mdx';
 import RspackErrorType from '../../types/rspack-error.mdx';
 import CompilationDependenciesType from '../../types/compilation-dependencies.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
@@ -611,23 +612,21 @@ class MyPlugin {
 }
 ```
 
-Available helpers:
-
-- Environment checks: `isIIFE`, `isModule`, `isNeutralPlatform`, `supportsConst`,
-  `supportsArrowFunction`, `supportsAsyncFunction`, `supportsOptionalChaining`, `supportsForOf`,
-  `supportsDestructuring`, `supportsBigIntLiteral`, `supportsDynamicImport`,
-  `supportsEcmaScriptModuleSyntax`, `supportTemplateLiteral`, `supportNodePrefixForCoreModules`
-- Code generation: `renderNodePrefixForCoreModule`, `returningFunction`, `basicFunction`,
-  `expressionFunction`, `emptyFunction`, `concatenation`, `destructureArray`, `destructureObject`,
-  `iife`, `forEach`
-- Missing module handling: `throwMissingModuleErrorBlock`, `throwMissingModuleErrorFunction`,
-  `missingModule`, `missingModuleStatement`, `missingModulePromise`
-
 The webpack methods that render references to other modules (`moduleId`, `moduleRaw`,
 `moduleExports`, `moduleNamespace`, `moduleNamespacePromise`, `importStatement`,
 `exportFromImport`, `blockPromise`, `asyncModuleFactory`, `syncModuleFactory`, `weakError`,
 `runtimeConditionExpression`) are not available, because Rspack keeps the module graph and the
 code generation results on the Rust side.
+
+<Collapse>
+  <CollapsePanel
+    className="collapse-code-panel"
+    header="RuntimeTemplate.ts"
+    key="RuntimeTemplate"
+  >
+    <RuntimeTemplateType />
+  </CollapsePanel>
+</Collapse>
 
 ### compiler
 

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -585,6 +585,50 @@ getCache(name: string): CacheFacade;
 
 The normalized options used by this Compilation, see [Configure Rspack](/config/) for details.
 
+### runtimeTemplate
+
+**Type**: `RuntimeTemplate`
+
+Helpers that generate runtime code matching the capabilities of the targeted environment, as
+declared by [`output.environment`](/config/output#outputenvironment). Use them instead of
+hand-written snippets so that generated code stays valid for older targets.
+
+```js
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
+      const { runtimeTemplate } = compilation;
+
+      // `() => (globalThis)` when arrow functions are supported,
+      // `function() { return globalThis; }` otherwise
+      runtimeTemplate.returningFunction('globalThis');
+
+      // `(a) => {\n\tconsole.log(a);\n}` when arrow functions are supported,
+      // `function(a) {\n\tconsole.log(a);\n}` otherwise
+      runtimeTemplate.basicFunction('a', 'console.log(a);');
+    });
+  }
+}
+```
+
+Available helpers:
+
+- Environment checks: `isIIFE`, `isModule`, `isNeutralPlatform`, `supportsConst`,
+  `supportsArrowFunction`, `supportsAsyncFunction`, `supportsOptionalChaining`, `supportsForOf`,
+  `supportsDestructuring`, `supportsBigIntLiteral`, `supportsDynamicImport`,
+  `supportsEcmaScriptModuleSyntax`, `supportTemplateLiteral`, `supportNodePrefixForCoreModules`
+- Code generation: `renderNodePrefixForCoreModule`, `returningFunction`, `basicFunction`,
+  `expressionFunction`, `emptyFunction`, `concatenation`, `destructureArray`, `destructureObject`,
+  `iife`, `forEach`
+- Missing module handling: `throwMissingModuleErrorBlock`, `throwMissingModuleErrorFunction`,
+  `missingModule`, `missingModuleStatement`, `missingModulePromise`
+
+The webpack methods that render references to other modules (`moduleId`, `moduleRaw`,
+`moduleExports`, `moduleNamespace`, `moduleNamespacePromise`, `importStatement`,
+`exportFromImport`, `blockPromise`, `asyncModuleFactory`, `syncModuleFactory`, `weakError`,
+`runtimeConditionExpression`) are not available, because Rspack keeps the module graph and the
+code generation results on the Rust side.
+
 ### compiler
 
 **Type**: `Compiler`

--- a/website/docs/en/types/runtime-template.mdx
+++ b/website/docs/en/types/runtime-template.mdx
@@ -1,0 +1,47 @@
+<>
+
+```ts
+type ConcatenationArg = string | { expr: string };
+
+declare class RuntimeTemplate {
+  compilation: Compilation;
+  outputOptions: OutputNormalized;
+  globalObject: string | undefined;
+  contentHashReplacement: string;
+
+  isIIFE(): boolean | undefined;
+  isModule(): boolean | undefined;
+  isNeutralPlatform(): boolean;
+
+  supportsConst(): boolean;
+  supportsArrowFunction(): boolean;
+  supportsAsyncFunction(): boolean;
+  supportsOptionalChaining(): boolean;
+  supportsForOf(): boolean;
+  supportsDestructuring(): boolean;
+  supportsBigIntLiteral(): boolean;
+  supportsDynamicImport(): boolean;
+  supportsEcmaScriptModuleSyntax(): boolean;
+  supportTemplateLiteral(): boolean;
+  supportNodePrefixForCoreModules(): boolean;
+
+  renderNodePrefixForCoreModule(mod: string): string;
+  returningFunction(returnValue: string, args?: string): string;
+  basicFunction(args: string, body: string | string[]): string;
+  expressionFunction(expression: string, args?: string): string;
+  emptyFunction(): string;
+  concatenation(...args: ConcatenationArg[]): string;
+  destructureArray(items: string[], value: string): string;
+  destructureObject(items: string[], value: string): string;
+  iife(args: string, body: string | string[]): string;
+  forEach(variable: string, array: string, body: string | string[]): string;
+
+  throwMissingModuleErrorBlock(options: { request?: string }): string;
+  throwMissingModuleErrorFunction(options: { request?: string }): string;
+  missingModule(options: { request?: string }): string;
+  missingModuleStatement(options: { request?: string }): string;
+  missingModulePromise(options: { request?: string }): string;
+}
+```
+
+</>

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -608,11 +608,6 @@ class MyPlugin {
 }
 ```
 
-webpack 中用于渲染模块间引用的方法（`moduleId`、`moduleRaw`、`moduleExports`、`moduleNamespace`、
-`moduleNamespacePromise`、`importStatement`、`exportFromImport`、`blockPromise`、
-`asyncModuleFactory`、`syncModuleFactory`、`weakError`、`runtimeConditionExpression`）暂不提供，
-因为 Rspack 将模块图与代码生成结果保存在 Rust 侧。
-
 <Collapse>
   <CollapsePanel
     className="collapse-code-panel"

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -15,6 +15,7 @@ import StatsType from '../../types/stats.mdx';
 import LoggerType from '../../types/logger.mdx';
 import CacheType from '../../types/cache.mdx';
 import CompilerType from '../../types/compiler.mdx';
+import RuntimeTemplateType from '../../types/runtime-template.mdx';
 import RspackErrorType from '../../types/rspack-error.mdx';
 import CompilationDependenciesType from '../../types/compilation-dependencies.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
@@ -607,22 +608,20 @@ class MyPlugin {
 }
 ```
 
-可用的方法：
-
-- 环境能力判断：`isIIFE`、`isModule`、`isNeutralPlatform`、`supportsConst`、
-  `supportsArrowFunction`、`supportsAsyncFunction`、`supportsOptionalChaining`、`supportsForOf`、
-  `supportsDestructuring`、`supportsBigIntLiteral`、`supportsDynamicImport`、
-  `supportsEcmaScriptModuleSyntax`、`supportTemplateLiteral`、`supportNodePrefixForCoreModules`
-- 代码生成：`renderNodePrefixForCoreModule`、`returningFunction`、`basicFunction`、
-  `expressionFunction`、`emptyFunction`、`concatenation`、`destructureArray`、`destructureObject`、
-  `iife`、`forEach`
-- 缺失模块处理：`throwMissingModuleErrorBlock`、`throwMissingModuleErrorFunction`、
-  `missingModule`、`missingModuleStatement`、`missingModulePromise`
-
 webpack 中用于渲染模块间引用的方法（`moduleId`、`moduleRaw`、`moduleExports`、`moduleNamespace`、
 `moduleNamespacePromise`、`importStatement`、`exportFromImport`、`blockPromise`、
 `asyncModuleFactory`、`syncModuleFactory`、`weakError`、`runtimeConditionExpression`）暂不提供，
 因为 Rspack 将模块图与代码生成结果保存在 Rust 侧。
+
+<Collapse>
+  <CollapsePanel
+    className="collapse-code-panel"
+    header="RuntimeTemplate.ts"
+    key="RuntimeTemplate"
+  >
+    <RuntimeTemplateType />
+  </CollapsePanel>
+</Collapse>
 
 ### compiler
 

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -582,6 +582,48 @@ getCache(name: string): CacheFacade;
 
 获取此 Compilation 使用的完整配置，详见[配置 Rspack](/config/)。
 
+### runtimeTemplate
+
+**类型：** `RuntimeTemplate`
+
+用于生成运行时代码的辅助方法，会根据 [`output.environment`](/config/output#outputenvironment)
+声明的目标环境能力来选择语法。相比手写代码片段，使用这些方法可以保证生成的代码在旧目标环境下依然合法。
+
+```js
+class MyPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
+      const { runtimeTemplate } = compilation;
+
+      // 支持箭头函数时为 `() => (globalThis)`，
+      // 否则为 `function() { return globalThis; }`
+      runtimeTemplate.returningFunction('globalThis');
+
+      // 支持箭头函数时为 `(a) => {\n\tconsole.log(a);\n}`，
+      // 否则为 `function(a) {\n\tconsole.log(a);\n}`
+      runtimeTemplate.basicFunction('a', 'console.log(a);');
+    });
+  }
+}
+```
+
+可用的方法：
+
+- 环境能力判断：`isIIFE`、`isModule`、`isNeutralPlatform`、`supportsConst`、
+  `supportsArrowFunction`、`supportsAsyncFunction`、`supportsOptionalChaining`、`supportsForOf`、
+  `supportsDestructuring`、`supportsBigIntLiteral`、`supportsDynamicImport`、
+  `supportsEcmaScriptModuleSyntax`、`supportTemplateLiteral`、`supportNodePrefixForCoreModules`
+- 代码生成：`renderNodePrefixForCoreModule`、`returningFunction`、`basicFunction`、
+  `expressionFunction`、`emptyFunction`、`concatenation`、`destructureArray`、`destructureObject`、
+  `iife`、`forEach`
+- 缺失模块处理：`throwMissingModuleErrorBlock`、`throwMissingModuleErrorFunction`、
+  `missingModule`、`missingModuleStatement`、`missingModulePromise`
+
+webpack 中用于渲染模块间引用的方法（`moduleId`、`moduleRaw`、`moduleExports`、`moduleNamespace`、
+`moduleNamespacePromise`、`importStatement`、`exportFromImport`、`blockPromise`、
+`asyncModuleFactory`、`syncModuleFactory`、`weakError`、`runtimeConditionExpression`）暂不提供，
+因为 Rspack 将模块图与代码生成结果保存在 Rust 侧。
+
 ### compiler
 
 **类型：** `Compiler`

--- a/website/docs/zh/types/runtime-template.mdx
+++ b/website/docs/zh/types/runtime-template.mdx
@@ -1,0 +1,47 @@
+<>
+
+```ts
+type ConcatenationArg = string | { expr: string };
+
+declare class RuntimeTemplate {
+  compilation: Compilation;
+  outputOptions: OutputNormalized;
+  globalObject: string | undefined;
+  contentHashReplacement: string;
+
+  isIIFE(): boolean | undefined;
+  isModule(): boolean | undefined;
+  isNeutralPlatform(): boolean;
+
+  supportsConst(): boolean;
+  supportsArrowFunction(): boolean;
+  supportsAsyncFunction(): boolean;
+  supportsOptionalChaining(): boolean;
+  supportsForOf(): boolean;
+  supportsDestructuring(): boolean;
+  supportsBigIntLiteral(): boolean;
+  supportsDynamicImport(): boolean;
+  supportsEcmaScriptModuleSyntax(): boolean;
+  supportTemplateLiteral(): boolean;
+  supportNodePrefixForCoreModules(): boolean;
+
+  renderNodePrefixForCoreModule(mod: string): string;
+  returningFunction(returnValue: string, args?: string): string;
+  basicFunction(args: string, body: string | string[]): string;
+  expressionFunction(expression: string, args?: string): string;
+  emptyFunction(): string;
+  concatenation(...args: ConcatenationArg[]): string;
+  destructureArray(items: string[], value: string): string;
+  destructureObject(items: string[], value: string): string;
+  iife(args: string, body: string | string[]): string;
+  forEach(variable: string, array: string, body: string | string[]): string;
+
+  throwMissingModuleErrorBlock(options: { request?: string }): string;
+  throwMissingModuleErrorFunction(options: { request?: string }): string;
+  missingModule(options: { request?: string }): string;
+  missingModuleStatement(options: { request?: string }): string;
+  missingModulePromise(options: { request?: string }): string;
+}
+```
+
+</>


### PR DESCRIPTION
## Summary

Adds `compilation.runtimeTemplate`, aligning with webpack's `RuntimeTemplate`.

Plugin authors currently have to hand-roll the environment branches when they emit runtime code (`() => …` vs `function() { … }`, `var [a, b] = c;` vs `var a = c[0];`, `for(const x of y)` vs `y.forEach(…)`, template literal vs string concatenation). `compilation.runtimeTemplate` derives all of that from `output.environment`, so generated code stays valid for the configured target.

The environment dependent branches mirror `RuntimeTemplate` in `crates/rspack_core/src/runtime_template.rs`, so JS-side generated code matches what Rspack's own Rust code generation produces for the same options.

What is available:

- Environment checks: `isIIFE`, `isModule`, `isNeutralPlatform`, `supportsConst`, `supportsArrowFunction`, `supportsAsyncFunction`, `supportsOptionalChaining`, `supportsForOf`, `supportsDestructuring`, `supportsBigIntLiteral`, `supportsDynamicImport`, `supportsEcmaScriptModuleSyntax`, `supportTemplateLiteral`, `supportNodePrefixForCoreModules`
- Code generation: `renderNodePrefixForCoreModule`, `returningFunction`, `basicFunction`, `expressionFunction`, `emptyFunction`, `concatenation`, `destructureArray`, `destructureObject`, `iife`, `forEach`
- Missing module handling: `throwMissingModuleErrorBlock`, `throwMissingModuleErrorFunction`, `missingModule`, `missingModuleStatement`, `missingModulePromise`
- Properties: `compilation`, `outputOptions`, `globalObject`, `contentHashReplacement`

Deliberate omissions, documented on the class and in the docs:

- The methods that render references to other modules (`moduleId`, `moduleRaw`, `moduleExports`, `moduleNamespace`, `moduleNamespacePromise`, `importStatement`, `exportFromImport`, `blockPromise`, `asyncModuleFactory`, `syncModuleFactory`, `weakError`, `runtimeConditionExpression`) need read access to the module graph and the code generation results, which Rspack keeps on the Rust side.
- `comment()` needs `compilation.requestShortener`, which Rspack does not have.
- `defineEsModuleFlagStatement()` needs runtime globals as webpack identifier strings, while Rspack resolves them from a numeric `RuntimeGlobals` enum whose final identifier depends on the runtime mode.

Pure TypeScript, no Rust or binding change: `outputOptions.environment` was already exposed on the JS side, and `Template` already provides `indent`/`asString`.

Example:

```js
class MyPlugin {
  apply(compiler) {
    compiler.hooks.compilation.tap('MyPlugin', (compilation) => {
      const { runtimeTemplate } = compilation;
      runtimeTemplate.returningFunction('globalThis');
      runtimeTemplate.basicFunction('a', 'console.log(a);');
    });
  }
}
```

## Related links

Closes #10014

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Test: `tests/rspack-test/compilerCases/runtime-template.js` asserts the exact output of every helper in both an ES5 `output.environment` (taken from the real compilation) and an ES2015 one.

Docs: `### runtimeTemplate` added to `website/docs/{en,zh}/api/javascript-api/compilation.mdx`.
