### PR TITLE
fix(css): exclude asset output path from URLs

### DIFF
--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -648,18 +648,27 @@ impl ParserAndGenerator for AssetParserAndGenerator {
 
           asset_info.set_source_filename(source_file_name);
 
+          let public_path = match module_generator_options
+            .and_then(|x| x.asset_public_path())
+            .unwrap_or_else(|| &compilation.options.output.public_path)
+          {
+            PublicPath::Filename(p) => PublicPath::render_filename(compilation, p).await,
+            PublicPath::Auto => AUTO_PUBLIC_PATH_PLACEHOLDER.to_string(),
+          };
+
+          if generate_context.requested_source_type == SourceType::CssUrl {
+            // `filename` includes outputPath for emission, while CSS URLs only use the original
+            // filename so their public path stays independent from the output directory.
+            generate_context
+              .data
+              .insert(CodeGenerationDataUrl::new(format!(
+                "{public_path}{original_filename}"
+              )));
+          }
+
           generate_context
             .data
-            .insert(CodeGenerationDataFilename::new(
-              filename,
-              match module_generator_options
-                .and_then(|x| x.asset_public_path())
-                .unwrap_or_else(|| &compilation.options.output.public_path)
-              {
-                PublicPath::Filename(p) => PublicPath::render_filename(compilation, p).await,
-                PublicPath::Auto => AUTO_PUBLIC_PATH_PLACEHOLDER.to_string(),
-              },
-            ));
+            .insert(CodeGenerationDataFilename::new(filename, public_path));
           generate_context
             .data
             .insert(CodeGenerationDataAssetInfo::new(asset_info));

--- a/crates/rspack_plugin_css/src/dependency/url.rs
+++ b/crates/rspack_plugin_css/src/dependency/url.rs
@@ -9,6 +9,8 @@ use rspack_core::{
 
 use crate::{css_syntax::serialize_url_value, utils::AUTO_PUBLIC_PATH_PLACEHOLDER};
 
+const ASSET_AUTO_PUBLIC_PATH_PLACEHOLDER: &str = "__RSPACK_PLUGIN_ASSET_AUTO_PUBLIC_PATH__";
+
 #[cacheable]
 #[derive(Debug)]
 pub struct CssUrlDependency {
@@ -37,11 +39,19 @@ impl CssUrlDependency {
     let code_gen_result = compilation.code_generation_results.get_one(identifier);
 
     if let Some(url) = code_gen_result.data().get::<CodeGenerationDataUrl>() {
-      Some(url.inner().to_string())
+      Some(
+        url
+          .inner()
+          .cow_replace(
+            ASSET_AUTO_PUBLIC_PATH_PLACEHOLDER,
+            AUTO_PUBLIC_PATH_PLACEHOLDER,
+          )
+          .into_owned(),
+      )
     } else if let Some(data) = code_gen_result.data().get::<CodeGenerationDataFilename>() {
       let filename = data.filename();
       let public_path = data.public_path().cow_replace(
-        "__RSPACK_PLUGIN_ASSET_AUTO_PUBLIC_PATH__",
+        ASSET_AUTO_PUBLIC_PATH_PLACEHOLDER,
         AUTO_PUBLIC_PATH_PLACEHOLDER,
       );
       Some(format!("{public_path}{filename}"))

--- a/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style1.2.txt
+++ b/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style1.2.txt
@@ -1,6 +1,6 @@
 Object {
   getPropertyValue: [Function],
-  nested-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img2.png),
-  nested-nested-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img3.png),
-  same-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img1.png),
+  nested-dir: url(https://test.cases/path/bundle2/assets/img2.png),
+  nested-nested-dir: url(https://test.cases/path/bundle2/assets/img3.png),
+  same-dir: url(https://test.cases/path/bundle2/assets/img1.png),
 }

--- a/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style2.2.txt
+++ b/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style2.2.txt
@@ -1,6 +1,6 @@
 Object {
   getPropertyValue: [Function],
-  nested-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img3.png),
-  outer-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img1.png),
-  same-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img2.png),
+  nested-dir: url(https://test.cases/path/bundle2/assets/img3.png),
+  outer-dir: url(https://test.cases/path/bundle2/assets/img1.png),
+  same-dir: url(https://test.cases/path/bundle2/assets/img2.png),
 }

--- a/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style3.2.txt
+++ b/tests/rspack-test/configCases/css/url-and-asset-module-filename/__snapshot__/style3.2.txt
@@ -1,6 +1,6 @@
 Object {
   getPropertyValue: [Function],
-  outer-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img2.png),
-  outer-outer-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img1.png),
-  same-dir: url(https://test.cases/path/bundle2/assets/bundle2/assets/img3.png),
+  outer-dir: url(https://test.cases/path/bundle2/assets/img2.png),
+  outer-outer-dir: url(https://test.cases/path/bundle2/assets/img1.png),
+  same-dir: url(https://test.cases/path/bundle2/assets/img3.png),
 }

--- a/tests/rspack-test/configCases/css/url-and-asset-module-filename/index.js
+++ b/tests/rspack-test/configCases/css/url-and-asset-module-filename/index.js
@@ -7,35 +7,38 @@ it(`should generate correct url public path with css filename`, async () => {
 	const h3 = document.createElement('h3');
 	document.body.appendChild(h1);
 
-	let publicPath = '';
+	let assetPath = '';
 	switch (__STATS_I__) {
 		case 0:
-			publicPath = "../../bundle0/";
+			assetPath = "../../bundle0/assets/";
 			break;
 		case 1:
-			publicPath = "https://test.cases/path/bundle1/";
+			assetPath = "https://test.cases/path/bundle1/assets/";
 			break;
 		case 2:
-			publicPath = "https://test.cases/path/bundle2/assets/bundle2/";
+			assetPath = "https://test.cases/path/bundle2/assets/";
+			break;
+		case 3:
+			assetPath = "./img/";
 			break;
 	}
 	await import("./index.css").then(x => {
 		expect(Object.keys(x)).toEqual([]);
 		const css = getLinkSheet(document.querySelector("link"));
 		expect(css).toContain(`h1 {
-  same-dir: url("${publicPath}assets/img1.png");
-  nested-dir: url("${publicPath}assets/img2.png");
-  nested-nested-dir: url("${publicPath}assets/img3.png");
+  same-dir: url("${assetPath}img1.png");
+  nested-dir: url("${assetPath}img2.png");
+  nested-nested-dir: url("${assetPath}img3.png");
 }`);
 		expect(css).toContain(`h2 {
-  same-dir: url("${publicPath}assets/img2.png");
-  nested-dir: url("${publicPath}assets/img3.png");
-  outer-dir: url("${publicPath}assets/img1.png");
+  same-dir: url("${assetPath}img2.png");
+  nested-dir: url("${assetPath}img3.png");
+  outer-dir: url("${assetPath}img1.png");
 }`);
 		expect(css).toContain(`h3 {
-  same-dir: url("${publicPath}assets/img3.png");
-  outer-dir: url("${publicPath}assets/img2.png");
-  outer-outer-dir: url("${publicPath}assets/img1.png");
+  same-dir: url("${assetPath}img3.png");
+  outer-dir: url("${assetPath}img2.png");
+  outer-outer-dir: url("${assetPath}img1.png");
 }`);
 	});
 });

--- a/tests/rspack-test/configCases/css/url-and-asset-module-filename/rspack.config.js
+++ b/tests/rspack-test/configCases/css/url-and-asset-module-filename/rspack.config.js
@@ -59,4 +59,27 @@ module.exports = [
       ],
     },
   },
+  {
+    ...common,
+    output: {
+      cssChunkFilename: 'apps/desk/[name].css',
+    },
+    module: {
+      rules: [
+        {
+          test: /\.css$/,
+          type: 'css/auto',
+        },
+        {
+          test: /\.png$/i,
+          type: 'asset/resource',
+          generator: {
+            filename: 'img/[name][ext]',
+            outputPath: 'apps/desk/',
+            publicPath: './',
+          },
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
## Summary

- generate CSS asset URLs from the original asset filename while keeping `outputPath` only in the emitted filename
- preserve `publicPath: auto` placeholder rewriting for CSS URL code generation
- align the existing webpack parity case and cover assets emitted to `apps/desk/img/` while CSS references `./img/`

## Related links

Fixes #7916

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).