### PR TITLE
fix(rsc): store server compiler ID in native coordinator

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -371,7 +371,7 @@ export declare class JsContextModuleFactoryBeforeResolveData {
 }
 
 export declare class JsCoordinator {
-  constructor(getServerCompilerIdJsFn: () => ExternalObject<CompilerId>)
+  constructor()
 }
 
 export declare class JsDependencies {

--- a/crates/rspack_binding_api/src/plugins/rsc.rs
+++ b/crates/rspack_binding_api/src/plugins/rsc.rs
@@ -4,13 +4,13 @@ use futures::future::BoxFuture;
 use napi::{
   Env, Status,
   bindgen_prelude::{
-    ClassInstance, Either, Either3, External, ExternalRef, FromNapiValue, Function, JsObjectValue,
-    Null, Object, Promise, Reference, Undefined, ValidateNapiValue, WeakReference, sys,
+    ClassInstance, Either, Either3, FromNapiValue, Function, JsObjectValue, Null, Object, Promise,
+    Reference, Undefined, ValidateNapiValue, WeakReference, sys,
   },
   threadsafe_function::ThreadsafeFunction,
 };
 use once_cell::unsync::OnceCell;
-use rspack_core::{Compiler, CompilerId};
+use rspack_core::Compiler;
 use rspack_error::ToStringResultToRspackResultExt;
 use rspack_plugin_rsc::{
   Coordinator, OnManifest, RscClientPluginOptions, RscCssLinkProps, RscServerPluginOptions,
@@ -30,32 +30,10 @@ pub struct JsCoordinator {
 #[napi]
 impl JsCoordinator {
   #[napi(constructor)]
-  pub fn new(
-    get_server_compiler_id_js_fn: Function<'static, (), &'static External<CompilerId>>,
-  ) -> napi::Result<Self> {
-    let get_server_compiler_id = {
-      let ts_fn = Arc::new(
-        get_server_compiler_id_js_fn
-          .build_threadsafe_function::<()>()
-          .callee_handled::<false>()
-          .max_queue_size::<0>()
-          .weak::<true>()
-          .build()?,
-      );
-      Box::new(
-        move || -> BoxFuture<'static, rspack_error::Result<CompilerId>> {
-          let ts_fn = ts_fn.clone();
-          Box::pin(async move {
-            let external = ts_fn.call_async(()).await.to_rspack_result()?;
-            Ok(**external)
-          })
-        },
-      )
-    };
-
-    Ok(Self {
-      i: Arc::new(Coordinator::new(get_server_compiler_id)),
-    })
+  pub fn new() -> Self {
+    Self {
+      i: Arc::new(Coordinator::new()),
+    }
   }
 }
 

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -638,7 +638,7 @@ async fn make(&self, compilation: &mut Compilation) -> Result<()> {
   let plugin_state = PLUGIN_STATES.get(&server_compiler_id).ok_or_else(|| {
     rspack_error::error!(
       "RscClientPlugin: Plugin state not found in make hook for compiler {:#?}.",
-      compilation.compiler_id()
+      server_compiler_id
     )
   })?;
 

--- a/crates/rspack_plugin_rsc/src/coordinator.rs
+++ b/crates/rspack_plugin_rsc/src/coordinator.rs
@@ -1,4 +1,3 @@
-use futures::future::BoxFuture;
 use rspack_core::CompilerId;
 use rspack_error::Result;
 use tokio::sync::{Mutex, Notify};
@@ -15,8 +14,6 @@ enum State {
   Failed,
 }
 
-type GetServerCompilerId = Box<dyn Fn() -> BoxFuture<'static, Result<CompilerId>> + Sync + Send>;
-
 /// Coordinates the compilation sequence between Server Compiler and Client Compiler.
 ///
 /// Ensures the following compilation order:
@@ -29,20 +26,31 @@ type GetServerCompilerId = Box<dyn Fn() -> BoxFuture<'static, Result<CompilerId>
 pub struct Coordinator {
   state: Mutex<State>,
   state_notify: Notify,
-  get_server_compiler_id: GetServerCompilerId,
+  server_compiler_id: Mutex<Option<CompilerId>>,
+}
+
+impl Default for Coordinator {
+  fn default() -> Self {
+    Self::new()
+  }
 }
 
 impl Coordinator {
-  pub fn new(get_server_compiler_id: GetServerCompilerId) -> Self {
+  pub fn new() -> Self {
     Self {
       state: Mutex::new(State::Idle),
       state_notify: Default::default(),
-      get_server_compiler_id,
+      server_compiler_id: Default::default(),
     }
   }
 
   pub async fn get_server_compiler_id(&self) -> Result<CompilerId> {
-    (self.get_server_compiler_id)().await
+    (*self.server_compiler_id.lock().await).ok_or_else(|| {
+      rspack_error::error!(
+        "Server compiler ID is not registered in the RSC coordinator. \
+         Ensure RscServerPlugin starts compiling before RscClientPlugin."
+      )
+    })
   }
 
   async fn wait_for(&self, mut predicate: impl FnMut(State) -> bool) -> Result<()> {
@@ -100,13 +108,16 @@ impl Coordinator {
     self.wait_for(|s| s == State::Idle).await
   }
 
-  pub async fn start_server_entries_compilation(&self) -> Result<()> {
+  pub async fn start_server_entries_compilation(&self, compiler_id: CompilerId) -> Result<()> {
     loop {
-      if self
-        .set_if_current(State::Idle, State::ServerEntriesCompiling)
-        .await
       {
-        return Ok(());
+        let mut state = self.state.lock().await;
+        if *state == State::Idle {
+          *self.server_compiler_id.lock().await = Some(compiler_id);
+          *state = State::ServerEntriesCompiling;
+          self.state_notify.notify_waiters();
+          return Ok(());
+        }
       }
       self.wait_idle().await?;
     }

--- a/crates/rspack_plugin_rsc/src/server_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/server_plugin.rs
@@ -210,7 +210,10 @@ async fn this_compilation(
     .or_default()
     .css_link_props = self.css_link_props.clone();
 
-  self.coordinator.start_server_entries_compilation().await?;
+  self
+    .coordinator
+    .start_server_entries_compilation(compilation.compiler_id())
+    .await?;
 
   Ok(())
 }

--- a/packages/rspack/src/builtin-plugin/rsc/Coordinator.ts
+++ b/packages/rspack/src/builtin-plugin/rsc/Coordinator.ts
@@ -1,5 +1,5 @@
 import { JsCoordinator } from '@rspack/binding';
-import { type Compiler, GET_COMPILER_ID } from '../../Compiler';
+import type { Compiler } from '../../Compiler';
 import type { Compilation } from '../../exports';
 
 const PLUGIN_NAME = 'RscPlugin';
@@ -22,16 +22,7 @@ export class Coordinator {
       writable: false,
       value: () => {
         if (!this.#binding) {
-          this.#binding = new JsCoordinator(() => {
-            if (!this.#serverCompiler) {
-              throw new Error(
-                '[RscPlugin] Coordinator.getOrInitBinding() called before the server compiler was attached. ' +
-                  'Call coordinator.applyServerCompiler(serverCompiler) first.',
-              );
-            }
-            // @ts-ignore
-            return this.#serverCompiler[GET_COMPILER_ID]();
-          });
+          this.#binding = new JsCoordinator();
         }
         return this.#binding;
       },


### PR DESCRIPTION
## Summary

- Store the server compiler ID directly in the native RSC coordinator when server entry compilation starts.
- Remove the JavaScript callback/TSFN that returned a borrowed `External<CompilerId>` across an async Node-API boundary. Its lifetime depended on JavaScript GC and scheduling, which could cause intermittent plugin-state lookup failures.
- Read the owned server compiler ID from the coordinator in the client compiler.
- Correct the missing-state diagnostic to report the server compiler ID used for the lookup instead of the client compiler ID.

## Related links

- Flaky CI failure

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
