### PR TITLE
fix: inherit sideEffects through nested package metadata

### DIFF
--- a/crates/rspack_core/src/resolver/factory.rs
+++ b/crates/rspack_core/src/resolver/factory.rs
@@ -29,6 +29,10 @@ impl ResolverFactory {
     self.resolver.clear_cache();
   }
 
+  pub fn inner_fs(&self) -> Arc<dyn ReadableFileSystem> {
+    self.resolver.inner_fs()
+  }
+
   pub fn new(options: Resolve, fs: Arc<dyn ReadableFileSystem>) -> Self {
     Self {
       base_options: options.clone(),

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug, path::PathBuf, sync::RwLock};
 
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
@@ -16,7 +16,8 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
-use rspack_paths::{AssertUtf8, Utf8Path};
+use rspack_paths::{AssertUtf8, Utf8Path, Utf8PathBuf};
+use rustc_hash::FxHashMap;
 use sugar_path::SugarPath;
 use swc_experimental_ecma_ast::{ClassMember, Key, PropName};
 
@@ -33,6 +34,12 @@ enum SideEffects {
   Bool(bool),
   String(String),
   Array(Vec<String>),
+}
+
+#[derive(Clone, Debug)]
+struct OwningSideEffects {
+  side_effects: SideEffects,
+  package_root: Utf8PathBuf,
 }
 
 impl SideEffects {
@@ -119,18 +126,74 @@ impl<'a> ClassExt<'a> for ClassMember<'a> {
 #[derive(Debug, Default)]
 pub struct SideEffectsFlagPlugin {
   analyze_side_effects_free: bool,
+  owning_side_effects_cache: RwLock<FxHashMap<PathBuf, Option<OwningSideEffects>>>,
 }
 
 impl SideEffectsFlagPlugin {
   pub fn new(analyze_side_effects_free: bool) -> Self {
-    Self::new_inner(analyze_side_effects_free)
+    Self::new_inner(analyze_side_effects_free, Default::default())
+  }
+
+  async fn get_owning_side_effects(
+    &self,
+    data: &mut ModuleFactoryCreateData,
+    description_root: &Utf8Path,
+  ) -> Option<OwningSideEffects> {
+    if let Some(cached) = self
+      .owning_side_effects_cache
+      .read()
+      .expect("sideEffects cache lock should not be poisoned")
+      .get(description_root.as_std_path())
+      .cloned()
+    {
+      return cached;
+    }
+
+    let fs = data.resolver_factory.inner_fs();
+    let mut dir = description_root.parent();
+    let mut result = None;
+
+    while let Some(current) = dir {
+      if current.file_name() == Some("node_modules") {
+        break;
+      }
+
+      let description_file = current.join("package.json");
+      match fs.read(&description_file).await {
+        Ok(content) => {
+          data.add_file_dependencies([description_file.as_std_path()]);
+          if let Ok(description) = serde_json::from_slice::<serde_json::Value>(&content) {
+            if let Some(side_effects) = SideEffects::from_description(&description) {
+              result = Some(OwningSideEffects {
+                side_effects,
+                package_root: current.to_path_buf(),
+              });
+              break;
+            }
+            if description.get("name").is_some() {
+              break;
+            }
+          }
+        }
+        Err(_) => data.add_missing_dependencies([description_file.as_std_path()]),
+      }
+
+      dir = current.parent();
+    }
+
+    self
+      .owning_side_effects_cache
+      .write()
+      .expect("sideEffects cache lock should not be poisoned")
+      .insert(description_root.as_std_path().to_path_buf(), result.clone());
+    result
   }
 }
 
 #[plugin_hook(NormalModuleFactoryModule for SideEffectsFlagPlugin,tracing=false)]
 async fn nmf_module(
   &self,
-  _data: &mut ModuleFactoryCreateData,
+  data: &mut ModuleFactoryCreateData,
   create_data: &NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
@@ -149,12 +212,33 @@ async fn nmf_module(
     return Ok(());
   };
   let package_path = description.path();
-  let Some(side_effects) = SideEffects::from_description(description.json()) else {
-    return Ok(());
-  };
+  let (side_effects, package_path) =
+    if let Some(side_effects) = SideEffects::from_description(description.json()) {
+      (side_effects, package_path.assert_utf8().to_path_buf())
+    } else {
+      // A named package owns its metadata boundary even when it omits sideEffects.
+      if description.json().get("name").is_some() {
+        return Ok(());
+      }
+
+      let description_root = package_path.assert_utf8();
+      // Type-only nested package.json files shadow application metadata, but inside
+      // node_modules they should inherit sideEffects from the owning package root.
+      if !description_root
+        .components()
+        .any(|component| component.as_str() == "node_modules")
+      {
+        return Ok(());
+      }
+
+      let Some(owning) = self.get_owning_side_effects(data, description_root).await else {
+        return Ok(());
+      };
+      (owning.side_effects, owning.package_root)
+    };
   let relative_path = resource_path
     .as_std_path()
-    .relative(package_path)
+    .relative(package_path.as_std_path())
     .assert_utf8();
   let has_side_effects = get_side_effects_from_package_json(side_effects, relative_path.as_path());
 

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/index.js
@@ -1,0 +1,33 @@
+import { light as inheritedFalse } from "inherited-false";
+import { light as inheritedGlob } from "inherited-glob";
+import { light as explicitTrue } from "explicit-true";
+import { light as namedBoundary } from "named-boundary";
+import { light as anonymousBoundary } from "anonymous-boundary";
+import { light as localNested } from "./local-nested/esm/index.js";
+
+it("inherits sideEffects from the owning package past a type-only package.json", () => {
+  expect(inheritedFalse).toBe("inherited-false");
+  expect(globalThis.__nestedSideEffectsMarkers).not.toContain("inherited-false");
+});
+
+it("matches inherited sideEffects globs relative to the owning package root", () => {
+  expect(inheritedGlob).toBe("inherited-glob");
+  expect(globalThis.__nestedSideEffectsMarkers).not.toContain("inherited-glob");
+});
+
+it("honors an explicit sideEffects value on the nested package.json", () => {
+  expect(explicitTrue).toBe("explicit-true");
+  expect(globalThis.__nestedSideEffectsMarkers).toContain("explicit-true");
+});
+
+it("stops inheritance at named package and node_modules boundaries", () => {
+  expect(namedBoundary).toBe("named-boundary");
+  expect(anonymousBoundary).toBe("anonymous-boundary");
+  expect(globalThis.__nestedSideEffectsMarkers).toContain("named-boundary");
+  expect(globalThis.__nestedSideEffectsMarkers).toContain("anonymous-boundary");
+});
+
+it("keeps app-local nested package.json shadowing behavior", () => {
+  expect(localNested).toBe("local-nested");
+  expect(globalThis.__nestedSideEffectsMarkers).toContain("local-nested");
+});

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("local-nested");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "local-nested";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/local-nested/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("anonymous-boundary");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "anonymous-boundary";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/anonymous-boundary/package.json
@@ -1,0 +1,1 @@
+{"exports":"./esm/index.js"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("explicit-true");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "explicit-true";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module","sideEffects":true}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/explicit-true/package.json
@@ -1,0 +1,1 @@
+{"name":"explicit-true","sideEffects":false,"exports":"./esm/index.js"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("inherited-false");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "inherited-false";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-false/package.json
@@ -1,0 +1,1 @@
+{"name":"inherited-false","sideEffects":false,"exports":"./esm/index.js"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("inherited-glob");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "inherited-glob";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/inherited-glob/package.json
@@ -1,0 +1,1 @@
+{"name":"inherited-glob","sideEffects":["./index.js"],"exports":"./esm/index.js"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/heavy.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/heavy.js
@@ -1,0 +1,2 @@
+globalThis.__nestedSideEffectsMarkers ||= [];
+globalThis.__nestedSideEffectsMarkers.push("named-boundary");

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/index.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/index.js
@@ -1,0 +1,2 @@
+import "./heavy.js";
+export const light = "named-boundary";

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/esm/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/node_modules/named-boundary/package.json
@@ -1,0 +1,1 @@
+{"name":"named-boundary","exports":"./esm/index.js"}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/package.json
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "nested-package-json-side-effects-fixture",
+  "sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/nested-package-json-side-effects/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    minimize: false,
+    sideEffects: true,
+    usedExports: true,
+  },
+};


### PR DESCRIPTION
## Summary

- Inherit `sideEffects` from the owning package when a type-only nested `package.json` under `node_modules` omits it.
- Preserve named-package, install, and application-local metadata boundaries, and evaluate inherited globs relative to the owning package root.
- Add config cases for boolean and glob inheritance plus explicit and boundary behavior.

## Related links

- Upstream reference: https://github.com/webpack/webpack/pull/21686

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).