### PR TITLE
feat(cache): support module build cache in make

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2771,6 +2771,7 @@ export interface RawModuleRuleUse {
 }
 
 export interface RawNewCache {
+  module: boolean
   codeGeneration: boolean
   devtool: boolean
   loader: boolean

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1749,6 +1749,7 @@ CompilerOptions {
     experiments: Experiments {
         css: false,
         new_cache: NewCacheOptions {
+            module: false,
             code_generation: false,
             devtool: false,
             loader: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
@@ -4,6 +4,7 @@ use rspack_core::NewCacheOptions;
 #[derive(Debug, Default)]
 #[napi(object)]
 pub struct RawNewCache {
+  pub module: bool,
   pub code_generation: bool,
   pub devtool: bool,
   pub loader: bool,
@@ -13,6 +14,7 @@ pub struct RawNewCache {
 impl From<RawNewCache> for NewCacheOptions {
   fn from(value: RawNewCache) -> Self {
     Self {
+      module: value.module,
       code_generation: value.code_generation,
       devtool: value.devtool,
       loader: value.loader,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -124,6 +124,7 @@ impl Task<TaskContext> for AddTask {
       plugin_driver: context.plugin_driver.clone(),
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),
+      module_cache_context: context.module_cache.clone(),
       forwarded_ids,
     })])
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -124,7 +124,8 @@ impl Task<TaskContext> for AddTask {
       plugin_driver: context.plugin_driver.clone(),
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),
-      module_cache_context: context.module_cache.clone(),
+      module_build_cache: context.module_build_cache.clone(),
+      module_build_cache_counter: context.module_build_cache_counter.clone(),
       forwarded_ids,
     })])
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -125,7 +125,6 @@ impl Task<TaskContext> for AddTask {
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),
       module_build_cache: context.module_build_cache.clone(),
-      module_build_cache_counter: context.module_build_cache_counter.clone(),
       forwarded_ids,
     })])
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -4,123 +4,23 @@ use std::{
   time::{SystemTime, UNIX_EPOCH},
 };
 
-use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_fs::ReadableFileSystem;
 use rustc_hash::FxHashSet;
 
 use super::{
-  TaskContext, context::ModuleCacheContext, lazy::process_unlazy_dependencies,
-  process_dependencies::ProcessDependenciesTask,
+  TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, Cache, CacheFacade,
-  CacheValue, CompilationId, CompilerId, CompilerOptions, DependencyParents, Module,
-  ModuleCodeTemplate, NormalModuleBuildState, OptimizationBailoutItem, ResolverFactory,
-  SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheCount,
+  CacheFacade, CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
+  ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
-  new_cache::Snapshot,
+  new_cache::ModuleBuildCache,
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
   },
 };
-
-const MODULES_CACHE_NAMESPACE: &str = "Compilation/modules";
-
-type RestoredDependencies = Vec<BoxDependency>;
-// AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
-#[allow(clippy::vec_box)]
-type RestoredBlocks = Vec<Box<AsyncDependenciesBlock>>;
-type RestoredBuildResult = (
-  RestoredDependencies,
-  RestoredBlocks,
-  Vec<OptimizationBailoutItem>,
-);
-
-#[cacheable]
-struct CachedBuildResult<'a> {
-  dependencies: Vec<OwnedOrRef<'a, BoxDependency>>,
-  // AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
-  #[allow(clippy::vec_box)]
-  blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
-}
-
-impl CachedBuildResult<'_> {
-  fn from_build_result(build_result: &BuildResult) -> CachedBuildResult<'_> {
-    CachedBuildResult {
-      dependencies: build_result.dependencies.iter().map(Into::into).collect(),
-      blocks: build_result
-        .blocks
-        .iter()
-        .map(|block| block.as_ref().into())
-        .collect(),
-    }
-  }
-
-  fn into_parts(self) -> (RestoredDependencies, RestoredBlocks) {
-    (
-      self
-        .dependencies
-        .into_iter()
-        .map(OwnedOrRef::into_owned)
-        .collect(),
-      self
-        .blocks
-        .into_iter()
-        .map(|block| Box::new(block.into_owned()))
-        .collect(),
-    )
-  }
-}
-
-#[cacheable]
-#[derive(Debug)]
-struct ModuleBuildCacheEntry {
-  state: NormalModuleBuildState,
-  snapshot: Snapshot,
-  build_result: Vec<u8>,
-  optimization_bailouts: Vec<OptimizationBailoutItem>,
-}
-
-impl ModuleBuildCacheEntry {
-  fn from_build_result(
-    build_result: &BuildResult,
-    snapshot: Snapshot,
-    cache: &Cache,
-  ) -> rspack_error::Result<Option<Self>> {
-    let Some(module) = build_result.module.as_normal_module() else {
-      return Ok(None);
-    };
-    if !module.build_info().cacheable {
-      return Ok(None);
-    }
-    let Some(codec) = cache.codec() else {
-      return Ok(None);
-    };
-    Ok(Some(Self {
-      state: module.build_state(),
-      snapshot,
-      build_result: codec.encode(&CachedBuildResult::from_build_result(build_result))?,
-      optimization_bailouts: build_result.optimization_bailouts.clone(),
-    }))
-  }
-
-  fn restore(&self, module: &mut BoxModule) -> Option<()> {
-    module
-      .as_normal_module_mut()?
-      .restore_build_state(&self.state);
-    Some(())
-  }
-
-  fn build_result_parts(&self, cache: &Cache) -> rspack_error::Result<RestoredBuildResult> {
-    let codec = cache
-      .codec()
-      .ok_or_else(|| rspack_error::error!("New cache codec is unavailable"))?;
-    let cached: CachedBuildResult<'static> = codec.decode(&self.build_result)?;
-    let (dependencies, blocks) = cached.into_parts();
-    Ok((dependencies, blocks, self.optimization_bailouts.clone()))
-  }
-}
 
 #[derive(Debug)]
 pub struct BuildTask {
@@ -133,7 +33,8 @@ pub struct BuildTask {
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
-  pub(super) module_cache_context: Option<ModuleCacheContext>,
+  pub(super) module_build_cache: Option<ModuleBuildCache>,
+  pub(super) module_build_cache_counter: Option<Arc<CacheCount>>,
   pub forwarded_ids: ForwardedIdSet,
 }
 
@@ -153,75 +54,49 @@ impl Task<TaskContext> for BuildTask {
       runtime_template,
       mut module,
       fs,
-      module_cache_context,
+      module_build_cache,
+      module_build_cache_counter,
       forwarded_ids,
     } = *self;
 
-    let module_cache = if module.as_normal_module().is_some() {
-      module_cache_context.as_ref().map(|context| {
-        context
-          .cache
-          .facade(MODULES_CACHE_NAMESPACE)
-          .get_item_cache(module.identifier().as_str(), None)
-      })
-    } else {
-      None
-    };
-
-    if let (Some(module_cache), Some(module_cache_context)) = (&module_cache, &module_cache_context)
-    {
-      let entry = match module_cache.get::<ModuleBuildCacheEntry>() {
-        Ok(entry) => entry,
-        Err(error) => {
-          tracing::warn!("Restoring NormalModule build cache failed: {error}");
-          None
-        }
-      };
-      if let Some(entry) = entry
-        && !entry
-          .state
-          .need_build(&module_cache_context.value_cache_versions)
-      {
-        match module_cache_context
-          .cache
-          .check_module_snapshot_valid(&entry.snapshot)
-          .await
-        {
-          Ok(true) => match entry.build_result_parts(&module_cache_context.cache) {
-            Ok((dependencies, blocks, optimization_bailouts))
-              if entry.restore(&mut module).is_some() =>
-            {
-              plugin_driver
-                .compilation_hooks
-                .still_valid_module
-                .call(compiler_id, compilation_id, &mut module)
-                .await?;
-              return Ok(vec![Box::new(BuildResultTask {
-                build_result: Box::new(BuildResult {
-                  module,
-                  dependencies,
-                  blocks,
-                  optimization_bailouts,
-                }),
-                plugin_driver,
-                forwarded_ids,
-                invoke_succeed_module: false,
-              })]);
-            }
-            Ok(_) => {}
-            Err(error) => {
-              tracing::warn!("Decoding NormalModule build cache failed: {error}");
-            }
-          },
-          Ok(false) => {}
+    let use_module_build_cache =
+      module.as_normal_module().is_some() && module_build_cache.is_some();
+    let restored = match &module_build_cache {
+      Some(module_build_cache) if use_module_build_cache => {
+        match module_build_cache.restore(&mut module).await {
+          Ok(restored) => restored,
           Err(error) => {
-            tracing::warn!("Validating NormalModule build cache failed: {error}");
+            tracing::warn!("Restoring NormalModule build cache failed: {error}");
+            None
           }
         }
       }
+      _ => None,
+    };
+    if let Some(counter) = &module_build_cache_counter
+      && use_module_build_cache
+    {
+      if restored.is_some() {
+        counter.hit();
+      } else {
+        counter.miss();
+      }
+    }
+    if let Some(restored) = restored {
+      plugin_driver
+        .compilation_hooks
+        .still_valid_module
+        .call(compiler_id, compilation_id, &mut module)
+        .await?;
+      return Ok(vec![Box::new(BuildResultTask {
+        build_result: Box::new(restored.into_build_result(module)),
+        plugin_driver,
+        forwarded_ids,
+        invoke_succeed_module: false,
+      })]);
     }
 
-    let build_start_time = module_cache_context.as_ref().map(|_| {
+    let build_start_time = use_module_build_cache.then(|| {
       SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
@@ -234,7 +109,7 @@ impl Task<TaskContext> for BuildTask {
       .call(compiler_id, compilation_id, &mut module)
       .await?;
 
-    let mut result = module
+    let result = module
       .build(
         BuildContext {
           compiler_id,
@@ -250,47 +125,14 @@ impl Task<TaskContext> for BuildTask {
       )
       .await;
 
-    if let Ok(build_result) = &mut result
-      && let Some(module_cache) = module_cache
-      && let Some(module_cache_context) = &module_cache_context
+    if let Ok(build_result) = &result
+      && let Some(module_build_cache) = &module_build_cache
       && let Some(build_start_time) = build_start_time
+      && let Err(error) = module_build_cache
+        .store(build_result, build_start_time)
+        .await
     {
-      let snapshot = {
-        let build_info = build_result.module.build_info();
-        module_cache_context
-          .cache
-          .create_module_snapshot(
-            build_start_time,
-            &build_info.file_dependencies,
-            &build_info.context_dependencies,
-            &build_info.missing_dependencies,
-            &build_info.build_dependencies,
-          )
-          .await
-      };
-      match snapshot {
-        Ok(Some(snapshot)) => {
-          match ModuleBuildCacheEntry::from_build_result(
-            build_result,
-            snapshot,
-            &module_cache_context.cache,
-          ) {
-            Ok(Some(entry)) => {
-              if let Err(error) = module_cache.store(CacheValue::new(entry)) {
-                tracing::warn!("Storing NormalModule build cache failed: {error}");
-              }
-            }
-            Ok(None) => {}
-            Err(error) => {
-              tracing::warn!("Encoding NormalModule build cache failed: {error}");
-            }
-          }
-        }
-        Ok(None) => {}
-        Err(error) => {
-          tracing::warn!("Creating NormalModule build snapshot failed: {error}");
-        }
-      }
+      tracing::warn!("Storing NormalModule build cache failed: {error}");
     }
 
     result.map::<Vec<Box<dyn Task<TaskContext>>>, _>(|build_result| {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -27,6 +27,16 @@ use crate::{
 
 const MODULES_CACHE_NAMESPACE: &str = "Compilation/modules";
 
+type RestoredDependencies = Vec<BoxDependency>;
+// AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
+#[allow(clippy::vec_box)]
+type RestoredBlocks = Vec<Box<AsyncDependenciesBlock>>;
+type RestoredBuildResult = (
+  RestoredDependencies,
+  RestoredBlocks,
+  Vec<OptimizationBailoutItem>,
+);
+
 #[cacheable]
 struct CachedBuildResult<'a> {
   dependencies: Vec<OwnedOrRef<'a, BoxDependency>>,
@@ -47,7 +57,7 @@ impl CachedBuildResult<'_> {
     }
   }
 
-  fn into_parts(self) -> (Vec<BoxDependency>, Vec<Box<AsyncDependenciesBlock>>) {
+  fn into_parts(self) -> (RestoredDependencies, RestoredBlocks) {
     (
       self
         .dependencies
@@ -102,14 +112,7 @@ impl ModuleBuildCacheEntry {
     Some(())
   }
 
-  fn build_result_parts(
-    &self,
-    cache: &Cache,
-  ) -> rspack_error::Result<(
-    Vec<BoxDependency>,
-    Vec<Box<AsyncDependenciesBlock>>,
-    Vec<OptimizationBailoutItem>,
-  )> {
+  fn build_result_parts(&self, cache: &Cache) -> rspack_error::Result<RestoredBuildResult> {
     let codec = cache
       .codec()
       .ok_or_else(|| rspack_error::error!("New cache codec is unavailable"))?;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -11,8 +11,8 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheCount,
-  CacheFacade, CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheFacade,
+  CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
   ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
   new_cache::ModuleBuildCache,
@@ -34,7 +34,6 @@ pub struct BuildTask {
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
   pub(super) module_build_cache: Option<ModuleBuildCache>,
-  pub(super) module_build_cache_counter: Option<Arc<CacheCount>>,
   pub forwarded_ids: ForwardedIdSet,
 }
 
@@ -55,7 +54,6 @@ impl Task<TaskContext> for BuildTask {
       mut module,
       fs,
       module_build_cache,
-      module_build_cache_counter,
       forwarded_ids,
     } = *self;
 
@@ -73,15 +71,6 @@ impl Task<TaskContext> for BuildTask {
       }
       _ => None,
     };
-    if let Some(counter) = &module_build_cache_counter
-      && use_module_build_cache
-    {
-      if restored.is_some() {
-        counter.hit();
-      } else {
-        counter.miss();
-      }
-    }
     if let Some(restored) = restored {
       plugin_driver
         .compilation_hooks

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,10 +1,7 @@
-use std::{
-  collections::VecDeque,
-  sync::Arc,
-  time::{SystemTime, UNIX_EPOCH},
-};
+use std::{collections::VecDeque, sync::Arc};
 
 use rspack_fs::ReadableFileSystem;
+use rspack_util::current_time;
 use rustc_hash::FxHashSet;
 
 use super::{
@@ -85,12 +82,7 @@ impl Task<TaskContext> for BuildTask {
       })]);
     }
 
-    let build_start_time = use_module_build_cache.then(|| {
-      SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
-    });
+    let build_start_time = use_module_build_cache.then(current_time);
 
     plugin_driver
       .compilation_hooks

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,21 +1,123 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+  collections::VecDeque,
+  sync::Arc,
+  time::{SystemTime, UNIX_EPOCH},
+};
 
+use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_fs::ReadableFileSystem;
 use rustc_hash::FxHashSet;
 
 use super::{
-  TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
+  TaskContext, context::ModuleCacheContext, lazy::process_unlazy_dependencies,
+  process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheFacade,
-  CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
-  ResolverFactory, SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, Cache, CacheFacade,
+  CacheValue, CompilationId, CompilerId, CompilerOptions, DependencyParents, Module,
+  ModuleCodeTemplate, NormalModuleBuildState, OptimizationBailoutItem, ResolverFactory,
+  SharedPluginDriver,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
+  new_cache::Snapshot,
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
   },
 };
+
+const MODULES_CACHE_NAMESPACE: &str = "Compilation/modules";
+
+#[cacheable]
+struct CachedBuildResult<'a> {
+  dependencies: Vec<OwnedOrRef<'a, BoxDependency>>,
+  // AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
+  #[allow(clippy::vec_box)]
+  blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
+}
+
+impl CachedBuildResult<'_> {
+  fn from_build_result(build_result: &BuildResult) -> CachedBuildResult<'_> {
+    CachedBuildResult {
+      dependencies: build_result.dependencies.iter().map(Into::into).collect(),
+      blocks: build_result
+        .blocks
+        .iter()
+        .map(|block| block.as_ref().into())
+        .collect(),
+    }
+  }
+
+  fn into_parts(self) -> (Vec<BoxDependency>, Vec<Box<AsyncDependenciesBlock>>) {
+    (
+      self
+        .dependencies
+        .into_iter()
+        .map(OwnedOrRef::into_owned)
+        .collect(),
+      self
+        .blocks
+        .into_iter()
+        .map(|block| Box::new(block.into_owned()))
+        .collect(),
+    )
+  }
+}
+
+#[cacheable]
+#[derive(Debug)]
+struct ModuleBuildCacheEntry {
+  state: NormalModuleBuildState,
+  snapshot: Snapshot,
+  build_result: Vec<u8>,
+  optimization_bailouts: Vec<OptimizationBailoutItem>,
+}
+
+impl ModuleBuildCacheEntry {
+  fn from_build_result(
+    build_result: &BuildResult,
+    snapshot: Snapshot,
+    cache: &Cache,
+  ) -> rspack_error::Result<Option<Self>> {
+    let Some(module) = build_result.module.as_normal_module() else {
+      return Ok(None);
+    };
+    if !module.build_info().cacheable {
+      return Ok(None);
+    }
+    let Some(codec) = cache.codec() else {
+      return Ok(None);
+    };
+    Ok(Some(Self {
+      state: module.build_state(),
+      snapshot,
+      build_result: codec.encode(&CachedBuildResult::from_build_result(build_result))?,
+      optimization_bailouts: build_result.optimization_bailouts.clone(),
+    }))
+  }
+
+  fn restore(&self, module: &mut BoxModule) -> Option<()> {
+    module
+      .as_normal_module_mut()?
+      .restore_build_state(&self.state);
+    Some(())
+  }
+
+  fn build_result_parts(
+    &self,
+    cache: &Cache,
+  ) -> rspack_error::Result<(
+    Vec<BoxDependency>,
+    Vec<Box<AsyncDependenciesBlock>>,
+    Vec<OptimizationBailoutItem>,
+  )> {
+    let codec = cache
+      .codec()
+      .ok_or_else(|| rspack_error::error!("New cache codec is unavailable"))?;
+    let cached: CachedBuildResult<'static> = codec.decode(&self.build_result)?;
+    let (dependencies, blocks) = cached.into_parts();
+    Ok((dependencies, blocks, self.optimization_bailouts.clone()))
+  }
+}
 
 #[derive(Debug)]
 pub struct BuildTask {
@@ -28,6 +130,7 @@ pub struct BuildTask {
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
+  pub(super) module_cache_context: Option<ModuleCacheContext>,
   pub forwarded_ids: ForwardedIdSet,
 }
 
@@ -47,8 +150,80 @@ impl Task<TaskContext> for BuildTask {
       runtime_template,
       mut module,
       fs,
+      module_cache_context,
       forwarded_ids,
     } = *self;
+
+    let module_cache = if module.as_normal_module().is_some() {
+      module_cache_context.as_ref().map(|context| {
+        context
+          .cache
+          .facade(MODULES_CACHE_NAMESPACE)
+          .get_item_cache(module.identifier().as_str(), None)
+      })
+    } else {
+      None
+    };
+
+    if let (Some(module_cache), Some(module_cache_context)) = (&module_cache, &module_cache_context)
+    {
+      let entry = match module_cache.get::<ModuleBuildCacheEntry>() {
+        Ok(entry) => entry,
+        Err(error) => {
+          tracing::warn!("Restoring NormalModule build cache failed: {error}");
+          None
+        }
+      };
+      if let Some(entry) = entry
+        && !entry
+          .state
+          .need_build(&module_cache_context.value_cache_versions)
+      {
+        match module_cache_context
+          .cache
+          .check_module_snapshot_valid(&entry.snapshot)
+          .await
+        {
+          Ok(true) => match entry.build_result_parts(&module_cache_context.cache) {
+            Ok((dependencies, blocks, optimization_bailouts))
+              if entry.restore(&mut module).is_some() =>
+            {
+              plugin_driver
+                .compilation_hooks
+                .still_valid_module
+                .call(compiler_id, compilation_id, &mut module)
+                .await?;
+              return Ok(vec![Box::new(BuildResultTask {
+                build_result: Box::new(BuildResult {
+                  module,
+                  dependencies,
+                  blocks,
+                  optimization_bailouts,
+                }),
+                plugin_driver,
+                forwarded_ids,
+                invoke_succeed_module: false,
+              })]);
+            }
+            Ok(_) => {}
+            Err(error) => {
+              tracing::warn!("Decoding NormalModule build cache failed: {error}");
+            }
+          },
+          Ok(false) => {}
+          Err(error) => {
+            tracing::warn!("Validating NormalModule build cache failed: {error}");
+          }
+        }
+      }
+    }
+
+    let build_start_time = module_cache_context.as_ref().map(|_| {
+      SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+    });
 
     plugin_driver
       .compilation_hooks
@@ -56,7 +231,7 @@ impl Task<TaskContext> for BuildTask {
       .call(compiler_id, compilation_id, &mut module)
       .await?;
 
-    let result = module
+    let mut result = module
       .build(
         BuildContext {
           compiler_id,
@@ -72,11 +247,55 @@ impl Task<TaskContext> for BuildTask {
       )
       .await;
 
+    if let Ok(build_result) = &mut result
+      && let Some(module_cache) = module_cache
+      && let Some(module_cache_context) = &module_cache_context
+      && let Some(build_start_time) = build_start_time
+    {
+      let snapshot = {
+        let build_info = build_result.module.build_info();
+        module_cache_context
+          .cache
+          .create_module_snapshot(
+            build_start_time,
+            &build_info.file_dependencies,
+            &build_info.context_dependencies,
+            &build_info.missing_dependencies,
+            &build_info.build_dependencies,
+          )
+          .await
+      };
+      match snapshot {
+        Ok(Some(snapshot)) => {
+          match ModuleBuildCacheEntry::from_build_result(
+            build_result,
+            snapshot,
+            &module_cache_context.cache,
+          ) {
+            Ok(Some(entry)) => {
+              if let Err(error) = module_cache.store(CacheValue::new(entry)) {
+                tracing::warn!("Storing NormalModule build cache failed: {error}");
+              }
+            }
+            Ok(None) => {}
+            Err(error) => {
+              tracing::warn!("Encoding NormalModule build cache failed: {error}");
+            }
+          }
+        }
+        Ok(None) => {}
+        Err(error) => {
+          tracing::warn!("Creating NormalModule build snapshot failed: {error}");
+        }
+      }
+    }
+
     result.map::<Vec<Box<dyn Task<TaskContext>>>, _>(|build_result| {
       vec![Box::new(BuildResultTask {
         build_result: Box::new(build_result),
         plugin_driver,
         forwarded_ids,
+        invoke_succeed_module: true,
       })]
     })
   }
@@ -87,6 +306,7 @@ struct BuildResultTask {
   pub build_result: Box<BuildResult>,
   pub plugin_driver: SharedPluginDriver,
   pub forwarded_ids: ForwardedIdSet,
+  pub invoke_succeed_module: bool,
 }
 
 #[async_trait::async_trait]
@@ -99,14 +319,17 @@ impl Task<TaskContext> for BuildResultTask {
       build_result,
       plugin_driver,
       mut forwarded_ids,
+      invoke_succeed_module,
     } = *self;
     let mut module = build_result.module;
 
-    plugin_driver
-      .compilation_hooks
-      .succeed_module
-      .call(context.compiler_id, context.compilation_id, &mut module)
-      .await?;
+    if invoke_succeed_module {
+      plugin_driver
+        .compilation_hooks
+        .succeed_module
+        .call(context.compiler_id, context.compilation_id, &mut module)
+        .await?;
+    }
 
     let build_info = module.build_info();
 

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -6,9 +6,9 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::BuildModuleGraphArtifact;
 use crate::{
-  CacheCount, Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform,
-  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory,
-  ResolverFactory, RuntimeTemplate, SharedPluginDriver,
+  Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
+  RuntimeTemplate, SharedPluginDriver,
   incremental::Incremental,
   module_graph::ModuleGraph,
   new_cache::{Cache, ModuleBuildCache},
@@ -33,7 +33,6 @@ pub struct TaskContext {
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
   pub(super) module_build_cache: Option<ModuleBuildCache>,
-  pub(super) module_build_cache_counter: Option<Arc<CacheCount>>,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -65,7 +64,6 @@ impl TaskContext {
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
       module_build_cache,
-      module_build_cache_counter: None,
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -8,9 +8,15 @@ use super::BuildModuleGraphArtifact;
 use crate::{
   Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
-  new_cache::Cache,
+  RuntimeTemplate, SharedPluginDriver, ValueCacheVersions, incremental::Incremental,
+  module_graph::ModuleGraph, new_cache::Cache,
 };
+
+#[derive(Debug, Clone)]
+pub(super) struct ModuleCacheContext {
+  pub cache: Cache,
+  pub value_cache_versions: Arc<ValueCacheVersions>,
+}
 
 #[derive(Debug)]
 pub struct TaskContext {
@@ -30,6 +36,7 @@ pub struct TaskContext {
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
+  pub(super) module_cache: Option<ModuleCacheContext>,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -41,6 +48,13 @@ impl TaskContext {
     artifact: BuildModuleGraphArtifact,
     exports_info_artifact: ExportsInfoArtifact,
   ) -> Self {
+    let module_cache = compilation
+      .cache
+      .is_module_cache_enabled()
+      .then(|| ModuleCacheContext {
+        cache: compilation.cache.clone(),
+        value_cache_versions: Arc::new(compilation.value_cache_versions.clone()),
+      });
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
@@ -57,6 +71,7 @@ impl TaskContext {
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
+      module_cache,
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -46,7 +46,7 @@ impl TaskContext {
   ) -> Self {
     let module_build_cache = compilation
       .cache
-      .module_build_cache(Arc::new(compilation.value_cache_versions.clone()));
+      .module_build_cache(&compilation.value_cache_versions);
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -44,9 +44,7 @@ impl TaskContext {
     artifact: BuildModuleGraphArtifact,
     exports_info_artifact: ExportsInfoArtifact,
   ) -> Self {
-    let module_build_cache = compilation
-      .cache
-      .module_build_cache(&compilation.value_cache_versions);
+    let module_build_cache = compilation.module_build_cache();
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -6,17 +6,13 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::BuildModuleGraphArtifact;
 use crate::{
-  Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver, ValueCacheVersions, incremental::Incremental,
-  module_graph::ModuleGraph, new_cache::Cache,
+  CacheCount, Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory,
+  ResolverFactory, RuntimeTemplate, SharedPluginDriver,
+  incremental::Incremental,
+  module_graph::ModuleGraph,
+  new_cache::{Cache, ModuleBuildCache},
 };
-
-#[derive(Debug, Clone)]
-pub(super) struct ModuleCacheContext {
-  pub cache: Cache,
-  pub value_cache_versions: Arc<ValueCacheVersions>,
-}
 
 #[derive(Debug)]
 pub struct TaskContext {
@@ -36,7 +32,8 @@ pub struct TaskContext {
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
-  pub(super) module_cache: Option<ModuleCacheContext>,
+  pub(super) module_build_cache: Option<ModuleBuildCache>,
+  pub(super) module_build_cache_counter: Option<Arc<CacheCount>>,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -48,13 +45,9 @@ impl TaskContext {
     artifact: BuildModuleGraphArtifact,
     exports_info_artifact: ExportsInfoArtifact,
   ) -> Self {
-    let module_cache = compilation
+    let module_build_cache = compilation
       .cache
-      .is_module_cache_enabled()
-      .then(|| ModuleCacheContext {
-        cache: compilation.cache.clone(),
-        value_cache_versions: Arc::new(compilation.value_cache_versions.clone()),
-      });
+      .module_build_cache(Arc::new(compilation.value_cache_versions.clone()));
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
@@ -71,7 +64,8 @@ impl TaskContext {
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
-      module_cache,
+      module_build_cache,
+      module_build_cache_counter: None,
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -5,19 +5,15 @@ pub mod factorize;
 pub mod lazy;
 pub mod process_dependencies;
 
-use std::sync::Arc;
-
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use self::context::TaskContext;
 use super::BuildModuleGraphArtifact;
 use crate::{
-  BuildDependency, Compilation, ExportsInfoArtifact, Logger,
+  BuildDependency, Compilation, ExportsInfoArtifact,
   utils::task_loop::{Task, run_task_loop},
 };
-
-const LOGGER_NAME: &str = "rspack.Compilation";
 
 pub async fn repair(
   compilation: &Compilation,
@@ -71,16 +67,6 @@ pub async fn repair(
     .collect::<Vec<_>>();
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
-  let logger = compilation.get_logger(LOGGER_NAME);
-  ctx.module_build_cache_counter = ctx
-    .module_build_cache
-    .is_some()
-    .then(|| Arc::new(logger.cache("module build cache")));
   run_task_loop(&mut ctx, init_tasks).await?;
-  if let Some(counter) = ctx.module_build_cache_counter.take()
-    && let Some(counter) = Arc::into_inner(counter)
-  {
-    logger.cache_end(counter);
-  }
   Ok((ctx.artifact, ctx.exports_info_artifact))
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -5,15 +5,19 @@ pub mod factorize;
 pub mod lazy;
 pub mod process_dependencies;
 
+use std::sync::Arc;
+
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use self::context::TaskContext;
 use super::BuildModuleGraphArtifact;
 use crate::{
-  BuildDependency, Compilation, ExportsInfoArtifact,
+  BuildDependency, Compilation, ExportsInfoArtifact, Logger,
   utils::task_loop::{Task, run_task_loop},
 };
+
+const LOGGER_NAME: &str = "rspack.Compilation";
 
 pub async fn repair(
   compilation: &Compilation,
@@ -67,6 +71,16 @@ pub async fn repair(
     .collect::<Vec<_>>();
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
+  let logger = compilation.get_logger(LOGGER_NAME);
+  ctx.module_build_cache_counter = ctx
+    .module_build_cache
+    .is_some()
+    .then(|| Arc::new(logger.cache("module build cache")));
   run_task_loop(&mut ctx, init_tasks).await?;
+  if let Some(counter) = ctx.module_build_cache_counter.take()
+    && let Some(counter) = Arc::into_inner(counter)
+  {
+    logger.cache_end(counter);
+  }
   Ok((ctx.artifact, ctx.exports_info_artifact))
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -96,7 +96,7 @@ use crate::{
   legacy_cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCache, minimize::MinimizePersistentCache,
   },
-  new_cache::{Cache, CacheFacade},
+  new_cache::{Cache, CacheFacade, ModuleBuildCache, ModuleCache},
   to_identifier,
 };
 
@@ -238,6 +238,7 @@ pub struct Compilation {
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
   cache: Cache,
+  module_cache: Option<ModuleCache>,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -378,6 +379,7 @@ impl Compilation {
       diagnostics: Default::default(),
       logging,
       cache,
+      module_cache: None,
       plugin_driver,
       buildtime_plugin_driver,
       resolver_factory,
@@ -447,6 +449,18 @@ impl Compilation {
 
   pub fn get_cache(&self, name: &str) -> CacheFacade {
     self.cache.facade(name)
+  }
+
+  pub(crate) fn with_module_cache(mut self, module_cache: Option<ModuleCache>) -> Self {
+    self.module_cache = module_cache;
+    self
+  }
+
+  pub(crate) fn module_build_cache(&self) -> Option<ModuleBuildCache> {
+    self
+      .module_cache
+      .as_ref()
+      .map(|module_cache| module_cache.build_cache(&self.value_cache_versions))
   }
 
   pub fn id(&self) -> CompilationId {

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -96,7 +96,7 @@ use crate::{
   legacy_cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCache, minimize::MinimizePersistentCache,
   },
-  new_cache::{Cache, CacheFacade, ModuleBuildCache, ModuleCache},
+  new_cache::{Cache, CacheFacade, ModuleBuildCache, ModuleCache, ModuleCacheFactory},
   to_identifier,
 };
 
@@ -451,8 +451,21 @@ impl Compilation {
     self.cache.facade(name)
   }
 
-  pub(crate) fn with_module_cache(mut self, module_cache: Option<ModuleCache>) -> Self {
-    self.module_cache = module_cache;
+  pub(crate) fn with_module_cache(
+    mut self,
+    module_cache_factory: Option<&ModuleCacheFactory>,
+  ) -> Self {
+    let snapshot_options = match &self.options.cache {
+      CacheOptions::Persistent(options) => options.snapshot.clone(),
+      CacheOptions::Disabled | CacheOptions::Memory { .. } => Default::default(),
+    };
+    self.module_cache = module_cache_factory.map(|factory| {
+      factory.create_for_compilation(
+        self.input_filesystem.clone(),
+        snapshot_options,
+        self.options.output.hash_function,
+      )
+    });
     self
   }
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -27,7 +27,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{Cache, CacheFacade, ModuleCache, NewCache, create_cache},
+  new_cache::{Cache, CacheFacade, ModuleCacheFactory, NewCache, create_cache},
   trim_dir,
 };
 
@@ -103,7 +103,7 @@ pub struct Compiler {
   pub cache: Box<dyn LegacyCache>,
   incremental_artifacts: IncrementalArtifacts,
   new_cache: Cache,
-  module_cache: Option<ModuleCache>,
+  module_cache_factory: Option<ModuleCacheFactory>,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
   pub emitted_asset_versions: HashMap<String, String>,
@@ -164,7 +164,7 @@ impl Compiler {
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
     let NewCache {
       cache: new_cache,
-      module_cache,
+      module_cache_factory,
     } = create_cache(
       compiler_path.clone(),
       options.clone(),
@@ -207,7 +207,7 @@ impl Compiler {
         false,
         compiler_context.clone(),
       )
-      .with_module_cache(module_cache.clone()),
+      .with_module_cache(module_cache_factory.as_ref()),
       compiler_path,
       output_filesystem,
       intermediate_filesystem,
@@ -218,7 +218,7 @@ impl Compiler {
       cache,
       incremental_artifacts: IncrementalArtifacts::default(),
       new_cache,
-      module_cache,
+      module_cache_factory,
       emitted_asset_versions: Default::default(),
       input_filesystem,
       platform,
@@ -236,9 +236,6 @@ impl Compiler {
   }
 
   fn end_idle(&self) -> Result<Instant> {
-    if let Some(module_cache) = &self.module_cache {
-      module_cache.clear();
-    }
     self.new_cache.end_idle()?;
     Ok(Instant::now())
   }
@@ -257,8 +254,8 @@ impl Compiler {
     } else {
       Ok(())
     };
-    let record_dependency_id = if let Some(module_cache) = &self.module_cache {
-      module_cache.record_dependency_id(self.compilation.compiler_context.dependency_id())
+    let record_dependency_id = if let Some(module_cache_factory) = &self.module_cache_factory {
+      module_cache_factory.record_dependency_id(self.compilation.compiler_context.dependency_id())
     } else {
       Ok(())
     };
@@ -335,11 +332,11 @@ impl Compiler {
         false,
         self.compiler_context.clone(),
       )
-      .with_module_cache(self.module_cache.clone()),
+      .with_module_cache(self.module_cache_factory.as_ref()),
     );
     self.cache.before_compile(&mut self.compilation).await;
-    if let Some(module_cache) = &self.module_cache {
-      module_cache.restore_dependency_id();
+    if let Some(module_cache_factory) = &self.module_cache_factory {
+      module_cache_factory.restore_dependency_id();
     }
 
     self.compile().await?;

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -27,7 +27,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{Cache, CacheFacade, create_cache},
+  new_cache::{Cache, CacheFacade, ModuleCache, NewCache, create_cache},
   trim_dir,
 };
 
@@ -103,6 +103,7 @@ pub struct Compiler {
   pub cache: Box<dyn LegacyCache>,
   incremental_artifacts: IncrementalArtifacts,
   new_cache: Cache,
+  module_cache: Option<ModuleCache>,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
   pub emitted_asset_versions: HashMap<String, String>,
@@ -161,7 +162,10 @@ impl Compiler {
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
-    let new_cache = create_cache(
+    let NewCache {
+      cache: new_cache,
+      module_cache,
+    } = create_cache(
       compiler_path.clone(),
       options.clone(),
       input_filesystem.clone(),
@@ -202,7 +206,8 @@ impl Compiler {
         output_filesystem.clone(),
         false,
         compiler_context.clone(),
-      ),
+      )
+      .with_module_cache(module_cache.clone()),
       compiler_path,
       output_filesystem,
       intermediate_filesystem,
@@ -213,6 +218,7 @@ impl Compiler {
       cache,
       incremental_artifacts: IncrementalArtifacts::default(),
       new_cache,
+      module_cache,
       emitted_asset_versions: Default::default(),
       input_filesystem,
       platform,
@@ -230,6 +236,9 @@ impl Compiler {
   }
 
   fn end_idle(&self) -> Result<Instant> {
+    if let Some(module_cache) = &self.module_cache {
+      module_cache.clear();
+    }
     self.new_cache.end_idle()?;
     Ok(Instant::now())
   }
@@ -248,9 +257,11 @@ impl Compiler {
     } else {
       Ok(())
     };
-    let record_dependency_id = self
-      .new_cache
-      .record_dependency_id(self.compilation.compiler_context.dependency_id());
+    let record_dependency_id = if let Some(module_cache) = &self.module_cache {
+      module_cache.record_dependency_id(self.compilation.compiler_context.dependency_id())
+    } else {
+      Ok(())
+    };
     let begin_idle = self.new_cache.begin_idle();
 
     record_build_time
@@ -323,10 +334,13 @@ impl Compiler {
         self.output_filesystem.clone(),
         false,
         self.compiler_context.clone(),
-      ),
+      )
+      .with_module_cache(self.module_cache.clone()),
     );
     self.cache.before_compile(&mut self.compilation).await;
-    self.new_cache.restore_dependency_id();
+    if let Some(module_cache) = &self.module_cache {
+      module_cache.restore_dependency_id();
+    }
 
     self.compile().await?;
     self.compile_done().await?;

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -248,10 +248,18 @@ impl Compiler {
     } else {
       Ok(())
     };
+    let record_dependency_id = if self.new_cache.is_module_cache_enabled() {
+      self
+        .new_cache
+        .record_dependency_id(self.compilation.compiler_context.dependency_id())
+    } else {
+      Ok(())
+    };
     let begin_idle = self.new_cache.begin_idle();
 
     record_build_time
       .and(store_build_dependencies)
+      .and(record_dependency_id)
       .and(begin_idle)
   }
 
@@ -322,6 +330,9 @@ impl Compiler {
       ),
     );
     self.cache.before_compile(&mut self.compilation).await;
+    if self.new_cache.is_module_cache_enabled() {
+      self.new_cache.restore_dependency_id();
+    }
 
     self.compile().await?;
     self.compile_done().await?;

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -248,13 +248,9 @@ impl Compiler {
     } else {
       Ok(())
     };
-    let record_dependency_id = if self.new_cache.is_module_cache_enabled() {
-      self
-        .new_cache
-        .record_dependency_id(self.compilation.compiler_context.dependency_id())
-    } else {
-      Ok(())
-    };
+    let record_dependency_id = self
+      .new_cache
+      .record_dependency_id(self.compilation.compiler_context.dependency_id());
     let begin_idle = self.new_cache.begin_idle();
 
     record_build_time
@@ -330,9 +326,7 @@ impl Compiler {
       ),
     );
     self.cache.before_compile(&mut self.compilation).await;
-    if self.new_cache.is_module_cache_enabled() {
-      self.new_cache.restore_dependency_id();
-    }
+    self.new_cache.restore_dependency_id();
 
     self.compile().await?;
     self.compile_done().await?;

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -95,7 +95,8 @@ impl Compiler {
         self.output_filesystem.clone(),
         true,
         self.compiler_context.clone(),
-      );
+      )
+      .with_module_cache(self.module_cache.clone());
       next_compilation.hot_index = self.compilation.hot_index + 1;
 
       if next_compilation

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -96,7 +96,7 @@ impl Compiler {
         true,
         self.compiler_context.clone(),
       )
-      .with_module_cache(self.module_cache.clone());
+      .with_module_cache(self.module_cache_factory.as_ref());
       next_compilation.hot_index = self.compilation.hot_index + 1;
 
       if next_compilation

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -12,7 +12,7 @@ use rspack_cacheable::{
   with::{AsInner, AsInnerConverter, AsMap, AsOption, AsPreset, AsVec},
 };
 use rspack_collections::{Identifiable, Identifier, IdentifierMap, IdentifierSet};
-use rspack_error::{Diagnosable, Result};
+use rspack_error::{Diagnosable, Diagnostic, Result};
 use rspack_fs::ReadableFileSystem;
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher, write_u64_hex};
 use rspack_paths::InternedPathSet;
@@ -333,6 +333,18 @@ impl Default for BuildInfo {
       extras: Default::default(),
       deferred_pure_checks: HashSet::default(),
     }
+  }
+}
+
+impl BuildInfo {
+  pub(crate) fn need_build(
+    &self,
+    diagnostics: &[Diagnostic],
+    value_cache_versions: &ValueCacheVersions,
+  ) -> bool {
+    !self.cacheable
+      || value_cache_versions.has_diff(&self.value_dependencies)
+      || diagnostics.iter().any(|diagnostic| diagnostic.is_error())
   }
 }
 
@@ -832,10 +844,9 @@ pub trait Module:
   }
 
   fn need_build(&self, value_cache_version: &ValueCacheVersions) -> bool {
-    let build_info = self.build_info();
-    !build_info.cacheable
-      || value_cache_version.has_diff(&build_info.value_dependencies)
-      || self.diagnostics().iter().any(|item| item.is_error())
+    self
+      .build_info()
+      .need_build(&self.diagnostics(), value_cache_version)
   }
 
   fn need_id(&self) -> bool {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,12 +1,19 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+  sync::{Arc, OnceLock},
+  time::Duration,
+};
 
 use rspack_error::Result;
 use rspack_paths::InternedPathSet;
+use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
+  Snapshot,
   cache_value::CacheValueData,
+  snapshot::{FileSystemInfo, SnapshotValidationResult},
 };
+use crate::cache::CacheCodec;
 
 /// Cache entry point backed by memory and optional filesystem storage.
 ///
@@ -23,6 +30,9 @@ struct CacheStorage {
 struct CacheInner {
   compiler_path: String,
   storage: Option<CacheStorage>,
+  codec: Option<Arc<CacheCodec>>,
+  file_system_info: Option<FileSystemInfo>,
+  dependency_id_restored: OnceLock<()>,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
@@ -44,6 +54,30 @@ impl Cache {
           memory_cache,
           idle_file_cache,
         }),
+        codec: None,
+        file_system_info: None,
+        dependency_id_restored: OnceLock::new(),
+      }),
+    }
+  }
+
+  pub(crate) fn new_with_module_cache(
+    compiler_path: String,
+    memory_cache: MemoryCache,
+    idle_file_cache: Option<IdleFileCache>,
+    codec: Arc<CacheCodec>,
+    file_system_info: FileSystemInfo,
+  ) -> Self {
+    Self {
+      inner: Arc::new(CacheInner {
+        compiler_path,
+        storage: Some(CacheStorage {
+          memory_cache,
+          idle_file_cache,
+        }),
+        codec: Some(codec),
+        file_system_info: Some(file_system_info),
+        dependency_id_restored: OnceLock::new(),
       }),
     }
   }
@@ -53,8 +87,94 @@ impl Cache {
       inner: Arc::new(CacheInner {
         compiler_path,
         storage: None,
+        codec: None,
+        file_system_info: None,
+        dependency_id_restored: OnceLock::new(),
       }),
     }
+  }
+
+  pub(crate) fn is_module_cache_enabled(&self) -> bool {
+    self.inner.storage.is_some()
+      && self.inner.codec.is_some()
+      && self.inner.file_system_info.is_some()
+  }
+
+  pub(crate) fn codec(&self) -> Option<&CacheCodec> {
+    self.inner.codec.as_deref()
+  }
+
+  pub(crate) fn file_system_info(&self) -> Option<&FileSystemInfo> {
+    self.inner.file_system_info.as_ref()
+  }
+
+  pub(crate) async fn create_module_snapshot(
+    &self,
+    start_time: u64,
+    file_dependencies: &InternedPathSet,
+    context_dependencies: &InternedPathSet,
+    missing_dependencies: &InternedPathSet,
+    build_dependencies: &InternedPathSet,
+  ) -> Result<Option<Snapshot>> {
+    let Some(file_system_info) = self.file_system_info() else {
+      return Ok(None);
+    };
+    let mut files = file_dependencies.clone();
+    files.extend(build_dependencies.iter().cloned());
+    file_system_info
+      .create_snapshot(
+        Some(start_time),
+        &files,
+        context_dependencies,
+        missing_dependencies,
+        file_system_info.module_strategy(),
+      )
+      .await
+      .map(Some)
+  }
+
+  pub(crate) async fn check_module_snapshot_valid(&self, snapshot: &Snapshot) -> Result<bool> {
+    let Some(file_system_info) = self.file_system_info() else {
+      return Ok(false);
+    };
+    Ok(matches!(
+      file_system_info.check_snapshot_valid(snapshot).await?,
+      SnapshotValidationResult::Valid
+    ))
+  }
+
+  /// Restore the dependency id generator before the first make pass.
+  ///
+  /// Cached dependencies retain their ids, so newly created dependencies must
+  /// continue after the largest id stored by the persistent cache.
+  pub(crate) fn restore_dependency_id(&self) {
+    if !self.is_module_cache_enabled() {
+      return;
+    }
+    self.inner.dependency_id_restored.get_or_init(|| {
+      let Some(file_cache) = self
+        .inner
+        .storage
+        .as_ref()
+        .and_then(|storage| storage.idle_file_cache.as_ref())
+      else {
+        return;
+      };
+
+      let dependency_id = match file_cache.restore_dependency_id() {
+        Ok(dependency_id) => dependency_id,
+        Err(error) => {
+          tracing::warn!("Restoring new cache dependency id failed: {error}");
+          None
+        }
+      };
+      if let Some(dependency_id) = dependency_id {
+        let current = get_current_dependency_id();
+        if current < dependency_id {
+          set_current_dependency_id(dependency_id);
+        }
+      }
+    });
   }
 
   pub(crate) fn facade(&self, name: &str) -> CacheFacade {
@@ -126,6 +246,20 @@ impl Cache {
     }
   }
 
+  pub(crate) fn record_dependency_id(&self, dependency_id: u32) -> Result<()> {
+    if !self.is_module_cache_enabled() {
+      return Ok(());
+    }
+    let Some(storage) = &self.inner.storage else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &storage.idle_file_cache {
+      file_cache.store_dependency_id(dependency_id)
+    } else {
+      Ok(())
+    }
+  }
+
   pub fn has_file_cache(&self) -> bool {
     self
       .inner
@@ -161,6 +295,9 @@ impl Cache {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
+    if let Some(file_system_info) = &self.inner.file_system_info {
+      file_system_info.clear();
+    }
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.end_idle()
     } else {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,17 +1,13 @@
-use std::{
-  sync::{Arc, OnceLock},
-  time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
 use rspack_error::Result;
 use rspack_paths::InternedPathSet;
-use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
-  module_build_cache::ModuleBuildCache,
-  snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult},
+  module_build_cache::{ModuleBuildCache, ModuleCacheState},
+  snapshot::FileSystemInfo,
 };
 use crate::{ValueCacheVersions, cache::CacheCodec};
 
@@ -30,9 +26,7 @@ struct CacheStorage {
 struct CacheInner {
   compiler_path: String,
   storage: Option<CacheStorage>,
-  codec: Option<Arc<CacheCodec>>,
-  file_system_info: Option<FileSystemInfo>,
-  dependency_id_restored: OnceLock<()>,
+  module_cache: Option<ModuleCacheState>,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
@@ -47,18 +41,7 @@ impl Cache {
     memory_cache: MemoryCache,
     idle_file_cache: Option<IdleFileCache>,
   ) -> Self {
-    Self {
-      inner: Arc::new(CacheInner {
-        compiler_path,
-        storage: Some(CacheStorage {
-          memory_cache,
-          idle_file_cache,
-        }),
-        codec: None,
-        file_system_info: None,
-        dependency_id_restored: OnceLock::new(),
-      }),
-    }
+    Self::new_with_storage(compiler_path, memory_cache, idle_file_cache, None)
   }
 
   pub(crate) fn new_with_module_cache(
@@ -68,6 +51,20 @@ impl Cache {
     codec: Arc<CacheCodec>,
     file_system_info: FileSystemInfo,
   ) -> Self {
+    Self::new_with_storage(
+      compiler_path,
+      memory_cache,
+      idle_file_cache,
+      Some(ModuleCacheState::new(codec, file_system_info)),
+    )
+  }
+
+  fn new_with_storage(
+    compiler_path: String,
+    memory_cache: MemoryCache,
+    idle_file_cache: Option<IdleFileCache>,
+    module_cache: Option<ModuleCacheState>,
+  ) -> Self {
     Self {
       inner: Arc::new(CacheInner {
         compiler_path,
@@ -75,9 +72,7 @@ impl Cache {
           memory_cache,
           idle_file_cache,
         }),
-        codec: Some(codec),
-        file_system_info: Some(file_system_info),
-        dependency_id_restored: OnceLock::new(),
+        module_cache,
       }),
     }
   }
@@ -87,69 +82,20 @@ impl Cache {
       inner: Arc::new(CacheInner {
         compiler_path,
         storage: None,
-        codec: None,
-        file_system_info: None,
-        dependency_id_restored: OnceLock::new(),
+        module_cache: None,
       }),
     }
   }
 
-  pub(crate) fn is_module_cache_enabled(&self) -> bool {
-    self.inner.storage.is_some()
-      && self.inner.codec.is_some()
-      && self.inner.file_system_info.is_some()
-  }
-
   pub(crate) fn module_build_cache(
     &self,
-    value_cache_versions: Arc<ValueCacheVersions>,
+    value_cache_versions: &ValueCacheVersions,
   ) -> Option<ModuleBuildCache> {
     self
-      .is_module_cache_enabled()
-      .then(|| ModuleBuildCache::new(self.clone(), value_cache_versions))
-  }
-
-  pub(crate) fn codec(&self) -> Option<&CacheCodec> {
-    self.inner.codec.as_deref()
-  }
-
-  pub(crate) fn file_system_info(&self) -> Option<&FileSystemInfo> {
-    self.inner.file_system_info.as_ref()
-  }
-
-  pub(crate) async fn create_module_snapshot(
-    &self,
-    start_time: u64,
-    file_dependencies: &InternedPathSet,
-    context_dependencies: &InternedPathSet,
-    missing_dependencies: &InternedPathSet,
-    build_dependencies: &InternedPathSet,
-  ) -> Result<Option<Snapshot>> {
-    let Some(file_system_info) = self.file_system_info() else {
-      return Ok(None);
-    };
-    let mut files = file_dependencies.clone();
-    files.extend(build_dependencies.iter().cloned());
-    file_system_info
-      .create_snapshot(
-        Some(start_time),
-        &files,
-        context_dependencies,
-        missing_dependencies,
-        file_system_info.module_strategy(),
-      )
-      .await
-      .map(Some)
-  }
-
-  pub(crate) async fn check_module_snapshot_valid(&self, snapshot: &Snapshot) -> Result<bool> {
-    let Some(file_system_info) = self.file_system_info() else {
-      return Ok(false);
-    };
-    Ok(matches!(
-      file_system_info.check_snapshot_valid(snapshot).await?,
-      SnapshotValidationResult::Valid
-    ))
+      .inner
+      .module_cache
+      .as_ref()
+      .map(|module_cache| module_cache.build_cache(self.clone(), value_cache_versions))
   }
 
   /// Restore the dependency id generator before the first make pass.
@@ -157,33 +103,9 @@ impl Cache {
   /// Cached dependencies retain their ids, so newly created dependencies must
   /// continue after the largest id stored by the persistent cache.
   pub(crate) fn restore_dependency_id(&self) {
-    if !self.is_module_cache_enabled() {
-      return;
+    if let Some(module_cache) = &self.inner.module_cache {
+      module_cache.restore_dependency_id(self.idle_file_cache());
     }
-    self.inner.dependency_id_restored.get_or_init(|| {
-      let Some(file_cache) = self
-        .inner
-        .storage
-        .as_ref()
-        .and_then(|storage| storage.idle_file_cache.as_ref())
-      else {
-        return;
-      };
-
-      let dependency_id = match file_cache.restore_dependency_id() {
-        Ok(dependency_id) => dependency_id,
-        Err(error) => {
-          tracing::warn!("Restoring new cache dependency id failed: {error}");
-          None
-        }
-      };
-      if let Some(dependency_id) = dependency_id {
-        let current = get_current_dependency_id();
-        if current < dependency_id {
-          set_current_dependency_id(dependency_id);
-        }
-      }
-    });
   }
 
   pub(crate) fn facade(&self, name: &str) -> CacheFacade {
@@ -256,25 +178,23 @@ impl Cache {
   }
 
   pub(crate) fn record_dependency_id(&self, dependency_id: u32) -> Result<()> {
-    if !self.is_module_cache_enabled() {
-      return Ok(());
-    }
-    let Some(storage) = &self.inner.storage else {
-      return Ok(());
-    };
-    if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.store_dependency_id(dependency_id)
+    if let Some(module_cache) = &self.inner.module_cache {
+      module_cache.record_dependency_id(self.idle_file_cache(), dependency_id)
     } else {
       Ok(())
     }
   }
 
-  pub fn has_file_cache(&self) -> bool {
+  fn idle_file_cache(&self) -> Option<&IdleFileCache> {
     self
       .inner
       .storage
       .as_ref()
-      .is_some_and(|storage| storage.idle_file_cache.is_some())
+      .and_then(|storage| storage.idle_file_cache.as_ref())
+  }
+
+  pub fn has_file_cache(&self) -> bool {
+    self.idle_file_cache().is_some()
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
@@ -304,8 +224,8 @@ impl Cache {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(file_system_info) = &self.inner.file_system_info {
-      file_system_info.clear();
+    if let Some(module_cache) = &self.inner.module_cache {
+      module_cache.clear();
     }
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.end_idle()

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -6,10 +6,7 @@ use rspack_paths::InternedPathSet;
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
-  module_build_cache::{ModuleBuildCache, ModuleCacheState},
-  snapshot::FileSystemInfo,
 };
-use crate::{ValueCacheVersions, cache::CacheCodec};
 
 /// Cache entry point backed by memory and optional filesystem storage.
 ///
@@ -26,7 +23,6 @@ struct CacheStorage {
 struct CacheInner {
   compiler_path: String,
   storage: Option<CacheStorage>,
-  module_cache: Option<ModuleCacheState>,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
@@ -41,30 +37,6 @@ impl Cache {
     memory_cache: MemoryCache,
     idle_file_cache: Option<IdleFileCache>,
   ) -> Self {
-    Self::new_with_storage(compiler_path, memory_cache, idle_file_cache, None)
-  }
-
-  pub(crate) fn new_with_module_cache(
-    compiler_path: String,
-    memory_cache: MemoryCache,
-    idle_file_cache: Option<IdleFileCache>,
-    codec: Arc<CacheCodec>,
-    file_system_info: FileSystemInfo,
-  ) -> Self {
-    Self::new_with_storage(
-      compiler_path,
-      memory_cache,
-      idle_file_cache,
-      Some(ModuleCacheState::new(codec, file_system_info)),
-    )
-  }
-
-  fn new_with_storage(
-    compiler_path: String,
-    memory_cache: MemoryCache,
-    idle_file_cache: Option<IdleFileCache>,
-    module_cache: Option<ModuleCacheState>,
-  ) -> Self {
     Self {
       inner: Arc::new(CacheInner {
         compiler_path,
@@ -72,7 +44,6 @@ impl Cache {
           memory_cache,
           idle_file_cache,
         }),
-        module_cache,
       }),
     }
   }
@@ -82,29 +53,7 @@ impl Cache {
       inner: Arc::new(CacheInner {
         compiler_path,
         storage: None,
-        module_cache: None,
       }),
-    }
-  }
-
-  pub(crate) fn module_build_cache(
-    &self,
-    value_cache_versions: &ValueCacheVersions,
-  ) -> Option<ModuleBuildCache> {
-    self
-      .inner
-      .module_cache
-      .as_ref()
-      .map(|module_cache| module_cache.build_cache(self.clone(), value_cache_versions))
-  }
-
-  /// Restore the dependency id generator before the first make pass.
-  ///
-  /// Cached dependencies retain their ids, so newly created dependencies must
-  /// continue after the largest id stored by the persistent cache.
-  pub(crate) fn restore_dependency_id(&self) {
-    if let Some(module_cache) = &self.inner.module_cache {
-      module_cache.restore_dependency_id(self.idle_file_cache());
     }
   }
 
@@ -177,14 +126,6 @@ impl Cache {
     }
   }
 
-  pub(crate) fn record_dependency_id(&self, dependency_id: u32) -> Result<()> {
-    if let Some(module_cache) = &self.inner.module_cache {
-      module_cache.record_dependency_id(self.idle_file_cache(), dependency_id)
-    } else {
-      Ok(())
-    }
-  }
-
   fn idle_file_cache(&self) -> Option<&IdleFileCache> {
     self
       .inner
@@ -224,9 +165,6 @@ impl Cache {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
-    if let Some(module_cache) = &self.inner.module_cache {
-      module_cache.clear();
-    }
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.end_idle()
     } else {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -9,11 +9,11 @@ use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
-  Snapshot,
   cache_value::CacheValueData,
-  snapshot::{FileSystemInfo, SnapshotValidationResult},
+  module_build_cache::ModuleBuildCache,
+  snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult},
 };
-use crate::cache::CacheCodec;
+use crate::{ValueCacheVersions, cache::CacheCodec};
 
 /// Cache entry point backed by memory and optional filesystem storage.
 ///
@@ -98,6 +98,15 @@ impl Cache {
     self.inner.storage.is_some()
       && self.inner.codec.is_some()
       && self.inner.file_system_info.is_some()
+  }
+
+  pub(crate) fn module_build_cache(
+    &self,
+    value_cache_versions: Arc<ValueCacheVersions>,
+  ) -> Option<ModuleBuildCache> {
+    self
+      .is_module_cache_enabled()
+      .then(|| ModuleBuildCache::new(self.clone(), value_cache_versions))
   }
 
   pub(crate) fn codec(&self) -> Option<&CacheCodec> {

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -12,15 +12,17 @@ pub use turbo::{Database, DatabaseValue};
 pub enum DatabaseFamily {
   Cache,
   Validator,
+  Meta,
 }
 
 impl DatabaseFamily {
-  pub const COUNT: usize = 2;
+  pub const COUNT: usize = 3;
 
   pub const fn index(self) -> usize {
     match self {
       Self::Cache => 0,
       Self::Validator => 1,
+      Self::Meta => 2,
     }
   }
 }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -325,6 +325,10 @@ fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
         name: "validator",
         kind: FamilyKind::SingleValue,
       },
+      FamilyConfig {
+        name: "meta",
+        kind: FamilyKind::SingleValue,
+      },
     ],
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -19,6 +19,7 @@ const VALIDATOR_KEY: &[u8] = b"validator";
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: Option<InternedPathSet>,
+  max_dependencies_id: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -139,6 +140,24 @@ impl FileCacheStrategy {
       .extend(dependencies);
   }
 
+  pub fn store_dependency_id(&mut self, dependency_id: u32) {
+    if self.readonly {
+      return;
+    }
+    self.validator.store_dependency_id(dependency_id);
+    self.pending_writes.max_dependencies_id = Some(
+      self
+        .pending_writes
+        .max_dependencies_id
+        .unwrap_or_default()
+        .max(dependency_id),
+    );
+  }
+
+  pub fn restore_dependency_id(&self) -> Option<u32> {
+    Some(self.validator.restore_dependency_id())
+  }
+
   pub(super) fn restore(
     &self,
     key: &CacheKey,
@@ -172,6 +191,8 @@ impl FileCacheStrategy {
     if self.has_pending_writes() {
       let encoded_validator = if let Some(dependencies) = &self.pending_writes.build_dependencies {
         Some(self.validator.update(dependencies.iter().cloned()).await?)
+      } else if self.pending_writes.max_dependencies_id.is_some() {
+        Some(self.validator.encode()?)
       } else {
         None
       };
@@ -199,6 +220,7 @@ impl FileCacheStrategy {
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
+      self.pending_writes.max_dependencies_id = None;
     }
 
     for _ in 0..max_compaction_passes {
@@ -222,6 +244,8 @@ impl FileCacheStrategy {
   }
 
   pub fn has_pending_writes(&self) -> bool {
-    !self.pending_writes.entries.is_empty() || self.pending_writes.build_dependencies.is_some()
+    !self.pending_writes.entries.is_empty()
+      || self.pending_writes.build_dependencies.is_some()
+      || self.pending_writes.max_dependencies_id.is_some()
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -14,12 +14,13 @@ use super::{
 use crate::cache::CacheCodec;
 
 const VALIDATOR_KEY: &[u8] = b"validator";
+const MAX_DEPENDENCY_ID_KEY: &[u8] = b"max_dependency_id";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: Option<InternedPathSet>,
-  max_dependencies_id: Option<u32>,
+  max_dependency_id: Option<u32>,
 }
 
 #[derive(Debug)]
@@ -34,6 +35,7 @@ pub struct FileCacheStrategy {
   codec: Arc<CacheCodec>,
   database: Database,
   pending_writes: PendingWrites,
+  max_dependency_id: u32,
   readonly: bool,
 }
 
@@ -70,6 +72,7 @@ impl FileCacheStrategy {
       codec,
       database,
       pending_writes: PendingWrites::default(),
+      max_dependency_id: 0,
       readonly,
     })
   }
@@ -107,6 +110,12 @@ impl FileCacheStrategy {
         self.database.reset()?;
       }
     }
+    self.max_dependency_id = self
+      .database
+      .get(DatabaseFamily::Meta, MAX_DEPENDENCY_ID_KEY)?
+      .map(|data| self.codec.decode::<u32>(&data))
+      .transpose()?
+      .unwrap_or_default();
     Ok(())
   }
 
@@ -144,18 +153,18 @@ impl FileCacheStrategy {
     if self.readonly {
       return;
     }
-    self.validator.store_dependency_id(dependency_id);
-    self.pending_writes.max_dependencies_id = Some(
+    self.max_dependency_id = self.max_dependency_id.max(dependency_id);
+    self.pending_writes.max_dependency_id = Some(
       self
         .pending_writes
-        .max_dependencies_id
+        .max_dependency_id
         .unwrap_or_default()
         .max(dependency_id),
     );
   }
 
   pub fn restore_dependency_id(&self) -> Option<u32> {
-    Some(self.validator.restore_dependency_id())
+    Some(self.max_dependency_id)
   }
 
   pub(super) fn restore(
@@ -191,11 +200,14 @@ impl FileCacheStrategy {
     if self.has_pending_writes() {
       let encoded_validator = if let Some(dependencies) = &self.pending_writes.build_dependencies {
         Some(self.validator.update(dependencies.iter().cloned()).await?)
-      } else if self.pending_writes.max_dependencies_id.is_some() {
-        Some(self.validator.encode()?)
       } else {
         None
       };
+      let encoded_max_dependency_id = self
+        .pending_writes
+        .max_dependency_id
+        .map(|_| self.codec.encode(&self.max_dependency_id))
+        .transpose()?;
       let cache_entries = self
         .pending_writes
         .entries
@@ -216,11 +228,18 @@ impl FileCacheStrategy {
           validator.as_slice(),
         ));
       }
+      if let Some(max_dependency_id) = &encoded_max_dependency_id {
+        writes.push(DatabaseWrite::new(
+          DatabaseFamily::Meta,
+          MAX_DEPENDENCY_ID_KEY,
+          max_dependency_id.as_slice(),
+        ));
+      }
       self.database.write_batch(writes)?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
-      self.pending_writes.max_dependencies_id = None;
+      self.pending_writes.max_dependency_id = None;
     }
 
     for _ in 0..max_compaction_passes {
@@ -246,6 +265,6 @@ impl FileCacheStrategy {
   pub fn has_pending_writes(&self) -> bool {
     !self.pending_writes.entries.is_empty()
       || self.pending_writes.build_dependencies.is_some()
-      || self.pending_writes.max_dependencies_id.is_some()
+      || self.pending_writes.max_dependency_id.is_some()
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -20,7 +20,7 @@ const MAX_DEPENDENCY_ID_KEY: &[u8] = b"max_dependency_id";
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   build_dependencies: Option<InternedPathSet>,
-  max_dependency_id: Option<u32>,
+  max_dependency_id_dirty: bool,
 }
 
 #[derive(Debug)]
@@ -150,21 +150,15 @@ impl FileCacheStrategy {
   }
 
   pub fn store_dependency_id(&mut self, dependency_id: u32) {
-    if self.readonly {
+    if self.readonly || dependency_id <= self.max_dependency_id {
       return;
     }
-    self.max_dependency_id = self.max_dependency_id.max(dependency_id);
-    self.pending_writes.max_dependency_id = Some(
-      self
-        .pending_writes
-        .max_dependency_id
-        .unwrap_or_default()
-        .max(dependency_id),
-    );
+    self.max_dependency_id = dependency_id;
+    self.pending_writes.max_dependency_id_dirty = true;
   }
 
-  pub fn restore_dependency_id(&self) -> Option<u32> {
-    Some(self.max_dependency_id)
+  pub fn restore_dependency_id(&self) -> u32 {
+    self.max_dependency_id
   }
 
   pub(super) fn restore(
@@ -205,8 +199,8 @@ impl FileCacheStrategy {
       };
       let encoded_max_dependency_id = self
         .pending_writes
-        .max_dependency_id
-        .map(|_| self.codec.encode(&self.max_dependency_id))
+        .max_dependency_id_dirty
+        .then(|| self.codec.encode(&self.max_dependency_id))
         .transpose()?;
       let cache_entries = self
         .pending_writes
@@ -239,7 +233,7 @@ impl FileCacheStrategy {
 
       self.pending_writes.entries.clear();
       self.pending_writes.build_dependencies = None;
-      self.pending_writes.max_dependency_id = None;
+      self.pending_writes.max_dependency_id_dirty = false;
     }
 
     for _ in 0..max_compaction_passes {
@@ -265,6 +259,6 @@ impl FileCacheStrategy {
   pub fn has_pending_writes(&self) -> bool {
     !self.pending_writes.entries.is_empty()
       || self.pending_writes.build_dependencies.is_some()
-      || self.pending_writes.max_dependency_id.is_some()
+      || self.pending_writes.max_dependency_id_dirty
   }
 }

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -48,7 +48,7 @@ enum Command {
   EndIdle,
   Shutdown(oneshot::Sender<Result<()>>),
   RestoreDependencyId {
-    result: sync_mpsc::SyncSender<Option<u32>>,
+    result: sync_mpsc::SyncSender<u32>,
   },
 }
 
@@ -300,7 +300,7 @@ impl IdleFileCache {
     self.send(Command::StoreDependencyId(dependency_id))
   }
 
-  pub fn restore_dependency_id(&self) -> Result<Option<u32>> {
+  pub fn restore_dependency_id(&self) -> Result<u32> {
     let (result, result_receiver) = sync_mpsc::sync_channel(1);
     self.send(Command::RestoreDependencyId { result })?;
     result_receiver

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -34,6 +34,7 @@ enum Command {
     encoder: CacheValueEncoder,
   },
   StoreBuildDependencies(InternedPathSet),
+  StoreDependencyId(u32),
   Restore {
     key: CacheKey,
     etag: Option<Etag>,
@@ -46,6 +47,9 @@ enum Command {
   },
   EndIdle,
   Shutdown(oneshot::Sender<Result<()>>),
+  RestoreDependencyId {
+    result: sync_mpsc::SyncSender<Option<u32>>,
+  },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -122,6 +126,9 @@ impl BackgroundJob {
       Command::StoreBuildDependencies(dependencies) => {
         self.strategy.store_build_dependencies(dependencies);
       }
+      Command::StoreDependencyId(dependency_id) => {
+        self.strategy.store_dependency_id(dependency_id);
+      }
       Command::Restore {
         key,
         etag,
@@ -164,6 +171,9 @@ impl BackgroundJob {
         self.idle_deadline = None;
         let _ = result.send(self.strategy.shutdown().await);
         return true;
+      }
+      Command::RestoreDependencyId { result } => {
+        let _ = result.send(self.strategy.restore_dependency_id());
       }
     }
     false
@@ -284,6 +294,18 @@ impl IdleFileCache {
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) -> Result<()> {
     self.send(Command::StoreBuildDependencies(dependencies))
+  }
+
+  pub fn store_dependency_id(&self, dependency_id: u32) -> Result<()> {
+    self.send(Command::StoreDependencyId(dependency_id))
+  }
+
+  pub fn restore_dependency_id(&self) -> Result<Option<u32>> {
+    let (result, result_receiver) = sync_mpsc::sync_channel(1);
+    self.send(Command::RestoreDependencyId { result })?;
+    result_receiver
+      .recv()
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -203,7 +203,7 @@ impl BackgroundJob {
 }
 
 /// Runs filesystem cache operations in one persistent background job.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct IdleFileCache {
   command_sender: mpsc::UnboundedSender<Command>,
   idle_epoch: Arc<AtomicU64>,

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -21,6 +21,7 @@ pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
 use rspack_fs::ReadableFileSystem;
+pub(crate) use snapshot::Snapshot;
 
 use self::snapshot::{BuildDeps, FileSystemInfo};
 use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::CacheCodec};
@@ -34,13 +35,28 @@ pub fn create_cache(
   if !compiler_options.experiments.new_cache.is_enabled() {
     return Cache::new_disabled(compiler_path);
   }
+  let module_cache_enabled = compiler_options.experiments.new_cache.module;
 
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => return Cache::new_disabled(compiler_path),
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      return Cache::new(compiler_path, MemoryCache::new(5), None);
+      if !module_cache_enabled {
+        return Cache::new(compiler_path, MemoryCache::new(5), None);
+      }
+      let file_system_info = FileSystemInfo::new(
+        input_filesystem,
+        Default::default(),
+        compiler_options.output.hash_function,
+      );
+      return Cache::new_with_module_cache(
+        compiler_path,
+        MemoryCache::new(5),
+        None,
+        Arc::new(CacheCodec::new(None)),
+        file_system_info,
+      );
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -74,17 +90,37 @@ pub fn create_cache(
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
-    codec,
-    file_system_info,
+    codec.clone(),
+    file_system_info.clone(),
     build_deps,
   ) {
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      return Cache::new(compiler_path, MemoryCache::default(), None);
+      return if module_cache_enabled {
+        Cache::new_with_module_cache(
+          compiler_path,
+          MemoryCache::default(),
+          None,
+          codec,
+          file_system_info,
+        )
+      } else {
+        Cache::new(compiler_path, MemoryCache::default(), None)
+      };
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
 
-  Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
+  if module_cache_enabled {
+    Cache::new_with_module_cache(
+      compiler_path,
+      MemoryCache::default(),
+      Some(idle_file_cache),
+      codec,
+      file_system_info,
+    )
+  } else {
+    Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
+  }
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -7,6 +7,7 @@ mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
+mod module_build_cache;
 mod snapshot;
 mod validator;
 
@@ -20,8 +21,8 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
+pub(crate) use module_build_cache::ModuleBuildCache;
 use rspack_fs::ReadableFileSystem;
-pub(crate) use snapshot::Snapshot;
 
 use self::snapshot::{BuildDeps, FileSystemInfo};
 use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::CacheCodec};

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -21,43 +21,52 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
-pub(crate) use module_build_cache::ModuleBuildCache;
+pub(crate) use module_build_cache::{ModuleBuildCache, ModuleCache};
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::{BuildDeps, FileSystemInfo};
 use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::CacheCodec};
 
-pub fn create_cache(
+pub(crate) struct NewCache {
+  pub(crate) cache: Cache,
+  pub(crate) module_cache: Option<ModuleCache>,
+}
+
+pub(crate) fn create_cache(
   compiler_path: String,
   compiler_options: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
   compilation_logging: CompilationLogging,
-) -> Cache {
+) -> NewCache {
   if !compiler_options.experiments.new_cache.is_enabled() {
-    return Cache::new_disabled(compiler_path);
+    return NewCache {
+      cache: Cache::new_disabled(compiler_path),
+      module_cache: None,
+    };
   }
   let module_cache_enabled = compiler_options.experiments.new_cache.module;
 
   let options = match &compiler_options.cache {
-    crate::CacheOptions::Disabled => return Cache::new_disabled(compiler_path),
+    crate::CacheOptions::Disabled => {
+      return NewCache {
+        cache: Cache::new_disabled(compiler_path),
+        module_cache: None,
+      };
+    }
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      if !module_cache_enabled {
-        return Cache::new(compiler_path, MemoryCache::new(5), None);
-      }
-      let file_system_info = FileSystemInfo::new(
-        input_filesystem,
-        Default::default(),
-        compiler_options.output.hash_function,
-      );
-      return Cache::new_with_module_cache(
-        compiler_path,
-        MemoryCache::new(5),
-        None,
-        Arc::new(CacheCodec::new(None)),
-        file_system_info,
-      );
+      let module_cache = module_cache_enabled.then(|| {
+        (
+          Arc::new(CacheCodec::new(None)),
+          FileSystemInfo::new(
+            input_filesystem,
+            Default::default(),
+            compiler_options.output.hash_function,
+          ),
+        )
+      });
+      return assemble_cache(compiler_path, MemoryCache::new(5), None, module_cache);
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -98,30 +107,32 @@ pub fn create_cache(
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      return if module_cache_enabled {
-        Cache::new_with_module_cache(
-          compiler_path,
-          MemoryCache::default(),
-          None,
-          codec,
-          file_system_info,
-        )
-      } else {
-        Cache::new(compiler_path, MemoryCache::default(), None)
-      };
+      let module_cache = module_cache_enabled.then_some((codec, file_system_info));
+      return assemble_cache(compiler_path, MemoryCache::default(), None, module_cache);
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
+  let module_cache = module_cache_enabled.then_some((codec, file_system_info));
+  assemble_cache(
+    compiler_path,
+    MemoryCache::default(),
+    Some(idle_file_cache),
+    module_cache,
+  )
+}
 
-  if module_cache_enabled {
-    Cache::new_with_module_cache(
-      compiler_path,
-      MemoryCache::default(),
-      Some(idle_file_cache),
-      codec,
-      file_system_info,
-    )
-  } else {
-    Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
+fn assemble_cache(
+  compiler_path: String,
+  memory_cache: MemoryCache,
+  idle_file_cache: Option<IdleFileCache>,
+  module_cache: Option<(Arc<CacheCodec>, FileSystemInfo)>,
+) -> NewCache {
+  let cache = Cache::new(compiler_path, memory_cache, idle_file_cache.clone());
+  let module_cache = module_cache.map(|(codec, file_system_info)| {
+    ModuleCache::new(cache.clone(), codec, file_system_info, idle_file_cache)
+  });
+  NewCache {
+    cache,
+    module_cache,
   }
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -21,7 +21,7 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
-pub(crate) use module_build_cache::{ModuleBuildCache, ModuleCache};
+pub(crate) use module_build_cache::{ModuleBuildCache, ModuleCache, ModuleCacheFactory};
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::{BuildDeps, FileSystemInfo};
@@ -29,7 +29,7 @@ use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::Cache
 
 pub(crate) struct NewCache {
   pub(crate) cache: Cache,
-  pub(crate) module_cache: Option<ModuleCache>,
+  pub(crate) module_cache_factory: Option<ModuleCacheFactory>,
 }
 
 pub(crate) fn create_cache(
@@ -41,7 +41,7 @@ pub(crate) fn create_cache(
   if !compiler_options.experiments.new_cache.is_enabled() {
     return NewCache {
       cache: Cache::new_disabled(compiler_path),
-      module_cache: None,
+      module_cache_factory: None,
     };
   }
   let module_cache_enabled = compiler_options.experiments.new_cache.module;
@@ -50,23 +50,14 @@ pub(crate) fn create_cache(
     crate::CacheOptions::Disabled => {
       return NewCache {
         cache: Cache::new_disabled(compiler_path),
-        module_cache: None,
+        module_cache_factory: None,
       };
     }
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      let module_cache = module_cache_enabled.then(|| {
-        (
-          Arc::new(CacheCodec::new(None)),
-          FileSystemInfo::new(
-            input_filesystem,
-            Default::default(),
-            compiler_options.output.hash_function,
-          ),
-        )
-      });
-      return assemble_cache(compiler_path, MemoryCache::new(5), None, module_cache);
+      let module_cache_codec = module_cache_enabled.then(|| Arc::new(CacheCodec::new(None)));
+      return assemble_cache(compiler_path, MemoryCache::new(5), None, module_cache_codec);
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -101,23 +92,28 @@ pub(crate) fn create_cache(
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
     codec.clone(),
-    file_system_info.clone(),
+    file_system_info,
     build_deps,
   ) {
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      let module_cache = module_cache_enabled.then_some((codec, file_system_info));
-      return assemble_cache(compiler_path, MemoryCache::default(), None, module_cache);
+      let module_cache_codec = module_cache_enabled.then_some(codec);
+      return assemble_cache(
+        compiler_path,
+        MemoryCache::default(),
+        None,
+        module_cache_codec,
+      );
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
-  let module_cache = module_cache_enabled.then_some((codec, file_system_info));
+  let module_cache_codec = module_cache_enabled.then_some(codec);
   assemble_cache(
     compiler_path,
     MemoryCache::default(),
     Some(idle_file_cache),
-    module_cache,
+    module_cache_codec,
   )
 }
 
@@ -125,14 +121,13 @@ fn assemble_cache(
   compiler_path: String,
   memory_cache: MemoryCache,
   idle_file_cache: Option<IdleFileCache>,
-  module_cache: Option<(Arc<CacheCodec>, FileSystemInfo)>,
+  module_cache_codec: Option<Arc<CacheCodec>>,
 ) -> NewCache {
   let cache = Cache::new(compiler_path, memory_cache, idle_file_cache.clone());
-  let module_cache = module_cache.map(|(codec, file_system_info)| {
-    ModuleCache::new(cache.clone(), codec, file_system_info, idle_file_cache)
-  });
+  let module_cache_factory =
+    module_cache_codec.map(|codec| ModuleCacheFactory::new(cache.clone(), codec, idle_file_cache));
   NewCache {
     cache,
-    module_cache,
+    module_cache_factory,
   }
 }

--- a/crates/rspack_core/src/new_cache/module_build_cache.rs
+++ b/crates/rspack_core/src/new_cache/module_build_cache.rs
@@ -5,6 +5,8 @@ use std::{
 
 use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_error::Result;
+use rspack_fs::ReadableFileSystem;
+use rspack_hash::HashFunction;
 use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
 use super::{
@@ -13,7 +15,8 @@ use super::{
 };
 use crate::{
   AsyncDependenciesBlock, BoxDependency, BoxModule, BuildInfo, BuildResult, Module,
-  NormalModuleBuildState, OptimizationBailoutItem, ValueCacheVersions, cache::CacheCodec,
+  NormalModuleBuildState, OptimizationBailoutItem, ValueCacheVersions,
+  cache::{CacheCodec, SnapshotOptions},
 };
 
 const MODULE_BUILD_CACHE_NAME: &str = "Compilation/modules";
@@ -80,50 +83,45 @@ impl ModuleBuildCacheEntry {
   }
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct ModuleCache {
-  inner: Arc<ModuleCacheInner>,
-}
-
+/// Creates compilation-local module cache views and owns persistent module metadata.
 #[derive(Debug)]
-struct ModuleCacheInner {
+pub(crate) struct ModuleCacheFactory {
   cache: CacheFacade,
   codec: Arc<CacheCodec>,
-  file_system_info: FileSystemInfo,
   idle_file_cache: Option<IdleFileCache>,
   dependency_id_restored: OnceLock<()>,
 }
 
-impl ModuleCache {
+impl ModuleCacheFactory {
   pub(crate) fn new(
     cache: Cache,
     codec: Arc<CacheCodec>,
-    file_system_info: FileSystemInfo,
     idle_file_cache: Option<IdleFileCache>,
   ) -> Self {
     Self {
-      inner: Arc::new(ModuleCacheInner {
-        cache: cache.facade(MODULE_BUILD_CACHE_NAME),
-        codec,
-        file_system_info,
-        idle_file_cache,
-        dependency_id_restored: OnceLock::new(),
-      }),
+      cache: cache.facade(MODULE_BUILD_CACHE_NAME),
+      codec,
+      idle_file_cache,
+      dependency_id_restored: OnceLock::new(),
     }
   }
 
-  pub(crate) fn build_cache(&self, value_cache_versions: &ValueCacheVersions) -> ModuleBuildCache {
-    ModuleBuildCache {
-      cache: self.inner.cache.clone(),
-      codec: self.inner.codec.clone(),
-      file_system_info: self.inner.file_system_info.clone(),
-      value_cache_versions: Arc::new(value_cache_versions.clone()),
+  pub(crate) fn create_for_compilation(
+    &self,
+    input_filesystem: Arc<dyn ReadableFileSystem>,
+    snapshot_options: SnapshotOptions,
+    hash_function: HashFunction,
+  ) -> ModuleCache {
+    ModuleCache {
+      cache: self.cache.clone(),
+      codec: self.codec.clone(),
+      file_system_info: FileSystemInfo::new(input_filesystem, snapshot_options, hash_function),
     }
   }
 
   pub(crate) fn restore_dependency_id(&self) {
-    self.inner.dependency_id_restored.get_or_init(|| {
-      let Some(file_cache) = &self.inner.idle_file_cache else {
+    self.dependency_id_restored.get_or_init(|| {
+      let Some(file_cache) = &self.idle_file_cache else {
         return;
       };
       let dependency_id = match file_cache.restore_dependency_id() {
@@ -141,15 +139,30 @@ impl ModuleCache {
   }
 
   pub(crate) fn record_dependency_id(&self, dependency_id: u32) -> Result<()> {
-    if let Some(file_cache) = &self.inner.idle_file_cache {
+    if let Some(file_cache) = &self.idle_file_cache {
       file_cache.store_dependency_id(dependency_id)
     } else {
       Ok(())
     }
   }
+}
 
-  pub(crate) fn clear(&self) {
-    self.inner.file_system_info.clear();
+/// Compilation-local view of webpack's `Compilation/modules` cache.
+#[derive(Debug)]
+pub(crate) struct ModuleCache {
+  cache: CacheFacade,
+  codec: Arc<CacheCodec>,
+  file_system_info: FileSystemInfo,
+}
+
+impl ModuleCache {
+  pub(crate) fn build_cache(&self, value_cache_versions: &ValueCacheVersions) -> ModuleBuildCache {
+    ModuleBuildCache {
+      cache: self.cache.clone(),
+      codec: self.codec.clone(),
+      file_system_info: self.file_system_info.clone(),
+      value_cache_versions: Arc::new(value_cache_versions.clone()),
+    }
   }
 }
 

--- a/crates/rspack_core/src/new_cache/module_build_cache.rs
+++ b/crates/rspack_core/src/new_cache/module_build_cache.rs
@@ -1,0 +1,196 @@
+use std::sync::Arc;
+
+use rspack_cacheable::{cacheable, utils::OwnedOrRef};
+use rspack_error::Result;
+
+use super::{Cache, CacheValue, snapshot::Snapshot};
+use crate::{
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildResult, Module, NormalModuleBuildState,
+  OptimizationBailoutItem, ValueCacheVersions,
+};
+
+const MODULE_BUILD_CACHE_NAME: &str = "Compilation/modules";
+
+type RestoredDependencies = Vec<BoxDependency>;
+// AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
+#[allow(clippy::vec_box)]
+type RestoredBlocks = Vec<Box<AsyncDependenciesBlock>>;
+
+#[cacheable]
+struct CachedBuildResult<'a> {
+  dependencies: Vec<OwnedOrRef<'a, BoxDependency>>,
+  // AsyncDependenciesBlock is recursive and intentionally stays behind a pointer.
+  #[allow(clippy::vec_box)]
+  blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
+}
+
+impl CachedBuildResult<'_> {
+  fn from_build_result(build_result: &BuildResult) -> CachedBuildResult<'_> {
+    CachedBuildResult {
+      dependencies: build_result.dependencies.iter().map(Into::into).collect(),
+      blocks: build_result
+        .blocks
+        .iter()
+        .map(|block| block.as_ref().into())
+        .collect(),
+    }
+  }
+
+  fn into_parts(self) -> (RestoredDependencies, RestoredBlocks) {
+    (
+      self
+        .dependencies
+        .into_iter()
+        .map(OwnedOrRef::into_owned)
+        .collect(),
+      self
+        .blocks
+        .into_iter()
+        .map(|block| Box::new(block.into_owned()))
+        .collect(),
+    )
+  }
+}
+
+#[cacheable]
+#[derive(Debug)]
+struct ModuleBuildCacheEntry {
+  state: NormalModuleBuildState,
+  snapshot: Snapshot,
+  build_result: Vec<u8>,
+  optimization_bailouts: Vec<OptimizationBailoutItem>,
+}
+
+impl ModuleBuildCacheEntry {
+  fn from_build_result(
+    build_result: &BuildResult,
+    snapshot: Snapshot,
+    cache: &Cache,
+  ) -> Result<Option<Self>> {
+    let Some(module) = build_result.module.as_normal_module() else {
+      return Ok(None);
+    };
+    if !module.build_info().cacheable {
+      return Ok(None);
+    }
+    let Some(codec) = cache.codec() else {
+      return Ok(None);
+    };
+    Ok(Some(Self {
+      state: module.build_state(),
+      snapshot,
+      build_result: codec.encode(&CachedBuildResult::from_build_result(build_result))?,
+      optimization_bailouts: build_result.optimization_bailouts.clone(),
+    }))
+  }
+
+  fn restore(&self, module: &mut BoxModule) -> Option<()> {
+    module
+      .as_normal_module_mut()?
+      .restore_build_state(&self.state);
+    Some(())
+  }
+
+  fn build_result_parts(&self, cache: &Cache) -> Result<RestoredModuleBuild> {
+    let codec = cache
+      .codec()
+      .ok_or_else(|| rspack_error::error!("New cache codec is unavailable"))?;
+    let cached: CachedBuildResult<'static> = codec.decode(&self.build_result)?;
+    let (dependencies, blocks) = cached.into_parts();
+    Ok(RestoredModuleBuild {
+      dependencies,
+      blocks,
+      optimization_bailouts: self.optimization_bailouts.clone(),
+    })
+  }
+}
+
+#[derive(Debug)]
+pub(crate) struct RestoredModuleBuild {
+  dependencies: RestoredDependencies,
+  blocks: RestoredBlocks,
+  optimization_bailouts: Vec<OptimizationBailoutItem>,
+}
+
+impl RestoredModuleBuild {
+  pub(crate) fn into_build_result(self, module: BoxModule) -> BuildResult {
+    BuildResult {
+      module,
+      dependencies: self.dependencies,
+      blocks: self.blocks,
+      optimization_bailouts: self.optimization_bailouts,
+    }
+  }
+}
+
+/// Per-NormalModule build cache aligned with webpack's `Compilation/modules` cache.
+#[derive(Debug, Clone)]
+pub(crate) struct ModuleBuildCache {
+  cache: Cache,
+  value_cache_versions: Arc<ValueCacheVersions>,
+}
+
+impl ModuleBuildCache {
+  pub(crate) fn new(cache: Cache, value_cache_versions: Arc<ValueCacheVersions>) -> Self {
+    Self {
+      cache,
+      value_cache_versions,
+    }
+  }
+
+  #[tracing::instrument("Cache::ModuleBuild::restore", skip_all)]
+  pub(crate) async fn restore(
+    &self,
+    module: &mut BoxModule,
+  ) -> Result<Option<RestoredModuleBuild>> {
+    let item_cache = self
+      .cache
+      .facade(MODULE_BUILD_CACHE_NAME)
+      .get_item_cache(module.identifier().as_str(), None);
+    let Some(entry) = item_cache.get::<ModuleBuildCacheEntry>()? else {
+      return Ok(None);
+    };
+    if entry.state.need_build(&self.value_cache_versions)
+      || !self
+        .cache
+        .check_module_snapshot_valid(&entry.snapshot)
+        .await?
+    {
+      return Ok(None);
+    }
+
+    let restored = entry.build_result_parts(&self.cache)?;
+    let Some(()) = entry.restore(module) else {
+      return Ok(None);
+    };
+    Ok(Some(restored))
+  }
+
+  #[tracing::instrument("Cache::ModuleBuild::store", skip_all)]
+  pub(crate) async fn store(&self, build_result: &BuildResult, start_time: u64) -> Result<()> {
+    let build_info = build_result.module.build_info();
+    let Some(snapshot) = self
+      .cache
+      .create_module_snapshot(
+        start_time,
+        &build_info.file_dependencies,
+        &build_info.context_dependencies,
+        &build_info.missing_dependencies,
+        &build_info.build_dependencies,
+      )
+      .await?
+    else {
+      return Ok(());
+    };
+    let Some(entry) =
+      ModuleBuildCacheEntry::from_build_result(build_result, snapshot, &self.cache)?
+    else {
+      return Ok(());
+    };
+    self
+      .cache
+      .facade(MODULE_BUILD_CACHE_NAME)
+      .get_item_cache(build_result.module.identifier().as_str(), None)
+      .store(CacheValue::new(entry))
+  }
+}

--- a/crates/rspack_core/src/new_cache/module_build_cache.rs
+++ b/crates/rspack_core/src/new_cache/module_build_cache.rs
@@ -1,12 +1,19 @@
-use std::sync::Arc;
+use std::{
+  borrow::Cow,
+  sync::{Arc, OnceLock},
+};
 
 use rspack_cacheable::{cacheable, utils::OwnedOrRef};
 use rspack_error::Result;
+use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
-use super::{Cache, CacheValue, snapshot::Snapshot};
+use super::{
+  Cache, CacheFacade, CacheValue, IdleFileCache,
+  snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult},
+};
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildResult, Module, NormalModuleBuildState,
-  OptimizationBailoutItem, ValueCacheVersions,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildInfo, BuildResult, Module,
+  NormalModuleBuildState, OptimizationBailoutItem, ValueCacheVersions, cache::CacheCodec,
 };
 
 const MODULE_BUILD_CACHE_NAME: &str = "Compilation/modules";
@@ -62,39 +69,7 @@ struct ModuleBuildCacheEntry {
 }
 
 impl ModuleBuildCacheEntry {
-  fn from_build_result(
-    build_result: &BuildResult,
-    snapshot: Snapshot,
-    cache: &Cache,
-  ) -> Result<Option<Self>> {
-    let Some(module) = build_result.module.as_normal_module() else {
-      return Ok(None);
-    };
-    if !module.build_info().cacheable {
-      return Ok(None);
-    }
-    let Some(codec) = cache.codec() else {
-      return Ok(None);
-    };
-    Ok(Some(Self {
-      state: module.build_state(),
-      snapshot,
-      build_result: codec.encode(&CachedBuildResult::from_build_result(build_result))?,
-      optimization_bailouts: build_result.optimization_bailouts.clone(),
-    }))
-  }
-
-  fn restore(&self, module: &mut BoxModule) -> Option<()> {
-    module
-      .as_normal_module_mut()?
-      .restore_build_state(&self.state);
-    Some(())
-  }
-
-  fn build_result_parts(&self, cache: &Cache) -> Result<RestoredModuleBuild> {
-    let codec = cache
-      .codec()
-      .ok_or_else(|| rspack_error::error!("New cache codec is unavailable"))?;
+  fn build_result_parts(&self, codec: &CacheCodec) -> Result<RestoredModuleBuild> {
     let cached: CachedBuildResult<'static> = codec.decode(&self.build_result)?;
     let (dependencies, blocks) = cached.into_parts();
     Ok(RestoredModuleBuild {
@@ -102,6 +77,71 @@ impl ModuleBuildCacheEntry {
       blocks,
       optimization_bailouts: self.optimization_bailouts.clone(),
     })
+  }
+}
+
+#[derive(Debug)]
+pub(super) struct ModuleCacheState {
+  codec: Arc<CacheCodec>,
+  file_system_info: FileSystemInfo,
+  dependency_id_restored: OnceLock<()>,
+}
+
+impl ModuleCacheState {
+  pub(super) fn new(codec: Arc<CacheCodec>, file_system_info: FileSystemInfo) -> Self {
+    Self {
+      codec,
+      file_system_info,
+      dependency_id_restored: OnceLock::new(),
+    }
+  }
+
+  pub(super) fn build_cache(
+    &self,
+    cache: Cache,
+    value_cache_versions: &ValueCacheVersions,
+  ) -> ModuleBuildCache {
+    ModuleBuildCache {
+      cache: cache.facade(MODULE_BUILD_CACHE_NAME),
+      codec: self.codec.clone(),
+      file_system_info: self.file_system_info.clone(),
+      value_cache_versions: Arc::new(value_cache_versions.clone()),
+    }
+  }
+
+  pub(super) fn restore_dependency_id(&self, file_cache: Option<&IdleFileCache>) {
+    self.dependency_id_restored.get_or_init(|| {
+      let Some(file_cache) = file_cache else {
+        return;
+      };
+      let dependency_id = match file_cache.restore_dependency_id() {
+        Ok(dependency_id) => dependency_id,
+        Err(error) => {
+          tracing::warn!("Restoring new cache dependency id failed: {error}");
+          return;
+        }
+      };
+      let current = get_current_dependency_id();
+      if current < dependency_id {
+        set_current_dependency_id(dependency_id);
+      }
+    });
+  }
+
+  pub(super) fn record_dependency_id(
+    &self,
+    file_cache: Option<&IdleFileCache>,
+    dependency_id: u32,
+  ) -> Result<()> {
+    if let Some(file_cache) = file_cache {
+      file_cache.store_dependency_id(dependency_id)
+    } else {
+      Ok(())
+    }
+  }
+
+  pub(super) fn clear(&self) {
+    self.file_system_info.clear();
   }
 }
 
@@ -126,71 +166,88 @@ impl RestoredModuleBuild {
 /// Per-NormalModule build cache aligned with webpack's `Compilation/modules` cache.
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCache {
-  cache: Cache,
+  cache: CacheFacade,
+  codec: Arc<CacheCodec>,
+  file_system_info: FileSystemInfo,
   value_cache_versions: Arc<ValueCacheVersions>,
 }
 
 impl ModuleBuildCache {
-  pub(crate) fn new(cache: Cache, value_cache_versions: Arc<ValueCacheVersions>) -> Self {
-    Self {
-      cache,
-      value_cache_versions,
-    }
-  }
-
   #[tracing::instrument("Cache::ModuleBuild::restore", skip_all)]
   pub(crate) async fn restore(
     &self,
     module: &mut BoxModule,
   ) -> Result<Option<RestoredModuleBuild>> {
+    if module.as_normal_module().is_none() {
+      return Ok(None);
+    }
     let item_cache = self
       .cache
-      .facade(MODULE_BUILD_CACHE_NAME)
       .get_item_cache(module.identifier().as_str(), None);
     let Some(entry) = item_cache.get::<ModuleBuildCacheEntry>()? else {
       return Ok(None);
     };
     if entry.state.need_build(&self.value_cache_versions)
-      || !self
-        .cache
-        .check_module_snapshot_valid(&entry.snapshot)
-        .await?
+      || !matches!(
+        self
+          .file_system_info
+          .check_snapshot_valid(&entry.snapshot)
+          .await?,
+        SnapshotValidationResult::Valid
+      )
     {
       return Ok(None);
     }
 
-    let restored = entry.build_result_parts(&self.cache)?;
-    let Some(()) = entry.restore(module) else {
+    let restored = entry.build_result_parts(&self.codec)?;
+    let Some(module) = module.as_normal_module_mut() else {
       return Ok(None);
     };
+    module.restore_build_state(&entry.state);
     Ok(Some(restored))
   }
 
   #[tracing::instrument("Cache::ModuleBuild::store", skip_all)]
   pub(crate) async fn store(&self, build_result: &BuildResult, start_time: u64) -> Result<()> {
-    let build_info = build_result.module.build_info();
-    let Some(snapshot) = self
-      .cache
-      .create_module_snapshot(
-        start_time,
-        &build_info.file_dependencies,
-        &build_info.context_dependencies,
-        &build_info.missing_dependencies,
-        &build_info.build_dependencies,
-      )
-      .await?
-    else {
+    let Some(module) = build_result.module.as_normal_module() else {
       return Ok(());
     };
-    let Some(entry) =
-      ModuleBuildCacheEntry::from_build_result(build_result, snapshot, &self.cache)?
-    else {
+    let build_info = module.build_info();
+    if !build_info.cacheable {
       return Ok(());
+    }
+    let snapshot = self.create_snapshot(build_info, start_time).await?;
+    let entry = ModuleBuildCacheEntry {
+      state: module.build_state(),
+      snapshot,
+      build_result: self
+        .codec
+        .encode(&CachedBuildResult::from_build_result(build_result))?,
+      optimization_bailouts: build_result.optimization_bailouts.clone(),
     };
     self
       .cache
-      .facade(MODULE_BUILD_CACHE_NAME)
       .get_item_cache(build_result.module.identifier().as_str(), None)
       .store(CacheValue::new(entry))
+  }
+
+  async fn create_snapshot(&self, build_info: &BuildInfo, start_time: u64) -> Result<Snapshot> {
+    let files = if build_info.build_dependencies.is_empty() {
+      Cow::Borrowed(&build_info.file_dependencies)
+    } else {
+      let mut files = build_info.file_dependencies.clone();
+      files.extend(build_info.build_dependencies.iter().cloned());
+      Cow::Owned(files)
+    };
+    self
+      .file_system_info
+      .create_snapshot(
+        Some(start_time),
+        &files,
+        &build_info.context_dependencies,
+        &build_info.missing_dependencies,
+        self.file_system_info.module_strategy(),
+      )
+      .await
   }
 }

--- a/crates/rspack_core/src/new_cache/module_build_cache.rs
+++ b/crates/rspack_core/src/new_cache/module_build_cache.rs
@@ -80,38 +80,50 @@ impl ModuleBuildCacheEntry {
   }
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct ModuleCache {
+  inner: Arc<ModuleCacheInner>,
+}
+
 #[derive(Debug)]
-pub(super) struct ModuleCacheState {
+struct ModuleCacheInner {
+  cache: CacheFacade,
   codec: Arc<CacheCodec>,
   file_system_info: FileSystemInfo,
+  idle_file_cache: Option<IdleFileCache>,
   dependency_id_restored: OnceLock<()>,
 }
 
-impl ModuleCacheState {
-  pub(super) fn new(codec: Arc<CacheCodec>, file_system_info: FileSystemInfo) -> Self {
+impl ModuleCache {
+  pub(crate) fn new(
+    cache: Cache,
+    codec: Arc<CacheCodec>,
+    file_system_info: FileSystemInfo,
+    idle_file_cache: Option<IdleFileCache>,
+  ) -> Self {
     Self {
-      codec,
-      file_system_info,
-      dependency_id_restored: OnceLock::new(),
+      inner: Arc::new(ModuleCacheInner {
+        cache: cache.facade(MODULE_BUILD_CACHE_NAME),
+        codec,
+        file_system_info,
+        idle_file_cache,
+        dependency_id_restored: OnceLock::new(),
+      }),
     }
   }
 
-  pub(super) fn build_cache(
-    &self,
-    cache: Cache,
-    value_cache_versions: &ValueCacheVersions,
-  ) -> ModuleBuildCache {
+  pub(crate) fn build_cache(&self, value_cache_versions: &ValueCacheVersions) -> ModuleBuildCache {
     ModuleBuildCache {
-      cache: cache.facade(MODULE_BUILD_CACHE_NAME),
-      codec: self.codec.clone(),
-      file_system_info: self.file_system_info.clone(),
+      cache: self.inner.cache.clone(),
+      codec: self.inner.codec.clone(),
+      file_system_info: self.inner.file_system_info.clone(),
       value_cache_versions: Arc::new(value_cache_versions.clone()),
     }
   }
 
-  pub(super) fn restore_dependency_id(&self, file_cache: Option<&IdleFileCache>) {
-    self.dependency_id_restored.get_or_init(|| {
-      let Some(file_cache) = file_cache else {
+  pub(crate) fn restore_dependency_id(&self) {
+    self.inner.dependency_id_restored.get_or_init(|| {
+      let Some(file_cache) = &self.inner.idle_file_cache else {
         return;
       };
       let dependency_id = match file_cache.restore_dependency_id() {
@@ -128,20 +140,16 @@ impl ModuleCacheState {
     });
   }
 
-  pub(super) fn record_dependency_id(
-    &self,
-    file_cache: Option<&IdleFileCache>,
-    dependency_id: u32,
-  ) -> Result<()> {
-    if let Some(file_cache) = file_cache {
+  pub(crate) fn record_dependency_id(&self, dependency_id: u32) -> Result<()> {
+    if let Some(file_cache) = &self.inner.idle_file_cache {
       file_cache.store_dependency_id(dependency_id)
     } else {
       Ok(())
     }
   }
 
-  pub(super) fn clear(&self) {
-    self.file_system_info.clear();
+  pub(crate) fn clear(&self) {
+    self.inner.file_system_info.clear();
   }
 }
 

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -118,16 +118,6 @@ impl FileSystemInfo {
     }
   }
 
-  pub fn clear(&self) {
-    self.file_timestamps.clear();
-    self.file_hashes.clear();
-    self.file_timestamp_hashes.clear();
-    self.context_timestamps.clear();
-    self.context_hashes.clear();
-    self.context_timestamp_hashes.clear();
-    self.managed_items.clear();
-  }
-
   pub fn module_strategy(&self) -> SnapshotStrategyOptions {
     self.options.dependencies_strategy()
   }

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -118,6 +118,20 @@ impl FileSystemInfo {
     }
   }
 
+  pub fn clear(&self) {
+    self.file_timestamps.clear();
+    self.file_hashes.clear();
+    self.file_timestamp_hashes.clear();
+    self.context_timestamps.clear();
+    self.context_hashes.clear();
+    self.context_timestamp_hashes.clear();
+    self.managed_items.clear();
+  }
+
+  pub fn module_strategy(&self) -> SnapshotStrategyOptions {
+    self.options.dependencies_strategy()
+  }
+
   /// See webpack's snapshot creation implementation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L2525-L3079
   #[tracing::instrument("Cache::FileSystemInfo::create_snapshot", skip_all)]

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -12,7 +12,6 @@ use crate::cache::CacheCodec;
 struct CacheValidatorData {
   rspack_pkg_version: String,
   cache_version: String,
-  max_dependencies_id: u32,
   build_dependencies: InternedPathSet,
   build_dependencies_snapshot: Snapshot,
 }
@@ -22,7 +21,6 @@ impl CacheValidatorData {
     Self {
       rspack_pkg_version,
       cache_version,
-      max_dependencies_id: 0,
       build_dependencies: Default::default(),
       build_dependencies_snapshot: Default::default(),
     }
@@ -129,18 +127,6 @@ impl CacheValidator {
       );
       self.data.build_dependencies.extend(resolved.dependencies);
     }
-    self.codec.encode(&self.data)
-  }
-
-  pub(super) fn store_dependency_id(&mut self, dependency_id: u32) {
-    self.data.max_dependencies_id = self.data.max_dependencies_id.max(dependency_id);
-  }
-
-  pub(super) fn restore_dependency_id(&self) -> u32 {
-    self.data.max_dependencies_id
-  }
-
-  pub(super) fn encode(&self) -> Result<Vec<u8>> {
     self.codec.encode(&self.data)
   }
 }

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -12,6 +12,7 @@ use crate::cache::CacheCodec;
 struct CacheValidatorData {
   rspack_pkg_version: String,
   cache_version: String,
+  max_dependencies_id: u32,
   build_dependencies: InternedPathSet,
   build_dependencies_snapshot: Snapshot,
 }
@@ -21,6 +22,7 @@ impl CacheValidatorData {
     Self {
       rspack_pkg_version,
       cache_version,
+      max_dependencies_id: 0,
       build_dependencies: Default::default(),
       build_dependencies_snapshot: Default::default(),
     }
@@ -127,6 +129,18 @@ impl CacheValidator {
       );
       self.data.build_dependencies.extend(resolved.dependencies);
     }
+    self.codec.encode(&self.data)
+  }
+
+  pub(super) fn store_dependency_id(&mut self, dependency_id: u32) {
+    self.data.max_dependencies_id = self.data.max_dependencies_id.max(dependency_id);
+  }
+
+  pub(super) fn restore_dependency_id(&self) -> u32 {
+    self.data.max_dependencies_id
+  }
+
+  pub(super) fn encode(&self) -> Result<Vec<u8>> {
     self.codec.encode(&self.data)
   }
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -168,12 +168,9 @@ pub(crate) struct NormalModuleBuildState {
 
 impl NormalModuleBuildState {
   pub(crate) fn need_build(&self, value_cache_versions: &ValueCacheVersions) -> bool {
-    !self.build_info.cacheable
-      || value_cache_versions.has_diff(&self.build_info.value_dependencies)
-      || self
-        .diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.is_error())
+    self
+      .build_info
+      .need_build(&self.diagnostics, value_cache_versions)
   }
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -35,7 +35,7 @@ use crate::{
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem,
   OutputOptions, ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve,
   ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType, contextify,
+  SideEffectsStateArtifact, SourceType, ValueCacheVersions, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
@@ -152,6 +152,31 @@ pub struct NormalModule {
   source_map_kind: SourceMapKind,
 }
 
+#[cacheable]
+#[derive(Debug)]
+pub(crate) struct NormalModuleBuildState {
+  #[cacheable(with=AsOption<AsPreset>)]
+  source: Option<BoxSource>,
+  diagnostics: Vec<Diagnostic>,
+  code_generation_dependencies: Option<Vec<DependencyId>>,
+  presentational_dependencies: Option<Vec<DependencyCodeGenerationRef>>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
+  parsed: bool,
+  source_map_kind: SourceMapKind,
+}
+
+impl NormalModuleBuildState {
+  pub(crate) fn need_build(&self, value_cache_versions: &ValueCacheVersions) -> bool {
+    !self.build_info.cacheable
+      || value_cache_versions.has_diff(&self.build_info.value_dependencies)
+      || self
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.is_error())
+  }
+}
+
 static DEBUG_ID: AtomicUsize = AtomicUsize::new(1);
 
 impl NormalModule {
@@ -236,6 +261,37 @@ impl NormalModule {
 
   pub fn id(&self) -> ModuleIdentifier {
     self.id
+  }
+
+  pub(crate) fn build_state(&self) -> NormalModuleBuildState {
+    NormalModuleBuildState {
+      source: self.source.clone(),
+      diagnostics: self.diagnostics.clone(),
+      code_generation_dependencies: self.code_generation_dependencies.clone(),
+      presentational_dependencies: self.presentational_dependencies.clone(),
+      build_info: self.build_info.clone(),
+      build_meta: self.build_meta.clone(),
+      parsed: self.parsed,
+      source_map_kind: self.source_map_kind,
+    }
+  }
+
+  pub(crate) fn restore_build_state(&mut self, state: &NormalModuleBuildState) {
+    let import_phase = self.build_info.import_phase;
+    self.source.clone_from(&state.source);
+    self.diagnostics.clone_from(&state.diagnostics);
+    self
+      .code_generation_dependencies
+      .clone_from(&state.code_generation_dependencies);
+    self
+      .presentational_dependencies
+      .clone_from(&state.presentational_dependencies);
+    self.build_info.clone_from(&state.build_info);
+    self.build_info.import_phase = import_phase;
+    self.build_meta.clone_from(&state.build_meta);
+    self.parsed = state.parsed;
+    self.source_map_kind = state.source_map_kind;
+    self.cached_source_sizes = SourceSizeCache::default();
   }
 
   pub fn match_resource(&self) -> Option<&ResourceData> {

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -25,6 +25,7 @@ use runtime_mode::RuntimeMode;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct NewCacheOptions {
+  pub module: bool,
   pub code_generation: bool,
   pub devtool: bool,
   pub loader: bool,
@@ -34,6 +35,7 @@ pub struct NewCacheOptions {
 impl NewCacheOptions {
   pub const fn all() -> Self {
     Self {
+      module: true,
       code_generation: true,
       devtool: true,
       loader: true,
@@ -42,7 +44,7 @@ impl NewCacheOptions {
   }
 
   pub const fn is_enabled(self) -> bool {
-    self.code_generation || self.devtool || self.loader || self.minimize
+    self.module || self.code_generation || self.devtool || self.loader || self.minimize
   }
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -281,6 +281,7 @@ const applyExperimentsDefaults = (
   D(experiments, 'futureDefaults', false);
   D(experiments, 'newCache', false);
   if (typeof experiments.newCache === 'object') {
+    D(experiments.newCache, 'module', true);
     D(experiments.newCache, 'codeGeneration', true);
     D(experiments.newCache, 'devtool', true);
     D(experiments.newCache, 'loader', true);

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3117,6 +3117,8 @@ export type UseInputFileSystem = false | RegExp[];
 
 /** Fine-grained switches for the experimental new cache implementation. */
 export type NewCache = {
+  /** Enable the module build cache used during make. @default true */
+  module?: boolean;
   /** Enable the module code generation cache. @default true */
   codeGeneration?: boolean;
   /** Enable the devtool asset cache. @default true */

--- a/tests/rspack-test/compilerCases/new-cache-normal-module-disabled.js
+++ b/tests/rspack-test/compilerCases/new-cache-normal-module-disabled.js
@@ -1,0 +1,71 @@
+const { createFsFromVolume, Volume } = require("memfs");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCacheNormalModuleDisabledTestPlugin";
+
+class NewCacheNormalModuleDisabledTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const run = compiler =>
+	new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve();
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should not use the new module cache when module cache is disabled",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-normal-module-incremental-false"),
+			entry: "./index.js",
+			cache: true,
+			incremental: false,
+			experiments: {
+				newCache: {
+					module: false,
+					codeGeneration: true,
+					devtool: false,
+					minimize: false
+				}
+			},
+			output: {
+				path: "/directory"
+			},
+			plugins: [new NewCacheNormalModuleDisabledTestPlugin()]
+		};
+	},
+	compiler(_, compiler) {
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+	},
+	async build(_, compiler) {
+		await run(compiler);
+		await run(compiler);
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"buildModule",
+			"succeedModule"
+		]);
+	}
+};

--- a/tests/rspack-test/compilerCases/new-cache-normal-module-incremental-false.js
+++ b/tests/rspack-test/compilerCases/new-cache-normal-module-incremental-false.js
@@ -1,0 +1,92 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { createFsFromVolume, Volume } = require("memfs");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCacheNormalModuleIncrementalFalseTestPlugin";
+
+class NewCacheNormalModuleIncrementalFalseTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const run = compiler =>
+	new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve();
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should use the new module cache when incremental compilation is disabled",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-normal-module-incremental-false"),
+			entry: "./index.js",
+			cache: true,
+			incremental: false,
+			experiments: {
+				newCache: {
+					module: true,
+					codeGeneration: false,
+					devtool: false,
+					minimize: false
+				}
+			},
+			output: {
+				path: "/directory"
+			},
+			plugins: [new NewCacheNormalModuleIncrementalFalseTestPlugin()]
+		};
+	},
+	compiler(_, compiler) {
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+	},
+	async build(context, compiler) {
+		const source = context.getSource(
+			"new-cache-normal-module-incremental-false/index.js"
+		);
+		const original = fs.readFileSync(source, "utf-8");
+
+		try {
+			await run(compiler);
+			await run(compiler);
+			fs.writeFileSync(source, 'export default "changed";\n');
+			await run(compiler);
+		} finally {
+			fs.writeFileSync(source, original);
+		}
+
+		const output = compiler.outputFileSystem.readFileSync(
+			path.posix.join("/directory", "main.js"),
+			"utf-8"
+		);
+		expect(output).toContain("changed");
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule",
+			"buildModule",
+			"succeedModule"
+		]);
+	}
+};

--- a/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
+++ b/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
@@ -4,6 +4,23 @@ const rspack = require("@rspack/core");
 const hooks = [];
 const PLUGIN_NAME = "NewCachePersistentNormalModuleTestPlugin";
 
+const getModuleBuildCacheCount = stats => {
+	const logging = stats.toJson({ all: false, logging: "verbose" }).logging;
+	const entries = logging["rspack.Compilation"]?.entries ?? [];
+	const cacheEntry = entries.find(
+		entry =>
+			entry.type === "cache" &&
+			entry.message?.startsWith("module build cache:")
+	);
+	expect(cacheEntry).toBeTruthy();
+	const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
+	expect(match).toBeTruthy();
+	return {
+		hits: Number(match[1]),
+		total: Number(match[2])
+	};
+};
+
 class NewCachePersistentNormalModuleTestPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
@@ -56,7 +73,7 @@ const runCompiler = (context, cacheDirectory, output) =>
 						new Error(stats.toString({ all: false, errors: true }))
 					);
 				}
-				resolve();
+				resolve(stats);
 			});
 		});
 	});
@@ -77,8 +94,17 @@ module.exports = {
 		);
 		fs.rmSync(cacheDirectory, { recursive: true, force: true });
 
-		await runCompiler(context, cacheDirectory, context.getDist("output-1"));
-		await runCompiler(context, cacheDirectory, context.getDist("output-2"));
+		const coldCount = getModuleBuildCacheCount(
+			await runCompiler(context, cacheDirectory, context.getDist("output-1"))
+		);
+		const warmCount = getModuleBuildCacheCount(
+			await runCompiler(context, cacheDirectory, context.getDist("output-2"))
+		);
+
+		expect(coldCount.total).toBeGreaterThan(0);
+		expect(coldCount.hits).toBe(0);
+		expect(warmCount.total).toBeGreaterThan(0);
+		expect(warmCount.hits).toBe(warmCount.total);
 	},
 	check() {
 		expect(hooks).toEqual([

--- a/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
+++ b/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
@@ -1,0 +1,90 @@
+const fs = require("node:fs");
+const rspack = require("@rspack/core");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCachePersistentNormalModuleTestPlugin";
+
+class NewCachePersistentNormalModuleTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const runCompiler = (context, cacheDirectory, output) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			context: context.getSource("new-cache-normal-module"),
+			entry: "./index.js",
+			cache: {
+				type: "persistent",
+				storage: {
+					type: "filesystem",
+					location: cacheDirectory
+				}
+			},
+			incremental: true,
+			experiments: {
+				newCache: {
+					module: true,
+					codeGeneration: false,
+					devtool: false,
+					minimize: false
+				}
+			},
+			output: {
+				path: output
+			},
+			plugins: [new NewCachePersistentNormalModuleTestPlugin()]
+		});
+
+		compiler.run((error, stats) => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) return reject(finalError);
+				if (stats.hasErrors()) {
+					return reject(
+						new Error(stats.toString({ all: false, errors: true }))
+					);
+				}
+				resolve();
+			});
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should restore unchanged NormalModule builds from the new persistent cache",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-normal-module"),
+			entry: "./index.js"
+		};
+	},
+	async build(context) {
+		const cacheDirectory = context.getDist(
+			"new-cache-persistent-normal-module-cache"
+		);
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+		await runCompiler(context, cacheDirectory, context.getDist("output-1"));
+		await runCompiler(context, cacheDirectory, context.getDist("output-2"));
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule"
+		]);
+	}
+};

--- a/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
+++ b/tests/rspack-test/compilerCases/new-cache-persistent-normal-module.js
@@ -4,23 +4,6 @@ const rspack = require("@rspack/core");
 const hooks = [];
 const PLUGIN_NAME = "NewCachePersistentNormalModuleTestPlugin";
 
-const getModuleBuildCacheCount = stats => {
-	const logging = stats.toJson({ all: false, logging: "verbose" }).logging;
-	const entries = logging["rspack.Compilation"]?.entries ?? [];
-	const cacheEntry = entries.find(
-		entry =>
-			entry.type === "cache" &&
-			entry.message?.startsWith("module build cache:")
-	);
-	expect(cacheEntry).toBeTruthy();
-	const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
-	expect(match).toBeTruthy();
-	return {
-		hits: Number(match[1]),
-		total: Number(match[2])
-	};
-};
-
 class NewCachePersistentNormalModuleTestPlugin {
 	apply(compiler) {
 		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
@@ -94,17 +77,8 @@ module.exports = {
 		);
 		fs.rmSync(cacheDirectory, { recursive: true, force: true });
 
-		const coldCount = getModuleBuildCacheCount(
-			await runCompiler(context, cacheDirectory, context.getDist("output-1"))
-		);
-		const warmCount = getModuleBuildCacheCount(
-			await runCompiler(context, cacheDirectory, context.getDist("output-2"))
-		);
-
-		expect(coldCount.total).toBeGreaterThan(0);
-		expect(coldCount.hits).toBe(0);
-		expect(warmCount.total).toBeGreaterThan(0);
-		expect(warmCount.hits).toBe(warmCount.total);
+		await runCompiler(context, cacheDirectory, context.getDist("output-1"));
+		await runCompiler(context, cacheDirectory, context.getDist("output-2"));
 	},
 	check() {
 		expect(hooks).toEqual([

--- a/tests/rspack-test/compilerCases/new-cache-value-dependencies.js
+++ b/tests/rspack-test/compilerCases/new-cache-value-dependencies.js
@@ -1,0 +1,101 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+
+const hooks = [];
+const PLUGIN_NAME = "NewCacheValueDependenciesTestPlugin";
+
+class NewCacheValueDependenciesTestPlugin {
+	apply(compiler) {
+		compiler.hooks.compilation.tap(PLUGIN_NAME, compilation => {
+			for (const hookName of [
+				"buildModule",
+				"succeedModule",
+				"stillValidModule"
+			]) {
+				compilation.hooks[hookName].tap(PLUGIN_NAME, module => {
+					if (module.resource?.endsWith("index.js")) hooks.push(hookName);
+				});
+			}
+		});
+	}
+}
+
+const runCompiler = (context, cacheDirectory, output, value) =>
+	new Promise((resolve, reject) => {
+		const compiler = rspack({
+			context: context.getSource("new-cache-value-dependencies"),
+			entry: "./index.js",
+			cache: {
+				type: "persistent",
+				storage: {
+					type: "filesystem",
+					location: cacheDirectory
+				}
+			},
+			incremental: true,
+			experiments: {
+				newCache: {
+					module: true,
+					codeGeneration: false,
+					devtool: false,
+					minimize: false
+				}
+			},
+			output: {
+				path: output
+			},
+			plugins: [
+				new rspack.DefinePlugin({ VALUE: JSON.stringify(value) }),
+				new NewCacheValueDependenciesTestPlugin()
+			]
+		});
+
+		compiler.run((error, stats) => {
+			compiler.close(closeError => {
+				const finalError = error || closeError;
+				if (finalError) return reject(finalError);
+				if (stats.hasErrors()) {
+					return reject(
+						new Error(stats.toString({ all: false, errors: true }))
+					);
+				}
+				resolve();
+			});
+		});
+	});
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should invalidate the new cache when value dependencies change",
+	options(context) {
+		return {
+			context: context.getSource("new-cache-value-dependencies"),
+			entry: "./index.js"
+		};
+	},
+	async build(context) {
+		const cacheDirectory = context.getDist(
+			"new-cache-value-dependencies-cache"
+		);
+		fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+		await runCompiler(context, cacheDirectory, context.getDist("output-1"), "first");
+		await runCompiler(context, cacheDirectory, context.getDist("output-2"), "first");
+		const output = context.getDist("output-3");
+		await runCompiler(context, cacheDirectory, output, "second");
+
+		expect(fs.readFileSync(path.join(output, "main.js"), "utf-8")).toContain(
+			"second"
+		);
+	},
+	check() {
+		expect(hooks).toEqual([
+			"buildModule",
+			"succeedModule",
+			"stillValidModule",
+			"buildModule",
+			"succeedModule"
+		]);
+	}
+};

--- a/tests/rspack-test/fixtures/new-cache-normal-module-incremental-false/index.js
+++ b/tests/rspack-test/fixtures/new-cache-normal-module-incremental-false/index.js
@@ -1,0 +1,1 @@
+export default "original";

--- a/tests/rspack-test/fixtures/new-cache-normal-module/dep.js
+++ b/tests/rspack-test/fixtures/new-cache-normal-module/dep.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/tests/rspack-test/fixtures/new-cache-normal-module/index.js
+++ b/tests/rspack-test/fixtures/new-cache-normal-module/index.js
@@ -1,0 +1,3 @@
+import value from "./dep";
+
+export default value;

--- a/tests/rspack-test/fixtures/new-cache-value-dependencies/index.js
+++ b/tests/rspack-test/fixtures/new-cache-value-dependencies/index.js
@@ -1,0 +1,1 @@
+globalThis.value = VALUE;

--- a/tests/rspack-test/statsAPICases/cache-disabled.js
+++ b/tests/rspack-test/statsAPICases/cache-disabled.js
@@ -37,7 +37,6 @@ module.exports = {
 			all: false,
 			logging: "verbose"
 		});
-		expect(stats).not.toContain("module build cache");
 		expect(stats).not.toContain("module factorize cache");
 		expect(stats).not.toContain("module code generation cache");
 	}


### PR DESCRIPTION
## Summary

- Add `experiments.newCache.module` to cache NormalModule build results during make.
- Restore cached builds with snapshot validation, including build dependencies and build timestamps.
- Persist `max_dependency_id` in a dedicated `meta` database family.
- Keep the implementation scoped to `new_cache.module`; `legacy_cache` is unchanged.

## Related links

- #15322