### PR TITLE
perf(core): store FactorizeInfo path dependencies as compact slices

### DIFF
--- a/crates/rspack_core/src/artifacts/factorization_artifact.rs
+++ b/crates/rspack_core/src/artifacts/factorization_artifact.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::cacheable;
 use rspack_error::Diagnostic;
-use rspack_paths::InternedPathSet;
+use rspack_paths::{InternedPath, InternedPathSet};
 use rustc_hash::FxHashMap;
 
 use crate::DependencyId;
@@ -9,9 +9,9 @@ use crate::DependencyId;
 #[derive(Debug, Clone)]
 pub struct FactorizeInfo {
   related_dep_ids: Vec<DependencyId>,
-  file_dependencies: InternedPathSet,
-  context_dependencies: InternedPathSet,
-  missing_dependencies: InternedPathSet,
+  file_dependencies: Box<[InternedPath]>,
+  context_dependencies: Box<[InternedPath]>,
+  missing_dependencies: Box<[InternedPath]>,
   diagnostics: Vec<Diagnostic>,
 }
 
@@ -29,9 +29,9 @@ impl FactorizeInfo {
     );
     Self {
       related_dep_ids,
-      file_dependencies,
-      context_dependencies,
-      missing_dependencies,
+      file_dependencies: file_dependencies.into_iter().collect(),
+      context_dependencies: context_dependencies.into_iter().collect(),
+      missing_dependencies: missing_dependencies.into_iter().collect(),
       diagnostics,
     }
   }
@@ -48,15 +48,15 @@ impl FactorizeInfo {
     &self.related_dep_ids
   }
 
-  pub fn file_dependencies(&self) -> &InternedPathSet {
+  pub fn file_dependencies(&self) -> &[InternedPath] {
     &self.file_dependencies
   }
 
-  pub fn context_dependencies(&self) -> &InternedPathSet {
+  pub fn context_dependencies(&self) -> &[InternedPath] {
     &self.context_dependencies
   }
 
-  pub fn missing_dependencies(&self) -> &InternedPathSet {
+  pub fn missing_dependencies(&self) -> &[InternedPath] {
     &self.missing_dependencies
   }
 

--- a/crates/rspack_core/src/utils/file_counter/mod.rs
+++ b/crates/rspack_core/src/utils/file_counter/mod.rs
@@ -3,7 +3,7 @@ mod resource_id;
 use std::hash::BuildHasherDefault;
 
 use rspack_collections::IdentifierSet;
-use rspack_paths::{InternedPath, InternedPathMap, InternedPathSet};
+use rspack_paths::{InternedPath, InternedPathMap};
 use rustc_hash::FxHashSet;
 use ustr::IdentityHasher;
 
@@ -56,7 +56,11 @@ impl FileCounter {
   /// Add batch [`PathBuf`] to counter
   ///
   /// It will add resource_id at the PathBuf in inner hashmap
-  pub fn add_files(&mut self, resource_id: &ResourceId, paths: &InternedPathSet) {
+  pub fn add_files<'a>(
+    &mut self,
+    resource_id: &ResourceId,
+    paths: impl IntoIterator<Item = &'a InternedPath>,
+  ) {
     for path in paths {
       let list = self.inner.entry(path.clone()).or_default();
       if list.is_empty() {
@@ -73,7 +77,11 @@ impl FileCounter {
   ///
   /// If the PathBuf resource_id is empty after reduction, the record will be deleted
   /// If PathBuf does not exist, panic will occur.
-  pub fn remove_files(&mut self, resource_id: &ResourceId, paths: &InternedPathSet) {
+  pub fn remove_files<'a>(
+    &mut self,
+    resource_id: &ResourceId,
+    paths: impl IntoIterator<Item = &'a InternedPath>,
+  ) {
     for path in paths {
       let Some(list) = self.inner.get_mut(path) else {
         panic!("unable to remove untracked file {}", path.to_string_lossy());


### PR DESCRIPTION
## Why

`FactorizeInfo` keeps three `InternedPathSet` per factorization, but nothing ever looks a path up in
them — every reader just iterates. A `HashSet` is the wrong container for that, and it is expensive:
hashbrown rounds up to a power-of-two bucket count at 87.5% load, so the average 225 entries take
512 buckets — 4624 B for 1800 B of payload, **2.6×**. Where the source has duplicates the table gets
1024 buckets for 227 elements, **5.1×**.



This PR does not change what is collected. It changes what it is stored in: `Box<[InternedPath]>`,
sized exactly to the payload.

## Measurements

Large monorepo build, persistent cache off:

| | base | this PR | Δ |
|---|---|---|---|
| live bytes at peak, the three sets | 1093 MB | 377–405 MB | **−0.7 GB (−63%)** |
| peak RSS, whole process (3 alternating A/B pairs) | 12987 MB | 12288 MB | **−699 MB (−5%)** |

Two more allocators reproduce the RSS result independently (jemalloc −547 MB, glibc −567 MB;
9 of 9 paired differences negative). `MI_STAT=2` shows the mechanism directly — the same number of
objects moved into a smaller size class:

```
bin 33 (5120 B blocks)   allocation count   312.8 K → 313.0 K   (+0.06%)
                         peak live          1.0 GiB → 243.2 MiB
```

The saving scales with *factorizations × entries per set* (here 183,320 × ~225), so a small project
should expect proportionally less.

## Notes

- `FactorizeInfo::new` still takes `InternedPathSet` and converts internally, so no caller changes.
  The set is what guarantees the slices stay duplicate-free, which `FileCounter::remove_files`
  requires (it panics on removing an untracked path).
- `FileCounter::add_files` / `remove_files` now take `impl IntoIterator<Item = &InternedPath>` so
  both the new slices and `BuildInfo`'s existing `InternedPathSet` fields can be passed. `BuildInfo`
  is untouched.
- This changes the persistent cache serialization format for `FactorizeInfo`.
