### PR TITLE
refactor(split-chunks): skip disjoint group cleanup

### DIFF
--- a/crates/rspack_plugin_split_chunks/src/common.rs
+++ b/crates/rspack_plugin_split_chunks/src/common.rs
@@ -234,6 +234,14 @@ pub struct FallbackCacheGroup {
 pub type ModuleSizes = IdentifierMap<FxHashMap<SourceType, f64>>;
 pub(crate) type ModuleChunks = Vec<FxHashSet<ChunkUkey>>;
 
+/// Returns a lossy mask for quickly proving that two chunk sets are disjoint. Chunk keys may
+/// collide in the mask, so overlapping masks must always fall back to an exact check.
+pub(crate) fn chunk_mask<'a>(chunks: impl Iterator<Item = &'a ChunkUkey>) -> u64 {
+  chunks.fold(0, |mask, chunk| {
+    mask | (1u64 << (chunk.as_u32() & (u64::BITS - 1)))
+  })
+}
+
 #[derive(Debug)]
 pub(crate) enum ModuleChunkMap {
   Shared {
@@ -244,6 +252,13 @@ pub(crate) enum ModuleChunkMap {
 }
 
 impl ModuleChunkMap {
+  pub fn chunk_mask(&self) -> u64 {
+    match self {
+      Self::Shared { chunks, .. } => chunk_mask(chunks.iter()),
+      Self::ByModule(module_chunks) => chunk_mask(module_chunks.values().flatten()),
+    }
+  }
+
   pub fn get(&self, module: &ModuleIdentifier) -> Option<&FxHashSet<ChunkUkey>> {
     match self {
       Self::Shared { modules, chunks } => modules.contains(module).then_some(chunks),

--- a/crates/rspack_plugin_split_chunks/src/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/module_group.rs
@@ -7,7 +7,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::{
   CacheGroup,
-  common::{ModuleSizes, SplitChunkSizes},
+  common::{ModuleSizes, SplitChunkSizes, chunk_mask},
 };
 
 pub(crate) struct IndexedCacheGroup<'a> {
@@ -135,6 +135,10 @@ pub(crate) struct ModuleGroup {
   /// `Chunk`s which `Module`s in this ModuleGroup belong to
   #[debug(skip)]
   pub chunks: FxHashSet<ChunkUkey>,
+  /// A conservative snapshot of the group's chunks before selection starts. Later operations only
+  /// remove chunks, so retaining the original bits can add false positives but never false
+  /// negatives to cleanup filtering.
+  chunk_mask: u64,
   modules_for_compare: ModulesForCompare,
   added: Vec<ModuleIdentifier>,
   removed: Vec<ModuleIdentifier>,
@@ -157,6 +161,7 @@ impl ModuleGroup {
       sizes: Default::default(),
       source_types_modules: Default::default(),
       chunks: Default::default(),
+      chunk_mask: 0,
       modules_for_compare: Default::default(),
       chunk_name,
       added: Default::default(),
@@ -292,6 +297,7 @@ impl ModuleGroup {
   }
 
   pub fn prepare_modules_for_sizes_and_compare(&mut self) {
+    self.chunk_mask = chunk_mask(self.chunks.iter());
     let modules = self.modules.iter().copied().collect::<Vec<_>>();
     self.added = modules.clone();
     self.modules_for_compare.prepare(modules);
@@ -300,6 +306,10 @@ impl ModuleGroup {
 
   pub fn sorted_modules_for_compare(&mut self) -> &[ModuleIdentifier] {
     self.modules_for_compare.sorted()
+  }
+
+  pub fn may_have_chunks_in_mask(&self, mask: u64) -> bool {
+    self.chunk_mask & mask != 0
   }
 
   pub fn get_cache_group<'a>(&self, cache_groups: &'a [CacheGroup]) -> &'a CacheGroup {

--- a/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
+++ b/crates/rspack_plugin_split_chunks/src/plugin/module_group.rs
@@ -799,9 +799,13 @@ impl SplitChunksPlugin {
     module_sizes: &ModuleSizes,
   ) {
     // remove all modules from other entries and update size
+    let placed_chunk_mask = placed_module_chunks.chunk_mask();
     let keys_of_invalid_group = module_group_map
       .par_iter_mut()
       .filter_map(|(key, other_module_group)| {
+        if !other_module_group.may_have_chunks_in_mask(placed_chunk_mask) {
+          return None;
+        }
         let duplicated_modules = match (
           placed_module_chunks,
           other_module_group.shared_module_chunks(),


### PR DESCRIPTION
## Summary

- Add a lossy 64-bit chunk mask for quickly proving chunk sets are disjoint.
- Snapshot each module group mask before selection, where subsequent mutations only remove chunks.
- Skip module-group cleanup when masks do not overlap, while retaining the existing exact intersection checks for overlapping masks.

The mask may produce false positives because different chunk keys can map to the same bit, but it cannot produce false negatives. An overlapping mask therefore falls back to the original cleanup path, preserving behavior while avoiding repeated module scans and hash lookups for definitely disjoint groups.

## Related links

N/A

## Tests

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:unit`
- `cargo fmt --all --check`

## Checklist

- [x] Tests updated (not required; existing split chunks coverage passes).
- [x] Documentation updated (not required; no user-facing behavior change).