### PR TITLE
fix: pre-register modules before chunk graph splitting

### DIFF
--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -28,6 +28,14 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     .copied()
     .collect::<Vec<_>>();
 
+  // make sure all module (weak dependency particularly) has a cgm
+  for module_identifier in &all_modules {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .add_module(*module_identifier)
+  }
+
   splitter.prepare(&all_modules, compilation)?;
 
   splitter.update_with_compilation(compilation)?;
@@ -41,14 +49,6 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
 
   // remove empty chunk groups
   splitter.remove_orphan(compilation)?;
-
-  // make sure all module (weak dependency particularly) has a cgm
-  for module_identifier in all_modules {
-    compilation
-      .build_chunk_graph_artifact
-      .chunk_graph
-      .add_module(module_identifier)
-  }
 
   compilation
     .build_chunk_graph_artifact

--- a/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/mod.rs
@@ -28,12 +28,12 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
     .copied()
     .collect::<Vec<_>>();
 
-  // make sure all module (weak dependency particularly) has a cgm
+  // Make sure all modules (particularly weak dependencies) have a CGM before splitting.
   for module_identifier in &all_modules {
     compilation
       .build_chunk_graph_artifact
       .chunk_graph
-      .add_module(*module_identifier)
+      .add_module(*module_identifier);
   }
 
   splitter.prepare(&all_modules, compilation)?;
@@ -49,6 +49,14 @@ pub fn build_chunk_graph(compilation: &mut Compilation) -> rspack_error::Result<
 
   // remove empty chunk groups
   splitter.remove_orphan(compilation)?;
+
+  // Orphan cleanup may remove the CGM of a module that remains in the module graph.
+  for module_identifier in all_modules {
+    compilation
+      .build_chunk_graph_artifact
+      .chunk_graph
+      .add_module(module_identifier);
+  }
 
   compilation
     .build_chunk_graph_artifact

--- a/tests/rspack-test/configCases/chunk-graph/issue-15136/index.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15136/index.js
@@ -1,0 +1,7 @@
+import { isEqual, startsWith, uniq } from "lodash-es";
+
+it("should register transformed ESM modules before splitting the chunk graph", () => {
+	expect(startsWith("rspack", "rsp")).toBe(true);
+	expect(isEqual({ modules: ["a", "b"] }, { modules: ["a", "b"] })).toBe(true);
+	expect(uniq(["entry", "shared", "entry"])).toEqual(["entry", "shared"]);
+});

--- a/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
@@ -1,0 +1,13 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	mode: "production",
+	module: {
+		rules: [
+			{
+				test: /\.js$/,
+				type: "javascript/esm",
+				use: "builtin:swc-loader"
+			}
+		]
+	}
+};

--- a/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15136/rspack.config.js
@@ -1,13 +1,13 @@
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	mode: "production",
-	module: {
-		rules: [
-			{
-				test: /\.js$/,
-				type: "javascript/esm",
-				use: "builtin:swc-loader"
-			}
-		]
-	}
+  mode: 'production',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        type: 'javascript/esm',
+        use: 'builtin:swc-loader',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## Summary

Add a config-case reproduction that imports representative `lodash-es` functions while applying `builtin:swc-loader` to JavaScript ESM, so successful compilation and execution prove the reported module path no longer panics. In `build_chunk_graph`, register the complete `all_modules` set in the chunk graph before entry preparation and splitting can read or connect module state, while keeping chunk membership empty until the splitter establishes it. Remove the now-redundant post-split registration loop, preserving the special handling of weak or otherwise unconnected modules without relaxing `expect_chunk_graph_module` callers.

Rspack can panic with `Module(...) should be added before using` while production bundling walks `lodash-es` modules transformed by `builtin:swc-loader`. The panic identifies `ChunkGraph`'s missing-module assertion, and the build-chunk-graph flow currently waits until after splitting and orphan removal to register every module identifier. That ordering leaves modules which are skipped, weakly connected, or reached through a transformed ESM dependency vulnerable to chunk-graph queries before their `ChunkGraphModule` record exists. The fix must preserve the assertion as an internal invariant and prevent the invalid state instead of converting the panic into a silent empty result.

Fixes #15136

## Related links

Not applicable to this change.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
