### PR TITLE
feat(cache): support builtin swc-loader cache

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -961,6 +961,7 @@ export interface JsLoaderCacheEntry {
   sourceMap?: Uint8Array
   addedDependencies: JsLoaderDependencies
   removedDependencies: JsLoaderDependencies
+  parseMeta: Record<string, string>
 }
 
 export interface JsLoaderContext {

--- a/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
@@ -1,8 +1,11 @@
-use std::sync::{Arc, Mutex};
+use std::{
+  collections::HashMap,
+  sync::{Arc, Mutex},
+};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
-use rspack_cacheable::cacheable;
+use rspack_cacheable::{cacheable, with::AsMap};
 use rspack_core::{
   CacheFacade, CacheValue, Content, Etag, FileSystemInfo, LoaderCacheDependencySnapshot,
   LoaderDependencies, Resolver, loader_cache_dependency_snapshot,
@@ -22,6 +25,8 @@ struct LoaderCacheEntry {
   content_is_string: bool,
   source_map: Option<Vec<u8>>,
   dependency_snapshot: LoaderCacheDependencySnapshot,
+  #[cacheable(with=AsMap)]
+  parse_meta: HashMap<String, String>,
 }
 
 #[napi(object)]
@@ -30,6 +35,7 @@ pub struct JsLoaderCacheEntry {
   pub source_map: Option<Uint8Array>,
   pub added_dependencies: JsLoaderDependencies,
   pub removed_dependencies: JsLoaderDependencies,
+  pub parse_meta: HashMap<String, String>,
 }
 
 #[derive(Clone)]
@@ -188,6 +194,7 @@ impl JsLoaderCache {
       source_map: entry.source_map.clone().map(Into::into),
       added_dependencies: (&dependencies).into(),
       removed_dependencies: Default::default(),
+      parse_meta: entry.parse_meta.clone(),
     }))
   }
 
@@ -218,6 +225,7 @@ impl JsLoaderCache {
       content_is_string,
       source_map: output.source_map.map(|source_map| source_map.to_vec()),
       dependency_snapshot,
+      parse_meta: output.parse_meta,
     };
     let item_cache = loader_cache_item(&self.cache, &self.module_identifier, loader_name, etag);
     item_cache

--- a/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
@@ -1,7 +1,4 @@
-use std::{
-  collections::HashMap,
-  sync::{Arc, Mutex},
-};
+use std::sync::{Arc, Mutex};
 
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
@@ -16,6 +13,7 @@ use rspack_error::Result;
 use rspack_hash::{HashFunction, RspackHasher};
 use rspack_loader_runner::LoaderRunnerOptions;
 use rspack_paths::Utf8Path;
+use rspack_util::fx_hash::FxHashMap as HashMap;
 
 use super::context::JsLoaderDependencies;
 

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
 use bitflags::bitflags;
-use rspack_cacheable::cacheable;
+use rspack_cacheable::{cacheable, with::AsMap};
 use rspack_collections::Identifiable;
 use rspack_error::Result;
 use rspack_hash::{HashFunction, RspackHasher};
-use rspack_loader_runner::{Content, LoaderContext, LoaderDependencies};
+use rspack_loader_runner::{Content, LoaderContext, LoaderDependencies, ParseMeta};
 use rspack_paths::{InternedPath, InternedPathSet};
 use rspack_sources::SourceMap;
 use rspack_util::time::current_time;
@@ -161,6 +161,8 @@ struct LoaderCacheEntry {
   content_is_string: bool,
   source_map: Option<String>,
   dependency_snapshot: LoaderCacheDependencySnapshot,
+  #[cacheable(with=AsMap)]
+  parse_meta: ParseMeta,
 }
 
 pub(crate) struct LoaderCacheMissState {
@@ -245,6 +247,7 @@ pub(crate) async fn before_normal_loader(
     let mut dependencies = LoaderDependencies::default();
     restore_loader_cache_dependencies(&entry.dependency_snapshot, &mut dependencies);
     context.add_dependencies(&dependencies);
+    context.parse_meta = entry.parse_meta.clone();
     context.__finish_with((content, source_map, None));
     return Ok(LoaderCacheAction::Hit);
   }
@@ -261,7 +264,6 @@ pub(crate) async fn after_normal_loader(
     || !context.context.module.build_info().assets.is_empty()
     || !context.context.module.build_info().extras.is_empty()
     || context.additional_data().is_some()
-    || !context.parse_meta.is_empty()
   {
     return Ok(());
   }
@@ -288,6 +290,7 @@ pub(crate) async fn after_normal_loader(
     content_is_string,
     source_map: context.source_map().map(SourceMap::to_json),
     dependency_snapshot,
+    parse_meta: context.parse_meta.clone(),
   };
   let loader_name = context.current_loader().loader_name();
   let module_identifier = context.context.module.identifier();

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -11,7 +11,8 @@ use rspack_sources::SourceMap;
 use rspack_util::time::current_time;
 
 use crate::{
-  CacheFacade, CacheValue, Etag, FileSystemInfo, ItemCacheFacade, Module, RunnerContext,
+  CacheFacade, CacheValue, Etag, FileSystemInfo, IsolatedDts, ItemCacheFacade, Module, RscMeta,
+  RunnerContext,
   cache::SnapshotStrategyOptions,
   new_cache::{Snapshot, SnapshotValidationResult},
 };
@@ -163,6 +164,8 @@ struct LoaderCacheEntry {
   dependency_snapshot: LoaderCacheDependencySnapshot,
   #[cacheable(with=AsMap)]
   parse_meta: ParseMeta,
+  isolated_dts: Option<Box<IsolatedDts>>,
+  rsc: Option<RscMeta>,
 }
 
 pub(crate) struct LoaderCacheMissState {
@@ -207,6 +210,8 @@ pub(crate) async fn before_normal_loader(
     || !context.parse_meta.is_empty()
     || !context.context.module.build_info().assets.is_empty()
     || !context.context.module.build_info().extras.is_empty()
+    || context.context.module.build_info().isolated_dts.is_some()
+    || context.context.module.build_info().rsc.is_some()
     || !existing_dependencies.context.is_empty()
     || !existing_dependencies.missing.is_empty()
   {
@@ -248,6 +253,9 @@ pub(crate) async fn before_normal_loader(
     restore_loader_cache_dependencies(&entry.dependency_snapshot, &mut dependencies);
     context.add_dependencies(&dependencies);
     context.parse_meta = entry.parse_meta.clone();
+    let build_info = context.context.module.build_info_mut();
+    build_info.isolated_dts = entry.isolated_dts.clone();
+    build_info.rsc = entry.rsc.clone();
     context.__finish_with((content, source_map, None));
     return Ok(LoaderCacheAction::Hit);
   }
@@ -291,6 +299,8 @@ pub(crate) async fn after_normal_loader(
     source_map: context.source_map().map(SourceMap::to_json),
     dependency_snapshot,
     parse_meta: context.parse_meta.clone(),
+    isolated_dts: context.context.module.build_info().isolated_dts.clone(),
+    rsc: context.context.module.build_info().rsc.clone(),
   };
   let loader_name = context.current_loader().loader_name();
   let module_identifier = context.context.module.identifier();

--- a/crates/rspack_core/src/parser_and_generator.rs
+++ b/crates/rspack_core/src/parser_and_generator.rs
@@ -7,7 +7,7 @@ use rspack_cacheable::{
 };
 use rspack_error::{Result, TWithDiagnosticArray};
 use rspack_hash::RspackHashDigest;
-use rspack_loader_runner::{AdditionalData, ParseMeta, ResourceData};
+use rspack_loader_runner::{AdditionalData, ParseMeta, ParseMetaValue, ResourceData};
 use rspack_sources::BoxSource;
 use rspack_util::{ext::AsAny, source_map::SourceMapKind};
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -52,6 +52,17 @@ pub struct CollectedTypeScriptInfo {
   pub type_exports: FxHashSet<Atom>,
   #[cacheable(with=AsMap<AsPreset>)]
   pub exported_enums: FxHashMap<Atom, TSEnumValue>,
+}
+
+#[cacheable_dyn]
+impl ParseMetaValue for CollectedTypeScriptInfo {
+  fn clone_parse_meta(&self) -> Box<dyn ParseMetaValue> {
+    Box::new(self.clone())
+  }
+
+  fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
+    self
+  }
 }
 
 pub const COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY: &str = "rspack-collected-ts-info";

--- a/crates/rspack_loader_runner/src/content.rs
+++ b/crates/rspack_loader_runner/src/content.rs
@@ -1,4 +1,5 @@
 use std::{
+  any::Any,
   fmt::Debug,
   path::{Path, PathBuf},
   sync::Arc,
@@ -7,7 +8,8 @@ use std::{
 use anymap::CloneAny;
 use once_cell::sync::OnceCell;
 use rspack_cacheable::{
-  cacheable,
+  cacheable, cacheable_dyn,
+  rkyv::string::ArchivedString,
   utils::PortablePath,
   with::{As, AsInner, AsOption, AsPreset},
 };
@@ -342,4 +344,34 @@ impl DescriptionData {
 }
 
 pub type AdditionalData = anymap::Map<dyn CloneAny + Send + Sync>;
-pub type ParseMeta = FxHashMap<String, Box<dyn CloneAny + Send + Sync>>;
+
+#[cacheable_dyn]
+pub trait ParseMetaValue: CloneAny + Send + Sync {
+  fn clone_parse_meta(&self) -> Box<dyn ParseMetaValue>;
+  fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync>;
+}
+
+impl Clone for Box<dyn ParseMetaValue> {
+  fn clone(&self) -> Self {
+    self.clone_parse_meta()
+  }
+}
+
+impl Debug for dyn ParseMetaValue {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.debug_struct("ParseMetaValue").finish_non_exhaustive()
+  }
+}
+
+#[cacheable_dyn]
+impl ParseMetaValue for String {
+  fn clone_parse_meta(&self) -> Box<dyn ParseMetaValue> {
+    Box::new(self.clone())
+  }
+
+  fn into_any(self: Box<Self>) -> Box<dyn Any + Send + Sync> {
+    self
+  }
+}
+
+pub type ParseMeta = FxHashMap<String, Box<dyn ParseMetaValue>>;

--- a/crates/rspack_loader_runner/src/lib.rs
+++ b/crates/rspack_loader_runner/src/lib.rs
@@ -8,7 +8,9 @@ mod plugin;
 mod runner;
 mod scheme;
 
-pub use content::{AdditionalData, Content, DescriptionData, ParseMeta, ResourceData};
+pub use content::{
+  AdditionalData, Content, DescriptionData, ParseMeta, ParseMetaValue, ResourceData,
+};
 pub use context::{LoaderContext, LoaderDependencies, State};
 pub use loader::{DisplayWithSuffix, Loader, LoaderItem, ResourceParsedData, parse_resource};
 pub use plugin::LoaderRunnerPlugin;

--- a/crates/rspack_plugin_extract_css/src/parser_plugin.rs
+++ b/crates/rspack_plugin_extract_css/src/parser_plugin.rs
@@ -27,9 +27,7 @@ pub struct PluginCssExtractParserPlugin {
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for PluginCssExtractParserPlugin {
   fn finish(&self, parser: &mut JavascriptParser<'p>) -> Option<bool> {
     let deps = if let Some(data_str) = parser.parse_meta.remove(PLUGIN_NAME)
-      && let Ok(data_str) = (data_str as Box<dyn std::any::Any>)
-        .downcast::<String>()
-        .map(|i| *i)
+      && let Ok(data_str) = data_str.into_any().downcast::<String>().map(|i| *i)
     {
       let data = if let Some(data) = self.cache.get(&data_str) {
         data.clone()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -259,8 +259,9 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     let mut diagnostics: Vec<Diagnostic> = vec![];
 
     if let Some(collected_ts_info) = parse_meta.remove(COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY)
-      && let Ok(collected_ts_info) =
-        (collected_ts_info as Box<dyn std::any::Any>).downcast::<CollectedTypeScriptInfo>()
+      && let Ok(collected_ts_info) = collected_ts_info
+        .into_any()
+        .downcast::<CollectedTypeScriptInfo>()
     {
       build_info.collected_typescript_info = Some(*collected_ts_info);
     }

--- a/packages/rspack/src/loader-runner/cache.ts
+++ b/packages/rspack/src/loader-runner/cache.ts
@@ -13,6 +13,7 @@ export type LoaderCacheEntry = {
   sourceMap?: Uint8Array;
   addedDependencies: LoaderDependencies;
   removedDependencies: LoaderDependencies;
+  parseMeta: Record<string, string>;
 };
 
 type LoaderCacheApi = {
@@ -61,6 +62,7 @@ export class LoaderCache {
     );
     if (hit) {
       this.#dependencies.addDependencies(hit.addedDependencies);
+      Object.assign(context.__internal__parseMeta, hit.parseMeta);
     }
     return hit;
   }
@@ -72,11 +74,7 @@ export class LoaderCache {
     additionalData: unknown,
   ) {
     const context = this.#context;
-    if (
-      !context.cacheable ||
-      !isNil(additionalData) ||
-      Object.keys(context.__internal__parseMeta).length > 0
-    ) {
+    if (!context.cacheable || !isNil(additionalData)) {
       return;
     }
 
@@ -85,6 +83,7 @@ export class LoaderCache {
       sourceMap,
       addedDependencies: this.#dependencies.added,
       removedDependencies: this.#dependencies.removed,
+      parseMeta: { ...context.__internal__parseMeta },
     });
   }
 

--- a/packages/rspack/src/loader-runner/cache.ts
+++ b/packages/rspack/src/loader-runner/cache.ts
@@ -16,6 +16,11 @@ export type LoaderCacheEntry = {
   parseMeta: Record<string, string>;
 };
 
+export type WorkerCacheResult =
+  | { type: 'disabled' }
+  | { type: 'miss' }
+  | { type: 'hit'; entry: LoaderCacheEntry };
+
 type LoaderCacheApi = {
   get(
     loaderIndex: number,
@@ -91,10 +96,11 @@ export class LoaderCache {
     loaderIndex: number,
     content: LoaderCacheContent | null | undefined,
     additionalData: unknown,
-  ) {
+  ): Promise<WorkerCacheResult> {
     const hit = await this.get(loaderIndex, content, additionalData);
-    if (!hit) return undefined;
-    return hit;
+    if (hit === undefined) return { type: 'disabled' };
+    if (hit === null) return { type: 'miss' };
+    return { type: 'hit', entry: hit };
   }
 
   async workerStore(

--- a/packages/rspack/src/loader-runner/worker.ts
+++ b/packages/rspack/src/loader-runner/worker.ts
@@ -13,6 +13,7 @@ import { cleverMerge } from '../util/cleverMerge';
 import { createHash } from '../util/createHash';
 import { absolutify, contextify } from '../util/identifier';
 import { memoize } from '../util/memoize';
+import type { WorkerCacheResult } from './cache';
 import loadLoader from './loadLoader';
 import {
   isWorkerResponseErrorMessage,
@@ -535,6 +536,7 @@ async function loaderImpl(
       while (loaderContext.loaderIndex >= 0) {
         const currentLoaderObject =
           loaderContext.loaders[loaderContext.loaderIndex];
+        let cacheResult: WorkerCacheResult | undefined;
 
         if (shouldYieldToMainThread(currentLoaderObject)) break;
         if (currentLoaderObject.normalExecuted) {
@@ -549,20 +551,22 @@ async function loaderImpl(
         try {
           if (currentLoaderObject.loaderItem.cache) {
             waitForPendingRequest(pendingDependencyRequest);
-            const hit = await sendRequest(
+            const result: WorkerCacheResult = await sendRequest(
               RequestType.LoaderCacheGet,
               loaderContext.loaderIndex,
               args[0],
               args[2],
             );
-            if (hit) {
+            cacheResult = result;
+            if (result.type === 'hit') {
+              const { entry } = result;
               currentLoaderObject.normalExecuted = true;
               args = [
-                typeof hit.content === 'string'
-                  ? hit.content
-                  : hit.content && Buffer.from(hit.content),
-                hit.sourceMap
-                  ? toObject(Buffer.from(hit.sourceMap))
+                typeof entry.content === 'string'
+                  ? entry.content
+                  : entry.content && Buffer.from(entry.content),
+                entry.sourceMap
+                  ? toObject(Buffer.from(entry.sourceMap))
                   : undefined,
                 undefined,
               ];
@@ -576,7 +580,7 @@ async function loaderImpl(
           if (!fn) continue;
           convertArgs(args, !!currentLoaderObject.raw);
           args = (await runSyncOrAsync(fn, loaderContext, args)) || [];
-          if (currentLoaderObject.loaderItem.cache) {
+          if (cacheResult?.type === 'miss') {
             waitForPendingRequest(pendingDependencyRequest);
             await sendRequest(
               RequestType.LoaderCacheStore,

--- a/tests/rspack-test/compilerCases/persistent-isolated-dts.js
+++ b/tests/rspack-test/compilerCases/persistent-isolated-dts.js
@@ -27,7 +27,7 @@ async function recreateCompiler(context) {
 /** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
 module.exports = {
   description:
-    "should re-emit declaration files assets after persistent cache recovery",
+    "should restore declaration metadata from the persistent loader cache",
   options(context) {
     const sourceDir = path.resolve(__dirname, "../fixtures", CASE_DIR);
     const workDir = context.getDist(WORK_DIR);
@@ -45,14 +45,19 @@ module.exports = {
           type: "commonjs"
         }
       },
+      cache: {
+        type: "persistent",
+        buildDependencies: [__filename],
+        storage: {
+          type: "filesystem",
+          location: context.getDist(CACHE_DIR)
+        }
+      },
       experiments: {
-        cache: {
-          type: "persistent",
-          buildDependencies: [__filename],
-          storage: {
-            type: "filesystem",
-            location: context.getDist(CACHE_DIR)
-          }
+        newCache: {
+          codeGeneration: false,
+          loader: true,
+          minimize: false
         }
       },
       module: {
@@ -62,7 +67,11 @@ module.exports = {
             type: "javascript/auto",
             use: {
               loader: "builtin:swc-loader",
+              cache: true,
               options: {
+                collectTypeScriptInfo: {
+                  exportedEnum: true
+                },
                 jsc: {
                   parser: {
                     syntax: "typescript"

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/enum.ts
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/enum.ts
@@ -1,0 +1,3 @@
+export enum E {
+  A,
+}

--- a/tests/rspack-test/watchCases/loaders/loader-cache/0/index.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/0/index.js
@@ -1,3 +1,5 @@
+import { E } from "./enum";
+
 const value = require("./value");
 const moduleA = require("./module-a");
 const moduleB = require("./module-b");
@@ -30,6 +32,9 @@ it("should cache each opted-in loader until its input changes", () => {
 	});
 	expect(moduleA).toBe("module-a.js");
 	expect(moduleB).toBe("module-b.js");
+	expect(E.A).toBe(0);
+	const generated = require("fs").readFileSync(__filename, "utf-8");
+	expect(generated).toContain("inlined export .E.A");
 	expect(bom).toEqual({
 		hasBom: true,
 		producerRuns: 1,

--- a/tests/rspack-test/watchCases/loaders/loader-cache/1/enum.ts
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/1/enum.ts
@@ -1,0 +1,3 @@
+export enum E {
+  A,
+}

--- a/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/rspack.config.js
@@ -11,8 +11,28 @@ module.exports = {
       minimize: false,
     },
   },
+  optimization: {
+    inlineExports: true,
+  },
+  resolve: {
+    extensions: ['.ts', '...'],
+  },
   module: {
     rules: [
+      {
+        test: /enum\.ts$/,
+        use: [
+          {
+            loader: 'builtin:swc-loader',
+            options: {
+              collectTypeScriptInfo: {
+                exportedEnum: true,
+              },
+            },
+            cache: true,
+          },
+        ],
+      },
       {
         test: /value\.js$/,
         use: [

--- a/tests/rspack-test/watchCases/loaders/loader-cache/test.config.js
+++ b/tests/rspack-test/watchCases/loaders/loader-cache/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  ignoreNotFriendlyForIncrementalWarnings: true,
+};


### PR DESCRIPTION
## Summary

- make `ParseMeta` values support rkyv dynamic serialization and deserialization through `ParseMetaValue`
- persist and restore `parse_meta` together with loader content and source maps
- synchronize JavaScript loader cache entries with string-based parse metadata
- allow `builtin:swc-loader` to use loader cache when it emits collected TypeScript metadata

For example, `builtin:swc-loader` can collect exported TypeScript enum metadata on the initial build. When the loader input is unchanged on a later build, the loader cache restores that metadata so the JavaScript parser can still inline `E.A` without rerunning SWC.

## Related links

- Follow-up to #15236

## Testing

- `cargo check -p rspack_loader_runner -p rspack_core -p rspack_binding_api -p rspack_plugin_javascript -p rspack_plugin_extract_css -p rspack_loader_swc`
- `pnpm run build:cli:dev`
- `pnpm run test -t "watchCases/loaders/loader-cache"` (15 tests passed)
- rkyv byte round-trip for `ParseMeta<CollectedTypeScriptInfo>`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_