### PR TITLE
feat(cache): add experiments.newCache.module

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2775,6 +2775,7 @@ export interface RawNewCache {
   devtool: boolean
   loader: boolean
   minimize: boolean
+  module: boolean
 }
 
 export interface RawNodeOption {

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1753,6 +1753,7 @@ CompilerOptions {
             devtool: false,
             loader: false,
             minimize: false,
+            module: false,
         },
         defer_import: false,
         source_import: false,

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/raw_new_cache.rs
@@ -8,6 +8,7 @@ pub struct RawNewCache {
   pub devtool: bool,
   pub loader: bool,
   pub minimize: bool,
+  pub module: bool,
 }
 
 impl From<RawNewCache> for NewCacheOptions {
@@ -17,6 +18,7 @@ impl From<RawNewCache> for NewCacheOptions {
       devtool: value.devtool,
       loader: value.loader,
       minimize: value.minimize,
+      module: value.module,
     }
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -125,6 +125,9 @@ impl Task<TaskContext> for AddTask {
       runtime_template: context.runtime_template.create_module_code_template(),
       fs: context.fs.clone(),
       forwarded_ids,
+      module_build_cache: context.module_build_cache.clone(),
+      module_build_cache_counter: context.module_build_cache_counter.clone(),
+      value_cache_versions: context.value_cache_versions.clone(),
     })])
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -7,10 +7,11 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheFacade,
-  CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
-  ResolverFactory, SharedPluginDriver,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheCount,
+  CacheFacade, CompilationId, CompilerId, CompilerOptions, DependencyParents, ModuleCodeTemplate,
+  ModuleIdentifier, ResolverFactory, SharedPluginDriver, ValueCacheVersions,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
+  new_cache::ModuleBuildCache,
   utils::{
     ResourceId,
     task_loop::{Task, TaskResult, TaskType},
@@ -29,6 +30,9 @@ pub struct BuildTask {
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
   pub forwarded_ids: ForwardedIdSet,
+  pub module_build_cache: Option<ModuleBuildCache>,
+  pub module_build_cache_counter: Option<Arc<CacheCount>>,
+  pub value_cache_versions: Arc<ValueCacheVersions>,
 }
 
 #[async_trait::async_trait]
@@ -48,29 +52,62 @@ impl Task<TaskContext> for BuildTask {
       mut module,
       fs,
       forwarded_ids,
+      module_build_cache,
+      module_build_cache_counter,
+      value_cache_versions,
     } = *self;
 
-    plugin_driver
-      .compilation_hooks
-      .build_module
-      .call(compiler_id, compilation_id, &mut module)
-      .await?;
+    let cached = match &module_build_cache {
+      Some(cache) => restore_from_cache(cache, &module.identifier(), &value_cache_versions).await,
+      None => None,
+    };
+    let from_cache = cached.is_some();
+    if let Some(counter) = &module_build_cache_counter {
+      if from_cache {
+        counter.hit();
+      } else {
+        counter.miss();
+      }
+    }
 
-    let result = module
-      .build(
-        BuildContext {
-          compiler_id,
-          compilation_id,
-          compiler_options: compiler_options.clone(),
-          loader_cache,
-          resolver_factory: resolver_factory.clone(),
-          plugin_driver: plugin_driver.clone(),
-          runtime_template,
-          fs: fs.clone(),
-        },
-        None,
-      )
-      .await;
+    // The hook may change module state that is part of the build result, so it
+    // has to run on the module that ends up in the module graph.
+    let result = if let Some(mut build_result) = cached {
+      plugin_driver
+        .compilation_hooks
+        .build_module
+        .call(compiler_id, compilation_id, &mut build_result.module)
+        .await?;
+      Ok(build_result)
+    } else {
+      plugin_driver
+        .compilation_hooks
+        .build_module
+        .call(compiler_id, compilation_id, &mut module)
+        .await?;
+      let result = module
+        .build(
+          BuildContext {
+            compiler_id,
+            compilation_id,
+            compiler_options: compiler_options.clone(),
+            loader_cache,
+            resolver_factory: resolver_factory.clone(),
+            plugin_driver: plugin_driver.clone(),
+            runtime_template,
+            fs: fs.clone(),
+          },
+          None,
+        )
+        .await;
+      if let Ok(build_result) = &result
+        && let Some(cache) = &module_build_cache
+        && let Err(error) = cache.store(build_result).await
+      {
+        tracing::warn!("Storing module build result to the cache failed: {error}");
+      }
+      result
+    };
 
     result.map::<Vec<Box<dyn Task<TaskContext>>>, _>(|build_result| {
       vec![Box::new(BuildResultTask {
@@ -79,6 +116,20 @@ impl Task<TaskContext> for BuildTask {
         forwarded_ids,
       })]
     })
+  }
+}
+
+async fn restore_from_cache(
+  cache: &ModuleBuildCache,
+  identifier: &ModuleIdentifier,
+  value_cache_versions: &ValueCacheVersions,
+) -> Option<BuildResult> {
+  match cache.get(identifier, value_cache_versions).await {
+    Ok(build_result) => build_result,
+    Err(error) => {
+      tracing::warn!("Restoring module build result from the cache failed: {error}");
+      None
+    }
   }
 }
 

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -6,10 +6,12 @@ use rustc_hash::FxHashMap as HashMap;
 
 use super::BuildModuleGraphArtifact;
 use crate::{
-  Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver, incremental::Incremental, module_graph::ModuleGraph,
-  new_cache::Cache,
+  CacheCount, Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory,
+  ResolverFactory, RuntimeTemplate, SharedPluginDriver, ValueCacheVersions,
+  incremental::Incremental,
+  module_graph::ModuleGraph,
+  new_cache::{Cache, ModuleBuildCache},
 };
 
 #[derive(Debug)]
@@ -30,6 +32,9 @@ pub struct TaskContext {
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
+  pub module_build_cache: Option<ModuleBuildCache>,
+  pub module_build_cache_counter: Option<Arc<CacheCount>>,
+  pub value_cache_versions: Arc<ValueCacheVersions>,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -41,6 +46,7 @@ impl TaskContext {
     artifact: BuildModuleGraphArtifact,
     exports_info_artifact: ExportsInfoArtifact,
   ) -> Self {
+    let module_build_cache = compilation.module_build_cache();
     Self {
       compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
@@ -57,6 +63,12 @@ impl TaskContext {
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
+      value_cache_versions: match &module_build_cache {
+        Some(_) => Arc::new(compilation.value_cache_versions.clone()),
+        None => Arc::default(),
+      },
+      module_build_cache,
+      module_build_cache_counter: None,
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -5,15 +5,19 @@ pub mod factorize;
 pub mod lazy;
 pub mod process_dependencies;
 
+use std::sync::Arc;
+
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 use self::context::TaskContext;
 use super::BuildModuleGraphArtifact;
 use crate::{
-  BuildDependency, Compilation, ExportsInfoArtifact,
+  BuildDependency, Compilation, ExportsInfoArtifact, Logger,
   utils::task_loop::{Task, run_task_loop},
 };
+
+const LOGGER_NAME: &str = "rspack.Compilation";
 
 pub async fn repair(
   compilation: &Compilation,
@@ -67,6 +71,18 @@ pub async fn repair(
     .collect::<Vec<_>>();
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact);
+  let logger = compilation.get_logger(LOGGER_NAME);
+  ctx.module_build_cache_counter = ctx
+    .module_build_cache
+    .is_some()
+    .then(|| Arc::new(logger.cache("module build cache")));
+
   run_task_loop(&mut ctx, init_tasks).await?;
+
+  if let Some(counter) = ctx.module_build_cache_counter.take()
+    && let Some(counter) = Arc::into_inner(counter)
+  {
+    logger.cache_end(counter);
+  }
   Ok((ctx.artifact, ctx.exports_info_artifact))
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use rspack_error::Result;
+use rspack_tasks::{get_current_dependency_id, set_current_dependency_id};
 
 use super::build_module_graph_pass;
 use crate::{
@@ -32,6 +33,7 @@ impl PassExt for BuildModuleGraphPhasePass {
   }
 
   async fn before_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) {
+    restore_dependency_id_counter(compilation);
     cache.before_build_module_graph(compilation).await;
   }
 
@@ -61,6 +63,32 @@ impl PassExt for BuildModuleGraphPhasePass {
   }
 
   async fn after_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) {
+    if let Some(module_build_cache) = compilation.module_build_cache()
+      && let Err(error) =
+        module_build_cache.store_dependency_id_counter(get_current_dependency_id())
+    {
+      tracing::warn!("Storing the dependency id counter to the cache failed: {error}");
+    }
     cache.after_build_module_graph(compilation).await;
+  }
+}
+
+/// Cached modules keep the dependency ids of the run that produced them, so the
+/// generator has to start above the highest id handed out so far. Only a cold
+/// compiler run may move the counter, otherwise ids already in use would be
+/// handed out twice.
+fn restore_dependency_id_counter(compilation: &Compilation) {
+  if get_current_dependency_id() != 0 {
+    return;
+  }
+  let Some(module_build_cache) = compilation.module_build_cache() else {
+    return;
+  };
+  match module_build_cache.restore_dependency_id_counter() {
+    Ok(Some(counter)) => set_current_dependency_id(counter),
+    Ok(None) => {}
+    Err(error) => {
+      tracing::warn!("Restoring the dependency id counter from the cache failed: {error}")
+    }
   }
 }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -96,7 +96,7 @@ use crate::{
   legacy_cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCache, minimize::MinimizePersistentCache,
   },
-  new_cache::{Cache, CacheFacade},
+  new_cache::{Cache, CacheFacade, ModuleBuildCache},
   to_identifier,
 };
 
@@ -447,6 +447,18 @@ impl Compilation {
 
   pub fn get_cache(&self, name: &str) -> CacheFacade {
     self.cache.facade(name)
+  }
+
+  /// The module build cache, absent unless `experiments.newCache.module` is
+  /// enabled and the cache itself is available.
+  pub fn module_build_cache(&self) -> Option<ModuleBuildCache> {
+    self
+      .options
+      .experiments
+      .new_cache
+      .module
+      .then(|| self.cache.module_build_cache())
+      .flatten()
   }
 
   pub fn id(&self) -> CompilationId {

--- a/crates/rspack_core/src/legacy_cache/mod.rs
+++ b/crates/rspack_core/src/legacy_cache/mod.rs
@@ -54,7 +54,7 @@ pub fn create_cache(
   intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
   compilation_logging: CompilationLogging,
 ) -> Box<dyn Cache> {
-  if compiler_option.experiments.new_cache.is_enabled() {
+  if compiler_option.experiments.new_cache.module {
     return Box::new(DisableCache);
   }
 

--- a/crates/rspack_core/src/legacy_cache/persistent/mod.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/mod.rs
@@ -199,12 +199,14 @@ impl Cache for PersistentCache {
       return;
     }
 
-    let cache_item = self
-      .ctx
-      .load_occasion(&self.minimize_occasion)
-      .await
-      .unwrap_or_default();
-    compilation.minimize_persistent_cache = Some(cache_item);
+    if !compilation.options.experiments.new_cache.minimize {
+      let cache_item = self
+        .ctx
+        .load_occasion(&self.minimize_occasion)
+        .await
+        .unwrap_or_default();
+      compilation.minimize_persistent_cache = Some(cache_item);
+    }
 
     if compilation.use_source_map_dev_tool_plugin_cache {
       let cache_item = self

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -6,7 +6,10 @@ use rspack_paths::InternedPathSet;
 use super::{
   CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
+  module_build_cache::{MODULE_BUILD_CACHE_NAME, ModuleBuildCache},
+  snapshot::FileSystemInfo,
 };
+use crate::cache::{CacheCodec, SnapshotStrategyOptions};
 
 /// Cache entry point backed by memory and optional filesystem storage.
 ///
@@ -17,6 +20,9 @@ use super::{
 struct CacheStorage {
   memory_cache: MemoryCache,
   idle_file_cache: Option<IdleFileCache>,
+  file_system_info: FileSystemInfo,
+  codec: Arc<CacheCodec>,
+  snapshot_strategy: SnapshotStrategyOptions,
 }
 
 #[derive(Debug)]
@@ -36,6 +42,9 @@ impl Cache {
     compiler_path: String,
     memory_cache: MemoryCache,
     idle_file_cache: Option<IdleFileCache>,
+    file_system_info: FileSystemInfo,
+    codec: Arc<CacheCodec>,
+    snapshot_strategy: SnapshotStrategyOptions,
   ) -> Self {
     Self {
       inner: Arc::new(CacheInner {
@@ -43,9 +52,23 @@ impl Cache {
         storage: Some(CacheStorage {
           memory_cache,
           idle_file_cache,
+          file_system_info,
+          codec,
+          snapshot_strategy,
         }),
       }),
     }
+  }
+
+  /// The per-module build cache, absent when the cache itself is disabled.
+  pub fn module_build_cache(&self) -> Option<ModuleBuildCache> {
+    let storage = self.inner.storage.as_ref()?;
+    Some(ModuleBuildCache::new(
+      self.facade(MODULE_BUILD_CACHE_NAME),
+      storage.file_system_info.clone(),
+      storage.codec.clone(),
+      storage.snapshot_strategy,
+    ))
   }
 
   pub fn new_disabled(compiler_path: String) -> Self {
@@ -161,6 +184,7 @@ impl Cache {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
+    storage.file_system_info.clear();
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.end_idle()
     } else {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -7,6 +7,7 @@ mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
+mod module_build_cache;
 mod snapshot;
 mod validator;
 
@@ -20,10 +21,17 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
+pub use module_build_cache::ModuleBuildCache;
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::{BuildDeps, FileSystemInfo};
-use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::CacheCodec};
+use crate::{
+  CompilationLogger, CompilationLogging, CompilerOptions,
+  cache::{CacheCodec, SnapshotOptions},
+};
+
+const NEW_CACHE_DIRECTORY: &str = "new-cache";
+const DATABASE_DIRECTORY: &str = "db";
 
 pub fn create_cache(
   compiler_path: String,
@@ -40,7 +48,21 @@ pub fn create_cache(
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      return Cache::new(compiler_path, MemoryCache::new(5), None);
+      let snapshot_options = SnapshotOptions::default();
+      let strategy = snapshot_options.dependencies_strategy();
+      let file_system_info = FileSystemInfo::new(
+        input_filesystem,
+        snapshot_options,
+        compiler_options.output.hash_function,
+      );
+      return Cache::new(
+        compiler_path,
+        MemoryCache::new(5),
+        None,
+        file_system_info,
+        Arc::new(CacheCodec::new(None)),
+        strategy,
+      );
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -51,6 +73,7 @@ pub fn create_cache(
     None
   };
   let codec = Arc::new(CacheCodec::new(project_root));
+  let snapshot_strategy = options.snapshot.dependencies_strategy();
   let file_system_info = FileSystemInfo::new(
     input_filesystem.clone(),
     options.snapshot.clone(),
@@ -61,12 +84,14 @@ pub fn create_cache(
     input_filesystem,
     CompilationLogger::new("rspack.newCache".to_string(), compilation_logging),
   );
+  // The database owns its directory: resetting it moves the whole directory
+  // away, so it must not be shared with the legacy cache, which stores its
+  // packs next to it under the configured storage location.
   let (base_path, database_path) = match &options.storage {
     crate::cache::StorageOptions::FileSystem { directory } => {
-      let base_path = directory.parent().unwrap_or_else(|| {
-        panic!("Persistent cache directory must have a parent directory: {directory}")
-      });
-      (base_path.to_path_buf(), directory.clone())
+      let base_path = directory.join(NEW_CACHE_DIRECTORY);
+      let database_path = base_path.join(DATABASE_DIRECTORY);
+      (base_path, database_path)
     }
   };
   let strategy = match FileCacheStrategy::new(
@@ -74,17 +99,31 @@ pub fn create_cache(
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
-    codec,
-    file_system_info,
+    codec.clone(),
+    file_system_info.clone(),
     build_deps,
   ) {
     Ok(strategy) => strategy,
     Err(error) => {
       tracing::warn!("Opening persistent cache database failed: {error}");
-      return Cache::new(compiler_path, MemoryCache::default(), None);
+      return Cache::new(
+        compiler_path,
+        MemoryCache::default(),
+        None,
+        file_system_info,
+        codec,
+        snapshot_strategy,
+      );
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
 
-  Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
+  Cache::new(
+    compiler_path,
+    MemoryCache::default(),
+    Some(idle_file_cache),
+    file_system_info,
+    codec,
+    snapshot_strategy,
+  )
 }

--- a/crates/rspack_core/src/new_cache/module_build_cache.rs
+++ b/crates/rspack_core/src/new_cache/module_build_cache.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use rspack_cacheable::{cacheable, utils::OwnedOrRef};
+use rspack_error::Result;
+
+use super::{
+  CacheFacade, CacheValue,
+  snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult},
+};
+use crate::{
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildResult, ModuleIdentifier,
+  OptimizationBailoutItem, ValueCacheVersions,
+  cache::{CacheCodec, SnapshotStrategyOptions},
+};
+
+/// Cache namespace of the module build results, aligned with webpack's
+/// `Compilation/modules` cache.
+pub(super) const MODULE_BUILD_CACHE_NAME: &str = "Compilation/modules";
+
+/// The dependency id generator is a per-run counter, so cached modules would
+/// collide with freshly created dependencies. Restoring the counter of the
+/// previous run keeps both id ranges disjoint.
+const DEPENDENCY_ID_COUNTER_KEY: &str = "dependencyIdCounter";
+
+#[cacheable]
+struct CachedModule<'a> {
+  snapshot: OwnedOrRef<'a, Snapshot>,
+  module: OwnedOrRef<'a, BoxModule>,
+  dependencies: Vec<OwnedOrRef<'a, BoxDependency>>,
+  blocks: Vec<OwnedOrRef<'a, AsyncDependenciesBlock>>,
+  optimization_bailouts: Vec<OwnedOrRef<'a, OptimizationBailoutItem>>,
+}
+
+/// Per-module build cache backed by the shared memory and filesystem caches.
+///
+/// This is the equivalent of webpack's `Compilation/modules` item cache: a
+/// built module is stored under its identifier together with a filesystem
+/// snapshot, and a later build reuses it while the snapshot stays valid.
+#[derive(Debug, Clone)]
+pub struct ModuleBuildCache {
+  cache: CacheFacade,
+  file_system_info: FileSystemInfo,
+  codec: Arc<CacheCodec>,
+  strategy: SnapshotStrategyOptions,
+}
+
+impl ModuleBuildCache {
+  pub(super) fn new(
+    cache: CacheFacade,
+    file_system_info: FileSystemInfo,
+    codec: Arc<CacheCodec>,
+    strategy: SnapshotStrategyOptions,
+  ) -> Self {
+    Self {
+      cache,
+      file_system_info,
+      codec,
+      strategy,
+    }
+  }
+
+  #[tracing::instrument("Cache::ModuleBuild::get", skip_all)]
+  pub async fn get(
+    &self,
+    identifier: &ModuleIdentifier,
+    value_cache_versions: &ValueCacheVersions,
+  ) -> Result<Option<BuildResult>> {
+    let Some(bytes) = self.cache.get::<Vec<u8>>(identifier.as_str(), None)? else {
+      return Ok(None);
+    };
+    let cached: CachedModule = self.codec.decode(bytes.as_slice())?;
+    if cached.module.as_ref().need_build(value_cache_versions) {
+      return Ok(None);
+    }
+    if !matches!(
+      self
+        .file_system_info
+        .check_snapshot_valid(cached.snapshot.as_ref())
+        .await?,
+      SnapshotValidationResult::Valid
+    ) {
+      return Ok(None);
+    }
+
+    Ok(Some(BuildResult {
+      module: cached.module.into_owned(),
+      dependencies: cached
+        .dependencies
+        .into_iter()
+        .map(OwnedOrRef::into_owned)
+        .collect(),
+      blocks: cached
+        .blocks
+        .into_iter()
+        .map(|block| Box::new(block.into_owned()))
+        .collect(),
+      optimization_bailouts: cached
+        .optimization_bailouts
+        .into_iter()
+        .map(OwnedOrRef::into_owned)
+        .collect(),
+    }))
+  }
+
+  /// Stores the build result exactly as `Module::build` returned it, before the
+  /// module graph wires the dependency and block ids into the module, so that a
+  /// restored result is a drop-in replacement for a freshly built one.
+  #[tracing::instrument("Cache::ModuleBuild::store", skip_all)]
+  pub async fn store(&self, build_result: &BuildResult) -> Result<()> {
+    let build_info = build_result.module.build_info();
+    if !build_info.cacheable {
+      return Ok(());
+    }
+
+    let snapshot = self
+      .file_system_info
+      .create_snapshot(
+        None,
+        &build_info.file_dependencies,
+        &build_info.context_dependencies,
+        &build_info.missing_dependencies,
+        self.strategy,
+      )
+      .await?;
+    let cached = CachedModule {
+      snapshot: (&snapshot).into(),
+      module: (&build_result.module).into(),
+      dependencies: build_result.dependencies.iter().map(Into::into).collect(),
+      blocks: build_result
+        .blocks
+        .iter()
+        .map(|block| (&**block).into())
+        .collect(),
+      optimization_bailouts: build_result
+        .optimization_bailouts
+        .iter()
+        .map(Into::into)
+        .collect(),
+    };
+    // Modules holding data that cannot be serialized, such as values owned by
+    // the JS side, are simply not cached.
+    let Ok(bytes) = self.codec.encode(&cached) else {
+      tracing::debug!(
+        "Skip caching module {} because it is not serializable",
+        build_result.module.identifier()
+      );
+      return Ok(());
+    };
+    self.cache.store(
+      build_result.module.identifier().as_str(),
+      None,
+      CacheValue::new(bytes),
+    )
+  }
+
+  pub fn restore_dependency_id_counter(&self) -> Result<Option<u32>> {
+    Ok(
+      self
+        .cache
+        .get::<u32>(DEPENDENCY_ID_COUNTER_KEY, None)?
+        .map(|value| *value),
+    )
+  }
+
+  pub fn store_dependency_id_counter(&self, counter: u32) -> Result<()> {
+    self
+      .cache
+      .store(DEPENDENCY_ID_COUNTER_KEY, None, CacheValue::new(counter))
+  }
+}

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -118,6 +118,21 @@ impl FileSystemInfo {
     }
   }
 
+  /// Drops every cached filesystem observation.
+  ///
+  /// webpack allocates a fresh `FileSystemInfo` per compilation, so an
+  /// observation never outlives the build that made it. This cache is owned by
+  /// the compiler, and has to be reset at the start of a build instead.
+  pub fn clear(&self) {
+    self.file_timestamps.clear();
+    self.file_hashes.clear();
+    self.file_timestamp_hashes.clear();
+    self.context_timestamps.clear();
+    self.context_hashes.clear();
+    self.context_timestamp_hashes.clear();
+    self.managed_items.clear();
+  }
+
   /// See webpack's snapshot creation implementation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L2525-L3079
   #[tracing::instrument("Cache::FileSystemInfo::create_snapshot", skip_all)]

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -29,6 +29,7 @@ pub struct NewCacheOptions {
   pub devtool: bool,
   pub loader: bool,
   pub minimize: bool,
+  pub module: bool,
 }
 
 impl NewCacheOptions {
@@ -38,11 +39,12 @@ impl NewCacheOptions {
       devtool: true,
       loader: true,
       minimize: true,
+      module: true,
     }
   }
 
   pub const fn is_enabled(self) -> bool {
-    self.code_generation || self.devtool || self.loader || self.minimize
+    self.code_generation || self.devtool || self.loader || self.minimize || self.module
   }
 }
 

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -285,6 +285,7 @@ const applyExperimentsDefaults = (
     D(experiments.newCache, 'devtool', true);
     D(experiments.newCache, 'loader', true);
     D(experiments.newCache, 'minimize', true);
+    D(experiments.newCache, 'module', true);
   }
   D(experiments, 'asyncWebAssembly', true);
   D(experiments, 'deferImport', false);

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3125,6 +3125,8 @@ export type NewCache = {
   loader?: boolean;
   /** Enable the asset minimization cache. @default true */
   minimize?: boolean;
+  /** Enable the module build cache used while making the module graph. @default true */
+  module?: boolean;
 };
 
 export type NewCachePresets = boolean;

--- a/tests/rspack-test/cacheCases/common/module-new-cache-disabled/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/common/module-new-cache-disabled/__snapshots__/stats-0.txt
@@ -1,0 +1,14 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-new-cache-disabled/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/module-new-cache-disabled/__snapshots__/stats-1.txt
@@ -1,0 +1,15 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> snapshot restored with no changed dependencies
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/module-new-cache-disabled/file.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache-disabled/file.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 1;

--- a/tests/rspack-test/cacheCases/common/module-new-cache-disabled/index.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache-disabled/index.js
@@ -1,0 +1,6 @@
+import value from "./file";
+
+it("should keep the legacy make cache when the module new cache is disabled", async () => {
+	expect(value).toBe(1);
+	if (COMPILER_INDEX < 1) await NEXT_START();
+});

--- a/tests/rspack-test/cacheCases/common/module-new-cache-disabled/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache-disabled/rspack.config.js
@@ -1,0 +1,36 @@
+let compilerIndex = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  experiments: {
+    newCache: {
+      module: false,
+    },
+  },
+  cache: {
+    type: 'persistent',
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        let builtModules = 0;
+        compiler.hooks.compilation.tap('Test Plugin', (compilation) => {
+          compilation.hooks.buildModule.tap('Test Plugin', () => {
+            builtModules++;
+          });
+        });
+        compiler.hooks.done.tap('Test Plugin', () => {
+          if (compilerIndex === 0) {
+            expect(builtModules).toBeGreaterThan(0);
+          } else {
+            // The legacy make cache restores the whole module graph, so a warm
+            // start must not build any module again.
+            expect(builtModules).toBe(0);
+          }
+          compilerIndex++;
+        });
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/cacheCases/common/module-new-cache/file.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache/file.js
@@ -1,0 +1,3 @@
+export default 1;
+---
+export default 1;

--- a/tests/rspack-test/cacheCases/common/module-new-cache/index.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache/index.js
@@ -1,0 +1,6 @@
+import value from "./file";
+
+it("should restore built modules from the new cache", async () => {
+	expect(value).toBe(1);
+	if (COMPILER_INDEX < 1) await NEXT_START();
+});

--- a/tests/rspack-test/cacheCases/common/module-new-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/module-new-cache/rspack.config.js
@@ -1,0 +1,44 @@
+let compilerIndex = 0;
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  experiments: {
+    newCache: true,
+  },
+  cache: {
+    type: 'persistent',
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.done.tap('Test Plugin', (stats) => {
+          const logging = stats.toJson({
+            all: false,
+            logging: 'verbose',
+          }).logging;
+          const entries = logging['rspack.Compilation']?.entries ?? [];
+          const cacheEntry = entries.find(
+            (entry) =>
+              entry.type === 'cache' &&
+              entry.message?.startsWith('module build cache:'),
+          );
+          expect(cacheEntry).toBeTruthy();
+
+          const match = cacheEntry.message.match(/\((\d+)\/(\d+)\)/);
+          expect(match).toBeTruthy();
+          const hits = Number(match[1]);
+          const total = Number(match[2]);
+          expect(total).toBeGreaterThan(0);
+
+          if (compilerIndex === 0) {
+            expect(hits).toBe(0);
+          } else {
+            expect(hits).toBe(total);
+          }
+          compilerIndex++;
+        });
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
@@ -9,6 +9,9 @@ module.exports = {
       codeGeneration: false,
       loader: true,
       minimize: false,
+      // This case asserts that an uncached loader reruns on every step, which
+      // the module build cache would skip for a rewrite with equal content.
+      module: false,
     },
   },
   module: {


### PR DESCRIPTION
## Why

Enabling `experiments.newCache` today turns the legacy cache off entirely, so the module graph loses its persistent cache while the new cache only covers code generation, devtool and minimize. There is no way to say "use the new cache for building modules" separately, and no way to fall back if it misbehaves.

`experiments.newCache.module` (default `true`) makes that a decision:

- **on** — `NormalModule` building goes through the new cache (memory + filesystem), aligned with webpack's `Compilation/modules` item cache: a built module is stored under its identifier together with a filesystem snapshot, and a later build reuses it while the snapshot stays valid and `Module::need_build` says so.
- **off** — the legacy cache is created exactly as before and keeps restoring the whole module graph. Only this flag gates it now, so the other new cache options can be used without giving that up.

## What

- `ModuleBuildCache` stores the build result exactly as `Module::build` returned it, before the module graph wires dependency and block ids into the module, so a restored result is a drop-in replacement for a freshly built one.
- Dependency ids are a per-run counter, so a cold run restores the counter of the previous run before making the module graph — otherwise cached dependencies would collide with freshly created ones.
- `FileSystemInfo` is owned by the compiler rather than the compilation, so its filesystem observations are reset at the start of every build.
- The new cache database now lives in its own directory under the storage location. Resetting it moves the whole directory away, which used to take the legacy cache's packs with it once both can be enabled at the same time.
- `module build cache: (hit/total)` is reported in the compilation log.

## Test

- `cacheCases/common/module-new-cache` — cold start misses everything, a restart hits everything.
- `cacheCases/common/module-new-cache-disabled` — with the option off, a warm start builds no module at all and the legacy make cache recovery shows up in the stats log.

## Notes for review

- `watchCases/loaders/loader-cache` pins `module: false`. Its `0/value.js` and `1/value.js` are byte-identical, and it asserts that an uncached loader reruns on every step. The module build cache skips the rebuild when the content hash is unchanged, which is the intended behaviour, so module level caching is out of scope for that case.
- Binary size grows by 104.25KB (68.12MB to 68.22MB, 0.15%), over the 50KB threshold. It comes from the rkyv code generated for the new cache entry, which covers `BoxModule` together with its dependencies and blocks. Whether that is worth raising the threshold for is a call for review.
