### PR TITLE
docs: remove outdated CodeSandbox example

### DIFF
--- a/website/docs/en/blog/announcing-1-4.mdx
+++ b/website/docs/en/blog/announcing-1-4.mdx
@@ -51,7 +51,7 @@ Notable changes:
 
 Starting with Rspack 1.4, we have added Wasm target support, which means Rspack can now run in browser environments, including online platforms like [StackBlitz](https://stackblitz.com/) ([WebContainers](https://blog.stackblitz.com/posts/introducing-webcontainers/)). This enables developers to quickly create prototypes and share code examples without having to configure local environments.
 
-You can try out our [online example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example) directly, or learn about the StackBlitz usage guide in [this documentation](/guide/start/quick-start#online-examples).
+You can try our [online example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example) directly.
 
 <video
   src="https://assets.rspack.rs/rspack/assets/rspack-v1-4-wasm-target.mp4"

--- a/website/docs/en/guide/start/introduction.mdx
+++ b/website/docs/en/guide/start/introduction.mdx
@@ -105,6 +105,10 @@ Rollup is built around ES modules and supports multiple output formats. Rspack c
 
 The overall architecture of Rspack shares many similarities with [Parcel](https://parceljs.org/). For example, both treat CSS assets as built-in supported modules and both support filter-based transformers. However, Parcel focuses more on out-of-the-box usability, while Rspack focuses more on providing flexible configuration for higher-level frameworks and tools. Parcel introduced features like the Unified Graph and built-in HTML support. Rspack also plans to support these features in the future.
 
+## Online example
+
+Try Rspack online with the [Rsbuild StackBlitz example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example).
+
 ## Next steps
 
 Please read [Quick start](/guide/start/quick-start) to start using Rspack.

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -95,16 +95,6 @@ npx -y create-rsbuild --dir my-app --template react
 npx -y create-rsbuild -d my-app -t react
 ```
 
-## Online examples
-
-We provide an online example based on Rsbuild. The example gives an intuitive feel for the build performance of Rspack and the development experience of Rsbuild:
-
-- [Rsbuild CodeSandbox example](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example)
-
-Here we also provide an online example based on Wasm and WebContainer on StackBlitz:
-
-- [Rsbuild StackBlitz Example](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)
-
 ## Manual installation
 
 Start by creating a project directory and generating an npm `package.json':

--- a/website/docs/zh/blog/announcing-1-4.mdx
+++ b/website/docs/zh/blog/announcing-1-4.mdx
@@ -51,7 +51,7 @@ Rspack 1.4 已经正式发布！
 
 从 Rspack 1.4 开始，我们正式引入了 Wasm target 支持，这意味着 Rspack 现在可以在浏览器环境中运行，包括 [StackBlitz](https://stackblitz.com/)（[WebContainers](https://blog.stackblitz.com/posts/introducing-webcontainers/)）等在线平台。这使得开发者无需配置本地环境，即可快速创建原型、分享代码示例。
 
-你可以直接体验我们提供的 [在线示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)，也可以在 [这篇文档](/guide/start/quick-start#在线示例) 中了解 StackBlitz 的使用指南。
+你可以直接体验我们提供的 [在线示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)。
 
 <video
   src="https://assets.rspack.rs/rspack/assets/rspack-v1-4-wasm-target.mp4"

--- a/website/docs/zh/guide/start/introduction.mdx
+++ b/website/docs/zh/guide/start/introduction.mdx
@@ -116,6 +116,10 @@ Rollup 以 ES Modules 为基础，同时支持多种输出格式。Rspack 则覆
 
 Rspack 的整体架构与 [Parcel](https://parceljs.org/) 有很多共同之处。例如都内置支持 CSS 资源，都支持基于 filter 的 transformer。然而，Parcel 更加注重开箱即用的体验，而 Rspack 更加注重为上层框架提供灵活的配置。Parcel 开创性地设计了 Unified Graph 和内置对 HTML 的支持。Rspack 也计划在未来支持这些特性。
 
+## 在线示例
+
+通过 [Rsbuild StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example) 在线体验 Rspack。
+
 ## 下一步
 
 请阅读 [快速上手](/guide/start/quick-start) 来开始使用 Rspack。

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -93,16 +93,6 @@ npx -y create-rsbuild --dir my-app --template react
 npx -y create-rsbuild -d my-app -t react
 ```
 
-## 在线示例
-
-我们提供了基于 Rsbuild 的在线示例，通过示例项目，你可以直观感受 Rspack 的构建性能和 Rsbuild 的开发体验：
-
-- [Rsbuild CodeSandbox 示例](https://codesandbox.io/p/github/rstackjs/rsbuild-codesandbox-example)
-
-同时我们也提供了基于 Wasm 和 WebContainers 的 StackBlitz 在线示例：
-
-- [Rsbuild StackBlitz 示例](https://stackblitz.com/~/github.com/rstackjs/rsbuild-stackblitz-example)
-
 ## 手动安装
 
 首先创建一个项目目录，并生成一个 npm `package.json` 文件：


### PR DESCRIPTION
## Summary

CodeSandbox no longer supports opening repository examples, leaving a broken link in the quick start. This PR removes the outdated link, moves the StackBlitz example to the introduction page, and removes stale quick-start section links from the Rspack 1.4 announcement.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).