### PR TITLE
perf(split-chunks): skip single-chunk used exports grouping

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -289,15 +289,23 @@ impl Combinator {
 
   fn group_chunks_by_exports(
     module_identifier: &ModuleIdentifier,
-    module_chunks: impl Iterator<Item = ChunkUkey>,
+    module_chunks: &FxHashSet<ChunkUkey>,
     exports_info_artifact: &ExportsInfoArtifact,
     chunk_by_ukey: &ChunkByUkey,
     chunk_index_map: &FxHashMap<ChunkUkey, u32>,
   ) -> Vec<ChunkCombination> {
+    // A single chunk cannot produce runtime-dependent usage groups.
+    if module_chunks.len() == 1 {
+      return vec![ChunkCombination {
+        key: get_key(module_chunks.iter().copied(), chunk_index_map),
+        chunks: Arc::new(module_chunks.clone()),
+      }];
+    }
+
     let exports_info = exports_info_artifact.get_exports_info_data(module_identifier);
     let mut grouped_by_used_exports: FxHashMap<UsageKey, FxHashSet<ChunkUkey>> = Default::default();
     let mut runtime_key_map = RuntimeKeyMap::default();
-    for chunk_ukey in module_chunks {
+    for chunk_ukey in module_chunks.iter().copied() {
       let chunk = chunk_by_ukey.expect_get(&chunk_ukey);
       let runtime = chunk.runtime();
       let usage_key = runtime_key_map
@@ -432,9 +440,7 @@ impl Combinator {
           module,
           module_chunks
             .get(module_index)
-            .expect("should have module chunks")
-            .iter()
-            .copied(),
+            .expect("should have module chunks"),
           exports_info_artifact,
           chunk_by_ukey,
           chunk_index_map,


### PR DESCRIPTION
## Summary

- Skip runtime-dependent used-exports grouping when a module belongs to exactly one chunk.
- Reuse the existing module chunk set instead of calculating usage keys and building temporary hash maps.
- Keep the original multi-chunk path unchanged, with no additional miss-path scan.

A single chunk cannot produce multiple runtime-dependent usage groups, so the fast path is equivalent to the existing grouping result.

Historical local Callgrind measurements on the React-10k production build with cache and minification disabled:

- `prepare-combinations`: 90.17M to 32.86M IR (-63.6%)
- complete SplitChunksPlugin run: 240.14M to 186.66M IR (-22.3%)
- output remained 19,027 modules, 17 chunks, and 18 assets


## Validation

- `cargo check -p rspack_plugin_split_chunks`
- `cargo clippy -p rspack_plugin_split_chunks -- -D warnings`
- `cargo fmt --all --check`
- split-chunks filtered suite: 200 passed
- `pnpm run test:unit`: 9,114 passed, 4 skipped; CLI 89 passed, 1 skipped; binding type test passed

## Checklist

- [x] Tests updated (not required; covered by existing split-chunks and used-exports cases).
- [x] Documentation updated (not required; no user-facing behavior changes).