### PR TITLE
refactor(cache): align new cache snapshots with webpack

### DIFF
--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -8,7 +8,7 @@ use super::{
   CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
   db::{Database, DatabaseFamily, DatabaseValue, DatabaseWrite},
-  snapshot::{BuildDeps, Snapshot},
+  snapshot::{BuildDeps, FileSystemInfo},
   validator::{CacheValidator, CacheValidatorResult},
 };
 use crate::cache::persistent::codec::CacheCodec;
@@ -53,7 +53,7 @@ impl FileCacheStrategy {
     rspack_pkg_version: String,
     cache_version: String,
     codec: Arc<CacheCodec>,
-    snapshot: Snapshot,
+    file_system_info: FileSystemInfo,
     build_deps: BuildDeps,
   ) -> Result<Self> {
     let (base_path, database_path) = database_paths;
@@ -63,7 +63,7 @@ impl FileCacheStrategy {
         rspack_pkg_version,
         cache_version,
         codec.clone(),
-        snapshot,
+        file_system_info,
         build_deps,
       ),
       codec,

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -22,7 +22,7 @@ pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
 use rspack_fs::ReadableFileSystem;
 
-use self::snapshot::{BuildDeps, Snapshot};
+use self::snapshot::{BuildDeps, FileSystemInfo};
 use crate::{
   CompilationLogger, CompilationLogging, CompilerOptions, cache::persistent::codec::CacheCodec,
 };
@@ -53,7 +53,11 @@ pub fn create_cache(
     None
   };
   let codec = Arc::new(CacheCodec::new(project_root));
-  let snapshot = Snapshot::new(options.snapshot.clone(), input_filesystem.clone());
+  let file_system_info = FileSystemInfo::new(
+    input_filesystem.clone(),
+    options.snapshot.clone(),
+    compiler_options.output.hash_function,
+  );
   let build_deps = BuildDeps::new(
     &options.build_dependencies,
     input_filesystem,
@@ -73,7 +77,7 @@ pub fn create_cache(
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
     codec,
-    snapshot,
+    file_system_info,
     build_deps,
   ) {
     Ok(strategy) => strategy,

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -1,9 +1,10 @@
 use std::{collections::VecDeque, path::PathBuf, sync::Arc};
 
+use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{AssertUtf8, InternedPath, InternedPathSet};
 
-use super::{Snapshot, SnapshotEntry};
+use super::{FileSystemInfo, Snapshot, SnapshotValidationResult};
 use crate::{
   CompilationLogger,
   cache::persistent::build_dependencies::{Helper, is_node_package_path},
@@ -20,6 +21,14 @@ pub enum BuildDepsValidationResult {
     modified_files: InternedPathSet,
     removed_files: InternedPathSet,
   },
+}
+
+#[derive(Debug, Default)]
+pub struct ResolvedBuildDependencies {
+  pub(crate) dependencies: InternedPathSet,
+  pub(crate) files: InternedPathSet,
+  pub(crate) contexts: InternedPathSet,
+  pub(crate) missing: InternedPathSet,
 }
 
 /// Build dependencies manager.
@@ -55,16 +64,27 @@ impl BuildDeps {
     &mut self,
     current: &InternedPathSet,
     paths: impl Iterator<Item = InternedPath>,
-  ) -> InternedPathSet {
+  ) -> ResolvedBuildDependencies {
     let mut helper = Helper::new(self.fs.clone(), self.logger.clone());
-    let mut added = InternedPathSet::default();
+    let mut resolved = ResolvedBuildDependencies::default();
     let mut queue = VecDeque::new();
     queue.extend(self.pending.iter().cloned());
     queue.extend(paths);
 
     while let Some(dependency) = queue.pop_front() {
-      if current.contains(&dependency) || !added.insert(dependency.clone()) {
+      if current.contains(&dependency) || !resolved.dependencies.insert(dependency.clone()) {
         continue;
+      }
+      match self.fs.metadata(dependency.assert_utf8()).await {
+        Ok(metadata) if metadata.is_directory => {
+          resolved.contexts.insert(dependency.clone());
+        }
+        Ok(_) => {
+          resolved.files.insert(dependency.clone());
+        }
+        Err(_) => {
+          resolved.missing.insert(dependency.clone());
+        }
       }
       if is_node_package_path(&dependency) {
         continue;
@@ -79,7 +99,7 @@ impl BuildDeps {
     }
 
     self.pending.clear();
-    added
+    resolved
   }
 
   /// Validate build dependencies.
@@ -87,17 +107,36 @@ impl BuildDeps {
   /// If any build dependency changed, this method returns an invalid result.
   pub async fn validate_snapshot(
     &self,
+    file_system_info: &FileSystemInfo,
     snapshot: &Snapshot,
-    entries: &[SnapshotEntry],
+    dependencies: &InternedPathSet,
     tracked_files: usize,
-  ) -> BuildDepsValidationResult {
-    let (modified_files, removed_files) = snapshot.calc_modified_paths(entries).await;
-    if !modified_files.is_empty() || !removed_files.is_empty() {
-      return BuildDepsValidationResult::Invalid {
-        modified_files,
+  ) -> Result<BuildDepsValidationResult> {
+    let validation = file_system_info.check_snapshot_valid(snapshot).await?;
+    let pending = self
+      .pending
+      .iter()
+      .filter(|path| !dependencies.contains(*path))
+      .cloned()
+      .collect::<InternedPathSet>();
+    match validation {
+      SnapshotValidationResult::Valid if pending.is_empty() => {
+        Ok(BuildDepsValidationResult::Valid { tracked_files })
+      }
+      SnapshotValidationResult::Valid => Ok(BuildDepsValidationResult::Invalid {
+        modified_files: pending,
+        removed_files: Default::default(),
+      }),
+      SnapshotValidationResult::Invalid {
+        mut modified_files,
         removed_files,
-      };
+      } => {
+        modified_files.extend(pending);
+        Ok(BuildDepsValidationResult::Invalid {
+          modified_files,
+          removed_files,
+        })
+      }
     }
-    BuildDepsValidationResult::Valid { tracked_files }
   }
 }

--- a/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/build_deps.rs
@@ -60,6 +60,9 @@ impl BuildDeps {
   ///
   /// For performance reasons, recursive searches stop at dependencies in
   /// `node_modules`.
+  ///
+  /// See webpack's build dependency resolution implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L1873-L2523
   pub async fn resolve_dependencies(
     &mut self,
     current: &InternedPathSet,

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -1,0 +1,948 @@
+use std::{
+  fmt,
+  sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+  },
+};
+
+use rspack_error::{Result, error};
+use rspack_fs::{Error as FsError, FileMetadata, ReadableFileSystem};
+use rspack_hash::{HashDigest, HashFunction, RspackHashDigest, RspackHasher};
+use rspack_parallel::TryFutureConsumer;
+use rspack_paths::{AssertUtf8, InternedPath, InternedPathDashMap, InternedPathSet};
+use simd_json::prelude::{ValueAsScalar, ValueObjectAccess};
+
+use super::{
+  ContextFileSystemInfoEntry, ContextTimestampAndHash, FileHash, FileSystemInfoEntry, Snapshot,
+  TimestampAndHash,
+};
+use crate::cache::persistent::snapshot::{SnapshotOptions, SnapshotStrategyOptions};
+
+static FS_ACCURACY: AtomicU64 = AtomicU64::new(2000);
+
+#[derive(Debug)]
+pub enum SnapshotValidationResult {
+  Valid,
+  Invalid {
+    modified_files: InternedPathSet,
+    removed_files: InternedPathSet,
+  },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SnapshotMode {
+  Timestamp,
+  Hash,
+  TimestampAndHash,
+}
+
+impl From<SnapshotStrategyOptions> for SnapshotMode {
+  fn from(value: SnapshotStrategyOptions) -> Self {
+    if value.hash {
+      if value.timestamp {
+        Self::TimestampAndHash
+      } else {
+        Self::Hash
+      }
+    } else {
+      // This matches webpack: timestamp is the fallback mode even when both
+      // option bits are false.
+      Self::Timestamp
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PathKind {
+  File,
+  Context,
+  Missing,
+}
+
+#[derive(Debug)]
+struct ContextValue {
+  safe_time: u64,
+  timestamp_hash: Option<RspackHashDigest>,
+  hash: Option<RspackHashDigest>,
+}
+
+/// Cached access to filesystem state and snapshot algorithms.
+///
+/// The module follows webpack's `FileSystemInfo` seam: callers provide path
+/// sets and a strategy, while path classification, managed package handling,
+/// timestamp accuracy, hashing, merging and validation stay behind this
+/// interface.
+#[derive(Clone)]
+pub struct FileSystemInfo {
+  fs: Arc<dyn ReadableFileSystem>,
+  options: Arc<SnapshotOptions>,
+  hash_function: HashFunction,
+  file_timestamps: Arc<InternedPathDashMap<Option<FileSystemInfoEntry>>>,
+  file_hashes: Arc<InternedPathDashMap<Option<FileHash>>>,
+  file_timestamp_hashes: Arc<InternedPathDashMap<Option<TimestampAndHash>>>,
+  context_timestamps: Arc<InternedPathDashMap<Option<ContextFileSystemInfoEntry>>>,
+  context_hashes: Arc<InternedPathDashMap<Option<RspackHashDigest>>>,
+  context_timestamp_hashes: Arc<InternedPathDashMap<Option<ContextTimestampAndHash>>>,
+  managed_items: Arc<InternedPathDashMap<Option<String>>>,
+}
+
+impl fmt::Debug for FileSystemInfo {
+  fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    formatter
+      .debug_struct("FileSystemInfo")
+      .finish_non_exhaustive()
+  }
+}
+
+impl FileSystemInfo {
+  pub fn new(
+    fs: Arc<dyn ReadableFileSystem>,
+    options: SnapshotOptions,
+    hash_function: HashFunction,
+  ) -> Self {
+    Self {
+      fs,
+      options: Arc::new(options),
+      hash_function,
+      file_timestamps: Default::default(),
+      file_hashes: Default::default(),
+      file_timestamp_hashes: Default::default(),
+      context_timestamps: Default::default(),
+      context_hashes: Default::default(),
+      context_timestamp_hashes: Default::default(),
+      managed_items: Default::default(),
+    }
+  }
+
+  #[tracing::instrument("Cache::FileSystemInfo::create_snapshot", skip_all)]
+  pub async fn create_snapshot(
+    &self,
+    start_time: Option<u64>,
+    files: &InternedPathSet,
+    contexts: &InternedPathSet,
+    missing: &InternedPathSet,
+    strategy: SnapshotStrategyOptions,
+  ) -> Result<Snapshot> {
+    let mut snapshot = Snapshot {
+      start_time,
+      ..Default::default()
+    };
+    let mode = strategy.into();
+
+    let files = self
+      .capture_non_managed(&mut snapshot, files, PathKind::File)
+      .await?;
+    let contexts = self
+      .capture_non_managed(&mut snapshot, contexts, PathKind::Context)
+      .await?;
+    let missing = self
+      .capture_non_managed(&mut snapshot, missing, PathKind::Missing)
+      .await?;
+
+    self.capture_files(&mut snapshot, files, mode).await?;
+    self.capture_contexts(&mut snapshot, contexts, mode).await?;
+    self.capture_missing(&mut snapshot, missing).await?;
+    Ok(snapshot)
+  }
+
+  pub fn merge_snapshots(&self, mut first: Snapshot, second: Snapshot) -> Snapshot {
+    first.merge(second);
+    first
+  }
+
+  pub fn build_dependencies_strategy(&self) -> SnapshotStrategyOptions {
+    self.options.dependencies_strategy()
+  }
+
+  #[tracing::instrument("Cache::FileSystemInfo::check_snapshot_valid", skip_all)]
+  pub async fn check_snapshot_valid(
+    &self,
+    snapshot: &Snapshot,
+  ) -> Result<SnapshotValidationResult> {
+    let mut modified_files = InternedPathSet::default();
+    let mut removed_files = InternedPathSet::default();
+    self
+      .validate_snapshot(snapshot, &mut modified_files, &mut removed_files)
+      .await?;
+    if modified_files.is_empty() && removed_files.is_empty() {
+      Ok(SnapshotValidationResult::Valid)
+    } else {
+      Ok(SnapshotValidationResult::Invalid {
+        modified_files,
+        removed_files,
+      })
+    }
+  }
+
+  async fn capture_non_managed(
+    &self,
+    snapshot: &mut Snapshot,
+    paths: &InternedPathSet,
+    kind: PathKind,
+  ) -> Result<Vec<InternedPath>> {
+    let mut captured = Vec::with_capacity(paths.len());
+    for path in paths {
+      let path_str = path.to_string_lossy();
+      if self.options.is_immutable_path(&path_str) {
+        managed_paths(snapshot, kind).insert(path.clone());
+        continue;
+      }
+      if self.options.is_managed_path(&path_str)
+        && let Some((managed_item, info)) = self.find_managed_item(path).await?
+      {
+        managed_paths(snapshot, kind).insert(path.clone());
+        snapshot
+          .managed_files
+          .get_or_insert_default()
+          .insert(InternedPath::from(managed_item.join("package.json")));
+        snapshot
+          .managed_item_info
+          .get_or_insert_default()
+          .insert(managed_item, info);
+        continue;
+      }
+      captured.push(path.clone());
+    }
+    Ok(captured)
+  }
+
+  async fn capture_files(
+    &self,
+    snapshot: &mut Snapshot,
+    paths: Vec<InternedPath>,
+    mode: SnapshotMode,
+  ) -> Result<()> {
+    match mode {
+      SnapshotMode::Timestamp => {
+        let map = snapshot.file_timestamps.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.file_timestamp(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+      SnapshotMode::Hash => {
+        let map = snapshot.file_hashes.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.file_hash(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+      SnapshotMode::TimestampAndHash => {
+        let map = snapshot.file_timestamp_hashes.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.file_timestamp_and_hash(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+    }
+    Ok(())
+  }
+
+  async fn capture_contexts(
+    &self,
+    snapshot: &mut Snapshot,
+    paths: Vec<InternedPath>,
+    mode: SnapshotMode,
+  ) -> Result<()> {
+    match mode {
+      SnapshotMode::Timestamp => {
+        let map = snapshot.context_timestamps.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.context_timestamp(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+      SnapshotMode::Hash => {
+        let map = snapshot.context_hashes.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.context_hash(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+      SnapshotMode::TimestampAndHash => {
+        let map = snapshot.context_timestamp_hashes.get_or_insert_default();
+        paths
+          .into_iter()
+          .map(|path| {
+            let this = self.clone();
+            async move {
+              let value = this.context_timestamp_and_hash(&path).await?;
+              Ok::<_, rspack_error::Error>((path, value))
+            }
+          })
+          .try_fut_consume(|(path, value)| {
+            map.insert(path, value);
+          })
+          .await?;
+      }
+    }
+    Ok(())
+  }
+
+  async fn capture_missing(&self, snapshot: &mut Snapshot, paths: Vec<InternedPath>) -> Result<()> {
+    let map = snapshot.missing_existence.get_or_insert_default();
+    paths
+      .into_iter()
+      .map(|path| {
+        let this = self.clone();
+        async move {
+          let exists = this.metadata(&path).await?.is_some();
+          Ok::<_, rspack_error::Error>((path, exists))
+        }
+      })
+      .try_fut_consume(|(path, exists)| {
+        map.insert(path, exists);
+      })
+      .await
+  }
+
+  async fn metadata(&self, path: &InternedPath) -> Result<Option<FileMetadata>> {
+    match self.fs.metadata(path.assert_utf8()).await {
+      Ok(metadata) => Ok(Some(metadata)),
+      Err(error) if is_not_found(&error) => Ok(None),
+      Err(error) => Err(error.into()),
+    }
+  }
+
+  async fn file_timestamp(&self, path: &InternedPath) -> Result<Option<FileSystemInfoEntry>> {
+    if let Some(entry) = self.file_timestamps.get(path) {
+      return Ok(entry.clone());
+    }
+    let entry = self.metadata(path).await?.map(|metadata| {
+      if metadata.is_directory {
+        FileSystemInfoEntry {
+          safe_time: 0,
+          timestamp: None,
+        }
+      } else {
+        let timestamp = metadata.mtime_ms;
+        let accuracy = apply_mtime(timestamp);
+        FileSystemInfoEntry {
+          safe_time: if timestamp == 0 {
+            u64::MAX
+          } else {
+            timestamp.saturating_add(accuracy)
+          },
+          timestamp: Some(timestamp),
+        }
+      }
+    });
+    self.file_timestamps.insert(path.clone(), entry.clone());
+    Ok(entry)
+  }
+
+  async fn file_hash(&self, path: &InternedPath) -> Result<Option<FileHash>> {
+    if let Some(entry) = self.file_hashes.get(path) {
+      return Ok(entry.clone());
+    }
+    let Some(metadata) = self.metadata(path).await? else {
+      self.file_hashes.insert(path.clone(), None);
+      return Ok(None);
+    };
+    let hash = if metadata.is_directory {
+      FileHash::Directory
+    } else {
+      let content = match self.fs.read(path.assert_utf8()).await {
+        Ok(content) => content,
+        Err(error) if is_not_found(&error) => {
+          self.file_hashes.insert(path.clone(), None);
+          return Ok(None);
+        }
+        Err(error) => return Err(error.into()),
+      };
+      FileHash::Digest(self.digest(&content))
+    };
+    self.file_hashes.insert(path.clone(), Some(hash.clone()));
+    Ok(Some(hash))
+  }
+
+  async fn file_timestamp_and_hash(&self, path: &InternedPath) -> Result<Option<TimestampAndHash>> {
+    if let Some(entry) = self.file_timestamp_hashes.get(path) {
+      return Ok(entry.clone());
+    }
+    let (Some(timestamp), Some(hash)) = (
+      self.file_timestamp(path).await?,
+      self.file_hash(path).await?,
+    ) else {
+      self.file_timestamp_hashes.insert(path.clone(), None);
+      return Ok(None);
+    };
+    let value = TimestampAndHash {
+      safe_time: timestamp.safe_time,
+      timestamp: timestamp.timestamp,
+      hash,
+    };
+    self
+      .file_timestamp_hashes
+      .insert(path.clone(), Some(value.clone()));
+    Ok(Some(value))
+  }
+
+  async fn context_timestamp(
+    &self,
+    path: &InternedPath,
+  ) -> Result<Option<ContextFileSystemInfoEntry>> {
+    if let Some(entry) = self.context_timestamps.get(path) {
+      return Ok(entry.clone());
+    }
+    let mut visiting = InternedPathSet::default();
+    let value = self
+      .context_value(path, SnapshotMode::Timestamp, &mut visiting)
+      .await?
+      .map(|value| ContextFileSystemInfoEntry {
+        safe_time: value.safe_time,
+        timestamp_hash: value
+          .timestamp_hash
+          .expect("timestamp mode should produce a timestamp hash"),
+      });
+    self.context_timestamps.insert(path.clone(), value.clone());
+    Ok(value)
+  }
+
+  async fn context_hash(&self, path: &InternedPath) -> Result<Option<RspackHashDigest>> {
+    if let Some(entry) = self.context_hashes.get(path) {
+      return Ok(entry.clone());
+    }
+    let mut visiting = InternedPathSet::default();
+    let value = self
+      .context_value(path, SnapshotMode::Hash, &mut visiting)
+      .await?
+      .map(|value| value.hash.expect("hash mode should produce a hash"));
+    self.context_hashes.insert(path.clone(), value.clone());
+    Ok(value)
+  }
+
+  async fn context_timestamp_and_hash(
+    &self,
+    path: &InternedPath,
+  ) -> Result<Option<ContextTimestampAndHash>> {
+    if let Some(entry) = self.context_timestamp_hashes.get(path) {
+      return Ok(entry.clone());
+    }
+    let mut visiting = InternedPathSet::default();
+    let value = self
+      .context_value(path, SnapshotMode::TimestampAndHash, &mut visiting)
+      .await?
+      .map(|value| ContextTimestampAndHash {
+        safe_time: value.safe_time,
+        timestamp_hash: value
+          .timestamp_hash
+          .expect("timestamp and hash mode should produce a timestamp hash"),
+        hash: value
+          .hash
+          .expect("timestamp and hash mode should produce a hash"),
+      });
+    self
+      .context_timestamp_hashes
+      .insert(path.clone(), value.clone());
+    Ok(value)
+  }
+
+  #[async_recursion::async_recursion]
+  async fn context_value(
+    &self,
+    path: &InternedPath,
+    mode: SnapshotMode,
+    visiting: &mut InternedPathSet,
+  ) -> Result<Option<ContextValue>> {
+    if !visiting.insert(path.clone()) {
+      return Ok(Some(self.context_leaf(
+        path.to_string_lossy().as_bytes(),
+        mode,
+        0,
+      )));
+    }
+
+    let result = self.context_value_inner(path, mode, visiting).await;
+    visiting.remove(path);
+    result
+  }
+
+  async fn context_value_inner(
+    &self,
+    path: &InternedPath,
+    mode: SnapshotMode,
+    visiting: &mut InternedPathSet,
+  ) -> Result<Option<ContextValue>> {
+    let symlink_metadata = match self.fs.symlink_metadata(path.assert_utf8()).await {
+      Ok(metadata) => Some(metadata),
+      Err(error) if is_not_found(&error) => None,
+      Err(error) => return Err(error.into()),
+    };
+    let Some(symlink_metadata) = symlink_metadata else {
+      return Ok(None);
+    };
+
+    if symlink_metadata.is_symlink {
+      let target = self.fs.canonicalize(path.assert_utf8()).await?;
+      let target = InternedPath::from(target);
+      let mut value = self.context_leaf(target.to_string_lossy().as_bytes(), mode, 0);
+      if let Some(target_value) = self.context_value(&target, mode, visiting).await? {
+        value.safe_time = value.safe_time.max(target_value.safe_time);
+        value.timestamp_hash = merge_digests(
+          self.hash_function,
+          value.timestamp_hash,
+          target_value.timestamp_hash,
+        );
+        value.hash = merge_digests(self.hash_function, value.hash, target_value.hash);
+      }
+      return Ok(Some(value));
+    }
+
+    let metadata = self
+      .metadata(path)
+      .await?
+      .expect("symlink metadata proved that the path exists");
+    if !metadata.is_directory {
+      return self.file_context_value(path, mode).await;
+    }
+
+    let mut children = match self.fs.read_dir(path.assert_utf8()).await {
+      Ok(children) => children,
+      Err(error) if is_not_found(&error) => return Ok(None),
+      Err(error) => return Err(error.into()),
+    };
+    children.sort_unstable();
+
+    let mut timestamp_hasher = mode
+      .uses_timestamp()
+      .then(|| RspackHasher::new(&self.hash_function));
+    let mut content_hasher = mode
+      .uses_hash()
+      .then(|| RspackHasher::new(&self.hash_function));
+    for child in &children {
+      if let Some(hasher) = &mut timestamp_hasher {
+        hasher.write(child.as_bytes());
+      }
+      if let Some(hasher) = &mut content_hasher {
+        hasher.write(child.as_bytes());
+      }
+    }
+
+    let mut safe_time = 0;
+    for child in children {
+      let child_path = InternedPath::from(path.join(child));
+      let child_path_str = child_path.to_string_lossy();
+      let child_value = if self.options.is_immutable_path(&child_path_str) {
+        None
+      } else if self.options.is_managed_path(&child_path_str) {
+        self
+          .find_managed_item(&child_path)
+          .await?
+          .map(|(_, info)| self.context_leaf(info.as_bytes(), mode, 0))
+      } else {
+        self.context_value(&child_path, mode, visiting).await?
+      };
+
+      let Some(child_value) = child_value else {
+        if let Some(hasher) = &mut timestamp_hasher {
+          hasher.write(b"n");
+        }
+        continue;
+      };
+      safe_time = safe_time.max(child_value.safe_time);
+      if let Some(hasher) = &mut timestamp_hasher {
+        if let Some(hash) = child_value.timestamp_hash {
+          hasher.write(b"d");
+          hasher.write(hash.encoded().as_bytes());
+        } else {
+          hasher.write(b"n");
+        }
+      }
+      if let Some(hasher) = &mut content_hasher
+        && let Some(hash) = child_value.hash
+      {
+        hasher.write(hash.encoded().as_bytes());
+      }
+    }
+
+    Ok(Some(ContextValue {
+      safe_time,
+      timestamp_hash: timestamp_hasher.map(digest_hasher),
+      hash: content_hasher.map(digest_hasher),
+    }))
+  }
+
+  async fn file_context_value(
+    &self,
+    path: &InternedPath,
+    mode: SnapshotMode,
+  ) -> Result<Option<ContextValue>> {
+    let timestamp = if mode.uses_timestamp() {
+      self.file_timestamp(path).await?
+    } else {
+      None
+    };
+    let hash = if mode.uses_hash() {
+      self.file_hash(path).await?
+    } else {
+      None
+    };
+    if timestamp.is_none() && hash.is_none() {
+      return Ok(None);
+    }
+
+    let safe_time = timestamp.as_ref().map_or(0, |entry| entry.safe_time);
+    let timestamp_hash = timestamp.map(|entry| {
+      let mut hasher = RspackHasher::new(&self.hash_function);
+      if let Some(timestamp) = entry.timestamp {
+        hasher.write(b"f");
+        hasher.write(timestamp.to_string().as_bytes());
+      }
+      digest_hasher(hasher)
+    });
+    let hash = hash.map(|hash| match hash {
+      FileHash::Digest(hash) => hash,
+      FileHash::Directory => self.digest(b"directory"),
+    });
+    Ok(Some(ContextValue {
+      safe_time,
+      timestamp_hash,
+      hash,
+    }))
+  }
+
+  fn context_leaf(&self, bytes: &[u8], mode: SnapshotMode, safe_time: u64) -> ContextValue {
+    ContextValue {
+      safe_time,
+      timestamp_hash: mode.uses_timestamp().then(|| self.digest(bytes)),
+      hash: mode.uses_hash().then(|| self.digest(bytes)),
+    }
+  }
+
+  fn digest(&self, bytes: &[u8]) -> RspackHashDigest {
+    let mut hasher = RspackHasher::new(&self.hash_function);
+    hasher.write(bytes);
+    digest_hasher(hasher)
+  }
+
+  async fn find_managed_item(&self, path: &InternedPath) -> Result<Option<(InternedPath, String)>> {
+    let mut current = if self
+      .metadata(path)
+      .await?
+      .is_some_and(|metadata| metadata.is_directory)
+    {
+      Some(path.clone())
+    } else {
+      path.parent().map(InternedPath::from)
+    };
+    while let Some(directory) = current {
+      let directory_str = directory.to_string_lossy();
+      if !self.options.is_managed_path(&directory_str) {
+        break;
+      }
+      if let Some(info) = self.managed_item_info(&directory).await? {
+        return Ok(Some((directory, info)));
+      }
+      current = directory.parent().map(InternedPath::from);
+    }
+    Ok(None)
+  }
+
+  async fn managed_item_info(&self, path: &InternedPath) -> Result<Option<String>> {
+    if let Some(info) = self.managed_items.get(path) {
+      return Ok(info.clone());
+    }
+    let package_json = InternedPath::from(path.join("package.json"));
+    let mut content = match self.fs.read(package_json.assert_utf8()).await {
+      Ok(content) => content,
+      Err(error) if is_not_found(&error) => {
+        self.managed_items.insert(path.clone(), None);
+        return Ok(None);
+      }
+      Err(error) => return Err(error.into()),
+    };
+    let package_json = simd_json::to_borrowed_value(&mut content)
+      .map_err(|error| error!("Failed to parse {package_json:?}: {error}"))?;
+    let Some(name) = package_json.get("name").and_then(|value| value.as_str()) else {
+      self.managed_items.insert(path.clone(), None);
+      return Ok(None);
+    };
+    let version = package_json
+      .get("version")
+      .and_then(|value| value.as_str())
+      .unwrap_or_default();
+    let info = format!("{name}@{version}");
+    self.managed_items.insert(path.clone(), Some(info.clone()));
+    Ok(Some(info))
+  }
+
+  #[async_recursion::async_recursion]
+  async fn validate_snapshot(
+    &self,
+    snapshot: &Snapshot,
+    modified_files: &mut InternedPathSet,
+    removed_files: &mut InternedPathSet,
+  ) -> Result<()> {
+    if let Some(children) = &snapshot.children {
+      for child in children {
+        self
+          .validate_snapshot(child, modified_files, removed_files)
+          .await?;
+      }
+    }
+
+    if let Some(entries) = &snapshot.file_timestamps {
+      for (path, expected) in entries {
+        let current = self.file_timestamp(path).await?;
+        if !file_timestamp_matches(current.as_ref(), expected.as_ref(), snapshot.start_time) {
+          record_invalid(path, current.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+    if let Some(entries) = &snapshot.file_hashes {
+      for (path, expected) in entries {
+        let current = self.file_hash(path).await?;
+        if current != *expected {
+          record_invalid(path, current.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+    if let Some(entries) = &snapshot.file_timestamp_hashes {
+      for (path, expected) in entries {
+        let current_timestamp = self.file_timestamp(path).await?;
+        let timestamp_matches = match expected {
+          Some(expected) => file_timestamp_matches(
+            current_timestamp.as_ref(),
+            Some(&FileSystemInfoEntry {
+              safe_time: expected.safe_time,
+              timestamp: expected.timestamp,
+            }),
+            snapshot.start_time,
+          ),
+          None => current_timestamp.is_none(),
+        };
+        if timestamp_matches {
+          continue;
+        }
+        let current_hash = self.file_hash(path).await?;
+        let expected_hash = expected.as_ref().map(|entry| &entry.hash);
+        if current_hash.as_ref() != expected_hash {
+          record_invalid(path, current_hash.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+
+    if let Some(entries) = &snapshot.context_timestamps {
+      for (path, expected) in entries {
+        let current = self.context_timestamp(path).await?;
+        if !context_timestamp_matches(current.as_ref(), expected.as_ref(), snapshot.start_time) {
+          record_invalid(path, current.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+    if let Some(entries) = &snapshot.context_hashes {
+      for (path, expected) in entries {
+        let current = self.context_hash(path).await?;
+        if current != *expected {
+          record_invalid(path, current.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+    if let Some(entries) = &snapshot.context_timestamp_hashes {
+      for (path, expected) in entries {
+        let current_timestamp = self.context_timestamp(path).await?;
+        let timestamp_matches = match expected {
+          Some(expected) => context_timestamp_matches(
+            current_timestamp.as_ref(),
+            Some(&ContextFileSystemInfoEntry {
+              safe_time: expected.safe_time,
+              timestamp_hash: expected.timestamp_hash.clone(),
+            }),
+            snapshot.start_time,
+          ),
+          None => current_timestamp.is_none(),
+        };
+        if timestamp_matches {
+          continue;
+        }
+        let current_hash = self.context_hash(path).await?;
+        let expected_hash = expected.as_ref().map(|entry| &entry.hash);
+        if current_hash.as_ref() != expected_hash {
+          record_invalid(path, current_hash.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+
+    if let Some(entries) = &snapshot.missing_existence {
+      for (path, expected) in entries {
+        let current = self.metadata(path).await?.is_some();
+        if current != *expected {
+          record_invalid(path, current, modified_files, removed_files);
+        }
+      }
+    }
+    if let Some(entries) = &snapshot.managed_item_info {
+      for (path, expected) in entries {
+        let current = self.managed_item_info(path).await?;
+        if current.as_ref() != Some(expected) {
+          record_invalid(path, current.is_some(), modified_files, removed_files);
+        }
+      }
+    }
+    Ok(())
+  }
+}
+
+impl SnapshotMode {
+  fn uses_timestamp(self) -> bool {
+    !matches!(self, Self::Hash)
+  }
+
+  fn uses_hash(self) -> bool {
+    !matches!(self, Self::Timestamp)
+  }
+}
+
+fn managed_paths(snapshot: &mut Snapshot, kind: PathKind) -> &mut InternedPathSet {
+  match kind {
+    PathKind::File => snapshot.managed_files.get_or_insert_default(),
+    PathKind::Context => snapshot.managed_contexts.get_or_insert_default(),
+    PathKind::Missing => snapshot.managed_missing.get_or_insert_default(),
+  }
+}
+
+fn file_timestamp_matches(
+  current: Option<&FileSystemInfoEntry>,
+  expected: Option<&FileSystemInfoEntry>,
+  start_time: Option<u64>,
+) -> bool {
+  match (current, expected) {
+    (None, None) => true,
+    (Some(current), Some(expected)) => {
+      if start_time.is_some_and(|start_time| current.safe_time > start_time) {
+        return false;
+      }
+      current.timestamp == expected.timestamp
+    }
+    _ => false,
+  }
+}
+
+fn context_timestamp_matches(
+  current: Option<&ContextFileSystemInfoEntry>,
+  expected: Option<&ContextFileSystemInfoEntry>,
+  start_time: Option<u64>,
+) -> bool {
+  match (current, expected) {
+    (None, None) => true,
+    (Some(current), Some(expected)) => {
+      if start_time.is_some_and(|start_time| current.safe_time > start_time) {
+        return false;
+      }
+      current.timestamp_hash == expected.timestamp_hash
+    }
+    _ => false,
+  }
+}
+
+fn record_invalid(
+  path: &InternedPath,
+  currently_exists: bool,
+  modified_files: &mut InternedPathSet,
+  removed_files: &mut InternedPathSet,
+) {
+  if currently_exists {
+    modified_files.insert(path.clone());
+  } else {
+    removed_files.insert(path.clone());
+  }
+}
+
+fn apply_mtime(mtime: u64) -> u64 {
+  let mut accuracy = FS_ACCURACY.load(Ordering::Relaxed);
+  loop {
+    let next = if accuracy > 1 && !mtime.is_multiple_of(2) {
+      1
+    } else if accuracy > 10 && !mtime.is_multiple_of(20) {
+      10
+    } else if accuracy > 100 && !mtime.is_multiple_of(200) {
+      100
+    } else if accuracy > 1000 && !mtime.is_multiple_of(2000) {
+      1000
+    } else {
+      accuracy
+    };
+    if next == accuracy {
+      return accuracy;
+    }
+    match FS_ACCURACY.compare_exchange_weak(accuracy, next, Ordering::Relaxed, Ordering::Relaxed) {
+      Ok(_) => return next,
+      Err(current) => accuracy = current,
+    }
+  }
+}
+
+fn merge_digests(
+  hash_function: HashFunction,
+  first: Option<RspackHashDigest>,
+  second: Option<RspackHashDigest>,
+) -> Option<RspackHashDigest> {
+  match (first, second) {
+    (None, None) => None,
+    (first, second) => {
+      let mut hasher = RspackHasher::new(&hash_function);
+      if let Some(first) = first {
+        hasher.write(first.encoded().as_bytes());
+      }
+      if let Some(second) = second {
+        hasher.write(second.encoded().as_bytes());
+      }
+      Some(digest_hasher(hasher))
+    }
+  }
+}
+
+fn digest_hasher(hasher: RspackHasher) -> RspackHashDigest {
+  hasher.digest(&HashDigest::Hex)
+}
+
+fn is_not_found(error: &FsError) -> bool {
+  matches!(error, FsError::Io(error) if error.kind() == std::io::ErrorKind::NotFound)
+}

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -73,6 +73,9 @@ struct ContextValue {
 /// sets and a strategy, while path classification, managed package handling,
 /// timestamp accuracy, hashing, merging and validation stay behind this
 /// interface.
+///
+/// See webpack's `FileSystemInfo` implementation:
+/// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L1282-L1450
 #[derive(Clone)]
 pub struct FileSystemInfo {
   fs: Arc<dyn ReadableFileSystem>,
@@ -115,6 +118,8 @@ impl FileSystemInfo {
     }
   }
 
+  /// See webpack's snapshot creation implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L2525-L3079
   #[tracing::instrument("Cache::FileSystemInfo::create_snapshot", skip_all)]
   pub async fn create_snapshot(
     &self,
@@ -146,6 +151,8 @@ impl FileSystemInfo {
     Ok(snapshot)
   }
 
+  /// See webpack's snapshot merge implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3081-L3166
   pub fn merge_snapshots(&self, mut first: Snapshot, second: Snapshot) -> Snapshot {
     first.merge(second);
     first
@@ -155,6 +162,8 @@ impl FileSystemInfo {
     self.options.dependencies_strategy()
   }
 
+  /// See webpack's snapshot validation implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3168-L3735
   #[tracing::instrument("Cache::FileSystemInfo::check_snapshot_valid", skip_all)]
   pub async fn check_snapshot_valid(
     &self,
@@ -350,6 +359,8 @@ impl FileSystemInfo {
     }
   }
 
+  /// See webpack's file timestamp and hash implementations:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3737-L3865
   async fn file_timestamp(&self, path: &InternedPath) -> Result<Option<FileSystemInfoEntry>> {
     if let Some(entry) = self.file_timestamps.get(path) {
       return Ok(entry.clone());
@@ -484,6 +495,8 @@ impl FileSystemInfo {
     Ok(value)
   }
 
+  /// See webpack's recursive context timestamp and hash implementations:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3867-L4490
   #[async_recursion::async_recursion]
   async fn context_value(
     &self,
@@ -685,6 +698,8 @@ impl FileSystemInfo {
     Ok(None)
   }
 
+  /// See webpack's managed item metadata implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L4505-L4577
   async fn managed_item_info(&self, path: &InternedPath) -> Result<Option<String>> {
     if let Some(info) = self.managed_items.get(path) {
       return Ok(info.clone());

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -80,7 +80,7 @@ pub struct Snapshot {
   pub(super) managed_contexts: Option<InternedPathSet>,
   pub(super) managed_missing: Option<InternedPathSet>,
   #[cacheable(omit_bounds)]
-  pub(super) children: Option<Vec<Box<Snapshot>>>,
+  pub(super) children: Option<Vec<Snapshot>>,
 }
 
 impl Snapshot {

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -15,6 +15,9 @@ pub use self::{
 /// `safe_time` mirrors webpack's filesystem-accuracy guard. A timestamp newer
 /// than a snapshot's start time cannot prove that the file stayed unchanged
 /// while the snapshot was being created.
+///
+/// See webpack's filesystem entry data structures:
+/// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L75-L132
 #[cacheable]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileSystemInfoEntry {
@@ -58,6 +61,9 @@ pub struct ContextTimestampAndHash {
 /// only the collections required by its strategy. Children are reserved for
 /// shared snapshots; ordinary build-dependency merges combine their maps
 /// directly.
+///
+/// See webpack's `Snapshot` data structure:
+/// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L303-L665
 #[cacheable]
 #[derive(Debug, Default)]
 pub struct Snapshot {
@@ -78,6 +84,8 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+  /// See webpack's snapshot merge implementation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3081-L3166
   pub(super) fn merge(&mut self, other: Self) {
     self.start_time = match (self.start_time, other.start_time) {
       (Some(first), Some(second)) => Some(first.min(second)),

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -1,119 +1,119 @@
 mod build_deps;
-
-use std::sync::Arc;
+mod file_system_info;
 
 use rspack_cacheable::cacheable;
-use rspack_fs::ReadableFileSystem;
-use rspack_paths::{InternedPath, InternedPathSet};
+use rspack_hash::RspackHashDigest;
+use rspack_paths::{InternedPathMap, InternedPathSet};
 
-pub use self::build_deps::{BuildDeps, BuildDepsValidationResult};
-use crate::cache::persistent::snapshot::{
-  SnapshotOptions, SnapshotStrategyOptions, Strategy, StrategyHelper, ValidateResult,
+pub use self::{
+  build_deps::{BuildDeps, BuildDepsValidationResult},
+  file_system_info::{FileSystemInfo, SnapshotValidationResult},
 };
 
+/// Timestamp information captured for a file.
+///
+/// `safe_time` mirrors webpack's filesystem-accuracy guard. A timestamp newer
+/// than a snapshot's start time cannot prove that the file stayed unchanged
+/// while the snapshot was being created.
 #[cacheable]
-#[derive(Debug)]
-pub struct SnapshotEntry {
-  path: InternedPath,
-  strategy: Strategy,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSystemInfoEntry {
+  safe_time: u64,
+  timestamp: Option<u64>,
 }
 
+#[cacheable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileHash {
+  Digest(RspackHashDigest),
+  Directory,
+}
+
+#[cacheable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimestampAndHash {
+  safe_time: u64,
+  timestamp: Option<u64>,
+  hash: FileHash,
+}
+
+#[cacheable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextFileSystemInfoEntry {
+  safe_time: u64,
+  timestamp_hash: RspackHashDigest,
+}
+
+#[cacheable]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextTimestampAndHash {
+  safe_time: u64,
+  timestamp_hash: RspackHashDigest,
+  hash: RspackHashDigest,
+}
+
+/// Serializable filesystem state captured by [`FileSystemInfo`].
+///
+/// The optional maps follow webpack's `Snapshot` layout: a snapshot allocates
+/// only the collections required by its strategy. Children are reserved for
+/// shared snapshots; ordinary build-dependency merges combine their maps
+/// directly.
 #[cacheable]
 #[derive(Debug, Default)]
-pub(super) struct BuildDependenciesSnapshot {
-  dependencies: InternedPathSet,
-  snapshots: Vec<SnapshotEntry>,
-}
-
-impl BuildDependenciesSnapshot {
-  pub(super) async fn validate(
-    &self,
-    snapshot: &Snapshot,
-    build_deps: &BuildDeps,
-  ) -> BuildDepsValidationResult {
-    build_deps
-      .validate_snapshot(snapshot, &self.snapshots, self.dependencies.len())
-      .await
-  }
-
-  pub(super) async fn update(
-    &mut self,
-    snapshot: &Snapshot,
-    build_deps: &mut BuildDeps,
-    paths: impl Iterator<Item = InternedPath>,
-  ) {
-    let added = build_deps
-      .resolve_dependencies(&self.dependencies, paths)
-      .await;
-    let snapshots = snapshot.add(added.iter().cloned()).await;
-    self.dependencies.extend(added);
-    self.snapshots.extend(snapshots);
-  }
-}
-
-/// Creates and validates filesystem snapshots stored by the new cache.
-#[derive(Debug)]
 pub struct Snapshot {
-  options: Arc<SnapshotOptions>,
-  fs: Arc<dyn ReadableFileSystem>,
+  pub(super) start_time: Option<u64>,
+  pub(super) file_timestamps: Option<InternedPathMap<Option<FileSystemInfoEntry>>>,
+  pub(super) file_hashes: Option<InternedPathMap<Option<FileHash>>>,
+  pub(super) file_timestamp_hashes: Option<InternedPathMap<Option<TimestampAndHash>>>,
+  pub(super) context_timestamps: Option<InternedPathMap<Option<ContextFileSystemInfoEntry>>>,
+  pub(super) context_hashes: Option<InternedPathMap<Option<RspackHashDigest>>>,
+  pub(super) context_timestamp_hashes: Option<InternedPathMap<Option<ContextTimestampAndHash>>>,
+  pub(super) missing_existence: Option<InternedPathMap<bool>>,
+  pub(super) managed_item_info: Option<InternedPathMap<String>>,
+  pub(super) managed_files: Option<InternedPathSet>,
+  pub(super) managed_contexts: Option<InternedPathSet>,
+  pub(super) managed_missing: Option<InternedPathSet>,
+  #[cacheable(omit_bounds)]
+  pub(super) children: Option<Vec<Box<Snapshot>>>,
 }
 
 impl Snapshot {
-  pub fn new(options: SnapshotOptions, fs: Arc<dyn ReadableFileSystem>) -> Self {
-    Self {
-      options: Arc::new(options),
-      fs,
-    }
-  }
+  pub(super) fn merge(&mut self, other: Self) {
+    self.start_time = match (self.start_time, other.start_time) {
+      (Some(first), Some(second)) => Some(first.min(second)),
+      (first, second) => first.or(second),
+    };
+    merge_maps(&mut self.file_timestamps, other.file_timestamps);
+    merge_maps(&mut self.file_hashes, other.file_hashes);
+    merge_maps(&mut self.file_timestamp_hashes, other.file_timestamp_hashes);
+    merge_maps(&mut self.context_timestamps, other.context_timestamps);
+    merge_maps(&mut self.context_hashes, other.context_hashes);
+    merge_maps(
+      &mut self.context_timestamp_hashes,
+      other.context_timestamp_hashes,
+    );
+    merge_maps(&mut self.missing_existence, other.missing_existence);
+    merge_maps(&mut self.managed_item_info, other.managed_item_info);
+    merge_sets(&mut self.managed_files, other.managed_files);
+    merge_sets(&mut self.managed_contexts, other.managed_contexts);
+    merge_sets(&mut self.managed_missing, other.managed_missing);
 
-  async fn calc_strategy(&self, helper: &StrategyHelper, path: &InternedPath) -> Option<Strategy> {
-    let path_str = path.to_string_lossy();
-    if self.options.is_immutable_path(&path_str) {
-      return None;
+    if let Some(children) = other.children {
+      self.children.get_or_insert_default().extend(children);
     }
-    if self.options.is_managed_path(&path_str)
-      && let Some(strategy) = helper.package_version(path).await
-    {
-      return Some(strategy);
-    }
-    Some(
-      helper
-        .dir_strategy(path, SnapshotStrategyOptions::hash())
-        .await,
-    )
   }
+}
 
-  #[tracing::instrument("Cache::Snapshot::add", skip_all)]
-  pub async fn add(&self, paths: impl Iterator<Item = InternedPath>) -> Vec<SnapshotEntry> {
-    let helper = StrategyHelper::new(self.fs.clone(), self.options.clone());
-    let mut entries = Vec::with_capacity(paths.size_hint().0);
-    for path in paths {
-      if let Some(strategy) = self.calc_strategy(&helper, &path).await {
-        entries.push(SnapshotEntry { path, strategy });
-      }
-    }
-    entries
-  }
+fn merge_maps<T>(target: &mut Option<InternedPathMap<T>>, source: Option<InternedPathMap<T>>) {
+  let Some(source) = source else {
+    return;
+  };
+  target.get_or_insert_default().extend(source);
+}
 
-  #[tracing::instrument("Cache::Snapshot::calc_modified_paths", skip_all)]
-  pub async fn calc_modified_paths(
-    &self,
-    entries: &[SnapshotEntry],
-  ) -> (InternedPathSet, InternedPathSet) {
-    let helper = StrategyHelper::new(self.fs.clone(), self.options.clone());
-    let mut modified_files = InternedPathSet::default();
-    let mut removed_files = InternedPathSet::default();
-    for entry in entries {
-      match helper.validate(&entry.path, &entry.strategy).await {
-        ValidateResult::Modified => {
-          modified_files.insert(entry.path.clone());
-        }
-        ValidateResult::Deleted => {
-          removed_files.insert(entry.path.clone());
-        }
-        ValidateResult::NoChanged => {}
-      }
-    }
-    (modified_files, removed_files)
-  }
+fn merge_sets(target: &mut Option<InternedPathSet>, source: Option<InternedPathSet>) {
+  let Some(source) = source else {
+    return;
+  };
+  target.get_or_insert_default().extend(source);
 }

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -66,6 +66,8 @@ impl CacheValidator {
     }
   }
 
+  /// See webpack's persistent build snapshot validation:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js#L1345-L1429
   pub(super) async fn validate(&mut self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
     let Some(data) = data else {
       return Ok(CacheValidatorResult::InvalidVersion);
@@ -98,6 +100,8 @@ impl CacheValidator {
     })
   }
 
+  /// See webpack's build dependency resolution and snapshot persistence:
+  /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js#L1510-L1625
   pub(super) async fn update(
     &mut self,
     paths: impl Iterator<Item = InternedPath>,

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -4,7 +4,7 @@ use rspack_cacheable::cacheable;
 use rspack_error::Result;
 use rspack_paths::{InternedPath, InternedPathSet};
 
-use super::snapshot::{BuildDependenciesSnapshot, BuildDeps, BuildDepsValidationResult, Snapshot};
+use super::snapshot::{BuildDeps, BuildDepsValidationResult, FileSystemInfo, Snapshot};
 use crate::cache::persistent::codec::CacheCodec;
 
 #[cacheable]
@@ -12,7 +12,8 @@ use crate::cache::persistent::codec::CacheCodec;
 struct CacheValidatorData {
   rspack_pkg_version: String,
   cache_version: String,
-  build_dependencies: BuildDependenciesSnapshot,
+  build_dependencies: InternedPathSet,
+  build_dependencies_snapshot: Snapshot,
 }
 
 impl CacheValidatorData {
@@ -21,6 +22,7 @@ impl CacheValidatorData {
       rspack_pkg_version,
       cache_version,
       build_dependencies: Default::default(),
+      build_dependencies_snapshot: Default::default(),
     }
   }
 
@@ -44,7 +46,7 @@ pub(super) enum CacheValidatorResult {
 pub(super) struct CacheValidator {
   data: CacheValidatorData,
   codec: Arc<CacheCodec>,
-  snapshot: Snapshot,
+  file_system_info: FileSystemInfo,
   build_deps: BuildDeps,
 }
 
@@ -53,13 +55,13 @@ impl CacheValidator {
     rspack_pkg_version: String,
     cache_version: String,
     codec: Arc<CacheCodec>,
-    snapshot: Snapshot,
+    file_system_info: FileSystemInfo,
     build_deps: BuildDeps,
   ) -> Self {
     Self {
       data: CacheValidatorData::new(rspack_pkg_version, cache_version),
       codec,
-      snapshot,
+      file_system_info,
       build_deps,
     }
   }
@@ -72,10 +74,15 @@ impl CacheValidator {
     if !validator.has_same_version(&self.data) {
       return Ok(CacheValidatorResult::InvalidVersion);
     }
-    let validation = validator
-      .build_dependencies
-      .validate(&self.snapshot, &self.build_deps)
-      .await;
+    let validation = self
+      .build_deps
+      .validate_snapshot(
+        &self.file_system_info,
+        &validator.build_dependencies_snapshot,
+        &validator.build_dependencies,
+        validator.build_dependencies.len(),
+      )
+      .await?;
     Ok(match validation {
       BuildDepsValidationResult::Valid { tracked_files } => {
         self.data = validator;
@@ -95,11 +102,27 @@ impl CacheValidator {
     &mut self,
     paths: impl Iterator<Item = InternedPath>,
   ) -> Result<Vec<u8>> {
-    self
-      .data
-      .build_dependencies
-      .update(&self.snapshot, &mut self.build_deps, paths)
+    let resolved = self
+      .build_deps
+      .resolve_dependencies(&self.data.build_dependencies, paths)
       .await;
+    if !resolved.dependencies.is_empty() {
+      let snapshot = self
+        .file_system_info
+        .create_snapshot(
+          None,
+          &resolved.files,
+          &resolved.contexts,
+          &resolved.missing,
+          self.file_system_info.build_dependencies_strategy(),
+        )
+        .await?;
+      self.data.build_dependencies_snapshot = self.file_system_info.merge_snapshots(
+        std::mem::take(&mut self.data.build_dependencies_snapshot),
+        snapshot,
+      );
+      self.data.build_dependencies.extend(resolved.dependencies);
+    }
     self.codec.encode(&self.data)
   }
 }

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/a.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/a.js
@@ -1,0 +1,11 @@
+export default 1;
+---
+export default 1;
+---
+export default 3;
+---
+export default 3;
+---
+export default 3;
+---
+export default 3;

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/b.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/b.js
@@ -1,0 +1,11 @@
+export default 1;
+---
+export default 1;
+---
+export default 1;
+---
+export default 4;
+---
+export default 4;
+---
+export default 4;

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/index.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/configs/index.js
@@ -1,0 +1,18 @@
+import "./a";
+require("./b");
+---
+import "./a";
+require("./b");
+---
+import "./a";
+require("./b");
+---
+import "./a";
+require("./b");
+---
+import "./a";
+require("./b");
+---
+import "./a";
+require("./b");
+export const changed = true;

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/file.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/file.js
@@ -1,0 +1,1 @@
+export default 1;

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/index.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/index.js
@@ -1,0 +1,6 @@
+import value from "./file";
+
+it("should validate new cache build dependencies", async () => {
+	expect(value).toBe(1);
+	if (COMPILER_INDEX < 5) await NEXT_START();
+});

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/rspack.config.js
@@ -1,48 +1,48 @@
-const path = require("path");
+const path = require('path');
 
-const buildDependency = path.join(__dirname, "./configs/index.js");
+const buildDependency = path.join(__dirname, './configs/index.js');
 let compilerIndex = 0;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-	context: __dirname,
-	experiments: {
-		newCache: true
-	},
-	cache: {
-		type: "persistent",
-		buildDependencies: [buildDependency]
-	},
-	plugins: [
-		{
-			apply(compiler) {
-				compiler.hooks.done.tap("Test Plugin", stats => {
-					const logging = stats.toJson({
-						all: false,
-						logging: "verbose"
-					}).logging;
-					const entries = logging["rspack.Compilation"]?.entries ?? [];
-					const cacheEntry = entries.find(
-						entry =>
-							entry.type === "cache" &&
-							entry.message?.startsWith("module code generation cache:")
-					);
-					expect(cacheEntry).toBeTruthy();
+  context: __dirname,
+  experiments: {
+    newCache: true,
+  },
+  cache: {
+    type: 'persistent',
+    buildDependencies: [buildDependency],
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.done.tap('Test Plugin', (stats) => {
+          const logging = stats.toJson({
+            all: false,
+            logging: 'verbose',
+          }).logging;
+          const entries = logging['rspack.Compilation']?.entries ?? [];
+          const cacheEntry = entries.find(
+            (entry) =>
+              entry.type === 'cache' &&
+              entry.message?.startsWith('module code generation cache:'),
+          );
+          expect(cacheEntry).toBeTruthy();
 
-					const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
-					expect(match).toBeTruthy();
-					const hits = Number(match[1]);
-					const total = Number(match[2]);
-					expect(total).toBeGreaterThan(0);
+          const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
+          expect(match).toBeTruthy();
+          const hits = Number(match[1]);
+          const total = Number(match[2]);
+          expect(total).toBeGreaterThan(0);
 
-					if (compilerIndex === 1 || compilerIndex === 4) {
-						expect(hits).toBe(total);
-					} else {
-						expect(hits).toBe(0);
-					}
-					compilerIndex++;
-				});
-			}
-		}
-	]
+          if (compilerIndex === 1 || compilerIndex === 4) {
+            expect(hits).toBe(total);
+          } else {
+            expect(hits).toBe(0);
+          }
+          compilerIndex++;
+        });
+      },
+    },
+  ],
 };

--- a/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/build-dependencies-new-cache/rspack.config.js
@@ -1,0 +1,48 @@
+const path = require("path");
+
+const buildDependency = path.join(__dirname, "./configs/index.js");
+let compilerIndex = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+	context: __dirname,
+	experiments: {
+		newCache: true
+	},
+	cache: {
+		type: "persistent",
+		buildDependencies: [buildDependency]
+	},
+	plugins: [
+		{
+			apply(compiler) {
+				compiler.hooks.done.tap("Test Plugin", stats => {
+					const logging = stats.toJson({
+						all: false,
+						logging: "verbose"
+					}).logging;
+					const entries = logging["rspack.Compilation"]?.entries ?? [];
+					const cacheEntry = entries.find(
+						entry =>
+							entry.type === "cache" &&
+							entry.message?.startsWith("module code generation cache:")
+					);
+					expect(cacheEntry).toBeTruthy();
+
+					const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
+					expect(match).toBeTruthy();
+					const hits = Number(match[1]);
+					const total = Number(match[2]);
+					expect(total).toBeGreaterThan(0);
+
+					if (compilerIndex === 1 || compilerIndex === 4) {
+						expect(hits).toBe(total);
+					} else {
+						expect(hits).toBe(0);
+					}
+					compilerIndex++;
+				});
+			}
+		}
+	]
+};


### PR DESCRIPTION
## Summary

- Align `new_cache` FileSystemInfo and Snapshot data structures and algorithms with webpack.
- Migrate persistent build dependency validation to the new Snapshot implementation.
- Add coverage for valid snapshots and direct or transitive build dependency changes.

## Related links

N/A

## Checklist

- [x] Tests updated.
- [x] Documentation not required.