### PR TITLE
docs: move LLMs UI to page outline

### DIFF
--- a/website/rstack.config.ts
+++ b/website/rstack.config.ts
@@ -94,6 +94,9 @@ define.doc(async () => {
       }),
     ],
     themeConfig: {
+      llmsUI: {
+        placement: 'outline',
+      },
       socialLinks: [
         {
           icon: 'github',


### PR DESCRIPTION
## Summary

This PR moves the LLMs UI action into the documentation page outline so it stays accessible alongside page navigation.

## Related links

https://github.com/rstackjs/rstack-cli/pull/414

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).