### PR TITLE
feat(cache): add intrastructure logging to the new cache

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -334,7 +334,7 @@ export declare class JsCompilation {
 }
 
 export declare class JsCompiler {
-  constructor(compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform)
+  constructor(compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void)
   setNonSkippableRegisters(kinds: Array<RegisterJsTapKind>): void
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void
@@ -440,7 +440,7 @@ export declare class JsResolverFactory {
 
 export declare class JsStats {
   toJson(jsOptions: JsStatsOptions): JsStatsCompilation
-  getLogging(acceptedTypes: number): Array<JsStatsLogging>
+  getLogging(acceptedTypes: number): Array<JsLog>
 }
 
 export declare class KnownBuildInfo {
@@ -1008,6 +1008,13 @@ export declare enum JsLoaderState {
   Normal = 'Normal'
 }
 
+export interface JsLog {
+  name: string
+  type: string
+  args: Array<string | number>
+  trace?: Array<string>
+}
+
 export interface JsModuleDescriptor {
   identifier: string
   name: string
@@ -1470,13 +1477,6 @@ export interface JsStatsError {
 export interface JsStatsGetAssets {
   assets: Array<JsStatsAsset>
   assetsByChunkName: Array<JsStatsAssetsByChunkName>
-}
-
-export interface JsStatsLogging {
-  name: string
-  type: string
-  args?: Array<string>
-  trace?: Array<string>
 }
 
 export interface JsStatsModule {

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -52,10 +52,10 @@ use rspack_core::{
   JsonParserOptions, LibraryName, LibraryNonUmdObject, LibraryOptions, LibraryType,
   MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions, ModuleRule, ModuleRuleEffect,
   ModuleType, NewCacheOptions, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption,
-  Optimization, OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo, PublicPath,
-  Resolve, RuleSetCondition, RuleSetLogicalConditions, SideEffectOption, StatsOptions,
-  TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType, incremental::IncrementalOptions,
-  runtime_mode::RuntimeMode,
+  Optimization, OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo,
+  PrintlnInfrastructureLogSink, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
+  SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType,
+  incremental::IncrementalOptions, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
@@ -469,7 +469,7 @@ impl CompilerBuilder {
       None,
       None,
       compiler_context,
-      None,
+      Arc::new(PrintlnInfrastructureLogSink),
       Arc::new(platform),
     ))
   }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -469,6 +469,7 @@ impl CompilerBuilder {
       None,
       None,
       compiler_context,
+      None,
       Arc::new(platform),
     ))
   }

--- a/crates/rspack_binding_api/Cargo.toml
+++ b/crates/rspack_binding_api/Cargo.toml
@@ -119,7 +119,7 @@ serde                                  = { workspace = true }
 serde_json                             = { workspace = true }
 simd-json                              = { workspace = true }
 swc_core                               = { workspace = true, default-features = false, features = ["ecma_transforms_react"] }
-tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "test-util", "tracing", "parking_lot"] }
+tokio                                  = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time", "test-util", "tracing", "parking_lot"] }
 ustr                                   = { workspace = true }
 
 [package.metadata.cargo-shear]

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -406,7 +406,7 @@ impl JsCompiler {
         Some(resolver_factory),
         Some(loader_resolver_factory),
         Some(compiler_context.clone()),
-        Some(infrastructure_log_sink),
+        infrastructure_log_sink,
         platform,
       );
 

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -75,6 +75,7 @@ mod fs_node;
 mod html;
 mod identifier;
 mod location;
+mod logging;
 mod module;
 mod module_graph;
 mod module_graph_connection;
@@ -126,10 +127,11 @@ use crate::{
   chunk_group::ChunkGroupWrapper,
   compilation::JsCompilationWrapper,
   compiler::{Compiler, CompilerState, CompilerStateGuard},
-  compiler_scoped_tsfn::CompilerScopedTsFnManager,
+  compiler_scoped_tsfn::{CompilerScopedTsFnHandle, CompilerScopedTsFnManager},
   dependency::DependencyWrapper,
   error::{ErrorCode, RspackResultToNapiResultExt},
   fs_node::{HybridFileSystem, NodeFileSystem, ThreadsafeNodeFS},
+  logging::{InfrastructureLogDispatcher, JsLog},
   module::ModuleObject,
   module_graph_connection::ModuleGraphConnectionWrapper,
   platform::RawCompilerPlatform,
@@ -226,6 +228,7 @@ fn cleanup_revoked_modules(ctx: CallContext) -> Result<()> {
 struct JsCompiler {
   // whether to skip drop compiler in finalize
   unsafe_fast_drop: bool,
+  infrastructure_log_dispatcher: Arc<InfrastructureLogDispatcher>,
   compiler_scoped_tsfn_manager: CompilerScopedTsFnManager,
   js_hooks_plugin: JsHooksAdapterPlugin,
   // call drop manually to avoid unnecessary drop overhead in cli build
@@ -242,7 +245,7 @@ impl JsCompiler {
   #[allow(clippy::too_many_arguments)]
   #[napi(
     constructor,
-    ts_args_type = "compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform"
+    ts_args_type = "compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void"
   )]
   pub fn new(
     env: Env,
@@ -257,6 +260,7 @@ impl JsCompiler {
     mut resolver_factory_reference: Reference<JsResolverFactory>,
     unsafe_fast_drop: bool,
     platform: RawCompilerPlatform,
+    raw_infrastructure_log_callback: Unknown<'static>,
   ) -> Result<Self> {
     tracing::info!(name:"rspack_version", version = rspack_workspace::rspack_pkg_version!());
 
@@ -271,6 +275,12 @@ impl JsCompiler {
     let register_js_taps: RegisterJsTaps = compiler_scoped_tsfn_manager.scope(|| unsafe {
       RegisterJsTaps::from_napi_value(env.raw(), raw_register_js_taps.raw())
     })?;
+    let infrastructure_log_callback: CompilerScopedTsFnHandle<Vec<JsLog>, ()> =
+      compiler_scoped_tsfn_manager.scope(|| unsafe {
+        CompilerScopedTsFnHandle::from_napi_value(env.raw(), raw_infrastructure_log_callback.raw())
+      })?;
+    let (infrastructure_log_sink, infrastructure_log_dispatcher) =
+      InfrastructureLogDispatcher::new(infrastructure_log_callback);
 
     let compiler_context = Arc::new(CompilerContext::new());
     CURRENT_COMPILER_CONTEXT.sync_scope(compiler_context.clone(), || {
@@ -396,10 +406,12 @@ impl JsCompiler {
         Some(resolver_factory),
         Some(loader_resolver_factory),
         Some(compiler_context.clone()),
+        Some(infrastructure_log_sink),
         platform,
       );
 
       Ok(Self {
+        infrastructure_log_dispatcher,
         compiler_scoped_tsfn_manager,
         compiler: ManuallyDrop::new(Compiler::from(rspack)),
         state: CompilerState::init(),
@@ -494,6 +506,7 @@ impl JsCompiler {
     // async operation. This allows us to safely extend the lifetime to 'static.
     let compiler =
       unsafe { std::mem::transmute::<&Compiler, &'static Compiler>(&reference.compiler) };
+    let infrastructure_log_dispatcher = self.infrastructure_log_dispatcher.clone();
 
     let wait_idle = self.state.wait_idle();
     let spawn_future_result = rspack_napi::runtime::promise_from_future(env, async move {
@@ -505,6 +518,7 @@ impl JsCompiler {
         .close()
         .await
         .to_napi_result_with_message(|e| print_error_diagnostic(e, compiler.options.stats.colors));
+      infrastructure_log_dispatcher.shutdown().await;
       result?;
       Ok(())
     });

--- a/crates/rspack_binding_api/src/logging.rs
+++ b/crates/rspack_binding_api/src/logging.rs
@@ -1,0 +1,278 @@
+use std::{
+  sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+  },
+  time::Duration,
+};
+
+use napi::Either;
+use napi_derive::napi;
+use rspack_core::{InfrastructureLogEvent, InfrastructureLogSink, LogType};
+use tokio::{
+  sync::{mpsc, oneshot},
+  time::sleep,
+};
+
+use crate::compiler_scoped_tsfn::CompilerScopedTsFnHandle;
+
+const INFRASTRUCTURE_LOG_BATCH_INTERVAL: Duration = Duration::from_millis(100);
+const INFRASTRUCTURE_LOG_BATCH_SIZE: usize = 8;
+const INFRASTRUCTURE_LOG_QUEUE_CAPACITY: usize = 32;
+
+type InfrastructureLogCallback = CompilerScopedTsFnHandle<Vec<JsLog>, ()>;
+type ShutdownRequest = Option<oneshot::Sender<()>>;
+
+#[napi(object, object_from_js = false)]
+pub struct JsLog {
+  pub name: String,
+  pub r#type: String,
+  pub args: Vec<Either<String, f64>>,
+  pub trace: Option<Vec<String>>,
+}
+
+impl From<(Arc<str>, LogType)> for JsLog {
+  fn from((name, log_type): (Arc<str>, LogType)) -> Self {
+    let name = name.to_string();
+    let (r#type, args, trace) = match log_type {
+      LogType::Error { message, trace } => ("error", vec![Either::A(message)], Some(trace)),
+      LogType::Warn { message, trace } => ("warn", vec![Either::A(message)], Some(trace)),
+      LogType::Info { message } => ("info", vec![Either::A(message)], None),
+      LogType::Log { message } => ("log", vec![Either::A(message)], None),
+      LogType::Debug { message } => ("debug", vec![Either::A(message)], None),
+      LogType::Trace { message, trace } => ("trace", vec![Either::A(message)], Some(trace)),
+      LogType::Group { message } => ("group", vec![Either::A(message)], None),
+      LogType::GroupCollapsed { message } => ("groupCollapsed", vec![Either::A(message)], None),
+      LogType::GroupEnd => ("groupEnd", vec![], None),
+      LogType::Profile { label } => ("profile", vec![Either::A(label.to_string())], None),
+      LogType::ProfileEnd { label } => ("profileEnd", vec![Either::A(label.to_string())], None),
+      LogType::Time {
+        label,
+        secs,
+        subsec_nanos,
+      } => (
+        "time",
+        vec![
+          Either::A(label.to_string()),
+          Either::B(secs as f64),
+          Either::B(subsec_nanos as f64),
+        ],
+        None,
+      ),
+      LogType::Clear => ("clear", vec![], None),
+      LogType::Status { message } => ("status", vec![Either::A(message)], None),
+      LogType::Cache { label, hit, total } => (
+        "cache",
+        vec![Either::A(format!(
+          "{label}: {:.1}% ({hit}/{total})",
+          if total == 0 {
+            0.0
+          } else {
+            hit as f32 / total as f32 * 100.0
+          }
+        ))],
+        None,
+      ),
+    };
+    Self {
+      name,
+      r#type: r#type.to_string(),
+      args,
+      trace,
+    }
+  }
+}
+
+impl From<InfrastructureLogEvent> for JsLog {
+  fn from(event: InfrastructureLogEvent) -> Self {
+    let mut log = Self::from((event.name, event.log_type));
+    log.trace = None;
+    log
+  }
+}
+
+struct BatchedInfrastructureLogSink {
+  sender: mpsc::Sender<InfrastructureLogEvent>,
+  closed: Arc<AtomicBool>,
+  dropped: Arc<AtomicUsize>,
+}
+
+impl InfrastructureLogSink for BatchedInfrastructureLogSink {
+  fn emit(&self, event: InfrastructureLogEvent) {
+    if self.closed.load(Ordering::Acquire) {
+      return;
+    }
+    match self.sender.try_send(event) {
+      Ok(()) => {}
+      Err(mpsc::error::TrySendError::Full(event)) => {
+        self.dropped.fetch_add(1, Ordering::Relaxed);
+        log_critical_fallback(event);
+      }
+      Err(mpsc::error::TrySendError::Closed(event)) => {
+        log_critical_fallback(event);
+      }
+    }
+  }
+}
+
+fn log_critical_fallback(event: InfrastructureLogEvent) {
+  match event.log_type {
+    LogType::Error { message, .. } => {
+      tracing::error!(name = %event.name, "Infrastructure logging queue is unavailable: {message}")
+    }
+    LogType::Warn { message, .. } => {
+      tracing::warn!(name = %event.name, "Infrastructure logging queue is unavailable: {message}")
+    }
+    _ => {}
+  }
+}
+
+pub struct InfrastructureLogDispatcher {
+  shutdown_sender: mpsc::UnboundedSender<ShutdownRequest>,
+  closed: Arc<AtomicBool>,
+}
+
+impl InfrastructureLogDispatcher {
+  pub fn new(callback: InfrastructureLogCallback) -> (Arc<dyn InfrastructureLogSink>, Arc<Self>) {
+    let (sender, receiver) = mpsc::channel(INFRASTRUCTURE_LOG_QUEUE_CAPACITY);
+    let (shutdown_sender, shutdown_receiver) = mpsc::unbounded_channel();
+    let closed = Arc::new(AtomicBool::new(false));
+    let dropped = Arc::new(AtomicUsize::new(0));
+    let sink = Arc::new(BatchedInfrastructureLogSink {
+      sender,
+      closed: closed.clone(),
+      dropped: dropped.clone(),
+    });
+    rspack_napi::runtime::spawn(run_dispatcher(
+      receiver,
+      shutdown_receiver,
+      callback,
+      dropped,
+    ));
+    (
+      sink,
+      Arc::new(Self {
+        shutdown_sender,
+        closed,
+      }),
+    )
+  }
+
+  pub async fn shutdown(&self) {
+    if self.closed.swap(true, Ordering::AcqRel) {
+      return;
+    }
+    let (sender, receiver) = oneshot::channel();
+    if self.shutdown_sender.send(Some(sender)).is_ok() {
+      let _ = receiver.await;
+    }
+  }
+}
+
+impl Drop for InfrastructureLogDispatcher {
+  fn drop(&mut self) {
+    if !self.closed.swap(true, Ordering::AcqRel) {
+      let _ = self.shutdown_sender.send(None);
+    }
+  }
+}
+
+async fn run_dispatcher(
+  mut receiver: mpsc::Receiver<InfrastructureLogEvent>,
+  mut shutdown_receiver: mpsc::UnboundedReceiver<ShutdownRequest>,
+  callback: InfrastructureLogCallback,
+  dropped: Arc<AtomicUsize>,
+) {
+  loop {
+    let first = tokio::select! {
+      biased;
+      shutdown = shutdown_receiver.recv() => {
+        flush_and_shutdown(&mut receiver, &callback, &dropped, shutdown.flatten()).await;
+        return;
+      }
+      event = receiver.recv() => {
+        let Some(event) = event else {
+          return;
+        };
+        event
+      }
+    };
+
+    let mut batch = Vec::with_capacity(INFRASTRUCTURE_LOG_BATCH_SIZE);
+    batch.push(first);
+    let delay = sleep(INFRASTRUCTURE_LOG_BATCH_INTERVAL);
+    tokio::pin!(delay);
+    let mut shutdown = None;
+
+    while batch.len() < INFRASTRUCTURE_LOG_BATCH_SIZE {
+      tokio::select! {
+        biased;
+        request = shutdown_receiver.recv() => {
+          shutdown = Some(request.flatten());
+          break;
+        }
+        event = receiver.recv() => {
+          let Some(event) = event else {
+            break;
+          };
+          batch.push(event);
+        }
+        _ = &mut delay => break,
+      }
+    }
+
+    dispatch_batch(&callback, &dropped, batch).await;
+    if let Some(shutdown) = shutdown {
+      flush_and_shutdown(&mut receiver, &callback, &dropped, shutdown).await;
+      return;
+    }
+  }
+}
+
+async fn flush_and_shutdown(
+  receiver: &mut mpsc::Receiver<InfrastructureLogEvent>,
+  callback: &InfrastructureLogCallback,
+  dropped: &AtomicUsize,
+  shutdown: ShutdownRequest,
+) {
+  // Prevent a producer that raced with `closed` from enqueueing after the final drain.
+  receiver.close();
+  let mut batch = Vec::with_capacity(INFRASTRUCTURE_LOG_BATCH_SIZE);
+  while let Some(event) = receiver.recv().await {
+    batch.push(event);
+    if batch.len() == INFRASTRUCTURE_LOG_BATCH_SIZE {
+      dispatch_batch(callback, dropped, std::mem::take(&mut batch)).await;
+    }
+  }
+  dispatch_batch(callback, dropped, batch).await;
+  if let Some(shutdown) = shutdown {
+    let _ = shutdown.send(());
+  }
+}
+
+async fn dispatch_batch(
+  callback: &InfrastructureLogCallback,
+  dropped: &AtomicUsize,
+  mut batch: Vec<InfrastructureLogEvent>,
+) {
+  let dropped = dropped.swap(0, Ordering::Relaxed);
+  if dropped != 0 {
+    batch.insert(
+      0,
+      InfrastructureLogEvent {
+        name: Arc::from("rspack.infrastructure"),
+        log_type: LogType::Warn {
+          message: format!("Dropped {dropped} infrastructure log messages"),
+          trace: vec![],
+        },
+      },
+    );
+  }
+  if batch.is_empty() {
+    return;
+  }
+  let logs = batch.into_iter().map(Into::into).collect::<Vec<_>>();
+  if let Err(error) = callback.call_with_sync(logs).await {
+    tracing::warn!("Sending infrastructure logs to JavaScript failed: {error}");
+  }
+}

--- a/crates/rspack_binding_api/src/stats.rs
+++ b/crates/rspack_binding_api/src/stats.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, cell::RefCell};
+use std::{borrow::Cow, cell::RefCell, sync::Arc};
 
 use napi::{
   Env,
@@ -251,71 +251,72 @@ pub struct JsStatsLogging<'a> {
   pub trace: Option<Vec<String>>,
 }
 
-impl<'a> From<(String, rspack_core::LogType)> for JsStatsLogging<'a> {
-  fn from(value: (String, rspack_core::LogType)) -> Self {
+impl<'a> From<(Arc<str>, rspack_core::LogType)> for JsStatsLogging<'a> {
+  fn from(value: (Arc<str>, rspack_core::LogType)) -> Self {
+    let name = value.0.to_string();
     match value.1 {
       rspack_core::LogType::Error { message, trace } => Self {
-        name: value.0,
+        name,
         r#type: "error",
         args: Some(vec![message]),
         trace: Some(trace),
       },
       rspack_core::LogType::Warn { message, trace } => Self {
-        name: value.0,
+        name,
         r#type: "warn",
         args: Some(vec![message]),
         trace: Some(trace),
       },
       rspack_core::LogType::Info { message } => Self {
-        name: value.0,
+        name,
         r#type: "info",
         args: Some(vec![message]),
         trace: None,
       },
       rspack_core::LogType::Log { message } => Self {
-        name: value.0,
+        name,
         r#type: "log",
         args: Some(vec![message]),
         trace: None,
       },
       rspack_core::LogType::Debug { message } => Self {
-        name: value.0,
+        name,
         r#type: "debug",
         args: Some(vec![message]),
         trace: None,
       },
       rspack_core::LogType::Trace { message, trace } => Self {
-        name: value.0,
+        name,
         r#type: "trace",
         args: Some(vec![message]),
         trace: Some(trace),
       },
       rspack_core::LogType::Group { message } => Self {
-        name: value.0,
+        name,
         r#type: "group",
         args: Some(vec![message]),
         trace: None,
       },
       rspack_core::LogType::GroupCollapsed { message } => Self {
-        name: value.0,
+        name,
         r#type: "groupCollapsed",
         args: Some(vec![message]),
         trace: None,
       },
       rspack_core::LogType::GroupEnd => Self {
-        name: value.0,
+        name,
         r#type: "groupEnd",
         args: None,
         trace: None,
       },
       rspack_core::LogType::Profile { label } => Self {
-        name: value.0,
+        name,
         r#type: "profile",
         args: Some(vec![label.to_string()]),
         trace: None,
       },
       rspack_core::LogType::ProfileEnd { label } => Self {
-        name: value.0,
+        name,
         r#type: "profileEnd",
         args: Some(vec![label.to_string()]),
         trace: None,
@@ -329,20 +330,20 @@ impl<'a> From<(String, rspack_core::LogType)> for JsStatsLogging<'a> {
         let mut time_buffer = ryu_js::Buffer::new();
         let time_str = time_buffer.format(ms);
         Self {
-          name: value.0,
+          name,
           r#type: "time",
           args: Some(vec![format!("{}: {} ms", label, time_str)]),
           trace: None,
         }
       }
       rspack_core::LogType::Clear => Self {
-        name: value.0,
+        name,
         r#type: "clear",
         args: None,
         trace: None,
       },
       rspack_core::LogType::Status { message } => Self {
-        name: value.0,
+        name,
         r#type: "status",
         args: Some(vec![message]),
         trace: None,
@@ -353,7 +354,7 @@ impl<'a> From<(String, rspack_core::LogType)> for JsStatsLogging<'a> {
         let mut total_buffer = itoa::Buffer::new();
         let total_str = total_buffer.format(total);
         Self {
-          name: value.0,
+          name,
           r#type: "cache",
           args: Some(vec![format!(
             "{}: {:.1}% ({}/{})",
@@ -1276,7 +1277,6 @@ impl JsStats {
     self
       .inner
       .get_logging()
-      .into_iter()
       .filter(|log| {
         let bit = log.1.to_bit_flag();
         accepted_types & bit == bit

--- a/crates/rspack_binding_api/src/stats.rs
+++ b/crates/rspack_binding_api/src/stats.rs
@@ -16,7 +16,7 @@ use rspack_napi::napi::{
   Either,
   bindgen_prelude::{Buffer, Result, SharedReference, ToNapiValue},
 };
-use rspack_util::{atom::Atom, itoa, numeric_id_value, ryu_js};
+use rspack_util::{atom::Atom, numeric_id_value};
 use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
@@ -24,6 +24,7 @@ use crate::{
   compilation::JsCompilation,
   error::{RspackError, RspackResultToNapiResultExt},
   identifier::JsIdentifier,
+  logging::JsLog,
 };
 
 // These handles are only used during the `to_json` call,
@@ -240,137 +241,6 @@ pub struct JsStatsModuleTraceDependency {
 impl From<rspack_core::StatsErrorModuleTraceDependency> for JsStatsModuleTraceDependency {
   fn from(stats: rspack_core::StatsErrorModuleTraceDependency) -> Self {
     Self { loc: stats.loc }
-  }
-}
-
-#[napi(object, object_from_js = false)]
-pub struct JsStatsLogging<'a> {
-  pub name: String,
-  pub r#type: &'a str,
-  pub args: Option<Vec<String>>,
-  pub trace: Option<Vec<String>>,
-}
-
-impl<'a> From<(Arc<str>, rspack_core::LogType)> for JsStatsLogging<'a> {
-  fn from(value: (Arc<str>, rspack_core::LogType)) -> Self {
-    let name = value.0.to_string();
-    match value.1 {
-      rspack_core::LogType::Error { message, trace } => Self {
-        name,
-        r#type: "error",
-        args: Some(vec![message]),
-        trace: Some(trace),
-      },
-      rspack_core::LogType::Warn { message, trace } => Self {
-        name,
-        r#type: "warn",
-        args: Some(vec![message]),
-        trace: Some(trace),
-      },
-      rspack_core::LogType::Info { message } => Self {
-        name,
-        r#type: "info",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::Log { message } => Self {
-        name,
-        r#type: "log",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::Debug { message } => Self {
-        name,
-        r#type: "debug",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::Trace { message, trace } => Self {
-        name,
-        r#type: "trace",
-        args: Some(vec![message]),
-        trace: Some(trace),
-      },
-      rspack_core::LogType::Group { message } => Self {
-        name,
-        r#type: "group",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::GroupCollapsed { message } => Self {
-        name,
-        r#type: "groupCollapsed",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::GroupEnd => Self {
-        name,
-        r#type: "groupEnd",
-        args: None,
-        trace: None,
-      },
-      rspack_core::LogType::Profile { label } => Self {
-        name,
-        r#type: "profile",
-        args: Some(vec![label.to_string()]),
-        trace: None,
-      },
-      rspack_core::LogType::ProfileEnd { label } => Self {
-        name,
-        r#type: "profileEnd",
-        args: Some(vec![label.to_string()]),
-        trace: None,
-      },
-      rspack_core::LogType::Time {
-        label,
-        secs,
-        subsec_nanos,
-      } => {
-        let ms = secs as f64 * 1000.0 + subsec_nanos as f64 / 1_000_000.0;
-        let mut time_buffer = ryu_js::Buffer::new();
-        let time_str = time_buffer.format(ms);
-        Self {
-          name,
-          r#type: "time",
-          args: Some(vec![format!("{}: {} ms", label, time_str)]),
-          trace: None,
-        }
-      }
-      rspack_core::LogType::Clear => Self {
-        name,
-        r#type: "clear",
-        args: None,
-        trace: None,
-      },
-      rspack_core::LogType::Status { message } => Self {
-        name,
-        r#type: "status",
-        args: Some(vec![message]),
-        trace: None,
-      },
-      rspack_core::LogType::Cache { label, hit, total } => {
-        let mut hit_buffer = itoa::Buffer::new();
-        let hit_str = hit_buffer.format(hit);
-        let mut total_buffer = itoa::Buffer::new();
-        let total_str = total_buffer.format(total);
-        Self {
-          name,
-          r#type: "cache",
-          args: Some(vec![format!(
-            "{}: {:.1}% ({}/{})",
-            label,
-            if total == 0 {
-              0 as f32
-            } else {
-              hit as f32 / total as f32 * 100_f32
-            },
-            hit_str,
-            total_str,
-          )]),
-          trace: None,
-        }
-      }
-    }
   }
 }
 
@@ -1273,7 +1143,7 @@ impl JsStats {
   }
 
   #[napi]
-  pub fn get_logging(&self, accepted_types: u32) -> Vec<JsStatsLogging<'_>> {
+  pub fn get_logging(&self, accepted_types: u32) -> Vec<JsLog> {
     self
       .inner
       .get_logging()

--- a/crates/rspack_core/src/cache/build_dependencies/mod.rs
+++ b/crates/rspack_core/src/cache/build_dependencies/mod.rs
@@ -25,13 +25,13 @@ use crate::{
 /// The toolkit will use ast to analyze the build dependency files and resolve the requests in them,
 /// treat the files associated with the requests as build dependency files,
 /// and continue processing them until all dependency files are calculated.
-pub struct Helper {
+pub struct Helper<L = CompilationLogger> {
   resolver: Resolver,
-  logger: CompilationLogger,
+  logger: L,
 }
 
-impl Helper {
-  pub fn new(fs: Arc<dyn ReadableFileSystem>, logger: CompilationLogger) -> Self {
+impl<L: Logger> Helper<L> {
+  pub fn new(fs: Arc<dyn ReadableFileSystem>, logger: L) -> Self {
     Helper {
       resolver: Resolver::new(
         ResolveOption {

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -1241,8 +1241,8 @@ impl Compilation {
     Ok((path, info))
   }
 
-  pub fn get_logger(&self, name: impl Into<String>) -> CompilationLogger {
-    CompilationLogger::new(name.into(), self.logging.clone())
+  pub fn get_logger(&self, name: impl Into<Arc<str>>) -> CompilationLogger {
+    CompilationLogger::new(name, self.logging.clone())
   }
 
   pub fn set_dependency_factory(

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -21,8 +21,7 @@ pub use self::rebuild::CompilationRecords;
 use crate::{
   BoxPlugin, CacheOptions, CleanOptions, Compilation, CompilationAsset, CompilationLogging,
   CompilerOptions, CompilerPlatform, ContextModuleFactory, Filename, InfrastructureLogSink,
-  KeepPattern, NormalModuleFactory, PluginDriver, PrintlnInfrastructureLogSink, ResolverFactory,
-  SharedPluginDriver,
+  KeepPattern, NormalModuleFactory, PluginDriver, ResolverFactory, SharedPluginDriver,
   artifacts::IncrementalArtifacts,
   compilation::build_module_graph::ModuleExecutor,
   fast_set,
@@ -133,7 +132,7 @@ impl Compiler {
     resolver_factory: Option<Arc<ResolverFactory>>,
     loader_resolver_factory: Option<Arc<ResolverFactory>>,
     compiler_context: Option<Arc<CompilerContext>>,
-    infrastructure_log_sink: Option<Arc<dyn InfrastructureLogSink>>,
+    infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
     platform: Arc<CompilerPlatform>,
   ) -> Self {
     #[cfg(debug_assertions)]
@@ -166,8 +165,6 @@ impl Compiler {
 
     let options = Arc::new(options);
     let compilation_logging: CompilationLogging = Default::default();
-    let infrastructure_log_sink =
-      infrastructure_log_sink.unwrap_or_else(|| Arc::new(PrintlnInfrastructureLogSink));
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -20,8 +20,9 @@ use tracing::instrument;
 pub use self::rebuild::CompilationRecords;
 use crate::{
   BoxPlugin, CacheOptions, CleanOptions, Compilation, CompilationAsset, CompilationLogging,
-  CompilerOptions, CompilerPlatform, ContextModuleFactory, Filename, KeepPattern,
-  NormalModuleFactory, PluginDriver, ResolverFactory, SharedPluginDriver,
+  CompilerOptions, CompilerPlatform, ContextModuleFactory, Filename, InfrastructureLogSink,
+  KeepPattern, NormalModuleFactory, PluginDriver, PrintlnInfrastructureLogSink, ResolverFactory,
+  SharedPluginDriver,
   artifacts::IncrementalArtifacts,
   compilation::build_module_graph::ModuleExecutor,
   fast_set,
@@ -132,6 +133,7 @@ impl Compiler {
     resolver_factory: Option<Arc<ResolverFactory>>,
     loader_resolver_factory: Option<Arc<ResolverFactory>>,
     compiler_context: Option<Arc<CompilerContext>>,
+    infrastructure_log_sink: Option<Arc<dyn InfrastructureLogSink>>,
     platform: Arc<CompilerPlatform>,
   ) -> Self {
     #[cfg(debug_assertions)]
@@ -164,6 +166,8 @@ impl Compiler {
 
     let options = Arc::new(options);
     let compilation_logging: CompilationLogging = Default::default();
+    let infrastructure_log_sink =
+      infrastructure_log_sink.unwrap_or_else(|| Arc::new(PrintlnInfrastructureLogSink));
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
@@ -171,7 +175,7 @@ impl Compiler {
       compiler_path.clone(),
       options.clone(),
       input_filesystem.clone(),
-      compilation_logging.clone(),
+      infrastructure_log_sink,
     );
     let cache = create_legacy_cache(
       &compiler_path,

--- a/crates/rspack_core/src/logger.rs
+++ b/crates/rspack_core/src/logger.rs
@@ -239,6 +239,98 @@ pub trait Logger {
   }
 }
 
+#[derive(Debug, Clone)]
+pub struct InfrastructureLogEvent {
+  pub name: Arc<str>,
+  pub log_type: LogType,
+}
+
+pub trait InfrastructureLogSink: Send + Sync {
+  fn emit(&self, event: InfrastructureLogEvent);
+}
+
+#[derive(Clone)]
+pub struct InfrastructureLogger {
+  sink: Arc<dyn InfrastructureLogSink>,
+  name: Arc<str>,
+}
+
+impl fmt::Debug for InfrastructureLogger {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    f.debug_struct("InfrastructureLogger")
+      .field("name", &self.name)
+      .finish_non_exhaustive()
+  }
+}
+
+impl InfrastructureLogger {
+  pub fn new(name: impl Into<Arc<str>>, sink: Arc<dyn InfrastructureLogSink>) -> Self {
+    Self {
+      sink,
+      name: name.into(),
+    }
+  }
+
+  pub fn get_child(&self, name: &str) -> Self {
+    let mut child_name = self.name.to_string();
+    child_name.push('/');
+    child_name.push_str(name);
+    Self {
+      sink: self.sink.clone(),
+      name: Arc::from(child_name),
+    }
+  }
+}
+
+impl Logger for InfrastructureLogger {
+  fn raw(&self, log_type: LogType) {
+    self.sink.emit(InfrastructureLogEvent {
+      name: self.name.clone(),
+      log_type,
+    });
+  }
+}
+
+#[derive(Debug, Default)]
+pub struct PrintlnInfrastructureLogSink;
+
+impl InfrastructureLogSink for PrintlnInfrastructureLogSink {
+  fn emit(&self, event: InfrastructureLogEvent) {
+    let name = event.name;
+    match event.log_type {
+      LogType::Error { message, .. }
+      | LogType::Warn { message, .. }
+      | LogType::Info { message }
+      | LogType::Log { message }
+      | LogType::Debug { message }
+      | LogType::Trace { message, .. } => println!("[{name}] {message}"),
+      LogType::Group { message } | LogType::GroupCollapsed { message } => {
+        println!("[{name}] {message}")
+      }
+      LogType::GroupEnd | LogType::Clear => {}
+      LogType::Profile { label } => println!("[{name}] Profile {label}"),
+      LogType::ProfileEnd { label } => println!("[{name}] Profile end {label}"),
+      LogType::Time {
+        label,
+        secs,
+        subsec_nanos,
+      } => println!(
+        "[{name}] {label}: {} ms",
+        secs as f64 * 1000.0 + subsec_nanos as f64 / 1_000_000.0
+      ),
+      LogType::Status { message } => println!("[{name}] {message}"),
+      LogType::Cache { label, hit, total } => println!(
+        "[{name}] {label}: {:.1}% ({hit}/{total})",
+        if total == 0 {
+          0.0
+        } else {
+          hit as f32 / total as f32 * 100.0
+        }
+      ),
+    }
+  }
+}
+
 pub struct StartTime {
   label: &'static str,
   start: Instant,

--- a/crates/rspack_core/src/logger.rs
+++ b/crates/rspack_core/src/logger.rs
@@ -275,12 +275,12 @@ impl CacheCount {
   }
 }
 
-pub type CompilationLogging = Arc<DashMap<String, Vec<LogType>, BuildHasherDefault<FxHasher>>>;
+pub type CompilationLogging = Arc<DashMap<Arc<str>, Vec<LogType>, BuildHasherDefault<FxHasher>>>;
 
 #[derive(Clone)]
 pub struct CompilationLogger {
   logging: CompilationLogging,
-  name: String,
+  name: Arc<str>,
 }
 
 impl fmt::Debug for CompilationLogger {
@@ -292,8 +292,21 @@ impl fmt::Debug for CompilationLogger {
 }
 
 impl CompilationLogger {
-  pub fn new(name: String, logging: CompilationLogging) -> Self {
-    Self { logging, name }
+  pub fn new(name: impl Into<Arc<str>>, logging: CompilationLogging) -> Self {
+    Self {
+      logging,
+      name: name.into(),
+    }
+  }
+
+  pub fn get_child(&self, name: &str) -> Self {
+    let mut child_name = self.name.to_string();
+    child_name.push('/');
+    child_name.push_str(name);
+    Self {
+      logging: self.logging.clone(),
+      name: Arc::from(child_name),
+    }
   }
 }
 

--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -47,6 +47,10 @@ impl Database {
     Ok(self.families[family.index()].get(key).cloned())
   }
 
+  pub fn is_empty(&self) -> bool {
+    self.families.iter().all(|family| family.is_empty())
+  }
+
   pub fn write_batch(&mut self, write: impl FnOnce(&DatabaseBatch) -> Result<()>) -> Result<()> {
     let batch = DatabaseBatch {
       writes: Mutex::new(Default::default()),

--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -5,6 +5,7 @@ use rspack_paths::Utf8PathBuf;
 use rustc_hash::FxHashMap;
 
 use super::DatabaseFamily;
+use crate::CompilationLogger;
 
 pub type DatabaseValue = Arc<[u8]>;
 
@@ -23,14 +24,23 @@ impl DatabaseBatch {
   }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Database {
   families: [FxHashMap<Vec<u8>, DatabaseValue>; DatabaseFamily::COUNT],
+  _logger: Arc<CompilationLogger>,
 }
 
 impl Database {
-  pub fn open(_base_path: Utf8PathBuf, _path: Utf8PathBuf, _readonly: bool) -> Result<Self> {
-    Ok(Self::default())
+  pub fn open(
+    _base_path: Utf8PathBuf,
+    _path: Utf8PathBuf,
+    _readonly: bool,
+    logger: Arc<CompilationLogger>,
+  ) -> Result<Self> {
+    Ok(Self {
+      families: Default::default(),
+      _logger: logger,
+    })
   }
 
   pub fn get(&self, family: DatabaseFamily, key: &[u8]) -> Result<Option<DatabaseValue>> {

--- a/crates/rspack_core/src/new_cache/db/memory.rs
+++ b/crates/rspack_core/src/new_cache/db/memory.rs
@@ -5,7 +5,7 @@ use rspack_paths::Utf8PathBuf;
 use rustc_hash::FxHashMap;
 
 use super::DatabaseFamily;
-use crate::CompilationLogger;
+use crate::InfrastructureLogger;
 
 pub type DatabaseValue = Arc<[u8]>;
 
@@ -27,7 +27,7 @@ impl DatabaseBatch {
 #[derive(Debug)]
 pub struct Database {
   families: [FxHashMap<Vec<u8>, DatabaseValue>; DatabaseFamily::COUNT],
-  _logger: Arc<CompilationLogger>,
+  _logger: Arc<InfrastructureLogger>,
 }
 
 impl Database {
@@ -35,7 +35,7 @@ impl Database {
     _base_path: Utf8PathBuf,
     _path: Utf8PathBuf,
     _readonly: bool,
-    logger: Arc<CompilationLogger>,
+    logger: Arc<InfrastructureLogger>,
   ) -> Result<Self> {
     Ok(Self {
       families: Default::default(),

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -1,5 +1,6 @@
 use std::{
   fmt,
+  sync::Arc,
   time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -11,7 +12,7 @@ use turbo_persistence::{
   WriteBatch,
 };
 
-use crate::new_cache::db::DatabaseFamily;
+use crate::{CompilationLogger, Logger, new_cache::db::DatabaseFamily};
 
 const STALE_DIRECTORY: &str = "_stale";
 const MB: u64 = 1024 * 1024;
@@ -177,6 +178,7 @@ pub struct Database {
   base_path: Utf8PathBuf,
   path: Utf8PathBuf,
   readonly: bool,
+  logger: Arc<CompilationLogger>,
 }
 
 impl fmt::Debug for Database {
@@ -190,13 +192,19 @@ impl fmt::Debug for Database {
 }
 
 impl Database {
-  pub fn open(base_path: Utf8PathBuf, path: Utf8PathBuf, readonly: bool) -> Result<Self> {
+  pub fn open(
+    base_path: Utf8PathBuf,
+    path: Utf8PathBuf,
+    readonly: bool,
+    logger: Arc<CompilationLogger>,
+  ) -> Result<Self> {
     let inner = open_database(&path, readonly)?;
     Ok(Self {
       inner,
       base_path,
       path,
       readonly,
+      logger,
     })
   }
 
@@ -244,17 +252,15 @@ impl Database {
     let stale_directory = self.stale_directory();
     match std::fs::remove_dir_all(stale_directory.as_std_path()) {
       Ok(()) => {
-        tracing::debug!(
-          path = %stale_directory,
-          "Removed stale persistent cache databases"
-        );
+        self.logger.debug(format!(
+          "Removed stale cache databases from {stale_directory}"
+        ));
       }
       Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
       Err(error) => {
-        tracing::warn!(
-          path = %stale_directory,
-          "Removing stale persistent cache databases failed: {error}"
-        );
+        self.logger.warn(format!(
+          "Removing stale cache databases from {stale_directory} failed: {error}"
+        ));
       }
     }
   }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -212,6 +212,10 @@ impl Database {
     Ok(self.inner.get(family.index(), &key)?)
   }
 
+  pub fn is_empty(&self) -> bool {
+    self.inner.is_empty()
+  }
+
   pub fn write_batch<'key>(
     &mut self,
     write: impl FnOnce(&DatabaseBatch<'_, 'key>) -> Result<()>,

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -12,7 +12,7 @@ use turbo_persistence::{
   WriteBatch,
 };
 
-use crate::{CompilationLogger, Logger, new_cache::db::DatabaseFamily};
+use crate::{InfrastructureLogger, Logger, new_cache::db::DatabaseFamily};
 
 const STALE_DIRECTORY: &str = "_stale";
 const MB: u64 = 1024 * 1024;
@@ -178,7 +178,7 @@ pub struct Database {
   base_path: Utf8PathBuf,
   path: Utf8PathBuf,
   readonly: bool,
-  logger: Arc<CompilationLogger>,
+  logger: Arc<InfrastructureLogger>,
 }
 
 impl fmt::Debug for Database {
@@ -196,7 +196,7 @@ impl Database {
     base_path: Utf8PathBuf,
     path: Utf8PathBuf,
     readonly: bool,
-    logger: Arc<CompilationLogger>,
+    logger: Arc<InfrastructureLogger>,
   ) -> Result<Self> {
     let inner = open_database(&path, readonly)?;
     Ok(Self {

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -8,7 +8,7 @@ use rustc_hash::FxHashMap;
 use super::{
   CacheKey, Etag, Meta,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
-  db::{Database, DatabaseFamily, DatabaseValue},
+  db::{Database, DatabaseFamily},
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
@@ -84,10 +84,13 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let data: Option<DatabaseValue> = self
+    let Some(data) = self
       .database
-      .get(DatabaseFamily::Validator, VALIDATOR_KEY)?;
-    let validation = self.validator.validate(data.as_deref()).await;
+      .get(DatabaseFamily::Validator, VALIDATOR_KEY)?
+    else {
+      return Ok(());
+    };
+    let validation = self.validator.validate(data).await;
     match validation {
       Ok(CacheValidatorResult::Valid) => {}
       Ok(CacheValidatorResult::InvalidVersion) => {

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -12,7 +12,7 @@ use super::{
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
-use crate::{CompilationLogger, Logger, cache::CacheCodec};
+use crate::{InfrastructureLogger, Logger, cache::CacheCodec};
 
 const VALIDATOR_KEY: &[u8] = b"validator";
 const META_KEY: &[u8] = b"meta";
@@ -37,7 +37,7 @@ pub struct FileCacheStrategy {
   database: Database,
   pending_writes: PendingWrites,
   readonly: bool,
-  logger: Arc<CompilationLogger>,
+  logger: Arc<InfrastructureLogger>,
 }
 
 impl fmt::Debug for FileCacheStrategy {
@@ -58,7 +58,7 @@ impl FileCacheStrategy {
     cache_version: String,
     codec: Arc<CacheCodec>,
     file_system_info: FileSystemInfo,
-    logger: Arc<CompilationLogger>,
+    logger: Arc<InfrastructureLogger>,
   ) -> Result<Self> {
     let (base_path, database_path) = database_paths;
     let start = logger.time("open cache database");

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -12,7 +12,7 @@ use super::{
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
-use crate::cache::CacheCodec;
+use crate::{CompilationLogger, Logger, cache::CacheCodec};
 
 const VALIDATOR_KEY: &[u8] = b"validator";
 const META_KEY: &[u8] = b"meta";
@@ -37,6 +37,7 @@ pub struct FileCacheStrategy {
   database: Database,
   pending_writes: PendingWrites,
   readonly: bool,
+  logger: Arc<CompilationLogger>,
 }
 
 impl fmt::Debug for FileCacheStrategy {
@@ -57,20 +58,26 @@ impl FileCacheStrategy {
     cache_version: String,
     codec: Arc<CacheCodec>,
     file_system_info: FileSystemInfo,
+    logger: Arc<CompilationLogger>,
   ) -> Result<Self> {
     let (base_path, database_path) = database_paths;
-    let database = Database::open(base_path, database_path, readonly)?;
+    let start = logger.time("open cache database");
+    let database = Database::open(base_path, database_path, readonly, logger.clone());
+    logger.time_end(start);
+    let database = database?;
     Ok(Self {
       validator: CacheValidator::new(
         rspack_pkg_version,
         cache_version,
         codec.clone(),
         file_system_info,
+        logger.clone(),
       ),
       codec,
       database,
       pending_writes: PendingWrites::default(),
       readonly,
+      logger,
     })
   }
 
@@ -82,32 +89,34 @@ impl FileCacheStrategy {
       .get(DatabaseFamily::Validator, VALIDATOR_KEY)?;
     let validation = self.validator.validate(data.as_deref()).await;
     match validation {
-      Ok(CacheValidatorResult::Valid) => {
-        tracing::debug!("Build dependencies snapshot is valid");
-      }
+      Ok(CacheValidatorResult::Valid) => {}
       Ok(CacheValidatorResult::InvalidVersion) => {
-        tracing::info!("Resetting persistent cache database because cache version changed");
-        self.database.reset()?;
-      }
-      Ok(CacheValidatorResult::InvalidError) => {
-        tracing::info!("Resetting persistent cache database because of an invalid cache error");
+        self
+          .logger
+          .log("Resetting cache, the cache version doesn't match");
         self.database.reset()?;
       }
       Ok(CacheValidatorResult::InvalidBuildDependencies {
         modified_files,
         removed_files,
       }) => {
-        tracing::info!(
-          modified_files = modified_files.len(),
-          removed_files = removed_files.len(),
-          "Resetting persistent cache database because build dependencies changed"
-        );
+        self.logger.log(format!(
+          "Resetting cache, build dependencies have changed ({} modified, {} removed)",
+          modified_files.len(),
+          removed_files.len()
+        ));
+        self.database.reset()?;
+      }
+      Ok(CacheValidatorResult::InvalidError) => {
+        self
+          .logger
+          .warn("Resetting cache, unexpected error occurred");
         self.database.reset()?;
       }
       Err(error) => {
-        tracing::warn!(
-          "Resetting persistent cache database because build dependencies validation failed: {error}"
-        );
+        self.logger.log(format!(
+          "Resetting cache, unexpected error occurred: {error}"
+        ));
         self.database.reset()?;
       }
     }
@@ -192,6 +201,8 @@ impl FileCacheStrategy {
     }
 
     if self.has_pending_writes() {
+      self.logger.log("Storing cache...");
+      let start = self.logger.time("store cache");
       let codec = &self.codec;
       let entries = &self.pending_writes.entries;
       let validator = if let Some(dependencies) = &self.pending_writes.new_build_dependencies {
@@ -205,7 +216,10 @@ impl FileCacheStrategy {
         .as_ref()
         .map(|meta| codec.encode(meta))
         .transpose()?;
-      self.database.write_batch(move |batch| {
+      let stored_items = entries.len()
+        + if validator.is_some() { 1 } else { 0 }
+        + if meta.is_some() { 1 } else { 0 };
+      let result = self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {
           let value = (pending.encoder)(&pending.entry, codec)?;
           batch.put(DatabaseFamily::Cache, key.as_bytes(), value)
@@ -217,11 +231,16 @@ impl FileCacheStrategy {
           batch.put(DatabaseFamily::Meta, META_KEY, meta)?;
         }
         Ok(())
-      })?;
+      });
+      self.logger.time_end(start);
+      result?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.new_build_dependencies = None;
       self.pending_writes.meta = None;
+      self
+        .logger
+        .log(format!("Stored cache ({stored_items} items)"));
     }
 
     for _ in 0..max_compaction_passes {

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -84,25 +84,25 @@ impl FileCacheStrategy {
   /// Validates the current database's build dependencies once before the
   /// background job starts serving commands.
   pub async fn db_validation(&mut self) -> Result<()> {
-    let Some(data) = self
-      .database
-      .get(DatabaseFamily::Validator, VALIDATOR_KEY)?
-    else {
+    if self.database.is_empty() {
       return Ok(());
-    };
-    let validation = self.validator.validate(data).await;
+    }
+    let data = self
+      .database
+      .get(DatabaseFamily::Validator, VALIDATOR_KEY)?;
+    let validation = self.validator.validate(data).await?;
     match validation {
-      Ok(CacheValidatorResult::Valid) => {}
-      Ok(CacheValidatorResult::InvalidVersion) => {
+      CacheValidatorResult::Valid => {}
+      CacheValidatorResult::InvalidVersion => {
         self
           .logger
           .log("Resetting cache, the cache version doesn't match");
         self.database.reset()?;
       }
-      Ok(CacheValidatorResult::InvalidBuildDependencies {
+      CacheValidatorResult::InvalidBuildDependencies {
         modified_files,
         removed_files,
-      }) => {
+      } => {
         self.logger.log(format!(
           "Resetting cache, build dependencies have changed ({} modified, {} removed)",
           modified_files.len(),
@@ -110,16 +110,10 @@ impl FileCacheStrategy {
         ));
         self.database.reset()?;
       }
-      Ok(CacheValidatorResult::InvalidError) => {
+      CacheValidatorResult::InvalidError => {
         self
           .logger
           .warn("Resetting cache, unexpected error occurred");
-        self.database.reset()?;
-      }
-      Err(error) => {
-        self.logger.log(format!(
-          "Resetting cache, unexpected error occurred: {error}"
-        ));
         self.database.reset()?;
       }
     }

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -19,7 +19,7 @@ use super::{
   CacheKey, CacheValue, Etag, FileCacheStrategy, Meta,
   cache_value::{CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
 };
-use crate::{CompilationLogger, Logger};
+use crate::{InfrastructureLogger, Logger};
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
@@ -61,7 +61,7 @@ struct IdleDeadline {
 
 struct BackgroundJob {
   strategy: FileCacheStrategy,
-  logger: Arc<CompilationLogger>,
+  logger: Arc<InfrastructureLogger>,
   command_receiver: mpsc::UnboundedReceiver<Command>,
   // A deadline remains valid only while this still matches its captured epoch.
   idle_epoch: Arc<AtomicU64>,
@@ -218,7 +218,7 @@ pub struct IdleFileCache {
 impl IdleFileCache {
   pub fn new(
     strategy: FileCacheStrategy,
-    logger: Arc<CompilationLogger>,
+    logger: Arc<InfrastructureLogger>,
     idle_timeout: Option<Duration>,
     idle_timeout_for_initial_store: Option<Duration>,
     idle_timeout_after_large_changes: Option<Duration>,

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -19,6 +19,7 @@ use super::{
   CacheKey, CacheValue, Etag, FileCacheStrategy, Meta,
   cache_value::{CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
 };
+use crate::{CompilationLogger, Logger};
 
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 const DEFAULT_IDLE_TIMEOUT_FOR_INITIAL_STORE: Duration = Duration::from_secs(5);
@@ -60,6 +61,7 @@ struct IdleDeadline {
 
 struct BackgroundJob {
   strategy: FileCacheStrategy,
+  logger: Arc<CompilationLogger>,
   command_receiver: mpsc::UnboundedReceiver<Command>,
   // A deadline remains valid only while this still matches its captured epoch.
   idle_epoch: Arc<AtomicU64>,
@@ -74,7 +76,9 @@ struct BackgroundJob {
 impl BackgroundJob {
   async fn run(mut self) {
     if let Err(error) = self.strategy.db_validation().await {
-      tracing::warn!("Validating persistent cache build dependencies failed: {error}");
+      self
+        .logger
+        .warn(format!("Validating cache database failed: {error}"));
       return;
     }
 
@@ -103,7 +107,9 @@ impl BackgroundJob {
 
       let Some(command) = command else {
         if self.strategy.has_pending_writes() {
-          tracing::warn!("Idle file cache was dropped before shutdown with pending cache items");
+          self
+            .logger
+            .warn("Idle file cache was dropped before shutdown with pending cache items");
         }
         return;
       };
@@ -186,7 +192,7 @@ impl BackgroundJob {
       .after_all_stored(MAX_IDLE_COMPACTION_PASSES, check_idle_ended)
       .await
     {
-      tracing::warn!("Finalizing idle file cache store failed: {error}");
+      self.logger.warn(format!("Caching failed: {error}"));
       return;
     }
     let time_spent_in_store = start.elapsed();
@@ -212,6 +218,7 @@ pub struct IdleFileCache {
 impl IdleFileCache {
   pub fn new(
     strategy: FileCacheStrategy,
+    logger: Arc<CompilationLogger>,
     idle_timeout: Option<Duration>,
     idle_timeout_for_initial_store: Option<Duration>,
     idle_timeout_after_large_changes: Option<Duration>,
@@ -225,6 +232,7 @@ impl IdleFileCache {
     let idle_epoch = Arc::new(AtomicU64::new(0));
     let background_job = BackgroundJob {
       strategy,
+      logger,
       command_receiver,
       idle_epoch: Arc::clone(&idle_epoch),
       idle_deadline: None,

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -27,13 +27,15 @@ pub use meta::Meta;
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::FileSystemInfo;
-use crate::{CompilationLogger, CompilationLogging, CompilerOptions, Logger, cache::CacheCodec};
+use crate::{
+  CompilerOptions, InfrastructureLogSink, InfrastructureLogger, Logger, cache::CacheCodec,
+};
 
 pub fn create_cache(
   compiler_path: String,
   compiler_options: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
-  compilation_logging: CompilationLogging,
+  infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
 ) -> Cache {
   if !compiler_options.experiments.new_cache.is_enabled() {
     return Cache::new_disabled(compiler_path);
@@ -55,9 +57,9 @@ pub fn create_cache(
     None
   };
   let codec = Arc::new(CacheCodec::new(project_root));
-  let logger = Arc::new(CompilationLogger::new(
+  let logger = Arc::new(InfrastructureLogger::new(
     "rspack.cache.IdleFileCache",
-    compilation_logging,
+    infrastructure_log_sink,
   ));
   let file_system_info = FileSystemInfo::new(
     input_filesystem.clone(),

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -27,7 +27,7 @@ pub use meta::Meta;
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::FileSystemInfo;
-use crate::{CompilationLogger, CompilationLogging, CompilerOptions, cache::CacheCodec};
+use crate::{CompilationLogger, CompilationLogging, CompilerOptions, Logger, cache::CacheCodec};
 
 pub fn create_cache(
   compiler_path: String,
@@ -49,15 +49,19 @@ pub fn create_cache(
     crate::CacheOptions::Persistent(options) => options,
   };
 
-  let portable_project_root = if options.portable {
+  let project_root = if options.portable {
     Some(compiler_options.context.as_path().to_path_buf())
   } else {
     None
   };
-  let codec = Arc::new(CacheCodec::new(portable_project_root));
+  let codec = Arc::new(CacheCodec::new(project_root));
+  let logger = Arc::new(CompilationLogger::new(
+    "rspack.cache.IdleFileCache",
+    compilation_logging.clone(),
+  ));
   let file_system_info = FileSystemInfo::new(
     input_filesystem.clone(),
-    CompilationLogger::new("rspack.FileSystemInfo".to_string(), compilation_logging),
+    logger.get_child("rspack.FileSystemInfo"),
     options.snapshot.clone(),
     compiler_options.output.hash_function,
   );
@@ -70,20 +74,24 @@ pub fn create_cache(
     }
   };
   let strategy = match FileCacheStrategy::new(
-    (base_path, database_path),
+    (base_path, database_path.clone()),
     options.readonly,
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
     codec,
     file_system_info,
+    logger.clone(),
   ) {
     Ok(strategy) => strategy,
     Err(error) => {
-      tracing::warn!("Opening persistent cache database failed: {error}");
+      logger.warn(format!(
+        "Restoring cache from {database_path} failed: {error}"
+      ));
+      logger.debug(format!("{error:?}"));
       return Cache::new(compiler_path, MemoryCache::default(), None);
     }
   };
-  let idle_file_cache = IdleFileCache::new(strategy, None, None, None);
+  let idle_file_cache = IdleFileCache::new(strategy, logger, None, None, None);
 
   Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -57,7 +57,7 @@ pub fn create_cache(
   let codec = Arc::new(CacheCodec::new(project_root));
   let logger = Arc::new(CompilationLogger::new(
     "rspack.cache.IdleFileCache",
-    compilation_logging.clone(),
+    compilation_logging,
   ));
   let file_system_info = FileSystemInfo::new(
     input_filesystem.clone(),
@@ -84,10 +84,7 @@ pub fn create_cache(
   ) {
     Ok(strategy) => strategy,
     Err(error) => {
-      logger.warn(format!(
-        "Restoring cache from {database_path} failed: {error}"
-      ));
-      logger.debug(format!("{error:?}"));
+      logger.warn(format!("Open cache from {database_path} failed: {error}"));
       return Cache::new(compiler_path, MemoryCache::default(), None);
     }
   };

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -126,7 +126,6 @@ impl FileSystemInfo {
 
   /// See webpack's snapshot creation implementation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L2525-L3079
-  #[tracing::instrument("Cache::FileSystemInfo::create_snapshot", skip_all)]
   pub async fn create_snapshot(
     &self,
     start_time: Option<u64>,
@@ -170,7 +169,6 @@ impl FileSystemInfo {
 
   /// See webpack's snapshot validation implementation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3168-L3735
-  #[tracing::instrument("Cache::FileSystemInfo::check_snapshot_valid", skip_all)]
   pub async fn check_snapshot_valid(
     &self,
     snapshot: &Snapshot,

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -13,7 +13,7 @@ use super::{
   TimestampAndHash,
 };
 use crate::{
-  CompilationLogger,
+  InfrastructureLogger,
   cache::{BuildDependencyHelper, SnapshotOptions, SnapshotStrategyOptions, is_node_package_path},
 };
 
@@ -82,7 +82,7 @@ struct ContextValue {
 #[derive(Clone)]
 pub struct FileSystemInfo {
   fs: Arc<dyn ReadableFileSystem>,
-  logger: CompilationLogger,
+  logger: InfrastructureLogger,
   options: Arc<SnapshotOptions>,
   hash_function: HashFunction,
   file_timestamps: Arc<InternedPathDashMap<Option<FileSystemInfoEntry>>>,
@@ -105,7 +105,7 @@ impl fmt::Debug for FileSystemInfo {
 impl FileSystemInfo {
   pub fn new(
     fs: Arc<dyn ReadableFileSystem>,
-    logger: CompilationLogger,
+    logger: InfrastructureLogger,
     options: SnapshotOptions,
     hash_function: HashFunction,
   ) -> Self {

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -6,7 +6,9 @@ use rspack_paths::{InternedPath, InternedPathSet};
 
 use super::snapshot::{FileSystemInfo, Snapshot};
 use crate::{
-  CompilationLogger, Logger, cache::CacheCodec, new_cache::snapshot::SnapshotValidationResult,
+  CompilationLogger, Logger,
+  cache::CacheCodec,
+  new_cache::{db::DatabaseValue, snapshot::SnapshotValidationResult},
 };
 
 #[cacheable]
@@ -69,11 +71,8 @@ impl CacheValidator {
 
   /// See webpack's persistent build snapshot validation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js#L1345-L1429
-  pub(super) async fn validate(&mut self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
-    let Some(data) = data else {
-      return Ok(CacheValidatorResult::InvalidError);
-    };
-    let validator = self.codec.decode::<CacheValidatorData>(data)?;
+  pub(super) async fn validate(&mut self, data: DatabaseValue) -> Result<CacheValidatorResult> {
+    let validator = self.codec.decode::<CacheValidatorData>(&data)?;
     if !validator.has_same_version(&self.data) {
       return Ok(CacheValidatorResult::InvalidVersion);
     }

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -6,7 +6,7 @@ use rspack_paths::{InternedPath, InternedPathSet};
 
 use super::snapshot::{FileSystemInfo, Snapshot};
 use crate::{
-  CompilationLogger, Logger,
+  InfrastructureLogger, Logger,
   cache::CacheCodec,
   new_cache::{db::DatabaseValue, snapshot::SnapshotValidationResult},
 };
@@ -50,7 +50,7 @@ pub(super) struct CacheValidator {
   data: CacheValidatorData,
   codec: Arc<CacheCodec>,
   file_system_info: FileSystemInfo,
-  logger: Arc<CompilationLogger>,
+  logger: Arc<InfrastructureLogger>,
 }
 
 impl CacheValidator {
@@ -59,7 +59,7 @@ impl CacheValidator {
     cache_version: String,
     codec: Arc<CacheCodec>,
     file_system_info: FileSystemInfo,
-    logger: Arc<CompilationLogger>,
+    logger: Arc<InfrastructureLogger>,
   ) -> Self {
     Self {
       data: CacheValidatorData::new(rspack_pkg_version, cache_version),

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -5,7 +5,9 @@ use rspack_error::Result;
 use rspack_paths::{InternedPath, InternedPathSet};
 
 use super::snapshot::{FileSystemInfo, Snapshot};
-use crate::{cache::CacheCodec, new_cache::snapshot::SnapshotValidationResult};
+use crate::{
+  CompilationLogger, Logger, cache::CacheCodec, new_cache::snapshot::SnapshotValidationResult,
+};
 
 #[cacheable]
 #[derive(Debug)]
@@ -46,6 +48,7 @@ pub(super) struct CacheValidator {
   data: CacheValidatorData,
   codec: Arc<CacheCodec>,
   file_system_info: FileSystemInfo,
+  logger: Arc<CompilationLogger>,
 }
 
 impl CacheValidator {
@@ -54,11 +57,13 @@ impl CacheValidator {
     cache_version: String,
     codec: Arc<CacheCodec>,
     file_system_info: FileSystemInfo,
+    logger: Arc<CompilationLogger>,
   ) -> Self {
     Self {
       data: CacheValidatorData::new(rspack_pkg_version, cache_version),
       codec,
       file_system_info,
+      logger,
     }
   }
 
@@ -66,7 +71,7 @@ impl CacheValidator {
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js#L1345-L1429
   pub(super) async fn validate(&mut self, data: Option<&[u8]>) -> Result<CacheValidatorResult> {
     let Some(data) = data else {
-      return Ok(CacheValidatorResult::InvalidVersion);
+      return Ok(CacheValidatorResult::InvalidError);
     };
     let validator = self.codec.decode::<CacheValidatorData>(data)?;
     if !validator.has_same_version(&self.data) {
@@ -75,10 +80,13 @@ impl CacheValidator {
     let Some(build_dependencies_snapshot) = &validator.build_dependencies_snapshot else {
       return Ok(CacheValidatorResult::InvalidError);
     };
+    let start = self.logger.time("check build dependencies");
     let validation = self
       .file_system_info
       .check_snapshot_valid(build_dependencies_snapshot)
-      .await?;
+      .await;
+    self.logger.time_end(start);
+    let validation = validation?;
     Ok(match validation {
       SnapshotValidationResult::Valid => {
         self.data = validator;
@@ -107,10 +115,18 @@ impl CacheValidator {
       return Ok(None);
     }
 
+    self.logger.debug(format!(
+      "Capturing build dependencies... ({} dependencies)",
+      new_build_dependencies.len()
+    ));
+    let start = self.logger.time("resolve build dependencies");
     let resolved = self
       .file_system_info
       .resolve_build_dependencies(new_build_dependencies.iter().cloned())
       .await;
+    self.logger.time_end(start);
+
+    let start = self.logger.time("snapshot build dependencies");
     let snapshot = self
       .file_system_info
       .create_snapshot(
@@ -120,7 +136,9 @@ impl CacheValidator {
         &resolved.missing,
         self.file_system_info.build_dependencies_strategy(),
       )
-      .await?;
+      .await;
+    self.logger.time_end(start);
+    let snapshot = snapshot?;
     self.data.build_dependencies_snapshot = Some(
       if let Some(current) = self.data.build_dependencies_snapshot.take() {
         self.file_system_info.merge_snapshots(current, snapshot)

--- a/crates/rspack_core/src/new_cache/validator.rs
+++ b/crates/rspack_core/src/new_cache/validator.rs
@@ -71,7 +71,13 @@ impl CacheValidator {
 
   /// See webpack's persistent build snapshot validation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js#L1345-L1429
-  pub(super) async fn validate(&mut self, data: DatabaseValue) -> Result<CacheValidatorResult> {
+  pub(super) async fn validate(
+    &mut self,
+    data: Option<DatabaseValue>,
+  ) -> Result<CacheValidatorResult> {
+    let Some(data) = data else {
+      return Ok(CacheValidatorResult::InvalidError);
+    };
     let validator = self.codec.decode::<CacheValidatorData>(&data)?;
     if !validator.has_same_version(&self.data) {
       return Ok(CacheValidatorResult::InvalidVersion);

--- a/crates/rspack_core/src/stats/mod.rs
+++ b/crates/rspack_core/src/stats/mod.rs
@@ -1,7 +1,10 @@
 use std::{
   borrow::Cow,
   hash::BuildHasherDefault,
-  sync::atomic::{AtomicU8, Ordering},
+  sync::{
+    Arc,
+    atomic::{AtomicU8, Ordering},
+  },
 };
 
 use dashmap::DashSet;
@@ -1110,17 +1113,16 @@ impl Stats<'_> {
     f(warnings)
   }
 
-  pub fn get_logging(&self) -> Vec<(String, LogType)> {
+  pub fn get_logging(&self) -> impl Iterator<Item = (Arc<str>, LogType)> {
     self
       .logging()
       .iter()
       .map(|item| {
         let (name, logs) = item.pair();
-        (name.to_owned(), logs.to_owned())
+        (name.clone(), logs.to_owned())
       })
       .sorted_by(|a, b| a.0.cmp(&b.0))
       .flat_map(|item| item.1.into_iter().map(move |log| (item.0.clone(), log)))
-      .collect()
   }
 
   pub fn get_hash(&self) -> Option<&str> {

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -49,7 +49,7 @@ import type { FileSystemInfoEntry } from './FileSystemInfo';
 import type { rspack } from './index';
 import Cache from './lib/Cache';
 import CacheFacade from './lib/CacheFacade';
-import { Logger } from './logging/Logger';
+import { Logger, type LogTypeEnum } from './logging/Logger';
 import { NormalModuleFactory } from './NormalModuleFactory';
 import { ResolverFactory } from './ResolverFactory';
 import { RuleSetCompiler } from './RuleSetCompiler';
@@ -433,6 +433,18 @@ class Compiler {
     );
   }
 
+  #logInfrastructure(name: string, type: LogTypeEnum, args: any[]): void {
+    if (this.hooks.infrastructureLog.call(name, type, args) === undefined) {
+      this.infrastructureLogger?.(name, type, args);
+    }
+  }
+
+  #logInfrastructureBatch(logs: binding.JsLog[]): void {
+    for (const log of logs) {
+      this.#logInfrastructure(log.name, log.type as LogTypeEnum, log.args);
+    }
+  }
+
   /**
    * @param name - name of the logger, or function called once to get the logger name
    * @returns a logger with that name
@@ -455,14 +467,7 @@ class Compiler {
             );
           }
         } else {
-          if (
-            this.hooks.infrastructureLog.call(normalizedName, type, args) ===
-            undefined
-          ) {
-            if (this.infrastructureLogger !== undefined) {
-              this.infrastructureLogger(normalizedName, type, args);
-            }
-          }
+          this.#logInfrastructure(normalizedName, type, args);
         }
       },
       (childName): any => {
@@ -960,6 +965,7 @@ class Compiler {
       ThreadsafeInputNodeFS.needsBinding(options.experiments.useInputFileSystem)
         ? ThreadsafeInputNodeFS.__to_binding(this.inputFileSystem)
         : undefined;
+    const compilerRef = new WeakRef(this);
 
     try {
       this.#instance = new instanceBinding.JsCompiler(
@@ -977,6 +983,12 @@ class Compiler {
         ResolverFactory.__to_binding(this.resolverFactory),
         this.unsafeFastDrop,
         this.#platform,
+        (logs) => {
+          const compiler = compilerRef.deref();
+          if (compiler) {
+            compiler.#logInfrastructureBatch(logs);
+          }
+        },
       );
 
       callback(null, this.#instance);

--- a/packages/rspack/src/logging/createConsoleLogger.ts
+++ b/packages/rspack/src/logging/createConsoleLogger.ts
@@ -103,6 +103,7 @@ const createConsoleLogger = ({
           console.log(...labeledArgs());
         }
         break;
+      case LogType.cache:
       case LogType.log:
         if (!debug && loglevel > LogLevel.log) return;
         console.log(...labeledArgs());

--- a/tests/rspack-test/compilerCases/infrastructure-logging.js
+++ b/tests/rspack-test/compilerCases/infrastructure-logging.js
@@ -1,5 +1,6 @@
 const { captureStdio } = require("@rspack/test-tools/helper/legacy/captureStdio");
 const { createFsFromVolume, Volume } = require("memfs");
+const fs = require("fs");
 
 class MyPlugin {
 	apply(compiler) {
@@ -26,6 +27,7 @@ const escapeAnsi = stringRaw =>
 		.replace(/\u001b\[([0-9;]*)m/g, "<CLR=$1>");
 
 let capture;
+let nativeInfrastructureLogs;
 
 /** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
 module.exports = [
@@ -178,6 +180,57 @@ module.exports = [
 			<t> <CLR=35,BOLD>[MyPlugin] Time: X ms</CLR>
 		`);
 			capture.restore();
+		}
+	},
+	{
+		description:
+			"should preserve native infrastructure logs emitted before the first compilation",
+		options(context) {
+			const cacheLocation = context.getDist("invalid-cache-location");
+			fs.writeFileSync(cacheLocation, "not a directory");
+			nativeInfrastructureLogs = [];
+			return {
+				context: context.getSource(),
+				entry: "./a",
+				experiments: {
+					newCache: true
+				},
+				cache: {
+					type: "persistent",
+					storage: {
+						type: "filesystem",
+						location: cacheLocation
+					}
+				},
+				infrastructureLogging: {
+					level: "none"
+				}
+			};
+		},
+		async compiler(context, compiler) {
+			compiler.outputFileSystem = createFsFromVolume(new Volume());
+			compiler.hooks.infrastructureLog.tap(
+				"NativeInfrastructureLoggingTest",
+				(name, type, args) => {
+					nativeInfrastructureLogs.push({ name, type, args });
+				}
+			);
+		},
+		async check() {
+			const findDatabaseWarning = () =>
+				nativeInfrastructureLogs.find(
+					log =>
+						log.name === "rspack.cache.IdleFileCache" &&
+						log.type === "warn" &&
+						log.args[0].includes("Open cache from")
+				);
+			for (let i = 0; i < 50; i++) {
+				if (findDatabaseWarning()) break;
+				await new Promise(resolve => setTimeout(resolve, 20));
+			}
+			const warning = findDatabaseWarning();
+			expect(warning).toBeTruthy();
+			expect(warning.args[0]).toContain("invalid-cache-location");
 		}
 	}
 ];


### PR DESCRIPTION
## Summary

- Add a Rust-side infrastructure logger and route the new persistent cache lifecycle, validation, persistence, and database messages through it at key locations aligned with webpack's `PackFileCacheStrategy`, replacing the new-cache tracing calls.
- Forward native infrastructure logs to JavaScript through a bounded dispatcher that sends up to 8 logs per batch or flushes every 100 ms, with a queue capacity of 32, dropped-message reporting, critical-log fallback, and a final flush during compiler shutdown.
- Feed native logs through the existing `compiler.hooks.infrastructureLog` and configured infrastructure logger so filtering, formatting, and interception behave consistently with JavaScript-originated logs, including logs emitted before the first compilation.
- Reuse a single `JsLog` representation for stats and infrastructure logging, and support shared hierarchical logger names with `Arc<str>`.
- Treat only a completely empty persistent-cache database as fresh; reset non-empty databases when validator data is missing or invalid.

## Related links

- [webpack `PackFileCacheStrategy`](https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/cache/PackFileCacheStrategy.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
