### PR TITLE
perf(resolver): collect path dependencies as lists and deduplicate once

### DIFF
--- a/crates/rspack_binding_api/src/resolver.rs
+++ b/crates/rspack_binding_api/src/resolver.rs
@@ -81,12 +81,12 @@ impl JsResolver {
             let mut resolve_request = ResolveRequest::from(resource);
             resolve_request.file_dependencies = resolve_dependencies
               .file_dependencies
-              .drain()
+              .drain(..)
               .map(|path| path.to_string_lossy().into_owned())
               .collect();
             resolve_request.missing_dependencies = resolve_dependencies
               .missing_dependencies
-              .drain()
+              .drain(..)
               .map(|path| path.to_string_lossy().into_owned())
               .collect();
             Ok(match simd_json::to_string(&resolve_request) {

--- a/crates/rspack_core/src/artifacts/factorization_artifact.rs
+++ b/crates/rspack_core/src/artifacts/factorization_artifact.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::cacheable;
 use rspack_error::Diagnostic;
-use rspack_paths::{InternedPath, InternedPathSet};
+use rspack_paths::{InternedPath, dedup_paths};
 use rustc_hash::FxHashMap;
 
 use crate::DependencyId;
@@ -11,7 +11,7 @@ pub struct FactorizeInfo {
   related_dep_ids: Vec<DependencyId>,
   /// These are only ever iterated, so they are stored as compact slices instead of hash sets.
   /// They must stay duplicate-free: `FileCounter::remove_files` panics when the same path is
-  /// removed twice. Building them from an `InternedPathSet` guarantees that.
+  /// removed twice. [`dedup_paths`] establishes that in `new`.
   file_dependencies: Box<[InternedPath]>,
   context_dependencies: Box<[InternedPath]>,
   missing_dependencies: Box<[InternedPath]>,
@@ -22,19 +22,22 @@ impl FactorizeInfo {
   pub fn new(
     diagnostics: Vec<Diagnostic>,
     related_dep_ids: Vec<DependencyId>,
-    file_dependencies: InternedPathSet,
-    context_dependencies: InternedPathSet,
-    missing_dependencies: InternedPathSet,
+    mut file_dependencies: Vec<InternedPath>,
+    mut context_dependencies: Vec<InternedPath>,
+    mut missing_dependencies: Vec<InternedPath>,
   ) -> Self {
     assert!(
       !related_dep_ids.is_empty(),
       "factorization should contain at least one dependency"
     );
+    dedup_paths(&mut file_dependencies);
+    dedup_paths(&mut context_dependencies);
+    dedup_paths(&mut missing_dependencies);
     Self {
       related_dep_ids,
-      file_dependencies: file_dependencies.into_iter().collect(),
-      context_dependencies: context_dependencies.into_iter().collect(),
-      missing_dependencies: missing_dependencies.into_iter().collect(),
+      file_dependencies: file_dependencies.into_boxed_slice(),
+      context_dependencies: context_dependencies.into_boxed_slice(),
+      missing_dependencies: missing_dependencies.into_boxed_slice(),
       diagnostics,
     }
   }

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Debug, sync::Arc};
 
 use rspack_error::{Diagnostic, Result};
-use rspack_paths::{InternedPath, InternedPathSet};
+use rspack_paths::InternedPath;
 
 use crate::{
   BoxModule, CompilationId, CompilerId, CompilerOptions, Context, DependencyRef, ModuleIdentifier,
@@ -22,9 +22,11 @@ pub struct ModuleFactoryCreateData {
   pub issuer_layer: Option<ModuleLayer>,
   pub resolver_factory: Arc<ResolverFactory>,
 
-  pub file_dependencies: InternedPathSet,
-  pub context_dependencies: InternedPathSet,
-  pub missing_dependencies: InternedPathSet,
+  /// Collected as plain lists and deduplicated once in `FactorizeInfo::new`, so that resolution
+  /// never has to build a hash set per dependency.
+  pub file_dependencies: Vec<InternedPath>,
+  pub context_dependencies: Vec<InternedPath>,
+  pub missing_dependencies: Vec<InternedPath>,
   pub diagnostics: Vec<Diagnostic>,
 }
 

--- a/crates/rspack_core/src/normal_module_factory.rs
+++ b/crates/rspack_core/src/normal_module_factory.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, collections::HashMap, ops::Deref, sync::Arc};
 use rspack_error::{Result, error};
 use rspack_hook::define_hook;
 use rspack_loader_runner::{Loader, Scheme, get_scheme};
-use rspack_paths::InternedPathSet;
+use rspack_paths::InternedPath;
 use rspack_util::{MergeFrom, fx_hash::FxDashMap};
 use sugar_path::SugarPath;
 use winnow::prelude::*;
@@ -727,8 +727,8 @@ impl NormalModuleFactory {
     let importer = data.issuer_identifier;
     let raw_request = data.request.clone();
 
-    let mut file_dependencies: InternedPathSet = Default::default();
-    let mut missing_dependencies: InternedPathSet = Default::default();
+    let mut file_dependencies: Vec<InternedPath> = Default::default();
+    let mut missing_dependencies: Vec<InternedPath> = Default::default();
 
     let plugin_driver = &self.plugin_driver;
     let loader_resolver = self.get_loader_resolver();

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -7,7 +7,7 @@ use std::{
 use rspack_error::{Error, Severity, cyan, yellow};
 use rspack_fs::ReadableFileSystem;
 use rspack_loader_runner::DescriptionData;
-use rspack_paths::{AssertUtf8, InternedPathSet};
+use rspack_paths::{AssertUtf8, InternedPath};
 use rspack_util::location::byte_line_column_to_offset;
 
 use super::{ResolveResult, Resource, boxfs::BoxFS};
@@ -18,11 +18,11 @@ use crate::{
 #[derive(Debug, Default, Clone)]
 pub struct ResolveDependencies {
   /// Files that were found on file system; entries carry the precomputed
-  /// `FxHash` from `rspack_resolver`.
-  pub file_dependencies: InternedPathSet,
+  /// `FxHash` from `rspack_resolver`. Duplicate-free.
+  pub file_dependencies: Vec<InternedPath>,
   /// Dependencies that were not found on file system; entries carry the
-  /// precomputed `FxHash` from `rspack_resolver`.
-  pub missing_dependencies: InternedPathSet,
+  /// precomputed `FxHash` from `rspack_resolver`. Duplicate-free.
+  pub missing_dependencies: Vec<InternedPath>,
 }
 
 /// Proxy to [nodejs_resolver::Error] or [rspack_resolver::ResolveError]

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -244,6 +244,18 @@ impl Hash for InternedPath {
   }
 }
 
+/// Drop duplicate paths in place.
+///
+/// Callers collect paths as plain lists and clean them up once here, rather than paying for a hash
+/// set per list. Sorting by the precomputed content hash keeps the result deterministic across
+/// runs — interned pointer addresses would not — and `dedup` then compares interned handles, which
+/// is a pointer comparison. Hash collisions between distinct paths end up adjacent but survive,
+/// because `dedup` uses `PartialEq`.
+pub fn dedup_paths(paths: &mut Vec<InternedPath>) {
+  paths.sort_unstable_by_key(InternedPath::precomputed_hash);
+  paths.dedup();
+}
+
 /// A standard `HashMap` using `InternedPath` as the key type with a custom `Hasher`
 /// that just uses the precomputed hash for speed instead of calculating it.
 pub type InternedPathMap<V> = HashMap<InternedPath, V, BuildHasherDefault<IdentityHasher>>;

--- a/crates/rspack_plugin_lazy_compilation/src/dependency.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/dependency.rs
@@ -4,16 +4,16 @@ use rspack_core::{
   DependencyType, ModuleDependency,
 };
 use rspack_error::Diagnostic;
-use rspack_paths::InternedPathSet;
+use rspack_paths::InternedPath;
 
 #[cacheable]
 #[derive(Debug, Clone)]
 pub struct DependencyOptions {
   pub request: String,
 
-  pub file_dependencies: InternedPathSet,
-  pub context_dependencies: InternedPathSet,
-  pub missing_dependencies: InternedPathSet,
+  pub file_dependencies: Vec<InternedPath>,
+  pub context_dependencies: Vec<InternedPath>,
+  pub missing_dependencies: Vec<InternedPath>,
   pub diagnostics: Vec<Diagnostic>,
 }
 

--- a/crates/rspack_resolver/src/lib.rs
+++ b/crates/rspack_resolver/src/lib.rs
@@ -89,7 +89,7 @@ use dashmap::DashSet;
 use futures::future::{BoxFuture, try_join_all};
 // Resolved dependencies are reported as interned paths, so consumers do not have to convert or
 // rehash them; re-exported for anyone reading a `ResolveContext`.
-pub use rspack_paths::{InternedPath, InternedPathSet};
+pub use rspack_paths::{InternedPath, InternedPathSet, dedup_paths};
 use rustc_hash::FxHashSet;
 
 use crate::{
@@ -118,11 +118,11 @@ type ResolveResult = Result<Option<CachedPath>, ResolveError>;
 /// Context returned from the [Resolver::resolve_with_context] API
 #[derive(Debug, Default, Clone)]
 pub struct ResolveContext {
-  /// Files that were found on file system
-  pub file_dependencies: InternedPathSet,
+  /// Files that were found on file system. Duplicate-free: see [`dedup_paths`].
+  pub file_dependencies: Vec<InternedPath>,
 
-  /// Dependencies that were not found on file system
-  pub missing_dependencies: InternedPathSet,
+  /// Dependencies that were not found on file system. Duplicate-free: see [`dedup_paths`].
+  pub missing_dependencies: Vec<InternedPath>,
 }
 
 /// Resolver with the current operating system as the file system
@@ -267,10 +267,12 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
       .resolve_tracing(directory.as_ref(), specifier, &mut ctx)
       .await;
     if let Some(deps) = &mut ctx.file_dependencies {
-      resolve_context.file_dependencies.extend(deps.drain(..));
+      resolve_context.file_dependencies.append(deps);
+      dedup_paths(&mut resolve_context.file_dependencies);
     }
     if let Some(deps) = &mut ctx.missing_dependencies {
-      resolve_context.missing_dependencies.extend(deps.drain(..));
+      resolve_context.missing_dependencies.append(deps);
+      dedup_paths(&mut resolve_context.missing_dependencies);
     }
     result
   }

--- a/crates/rspack_resolver/src/lib.rs
+++ b/crates/rspack_resolver/src/lib.rs
@@ -125,6 +125,26 @@ pub struct ResolveContext {
   pub missing_dependencies: Vec<InternedPath>,
 }
 
+/// Move one resolution's freshly collected paths into the caller's context, duplicate-free.
+///
+/// Deduplicating `collected` before the merge keeps the cost proportional to this resolution
+/// alone. A caller that reuses one `ResolveContext` across many calls would otherwise re-sort an
+/// ever-growing list on every call; here the second sort only runs once the context already
+/// holds something, and the common case — a fresh context per resolution — moves the vector
+/// across without copying or sorting twice.
+fn merge_dependencies(collected: &mut Option<Vec<InternedPath>>, into: &mut Vec<InternedPath>) {
+  let Some(collected) = collected else {
+    return;
+  };
+  dedup_paths(collected);
+  if into.is_empty() {
+    *into = std::mem::take(collected);
+  } else {
+    into.append(collected);
+    dedup_paths(into);
+  }
+}
+
 /// Resolver with the current operating system as the file system
 pub type Resolver = ResolverGeneric<FileSystemOs>;
 
@@ -266,14 +286,14 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     let result = self
       .resolve_tracing(directory.as_ref(), specifier, &mut ctx)
       .await;
-    if let Some(deps) = &mut ctx.file_dependencies {
-      resolve_context.file_dependencies.append(deps);
-      dedup_paths(&mut resolve_context.file_dependencies);
-    }
-    if let Some(deps) = &mut ctx.missing_dependencies {
-      resolve_context.missing_dependencies.append(deps);
-      dedup_paths(&mut resolve_context.missing_dependencies);
-    }
+    merge_dependencies(
+      &mut ctx.file_dependencies,
+      &mut resolve_context.file_dependencies,
+    );
+    merge_dependencies(
+      &mut ctx.missing_dependencies,
+      &mut resolve_context.missing_dependencies,
+    );
     result
   }
 

--- a/crates/rspack_resolver/src/tests/dependencies.rs
+++ b/crates/rspack_resolver/src/tests/dependencies.rs
@@ -167,8 +167,16 @@ mod windows {
         .iter()
         .map(|p| InternedPath::from(PathBuf::from(p)))
         .collect();
-      assert_eq!(ctx.file_dependencies, file_dependencies, "{name}");
-      assert_eq!(ctx.missing_dependencies, missing_dependencies, "{name}");
+      assert_eq!(
+        InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
+        file_dependencies,
+        "{name}"
+      );
+      assert_eq!(
+        InternedPathSet::from_iter(ctx.missing_dependencies.iter().cloned()),
+        missing_dependencies,
+        "{name}"
+      );
     }
   }
 }

--- a/crates/rspack_resolver/src/tests/dependencies.rs
+++ b/crates/rspack_resolver/src/tests/dependencies.rs
@@ -168,12 +168,20 @@ mod windows {
         .map(|p| InternedPath::from(PathBuf::from(p)))
         .collect();
       assert_eq!(
-        InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
+        ctx
+          .file_dependencies
+          .iter()
+          .cloned()
+          .collect::<InternedPathSet>(),
         file_dependencies,
         "{name}"
       );
       assert_eq!(
-        InternedPathSet::from_iter(ctx.missing_dependencies.iter().cloned()),
+        ctx
+          .missing_dependencies
+          .iter()
+          .cloned()
+          .collect::<InternedPathSet>(),
         missing_dependencies,
         "{name}"
       );

--- a/crates/rspack_resolver/src/tests/extensions.rs
+++ b/crates/rspack_resolver/src/tests/extensions.rs
@@ -64,7 +64,11 @@ async fn default_enforce_extension() {
     Ok(f.join("foo.ts"))
   );
   assert_eq!(
-    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
+    ctx
+      .file_dependencies
+      .iter()
+      .cloned()
+      .collect::<InternedPathSet>(),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("foo.ts")),
       InternedPath::from(f.join("package.json")),
@@ -92,14 +96,22 @@ async fn respect_enforce_extension() {
     Ok(f.join("foo.ts"))
   );
   assert_eq!(
-    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
+    ctx
+      .file_dependencies
+      .iter()
+      .cloned()
+      .collect::<InternedPathSet>(),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("foo.ts")),
       InternedPath::from(f.join("package.json")),
     ])
   );
   assert_eq!(
-    InternedPathSet::from_iter(ctx.missing_dependencies.iter().cloned()),
+    ctx
+      .missing_dependencies
+      .iter()
+      .cloned()
+      .collect::<InternedPathSet>(),
     InternedPathSet::from_iter([InternedPath::from(f.join("foo"))])
   );
 }

--- a/crates/rspack_resolver/src/tests/extensions.rs
+++ b/crates/rspack_resolver/src/tests/extensions.rs
@@ -64,7 +64,7 @@ async fn default_enforce_extension() {
     Ok(f.join("foo.ts"))
   );
   assert_eq!(
-    ctx.file_dependencies,
+    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("foo.ts")),
       InternedPath::from(f.join("package.json")),
@@ -92,14 +92,14 @@ async fn respect_enforce_extension() {
     Ok(f.join("foo.ts"))
   );
   assert_eq!(
-    ctx.file_dependencies,
+    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("foo.ts")),
       InternedPath::from(f.join("package.json")),
     ])
   );
   assert_eq!(
-    ctx.missing_dependencies,
+    InternedPathSet::from_iter(ctx.missing_dependencies.iter().cloned()),
     InternedPathSet::from_iter([InternedPath::from(f.join("foo"))])
   );
 }

--- a/crates/rspack_resolver/src/tests/incorrect_description_file.rs
+++ b/crates/rspack_resolver/src/tests/incorrect_description_file.rs
@@ -23,7 +23,7 @@ async fn incorrect_description_file_1() {
 
   assert!(matches!(resolution, Err(ResolveError::JSON(_))));
   assert_eq!(
-    ctx.file_dependencies,
+    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("pack1")),
       InternedPath::from(f.join("pack1/package.json")),

--- a/crates/rspack_resolver/src/tests/incorrect_description_file.rs
+++ b/crates/rspack_resolver/src/tests/incorrect_description_file.rs
@@ -23,7 +23,11 @@ async fn incorrect_description_file_1() {
 
   assert!(matches!(resolution, Err(ResolveError::JSON(_))));
   assert_eq!(
-    InternedPathSet::from_iter(ctx.file_dependencies.iter().cloned()),
+    ctx
+      .file_dependencies
+      .iter()
+      .cloned()
+      .collect::<InternedPathSet>(),
     InternedPathSet::from_iter([
       InternedPath::from(f.join("pack1")),
       InternedPath::from(f.join("pack1/package.json")),


### PR DESCRIPTION
Stacked on #15306 — review that one first; this PR's diff is against its branch.

> **Status: the premise behind this change did not survive measurement.** Kept open as a draft
> because the negative result and the arithmetic below are worth recording. See *Outcome*.

## What this assumed

Resolution collects path dependencies into a `Vec` that still contains duplicates, and
`HashSet::extend` reserves the whole (still-duplicated) `size_hint`. The assumption was that this
over-reserves substantially, so collecting into a plain list and deduplicating once in place would
avoid a per-resolution hash table.

## Why that is wrong

hashbrown rounds capacity to `next_power_of_two(cap * 8 / 7)`. With ~225 unique paths per
resolution and the measured duplication factor of **1.66×**:

| | raw `cap` | `cap * 8 / 7` | buckets |
|---|---|---|---|
| deduplicated | 225 | 257 | **512** |
| as actually reserved | 374 | 427 | **512** |

**The same bucket count.** The extra allocation this PR set out to remove is not small — it is
exactly zero. Crossing into 1024 buckets needs `cap ≥ 449`, i.e. a duplication factor of **1.996×**,
and this workload is below that threshold.

This also separates two things that look like one problem:

- **#15306** targets the *container's structural* overhead — hashbrown's 7/8 load factor plus
  power-of-two bucket counts make a 512-bucket table hold 225 entries in 4640 B where the payload is
  1800 B. That is 2.6×, it is independent of duplication, and removing it is a real 716 MB.
- **This PR** targets *duplicate-driven* over-reservation, which requires a duplication factor above
  2.0× to exist at all. At 1.66× there is nothing to remove.

## What measurement showed

Three alternating A/B pairs on a large monorepo build (mimalloc, cache off, output identical down
to the byte in every run):

| pages, cumulative | base | this branch | paired Δ |
|---|---|---|---|
| pair 1 | 250400 | 258400 | +8000 |
| pair 2 | 248400 | 258700 | +10300 |
| pair 3 | 252600 | 247800 | **−4800** |

The paired difference changes sign, and the two groups overlap (base 248400–252600, branch
247800–258700). `pages` peak behaves the same way: paired Δ from −800 to +200, groups overlapping.

**No difference was measured, in either direction** — which is exactly what the arithmetic above
predicts. `reserve(374)` and `reserve(225)` produce the same allocation, so there was never anything
for this change to save, and the measurement agrees.

What this does *not* say is that the two are identical. The run-to-run spread of this pipeline on
this workload bounds what it can resolve:

| axis | base spread | branch spread | resolves |
|---|---|---|---|
| pages, peak | 0.34% | 0.76% | effects above ~1% |
| pages, cumulative | 1.68% | 4.28% | effects above ~5% |
| `committed` peak | 7.0% | | — |
| user CPU | 7.8% | | — |
| wall clock | 10.0% | | — |

So the claim is "any difference is below ~5%", not "there is no difference". (`committed` cumulative
reads as 0.00% only because its display quantum is 0.1 GiB, i.e. 1.3%.)

Figures are page counts, not bytes: mimalloc's `pages` counter records how many times a page was
taken from a segment, and pages return to the segment for reuse, so it does not convert to a byte
figure. The byte-level question is unanswerable with the tooling available — `malloc req` needs
`MI_STAT>=2`, which this build does not enable, and heaptrack deadlocks against node
(`dl_iterate_phdr` holds `_dl_load_lock`, the allocation lands in heaptrack's malloc hook,
libunwind then blocks on its own lock).

## Outcome

The premise does not hold and the measurement is consistent with that: no memory difference in
either direction, above a resolution floor of roughly 5%. There is therefore no memory argument for
this change, and the CPU side cannot supply one either — the estimated effect is under 1% of user
CPU against a 7.8% run-to-run spread.

A run against this branch's current HEAD is still in flight. By the same arithmetic it is expected
to be null as well.
