### PR TITLE
feat(wasm): align wasmStreamingFallback with webpack

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2841,6 +2841,7 @@ export interface RawOutputOptions {
   publicPath: "auto" | JsFilename
   assetModuleFilename: JsFilename
   wasmLoading: string | false
+  wasmStreamingFallback: boolean
   enabledWasmLoadingTypes: Array<string>
   webassemblyModuleFilename: string
   filename: JsFilename

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -2128,6 +2128,8 @@ pub struct OutputOptionsBuilder {
   asset_module_filename: Option<Filename>,
   /// Set the wasm loading.
   wasm_loading: Option<WasmLoading>,
+  /// Set whether to fall back when streaming WebAssembly loading fails due to an incorrect MIME type.
+  wasm_streaming_fallback: Option<bool>,
   /// Set the wasm module filename.
   webassembly_module_filename: Option<Filename>,
   /// Set the unique name.
@@ -2219,6 +2221,7 @@ impl From<OutputOptions> for OutputOptionsBuilder {
       public_path: Some(value.public_path),
       asset_module_filename: Some(value.asset_module_filename),
       wasm_loading: Some(value.wasm_loading),
+      wasm_streaming_fallback: Some(value.wasm_streaming_fallback),
       webassembly_module_filename: Some(value.webassembly_module_filename),
       unique_name: Some(value.unique_name),
       chunk_loading: Some(value.chunk_loading),
@@ -2272,6 +2275,7 @@ impl From<&mut OutputOptionsBuilder> for OutputOptionsBuilder {
       public_path: value.public_path.take(),
       asset_module_filename: value.asset_module_filename.take(),
       wasm_loading: value.wasm_loading.take(),
+      wasm_streaming_fallback: value.wasm_streaming_fallback.take(),
       webassembly_module_filename: value.webassembly_module_filename.take(),
       unique_name: value.unique_name.take(),
       chunk_loading: value.chunk_loading.take(),
@@ -2367,6 +2371,14 @@ impl OutputOptionsBuilder {
   /// [`WasmLoadingType`]: rspack_core::options::WasmLoadingType
   pub fn wasm_loading(&mut self, loading: WasmLoading) -> &mut Self {
     self.wasm_loading = Some(loading);
+    self
+  }
+
+  /// Fall back to non-streaming WebAssembly loading when the server uses an incorrect MIME type.
+  ///
+  /// Default set to `true`.
+  pub fn wasm_streaming_fallback(&mut self, enabled: bool) -> &mut Self {
+    self.wasm_streaming_fallback = Some(enabled);
     self
   }
 
@@ -3136,6 +3148,7 @@ impl OutputOptionsBuilder {
       asset_module_filename,
       public_path,
       wasm_loading,
+      wasm_streaming_fallback: self.wasm_streaming_fallback.take().unwrap_or(true),
       webassembly_module_filename,
       unique_name,
       chunk_loading,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -22,6 +22,7 @@ CompilerOptions {
         wasm_loading: Enable(
             Fetch,
         ),
+        wasm_streaming_fallback: true,
         webassembly_module_filename: Filename(
             Template(
                 "[hash].module.wasm",

--- a/crates/rspack_binding_api/src/raw_options/raw_output.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_output.rs
@@ -100,6 +100,7 @@ pub struct RawOutputOptions {
   pub asset_module_filename: JsFilename,
   #[napi(ts_type = "string | false")]
   pub wasm_loading: RawWasmLoading,
+  pub wasm_streaming_fallback: bool,
   pub enabled_wasm_loading_types: Vec<String>,
   pub webassembly_module_filename: String,
   pub filename: JsFilename,
@@ -185,6 +186,7 @@ impl TryFrom<RawOutputOptions> for OutputOptions {
       public_path: value.public_path.into(),
       asset_module_filename: value.asset_module_filename.into(),
       wasm_loading: value.wasm_loading.into(),
+      wasm_streaming_fallback: value.wasm_streaming_fallback,
       webassembly_module_filename: value.webassembly_module_filename.into(),
       unique_name: value.unique_name,
       chunk_loading: value.chunk_loading.into(),

--- a/crates/rspack_core/src/options/output.rs
+++ b/crates/rspack_core/src/options/output.rs
@@ -35,6 +35,7 @@ pub struct OutputOptions {
   pub public_path: PublicPath,
   pub asset_module_filename: Filename,
   pub wasm_loading: WasmLoading,
+  pub wasm_streaming_fallback: bool,
   pub webassembly_module_filename: Filename,
   pub unique_name: String,
   pub chunk_loading: ChunkLoading,

--- a/crates/rspack_plugin_wasm/src/runtime.rs
+++ b/crates/rspack_plugin_wasm/src/runtime.rs
@@ -122,6 +122,7 @@ impl RuntimeModule for AsyncWasmCompileRuntimeModule {
         .cow_replace("$PATH", "wasmModuleFilename"),
       &self.generate_before_compile_streaming,
       self.supports_streaming,
+      compilation.options.output.wasm_streaming_fallback,
       runtime_template,
     ))
   }
@@ -168,6 +169,7 @@ impl RuntimeModule for AsyncWasmLoadingRuntimeModule {
         .cow_replace("$PATH", "wasmModuleFilename"),
       &self.generate_before_instantiate_streaming,
       self.supports_streaming,
+      compilation.options.output.wasm_streaming_fallback,
       runtime_template,
     ))
   }
@@ -182,6 +184,7 @@ fn get_async_wasm_loading(
   generate_before_load_binary_code: &str,
   generate_before_instantiate_streaming: &str,
   supports_streaming: bool,
+  streaming_fallback: bool,
   runtime_template: &RuntimeCodeTemplate,
 ) -> String {
   let fallback_code = r#"
@@ -190,21 +193,28 @@ fn get_async_wasm_loading(
           .then(function(res) { return Object.assign(exports, res.instance.exports);});
 "#;
 
+  let streaming_instantiation = if streaming_fallback {
+    r#"return WebAssembly.instantiateStreaming(res, importsObj)
+            .then(
+              function(res) { return Object.assign(exports, res.instance.exports);},
+              function(e) {
+                if(res.headers.get("Content-Type") !== "application/wasm") {
+                  console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
+                  return fallback();
+                }
+                throw e;
+              }
+            );"#
+  } else {
+    r#"return WebAssembly.instantiateStreaming(res, importsObj)
+            .then(function(res) { return Object.assign(exports, res.instance.exports);});"#
+  };
+
   let streaming_code = format!(
     r#"
       return req.then(function(res) {{
         if (typeof WebAssembly.instantiateStreaming === "function") {{
-{generate_before_instantiate_streaming}          return WebAssembly.instantiateStreaming(res, importsObj)
-            .then(
-              function(res) {{ return Object.assign(exports, res.instance.exports);}},
-              function(e) {{
-                if(res.headers.get("Content-Type") !== "application/wasm") {{
-                  console.warn("`WebAssembly.instantiateStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.instantiate` which is slower. Original error:\n", e);
-                  return fallback();
-                }}
-                throw e;
-              }}
-            );
+{generate_before_instantiate_streaming}          {streaming_instantiation}
         }}
         return fallback();
       }});
@@ -243,6 +253,7 @@ fn get_async_wasm_compile(
   generate_before_load_binary_code: &str,
   generate_before_compile_streaming: &str,
   supports_streaming: bool,
+  streaming_fallback: bool,
   runtime_template: &RuntimeCodeTemplate,
 ) -> String {
   let fallback_code = format!(
@@ -254,18 +265,24 @@ fn get_async_wasm_compile(
     runtime_template.basic_function("bytes", "return WebAssembly.compile(bytes);")
   );
 
+  let streaming_compilation = if streaming_fallback {
+    r#"return WebAssembly.compileStreaming(res)
+            .catch(function(e) {
+              if(res.headers.get("Content-Type") !== "application/wasm") {
+                console.warn("`WebAssembly.compileStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.compile` which is slower. Original error:\n", e);
+                return fallback();
+              }
+              throw e;
+            });"#
+  } else {
+    "return WebAssembly.compileStreaming(res);"
+  };
+
   let streaming_code = format!(
     r#"
       return req.then(function(res) {{
         if (typeof WebAssembly.compileStreaming === "function") {{
-{generate_before_compile_streaming}          return WebAssembly.compileStreaming(res)
-            .catch(function(e) {{
-              if(res.headers.get("Content-Type") !== "application/wasm") {{
-                console.warn("`WebAssembly.compileStreaming` failed because your server does not serve wasm with `application/wasm` MIME type. Falling back to `WebAssembly.compile` which is slower. Original error:\n", e);
-                return fallback();
-              }}
-              throw e;
-            }});
+{generate_before_compile_streaming}          {streaming_compilation}
         }}
         return fallback();
       }});

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -863,6 +863,7 @@ const applyOutputDefaults = (
   F(output, 'chunkLoadingGlobal', () => `rspackChunk${uniqueNameId}`);
   D(output, 'assetModuleFilename', '[hash][ext][query]');
   D(output, 'webassemblyModuleFilename', '[hash].module.wasm');
+  D(output, 'wasmStreamingFallback', true);
   D(output, 'compareBeforeEmit', true);
   if (output.path && !path.isAbsolute(output.path)) {
     if (!context) {

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -85,6 +85,7 @@ import type {
   TrustedTypes,
   UniqueName,
   WasmLoading,
+  WasmStreamingFallback,
   Watch,
   WatchOptions,
   WebassemblyModuleFilename,
@@ -178,6 +179,7 @@ export const getNormalizedRspackOptions = (
         hotUpdateGlobal: output.hotUpdateGlobal,
         assetModuleFilename: output.assetModuleFilename,
         wasmLoading: output.wasmLoading,
+        wasmStreamingFallback: output.wasmStreamingFallback,
         enabledChunkLoadingTypes: output.enabledChunkLoadingTypes
           ? [...output.enabledChunkLoadingTypes]
           : ['...'],
@@ -599,6 +601,7 @@ export interface OutputNormalized {
   importMetaName?: ImportMetaName;
   iife?: Iife;
   wasmLoading?: WasmLoading;
+  wasmStreamingFallback?: WasmStreamingFallback;
   enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;
   webassemblyModuleFilename?: WebassemblyModuleFilename;
   chunkFormat?: string | false;

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -74,6 +74,9 @@ export type WasmLoadingType = 'fetch' | 'async-node' | 'universal';
 /** Option to set the method of loading WebAssembly Modules. */
 export type WasmLoading = false | WasmLoadingType;
 
+/** Whether to fall back to non-streaming WebAssembly loading when streaming fails due to an incorrect MIME type. */
+export type WasmStreamingFallback = boolean;
+
 export type ScriptType = false | 'text/javascript' | 'module';
 
 export type LibraryCustomUmdObject = {
@@ -578,6 +581,13 @@ export type Output = {
    * @default 'fetch'
    * */
   wasmLoading?: WasmLoading;
+
+  /**
+   * Fall back to non-streaming WebAssembly instantiation or compilation when the server
+   * does not serve WebAssembly with the `application/wasm` MIME type.
+   * @default true
+   */
+  wasmStreamingFallback?: WasmStreamingFallback;
 
   /** List of wasm loading types enabled for use by entry points. */
   enabledWasmLoadingTypes?: EnabledWasmLoadingTypes;

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/index.js
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/index.js
@@ -1,0 +1,9 @@
+it("should fall back when the wasm MIME type is wrong", function() {
+	return import("./module").then(module => {
+		expect(module.run()).toEqual(42);
+		expect(window.__wasmStreamingFallbackWarnings).toHaveLength(1);
+		expect(window.__wasmStreamingFallbackWarnings[0][0]).toContain(
+			"application/wasm"
+		);
+	});
+});

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/module.js
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/module.js
@@ -1,0 +1,5 @@
+import { getNumber } from "./wasm.wat";
+
+export function run() {
+	return getNumber();
+}

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/rspack.config.js
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/rspack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  module: {
+    rules: [
+      {
+        test: /\.wat$/,
+        loader: 'wast-loader',
+        type: 'webassembly/async',
+      },
+    ],
+  },
+  output: {
+    chunkFilename: 'chunks/[name].async.js',
+    webassemblyModuleFilename: '[id].[hash].async.wasm',
+  },
+  experiments: {
+    asyncWebAssembly: true,
+  },
+};

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/test.config.js
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/test.config.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const url = require("url");
+
+module.exports = {
+	findBundle(_, options) {
+		const chunks = fs
+			.readdirSync(path.join(options.output.path, "chunks"))
+			.map(file => `./chunks/${file}`);
+		return [...chunks, "./bundle0.js"];
+	},
+	moduleScope(scope, _, options) {
+		const warnings = (scope.window.__wasmStreamingFallbackWarnings ??= []);
+		const sandboxConsole = Object.create(console);
+		sandboxConsole.warn = (...args) => warnings.push(args);
+		scope.window.console = sandboxConsole;
+		scope.fetch = resource =>
+			new Promise((resolve, reject) => {
+				const file = /^file:/i.test(resource)
+					? url.fileURLToPath(resource)
+					: path.join(options.output.path, path.basename(resource));
+
+				fs.readFile(file, (err, data) => {
+					if (err) {
+						reject(err);
+						return;
+					}
+
+					resolve(
+						new Response(data, {
+							headers: { "Content-Type": "application/octet-stream" }
+						})
+					);
+				});
+			});
+	}
+};

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/test.filter.js
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/test.filter.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = () =>
+	typeof WebAssembly !== "undefined" &&
+	typeof Response !== "undefined" &&
+	typeof WebAssembly.instantiateStreaming === "function";

--- a/tests/rspack-test/configCases/wasm/streaming-fallback/wasm.wat
+++ b/tests/rspack-test/configCases/wasm/streaming-fallback/wasm.wat
@@ -1,0 +1,4 @@
+(module
+  (type $t0 (func (result i32)))
+  (func $getNumber (export "getNumber") (type $t0) (result i32)
+    (i32.const 42)))

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -469,6 +469,7 @@ module.exports = {
 			    trustedTypes: undefined,
 			    uniqueName: @rspack/tests,
 			    wasmLoading: fetch,
+			    wasmStreamingFallback: true,
 			    webassemblyModuleFilename: [hash].module.wasm,
 			    workerChunkLoading: import-scripts,
 			    workerPublicPath: ,

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1821,6 +1821,23 @@ export default {
 };
 ```
 
+## output.wasmStreamingFallback
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls whether the generated WebAssembly loading runtime falls back to a non-streaming API when `WebAssembly.compileStreaming` or `WebAssembly.instantiateStreaming` rejects because the response does not use the `application/wasm` MIME type.
+
+Set this option to `false` to omit the fallback runtime code when your server always serves WebAssembly files with the correct MIME type.
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    wasmStreamingFallback: false,
+  },
+};
+```
+
 ## output.webassemblyModuleFilename
 
 - **Type:** `string`

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1812,6 +1812,23 @@ export default {
 };
 ```
 
+## output.wasmStreamingFallback
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+控制生成的 WebAssembly 加载运行时代码是否在 `WebAssembly.compileStreaming` 或 `WebAssembly.instantiateStreaming` 因响应未使用 `application/wasm` MIME 类型而失败时，回退到非流式 API。
+
+如果服务器始终以正确的 MIME 类型提供 WebAssembly 文件，可以将此选项设置为 `false`，从而省略相关的回退运行时代码。
+
+```js title="rspack.config.mjs"
+export default {
+  output: {
+    wasmStreamingFallback: false,
+  },
+};
+```
+
 ## output.webassemblyModuleFilename
 
 - **类型：** `string`


### PR DESCRIPTION
## Summary

webpack added `output.wasmStreamingFallback` in webpack/webpack#21299. This PR adds the corresponding option to Rspack for compatibility while preserving the existing fallback behavior by default.

> [!NOTE]
> This is my first contribution to Rspack. I've spent quite some time reading and learning the codebase, and I've tried to keep the changes small and reviewable. 
Much of the diff comes from tests, generated binding declarations, and snapshots. I'd really appreciate any feedback.

<!-- Describe what this PR does and why. -->

## Related links

- Part of #14556

- Based on #5491

- Webpack reference: webpack/webpack#21299

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

<img width="1494" height="906" alt="image" src="https://github.com/user-attachments/assets/9cdccfd5-d4b2-443d-a3f7-04b7c0fa4489" />
