### PR TITLE
docs: document experiments.runtimeMode

### DIFF
--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -277,9 +277,6 @@ When [`output.module`](/config/output#outputmodule) is `true` and [`output.libra
 
 ```js title="rspack.config.mjs"
 export default {
-  entry: {
-    main: './src/index.js',
-  },
   experiments: {
     runtimeMode: 'rspack',
   },
@@ -302,30 +299,13 @@ The generated runtime and a chunk that consumes it are organized like this (simp
 
 ```js
 // runtime.js
-var __webpack_modules__ = {};
-
-function __webpack_require__(moduleId) {
-  // Load and execute the module.
-}
-
-__webpack_require__.m = __webpack_modules__;
-__webpack_require__.n = compatGetDefaultExport;
-__webpack_require__.add = (modules) => {
-  Object.assign(__webpack_require__.m, modules);
-};
-
 export { __webpack_require__ };
 
 // main.js
 import { __webpack_require__ } from './runtime.js';
 
-__webpack_require__.add({
-  './src/cjs.js'(module) {
-    module.exports = 'value';
-  },
-});
-
-const value = __webpack_require__('./src/cjs.js');
+__webpack_require__.add(/* module factories */);
+const value = __webpack_require__(moduleId);
 const getDefault = __webpack_require__.n(value);
 ```
 
@@ -334,21 +314,6 @@ const getDefault = __webpack_require__.n(value);
 
 ```js
 // runtime.js
-var modules = {};
-
-function rspackRequire(moduleId) {
-  // Load and execute the module.
-}
-
-var moduleFactories = modules;
-moduleFactories.add = (newModules) => {
-  Object.assign(moduleFactories, newModules);
-};
-
-var compatGetDefaultExport = (module) => {
-  // Return a compatible default export getter.
-};
-
 export { rspackRequire, moduleFactories, compatGetDefaultExport };
 
 // main.js
@@ -358,13 +323,8 @@ import {
   compatGetDefaultExport,
 } from './runtime.js';
 
-moduleFactories.add({
-  './src/cjs.js'(module) {
-    module.exports = 'value';
-  },
-});
-
-const value = rspackRequire('./src/cjs.js');
+moduleFactories.add(/* module factories */);
+const value = rspackRequire(moduleId);
 const getDefault = compatGetDefaultExport(value);
 ```
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -273,10 +273,6 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 
 When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, setting `experiments.runtimeMode` to `'rspack'` generates cleaner output. Instead of exporting one `__webpack_require__` function with runtime helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import only the bindings it needs.
 
-:::warning Plugin compatibility
-Before enabling this option, check any plugins that inject runtime code. If the injected code directly depends on **`__webpack_require__`**, it will no longer work because the runtime argument passed to module factories changes to **`__rspack_context`** in `'rspack'` mode.
-:::
-
 ### Example
 
 ```js title="rspack.config.mjs"

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -274,106 +274,15 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 Controls how Rspack organizes the generated runtime code:
 
 - `'webpack'` keeps the webpack-compatible runtime layout. The module loading function and runtime helpers are exposed through `__webpack_require__`.
-- `'rspack'` uses Rspack's native runtime layout. It separates the module loading function from the runtime context, reducing the coupling between runtime responsibilities and producing a cleaner runtime structure.
+- `'rspack'` uses Rspack's native runtime layout. When combined with [`output.module`](/config/output#outputmodule) and [`modern-module`](/config/output#outputlibrarytype), it exports the loader, module factories, and runtime helpers as named ESM bindings.
 
-Enable the Rspack runtime layout with the following configuration:
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    runtimeMode: 'rspack',
-  },
-};
-```
+For regular builds, keep the default `'webpack'` mode. Enabling `'rspack'` is not recommended because it currently provides no clear user-facing benefit in these builds. The recommended use case is an ESM library built with `output.module: true` and `output.library.type: 'modern-module'`.
 
 :::warning Plugin compatibility
 Before enabling this option, check any plugins that inject runtime code. If the injected code directly depends on **`__webpack_require__`**, it will no longer work because the runtime argument passed to module factories changes to **`__rspack_context`** in `'rspack'` mode.
 :::
 
-### Regular output
-
-In a regular build, the default mode emits each runtime module in a separate IIFE and defines its helper directly on `__webpack_require__`. The `'rspack'` mode renders runtime helpers as named local bindings in a shared IIFE, then exposes the bindings required by module factories through a dedicated `__rspack_context` object. The module loading function is available through `__rspack_context.r`.
-
-The following simplified output shows the difference:
-
-<Tabs>
-  <Tab label="runtimeMode: 'webpack'">
-
-```js
-var __webpack_modules__ = {
-  './lib.js'(__unused_module, __webpack_exports__, __webpack_require__) {
-    __webpack_require__.r(__webpack_exports__);
-    __webpack_require__.d(__webpack_exports__, {
-      value: () => value,
-    });
-    const value = 42;
-  },
-};
-
-function __webpack_require__(moduleId) {
-  // Load and execute the module.
-  var module = { exports: {} };
-  __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-  return module.exports;
-}
-
-// One IIFE for each runtime module.
-(() => {
-  __webpack_require__.d = (exports, getters) => {
-    // Define getters for harmony exports.
-  };
-})();
-
-(() => {
-  __webpack_require__.r = (exports) => {
-    // Mark exports as an ES module.
-  };
-})();
-```
-
-  </Tab>
-  <Tab label="runtimeMode: 'rspack'">
-
-```js
-var __rspack_modules = {
-  './lib.js'(__unused_module, __rspack_exports, __rspack_context) {
-    __rspack_context.N(__rspack_exports);
-    __rspack_context.d(__rspack_exports, {
-      value: () => value,
-    });
-    const value = 42;
-  },
-};
-
-var __rspack_context = {};
-
-function __rspack_require(moduleId) {
-  // Load and execute the module.
-  var module = { exports: {} };
-  __rspack_modules[moduleId](module, module.exports, __rspack_context);
-  return module.exports;
-}
-
-__rspack_context.r = __rspack_require;
-
-// Runtime modules share one IIFE and use named local bindings.
-(function () {
-  var definePropertyGetters = (exports, getters) => {
-    // Define getters for harmony exports.
-  };
-  __rspack_context.d = definePropertyGetters;
-
-  var makeNamespaceObject = (exports) => {
-    // Mark exports as an ES module.
-  };
-  __rspack_context.N = makeNamespaceObject;
-})();
-```
-
-  </Tab>
-</Tabs>
-
-### ESM libraries with `modern-module`
+### Recommended use: ESM libraries with `modern-module`
 
 When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, `'rspack'` mode makes a separate runtime chunk more ESM-friendly. Instead of exporting one `__webpack_require__` function with helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import the bindings it needs directly.
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -271,7 +271,7 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 - **Type:** `'webpack' | 'rspack'`
 - **Default:** `'webpack'`
 
-When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, setting `experiments.runtimeMode` to `'rspack'` generates cleaner output. Instead of exporting one `__webpack_require__` function with runtime helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import only the bindings it needs.
+Setting `experiments.runtimeMode` to `'rspack'` enables Rspack's experimental runtime output. This output mode is still under development, so use it with caution. It currently generates cleaner output when [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`. In this case, instead of exporting one `__webpack_require__` function with runtime helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import only the bindings it needs.
 
 ### Example
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -271,20 +271,13 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 - **Type:** `'webpack' | 'rspack'`
 - **Default:** `'webpack'`
 
-Controls how Rspack organizes the generated runtime code:
-
-- `'webpack'` keeps the webpack-compatible runtime layout. The module loading function and runtime helpers are exposed through `__webpack_require__`.
-- `'rspack'` uses Rspack's native runtime layout. When combined with [`output.module`](/config/output#outputmodule) and [`modern-module`](/config/output#outputlibrarytype), it exports the loader, module factories, and runtime helpers as named ESM bindings.
-
-For regular builds, keep the default `'webpack'` mode. Enabling `'rspack'` is not recommended because it currently provides no clear user-facing benefit in these builds. The recommended use case is an ESM library built with `output.module: true` and `output.library.type: 'modern-module'`.
+When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, setting `experiments.runtimeMode` to `'rspack'` generates cleaner output. Instead of exporting one `__webpack_require__` function with runtime helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import only the bindings it needs.
 
 :::warning Plugin compatibility
 Before enabling this option, check any plugins that inject runtime code. If the injected code directly depends on **`__webpack_require__`**, it will no longer work because the runtime argument passed to module factories changes to **`__rspack_context`** in `'rspack'` mode.
 :::
 
-### Recommended use: ESM libraries with `modern-module`
-
-When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, `'rspack'` mode makes a separate runtime chunk more ESM-friendly. Instead of exporting one `__webpack_require__` function with helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import the bindings it needs directly.
+### Example
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -266,7 +266,7 @@ This option depends on `optimization.sideEffects`. If you disable [`optimization
 
 ## experiments.runtimeMode
 
-<ApiMeta addedVersion="2.1.0" />
+<ApiMeta addedVersion="2.2.0" />
 
 - **Type:** `'webpack' | 'rspack'`
 - **Default:** `'webpack'`

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -5,6 +5,7 @@ description: 'In minor releases, Rspack may change the APIs of experimental feat
 import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
 import PropertyType from '@components/PropertyType';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.js.org/configuration/experiments/" />
 
@@ -262,6 +263,172 @@ export default {
 :::warning
 This option depends on `optimization.sideEffects`. If you disable [`optimization.sideEffects`](/config/optimization#optimizationsideeffects), pure-function hints will not be analyzed.
 :::
+
+## experiments.runtimeMode
+
+<ApiMeta addedVersion="2.1.0" />
+
+- **Type:** `'webpack' | 'rspack'`
+- **Default:** `'webpack'`
+
+Controls how Rspack organizes the generated runtime code:
+
+- `'webpack'` keeps the webpack-compatible runtime layout. The module loading function and runtime helpers are exposed through `__webpack_require__`.
+- `'rspack'` uses Rspack's native runtime layout. It separates the module loading function from the runtime context, reducing the coupling between runtime responsibilities and producing a cleaner runtime structure.
+
+Enable the Rspack runtime layout with the following configuration:
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+};
+```
+
+:::warning Plugin compatibility
+Before enabling this option, check any plugins that inject runtime code. If the injected code directly depends on **`__webpack_require__`**, it will no longer work because the runtime argument passed to module factories changes to **`__rspack_context`** in `'rspack'` mode.
+:::
+
+### Regular output
+
+In a regular build, the default mode uses `__webpack_require__` both as a function and as a container for runtime helpers. The `'rspack'` mode passes a dedicated `__rspack_context` object to module factories and exposes the module loading function through `__rspack_context.r`.
+
+The following simplified output shows the difference:
+
+<Tabs>
+  <Tab label="runtimeMode: 'webpack'">
+
+```js
+function __webpack_require__(moduleId) {
+  // Load and execute the module.
+}
+
+__webpack_require__.d = definePropertyGetters;
+__webpack_require__.r = makeNamespaceObject;
+
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+```
+
+  </Tab>
+  <Tab label="runtimeMode: 'rspack'">
+
+```js
+var __rspack_context = {};
+
+function __rspack_require(moduleId) {
+  // Load and execute the module.
+}
+
+__rspack_context.r = __rspack_require;
+__rspack_context.d = definePropertyGetters;
+__rspack_context.N = makeNamespaceObject;
+
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+```
+
+  </Tab>
+</Tabs>
+
+### ESM libraries with `modern-module`
+
+When [`output.module`](/config/output#outputmodule) is `true` and [`output.library.type`](/config/output#outputlibrarytype) is `'modern-module'`, `'rspack'` mode makes a separate runtime chunk more ESM-friendly. Instead of exporting one `__webpack_require__` function with helpers attached as properties, the runtime exports the loader, module factories, and helpers as named ESM bindings. Each output chunk can import the bindings it needs directly.
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main: './src/index.js',
+  },
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+  output: {
+    module: true,
+    library: {
+      type: 'modern-module',
+    },
+  },
+  optimization: {
+    runtimeChunk: 'single',
+  },
+};
+```
+
+The generated runtime and a chunk that consumes it are organized like this (simplified):
+
+<Tabs>
+  <Tab label="runtimeMode: 'webpack'">
+
+```js
+// runtime.js
+var __webpack_modules__ = {};
+
+function __webpack_require__(moduleId) {
+  // Load and execute the module.
+}
+
+__webpack_require__.m = __webpack_modules__;
+__webpack_require__.n = compatGetDefaultExport;
+__webpack_require__.add = (modules) => {
+  Object.assign(__webpack_require__.m, modules);
+};
+
+export { __webpack_require__ };
+
+// main.js
+import { __webpack_require__ } from './runtime.js';
+
+__webpack_require__.add({
+  './src/cjs.js'(module) {
+    module.exports = 'value';
+  },
+});
+
+const value = __webpack_require__('./src/cjs.js');
+const getDefault = __webpack_require__.n(value);
+```
+
+  </Tab>
+  <Tab label="runtimeMode: 'rspack'">
+
+```js
+// runtime.js
+var modules = {};
+
+function rspackRequire(moduleId) {
+  // Load and execute the module.
+}
+
+var moduleFactories = modules;
+moduleFactories.add = (newModules) => {
+  Object.assign(moduleFactories, newModules);
+};
+
+var compatGetDefaultExport = (module) => {
+  // Return a compatible default export getter.
+};
+
+export { rspackRequire, moduleFactories, compatGetDefaultExport };
+
+// main.js
+import {
+  rspackRequire,
+  moduleFactories,
+  compatGetDefaultExport,
+} from './runtime.js';
+
+moduleFactories.add({
+  './src/cjs.js'(module) {
+    module.exports = 'value';
+  },
+});
+
+const value = rspackRequire('./src/cjs.js');
+const getDefault = compatGetDefaultExport(value);
+```
+
+  </Tab>
+</Tabs>
 
 ## experiments.useInputFileSystem
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -299,12 +299,20 @@ The generated runtime and a chunk that consumes it are organized like this (simp
 
 ```js
 // runtime.js
+var __webpack_modules__ = {};
+function __webpack_require__(moduleId) {
+  /* ... */
+}
+__webpack_require__.m = __webpack_modules__;
+__webpack_require__.n = (module) => {
+  /* ... */
+};
+
 export { __webpack_require__ };
 
 // main.js
 import { __webpack_require__ } from './runtime.js';
 
-__webpack_require__.add(/* module factories */);
 const value = __webpack_require__(moduleId);
 const getDefault = __webpack_require__.n(value);
 ```
@@ -314,16 +322,20 @@ const getDefault = __webpack_require__.n(value);
 
 ```js
 // runtime.js
+var modules = {};
+function rspackRequire(moduleId) {
+  /* ... */
+}
+var moduleFactories = modules;
+var compatGetDefaultExport = (module) => {
+  /* ... */
+};
+
 export { rspackRequire, moduleFactories, compatGetDefaultExport };
 
 // main.js
-import {
-  rspackRequire,
-  moduleFactories,
-  compatGetDefaultExport,
-} from './runtime.js';
+import { rspackRequire, compatGetDefaultExport } from './runtime.js';
 
-moduleFactories.add(/* module factories */);
 const value = rspackRequire(moduleId);
 const getDefault = compatGetDefaultExport(value);
 ```

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -292,7 +292,7 @@ Before enabling this option, check any plugins that inject runtime code. If the 
 
 ### Regular output
 
-In a regular build, the default mode uses `__webpack_require__` both as a function and as a container for runtime helpers. The `'rspack'` mode passes a dedicated `__rspack_context` object to module factories and exposes the module loading function through `__rspack_context.r`.
+In a regular build, the default mode emits each runtime module in a separate IIFE and defines its helper directly on `__webpack_require__`. The `'rspack'` mode renders runtime helpers as named local bindings in a shared IIFE, then exposes the bindings required by module factories through a dedicated `__rspack_context` object. The module loading function is available through `__rspack_context.r`.
 
 The following simplified output shows the difference:
 
@@ -300,31 +300,74 @@ The following simplified output shows the difference:
   <Tab label="runtimeMode: 'webpack'">
 
 ```js
+var __webpack_modules__ = {
+  './lib.js'(__unused_module, __webpack_exports__, __webpack_require__) {
+    __webpack_require__.r(__webpack_exports__);
+    __webpack_require__.d(__webpack_exports__, {
+      value: () => value,
+    });
+    const value = 42;
+  },
+};
+
 function __webpack_require__(moduleId) {
   // Load and execute the module.
+  var module = { exports: {} };
+  __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+  return module.exports;
 }
 
-__webpack_require__.d = definePropertyGetters;
-__webpack_require__.r = makeNamespaceObject;
+// One IIFE for each runtime module.
+(() => {
+  __webpack_require__.d = (exports, getters) => {
+    // Define getters for harmony exports.
+  };
+})();
 
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+(() => {
+  __webpack_require__.r = (exports) => {
+    // Mark exports as an ES module.
+  };
+})();
 ```
 
   </Tab>
   <Tab label="runtimeMode: 'rspack'">
 
 ```js
+var __rspack_modules = {
+  './lib.js'(__unused_module, __rspack_exports, __rspack_context) {
+    __rspack_context.N(__rspack_exports);
+    __rspack_context.d(__rspack_exports, {
+      value: () => value,
+    });
+    const value = 42;
+  },
+};
+
 var __rspack_context = {};
 
 function __rspack_require(moduleId) {
   // Load and execute the module.
+  var module = { exports: {} };
+  __rspack_modules[moduleId](module, module.exports, __rspack_context);
+  return module.exports;
 }
 
 __rspack_context.r = __rspack_require;
-__rspack_context.d = definePropertyGetters;
-__rspack_context.N = makeNamespaceObject;
 
-__rspack_modules[moduleId](module, module.exports, __rspack_context);
+// Runtime modules share one IIFE and use named local bindings.
+(function () {
+  var definePropertyGetters = (exports, getters) => {
+    // Define getters for harmony exports.
+  };
+  __rspack_context.d = definePropertyGetters;
+
+  var makeNamespaceObject = (exports) => {
+    // Mark exports as an ES module.
+  };
+  __rspack_context.N = makeNamespaceObject;
+})();
 ```
 
   </Tab>

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -274,106 +274,15 @@ export default {
 控制 Rspack 如何组织生成的 runtime 代码：
 
 - `'webpack'` 保留与 webpack 兼容的 runtime 结构，通过 `__webpack_require__` 同时暴露模块加载函数和 runtime 辅助函数。
-- `'rspack'` 使用 Rspack 原生的 runtime 结构，将模块加载函数与 runtime 上下文分离，降低不同 runtime 职责之间的耦合，产出更清晰的 runtime 结构。
+- `'rspack'` 使用 Rspack 原生的 runtime 结构。与 [`output.module`](/config/output#outputmodule) 和 [`modern-module`](/config/output#outputlibrarytype) 配合使用时，它会将加载函数、模块工厂和 runtime 辅助函数分别导出为具名 ESM 绑定。
 
-通过以下配置启用 Rspack runtime 结构：
-
-```js title="rspack.config.mjs"
-export default {
-  experiments: {
-    runtimeMode: 'rspack',
-  },
-};
-```
+对于常规构建，请保留默认的 `'webpack'` 模式。不建议在这类构建中开启 `'rspack'`，因为它目前没有明确的用户侧收益。推荐场景是通过 `output.module: true` 和 `output.library.type: 'modern-module'` 构建 ESM 库。
 
 :::warning 插件兼容性
 开启该选项前，请检查项目中会注入 runtime 代码的插件。如果注入的代码直接依赖 **`__webpack_require__`**，开启 `'rspack'` 模式后将无法工作，因为传递给模块工厂的 runtime 参数会变为 **`__rspack_context`**。
 :::
 
-### 常规产物
-
-在常规构建中，默认模式会为每个 runtime module 分别生成一个 IIFE，并直接在 `__webpack_require__` 上定义对应的辅助函数。`'rspack'` 模式会将 runtime 辅助函数生成为具名局部绑定，合并到一个共享 IIFE 中，再通过独立的 `__rspack_context` 对象向模块工厂暴露需要的绑定。其中，模块加载函数通过 `__rspack_context.r` 提供。
-
-下面是简化后的产物，用于说明两者的组织差异：
-
-<Tabs>
-  <Tab label="runtimeMode: 'webpack'">
-
-```js
-var __webpack_modules__ = {
-  './lib.js'(__unused_module, __webpack_exports__, __webpack_require__) {
-    __webpack_require__.r(__webpack_exports__);
-    __webpack_require__.d(__webpack_exports__, {
-      value: () => value,
-    });
-    const value = 42;
-  },
-};
-
-function __webpack_require__(moduleId) {
-  // 加载并执行模块。
-  var module = { exports: {} };
-  __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-  return module.exports;
-}
-
-// 每个 runtime module 分别使用一个 IIFE。
-(() => {
-  __webpack_require__.d = (exports, getters) => {
-    // 为 harmony exports 定义 getter。
-  };
-})();
-
-(() => {
-  __webpack_require__.r = (exports) => {
-    // 将 exports 标记为 ES module。
-  };
-})();
-```
-
-  </Tab>
-  <Tab label="runtimeMode: 'rspack'">
-
-```js
-var __rspack_modules = {
-  './lib.js'(__unused_module, __rspack_exports, __rspack_context) {
-    __rspack_context.N(__rspack_exports);
-    __rspack_context.d(__rspack_exports, {
-      value: () => value,
-    });
-    const value = 42;
-  },
-};
-
-var __rspack_context = {};
-
-function __rspack_require(moduleId) {
-  // 加载并执行模块。
-  var module = { exports: {} };
-  __rspack_modules[moduleId](module, module.exports, __rspack_context);
-  return module.exports;
-}
-
-__rspack_context.r = __rspack_require;
-
-// runtime modules 共用一个 IIFE，并使用具名局部绑定。
-(function () {
-  var definePropertyGetters = (exports, getters) => {
-    // 为 harmony exports 定义 getter。
-  };
-  __rspack_context.d = definePropertyGetters;
-
-  var makeNamespaceObject = (exports) => {
-    // 将 exports 标记为 ES module。
-  };
-  __rspack_context.N = makeNamespaceObject;
-})();
-```
-
-  </Tab>
-</Tabs>
-
-### 配合 `modern-module` 构建 ESM 库
+### 推荐场景：配合 `modern-module` 构建 ESM 库
 
 当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，`'rspack'` 模式会让独立 runtime chunk 的 ESM 结构更清晰。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 可以直接导入需要的绑定。
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -299,12 +299,20 @@ export default {
 
 ```js
 // runtime.js
+var __webpack_modules__ = {};
+function __webpack_require__(moduleId) {
+  /* ... */
+}
+__webpack_require__.m = __webpack_modules__;
+__webpack_require__.n = (module) => {
+  /* ... */
+};
+
 export { __webpack_require__ };
 
 // main.js
 import { __webpack_require__ } from './runtime.js';
 
-__webpack_require__.add(/* module factories */);
 const value = __webpack_require__(moduleId);
 const getDefault = __webpack_require__.n(value);
 ```
@@ -314,16 +322,20 @@ const getDefault = __webpack_require__.n(value);
 
 ```js
 // runtime.js
+var modules = {};
+function rspackRequire(moduleId) {
+  /* ... */
+}
+var moduleFactories = modules;
+var compatGetDefaultExport = (module) => {
+  /* ... */
+};
+
 export { rspackRequire, moduleFactories, compatGetDefaultExport };
 
 // main.js
-import {
-  rspackRequire,
-  moduleFactories,
-  compatGetDefaultExport,
-} from './runtime.js';
+import { rspackRequire, compatGetDefaultExport } from './runtime.js';
 
-moduleFactories.add(/* module factories */);
 const value = rspackRequire(moduleId);
 const getDefault = compatGetDefaultExport(value);
 ```

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -266,7 +266,7 @@ export default {
 
 ## experiments.runtimeMode
 
-<ApiMeta addedVersion="2.1.0" />
+<ApiMeta addedVersion="2.2.0" />
 
 - **类型：** `'webpack' | 'rspack'`
 - **默认值：** `'webpack'`

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -273,10 +273,6 @@ export default {
 
 当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，将 `experiments.runtimeMode` 设置为 `'rspack'` 可以精简产物。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 只需导入实际使用的绑定。
 
-:::warning 插件兼容性
-开启该选项前，请检查项目中会注入 runtime 代码的插件。如果注入的代码直接依赖 **`__webpack_require__`**，开启 `'rspack'` 模式后将无法工作，因为传递给模块工厂的 runtime 参数会变为 **`__rspack_context`**。
-:::
-
 ### 示例
 
 ```js title="rspack.config.mjs"

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -271,20 +271,13 @@ export default {
 - **类型：** `'webpack' | 'rspack'`
 - **默认值：** `'webpack'`
 
-控制 Rspack 如何组织生成的 runtime 代码：
-
-- `'webpack'` 保留与 webpack 兼容的 runtime 结构，通过 `__webpack_require__` 同时暴露模块加载函数和 runtime 辅助函数。
-- `'rspack'` 使用 Rspack 原生的 runtime 结构。与 [`output.module`](/config/output#outputmodule) 和 [`modern-module`](/config/output#outputlibrarytype) 配合使用时，它会将加载函数、模块工厂和 runtime 辅助函数分别导出为具名 ESM 绑定。
-
-对于常规构建，请保留默认的 `'webpack'` 模式。不建议在这类构建中开启 `'rspack'`，因为它目前没有明确的用户侧收益。推荐场景是通过 `output.module: true` 和 `output.library.type: 'modern-module'` 构建 ESM 库。
+当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，将 `experiments.runtimeMode` 设置为 `'rspack'` 可以精简产物。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 只需导入实际使用的绑定。
 
 :::warning 插件兼容性
 开启该选项前，请检查项目中会注入 runtime 代码的插件。如果注入的代码直接依赖 **`__webpack_require__`**，开启 `'rspack'` 模式后将无法工作，因为传递给模块工厂的 runtime 参数会变为 **`__rspack_context`**。
 :::
 
-### 推荐场景：配合 `modern-module` 构建 ESM 库
-
-当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，`'rspack'` 模式会让独立 runtime chunk 的 ESM 结构更清晰。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 可以直接导入需要的绑定。
+### 示例
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -271,7 +271,7 @@ export default {
 - **类型：** `'webpack' | 'rspack'`
 - **默认值：** `'webpack'`
 
-当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，将 `experiments.runtimeMode` 设置为 `'rspack'` 可以精简产物。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 只需导入实际使用的绑定。
+将 `experiments.runtimeMode` 设置为 `'rspack'` 会启用 Rspack 的实验性 runtime 产物。该产物模式仍在开发中，请谨慎使用。目前，它在 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时能够精简产物。在这种情况下，runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 只需导入实际使用的绑定。
 
 ### 示例
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -6,6 +6,7 @@ import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import WebpackLicense from '@components/WebpackLicense';
 import PropertyType from '@components/PropertyType';
 import { Table } from '@builtIns';
+import { Tabs, Tab } from '@theme';
 
 <WebpackLicense from="https://webpack.js.org/configuration/experiments/" />
 
@@ -262,6 +263,172 @@ export default {
 :::warning
 这个选项依赖 `optimization.sideEffects`。如果你关闭了 [`optimization.sideEffects`](/config/optimization#optimizationsideeffects)，pure function 相关提示将不会被分析。
 :::
+
+## experiments.runtimeMode
+
+<ApiMeta addedVersion="2.1.0" />
+
+- **类型：** `'webpack' | 'rspack'`
+- **默认值：** `'webpack'`
+
+控制 Rspack 如何组织生成的 runtime 代码：
+
+- `'webpack'` 保留与 webpack 兼容的 runtime 结构，通过 `__webpack_require__` 同时暴露模块加载函数和 runtime 辅助函数。
+- `'rspack'` 使用 Rspack 原生的 runtime 结构，将模块加载函数与 runtime 上下文分离，降低不同 runtime 职责之间的耦合，产出更清晰的 runtime 结构。
+
+通过以下配置启用 Rspack runtime 结构：
+
+```js title="rspack.config.mjs"
+export default {
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+};
+```
+
+:::warning 插件兼容性
+开启该选项前，请检查项目中会注入 runtime 代码的插件。如果注入的代码直接依赖 **`__webpack_require__`**，开启 `'rspack'` 模式后将无法工作，因为传递给模块工厂的 runtime 参数会变为 **`__rspack_context`**。
+:::
+
+### 常规产物
+
+在常规构建中，默认模式同时把 `__webpack_require__` 用作函数和 runtime 辅助函数的容器。`'rspack'` 模式会向模块工厂传入独立的 `__rspack_context` 对象，并通过 `__rspack_context.r` 暴露模块加载函数。
+
+下面是简化后的产物，用于说明两者的组织差异：
+
+<Tabs>
+  <Tab label="runtimeMode: 'webpack'">
+
+```js
+function __webpack_require__(moduleId) {
+  // 加载并执行模块。
+}
+
+__webpack_require__.d = definePropertyGetters;
+__webpack_require__.r = makeNamespaceObject;
+
+__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+```
+
+  </Tab>
+  <Tab label="runtimeMode: 'rspack'">
+
+```js
+var __rspack_context = {};
+
+function __rspack_require(moduleId) {
+  // 加载并执行模块。
+}
+
+__rspack_context.r = __rspack_require;
+__rspack_context.d = definePropertyGetters;
+__rspack_context.N = makeNamespaceObject;
+
+__rspack_modules[moduleId](module, module.exports, __rspack_context);
+```
+
+  </Tab>
+</Tabs>
+
+### 配合 `modern-module` 构建 ESM 库
+
+当 [`output.module`](/config/output#outputmodule) 为 `true`，且 [`output.library.type`](/config/output#outputlibrarytype) 为 `'modern-module'` 时，`'rspack'` 模式会让独立 runtime chunk 的 ESM 结构更清晰。runtime 不再只导出一个挂载了多个辅助函数的 `__webpack_require__`，而是将加载函数、模块工厂和辅助函数分别导出为具名 ESM 绑定，让每个产物 chunk 可以直接导入需要的绑定。
+
+```js title="rspack.config.mjs"
+export default {
+  entry: {
+    main: './src/index.js',
+  },
+  experiments: {
+    runtimeMode: 'rspack',
+  },
+  output: {
+    module: true,
+    library: {
+      type: 'modern-module',
+    },
+  },
+  optimization: {
+    runtimeChunk: 'single',
+  },
+};
+```
+
+生成的 runtime 及使用它的 chunk 会采用如下组织方式（代码经过简化）：
+
+<Tabs>
+  <Tab label="runtimeMode: 'webpack'">
+
+```js
+// runtime.js
+var __webpack_modules__ = {};
+
+function __webpack_require__(moduleId) {
+  // 加载并执行模块。
+}
+
+__webpack_require__.m = __webpack_modules__;
+__webpack_require__.n = compatGetDefaultExport;
+__webpack_require__.add = (modules) => {
+  Object.assign(__webpack_require__.m, modules);
+};
+
+export { __webpack_require__ };
+
+// main.js
+import { __webpack_require__ } from './runtime.js';
+
+__webpack_require__.add({
+  './src/cjs.js'(module) {
+    module.exports = 'value';
+  },
+});
+
+const value = __webpack_require__('./src/cjs.js');
+const getDefault = __webpack_require__.n(value);
+```
+
+  </Tab>
+  <Tab label="runtimeMode: 'rspack'">
+
+```js
+// runtime.js
+var modules = {};
+
+function rspackRequire(moduleId) {
+  // 加载并执行模块。
+}
+
+var moduleFactories = modules;
+moduleFactories.add = (newModules) => {
+  Object.assign(moduleFactories, newModules);
+};
+
+var compatGetDefaultExport = (module) => {
+  // 返回兼容的默认导出 getter。
+};
+
+export { rspackRequire, moduleFactories, compatGetDefaultExport };
+
+// main.js
+import {
+  rspackRequire,
+  moduleFactories,
+  compatGetDefaultExport,
+} from './runtime.js';
+
+moduleFactories.add({
+  './src/cjs.js'(module) {
+    module.exports = 'value';
+  },
+});
+
+const value = rspackRequire('./src/cjs.js');
+const getDefault = compatGetDefaultExport(value);
+```
+
+  </Tab>
+</Tabs>
 
 ## experiments.useInputFileSystem
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -277,9 +277,6 @@ export default {
 
 ```js title="rspack.config.mjs"
 export default {
-  entry: {
-    main: './src/index.js',
-  },
   experiments: {
     runtimeMode: 'rspack',
   },
@@ -302,30 +299,13 @@ export default {
 
 ```js
 // runtime.js
-var __webpack_modules__ = {};
-
-function __webpack_require__(moduleId) {
-  // 加载并执行模块。
-}
-
-__webpack_require__.m = __webpack_modules__;
-__webpack_require__.n = compatGetDefaultExport;
-__webpack_require__.add = (modules) => {
-  Object.assign(__webpack_require__.m, modules);
-};
-
 export { __webpack_require__ };
 
 // main.js
 import { __webpack_require__ } from './runtime.js';
 
-__webpack_require__.add({
-  './src/cjs.js'(module) {
-    module.exports = 'value';
-  },
-});
-
-const value = __webpack_require__('./src/cjs.js');
+__webpack_require__.add(/* module factories */);
+const value = __webpack_require__(moduleId);
 const getDefault = __webpack_require__.n(value);
 ```
 
@@ -334,21 +314,6 @@ const getDefault = __webpack_require__.n(value);
 
 ```js
 // runtime.js
-var modules = {};
-
-function rspackRequire(moduleId) {
-  // 加载并执行模块。
-}
-
-var moduleFactories = modules;
-moduleFactories.add = (newModules) => {
-  Object.assign(moduleFactories, newModules);
-};
-
-var compatGetDefaultExport = (module) => {
-  // 返回兼容的默认导出 getter。
-};
-
 export { rspackRequire, moduleFactories, compatGetDefaultExport };
 
 // main.js
@@ -358,13 +323,8 @@ import {
   compatGetDefaultExport,
 } from './runtime.js';
 
-moduleFactories.add({
-  './src/cjs.js'(module) {
-    module.exports = 'value';
-  },
-});
-
-const value = rspackRequire('./src/cjs.js');
+moduleFactories.add(/* module factories */);
+const value = rspackRequire(moduleId);
 const getDefault = compatGetDefaultExport(value);
 ```
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -292,7 +292,7 @@ export default {
 
 ### 常规产物
 
-在常规构建中，默认模式同时把 `__webpack_require__` 用作函数和 runtime 辅助函数的容器。`'rspack'` 模式会向模块工厂传入独立的 `__rspack_context` 对象，并通过 `__rspack_context.r` 暴露模块加载函数。
+在常规构建中，默认模式会为每个 runtime module 分别生成一个 IIFE，并直接在 `__webpack_require__` 上定义对应的辅助函数。`'rspack'` 模式会将 runtime 辅助函数生成为具名局部绑定，合并到一个共享 IIFE 中，再通过独立的 `__rspack_context` 对象向模块工厂暴露需要的绑定。其中，模块加载函数通过 `__rspack_context.r` 提供。
 
 下面是简化后的产物，用于说明两者的组织差异：
 
@@ -300,31 +300,74 @@ export default {
   <Tab label="runtimeMode: 'webpack'">
 
 ```js
+var __webpack_modules__ = {
+  './lib.js'(__unused_module, __webpack_exports__, __webpack_require__) {
+    __webpack_require__.r(__webpack_exports__);
+    __webpack_require__.d(__webpack_exports__, {
+      value: () => value,
+    });
+    const value = 42;
+  },
+};
+
 function __webpack_require__(moduleId) {
   // 加载并执行模块。
+  var module = { exports: {} };
+  __webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+  return module.exports;
 }
 
-__webpack_require__.d = definePropertyGetters;
-__webpack_require__.r = makeNamespaceObject;
+// 每个 runtime module 分别使用一个 IIFE。
+(() => {
+  __webpack_require__.d = (exports, getters) => {
+    // 为 harmony exports 定义 getter。
+  };
+})();
 
-__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+(() => {
+  __webpack_require__.r = (exports) => {
+    // 将 exports 标记为 ES module。
+  };
+})();
 ```
 
   </Tab>
   <Tab label="runtimeMode: 'rspack'">
 
 ```js
+var __rspack_modules = {
+  './lib.js'(__unused_module, __rspack_exports, __rspack_context) {
+    __rspack_context.N(__rspack_exports);
+    __rspack_context.d(__rspack_exports, {
+      value: () => value,
+    });
+    const value = 42;
+  },
+};
+
 var __rspack_context = {};
 
 function __rspack_require(moduleId) {
   // 加载并执行模块。
+  var module = { exports: {} };
+  __rspack_modules[moduleId](module, module.exports, __rspack_context);
+  return module.exports;
 }
 
 __rspack_context.r = __rspack_require;
-__rspack_context.d = definePropertyGetters;
-__rspack_context.N = makeNamespaceObject;
 
-__rspack_modules[moduleId](module, module.exports, __rspack_context);
+// runtime modules 共用一个 IIFE，并使用具名局部绑定。
+(function () {
+  var definePropertyGetters = (exports, getters) => {
+    // 为 harmony exports 定义 getter。
+  };
+  __rspack_context.d = definePropertyGetters;
+
+  var makeNamespaceObject = (exports) => {
+    // 将 exports 标记为 ES module。
+  };
+  __rspack_context.N = makeNamespaceObject;
+})();
 ```
 
   </Tab>


### PR DESCRIPTION
## Summary

- document `experiments.runtimeMode` as available from Rspack 2.2.0 in the English and Chinese configuration references
- clarify that the `rspack` runtime output is experimental, still under development, and should be used with caution
- show how enabling `runtimeMode: 'rspack'` with `output.module: true` and `modern-module` generates cleaner output through granular named runtime exports

## Related links

N/A

## Checklist

- [x] Tests updated (not required for a documentation-only change).
- [x] Documentation updated.

## Validation

- `rs fmt --check --no-cache website/docs/en/config/experiments.mdx website/docs/zh/config/experiments.mdx`
- `cspell` on both changed pages
- `case-police` on both changed pages
- `rs doc build` from `website/`