### PR TITLE
fix(minify): update swc_ecma_minifier to 61.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6712,9 +6712,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "61.0.0"
+version = "61.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e69fe76dfd4f43ed4a3e351cee1f183169789c744db2d6db73fbf693ae080424"
+checksum = "7ae5c3a7654e13c6e03d349eb1f91be566e0e79d223ef9d15b1a6e1f40c5cc23"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
@@ -6747,9 +6747,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "45.0.0"
+version = "45.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a380e3e36a2167f1a2c6fd725c87a3aee60d404505667ea2c7c9e85763a70e"
+checksum = "f0a5ca9f83036146e27ed32ee508c8e1ddf6a719c23a939cdda37491ba8264ba"
 dependencies = [
  "bitflags 2.13.1",
  "compact_str",
@@ -6931,9 +6931,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "49.0.0"
+version = "49.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efb43c0b7a0478fc084c55849e182ce85e7123070eb61cfeba67811ab253051"
+checksum = "9c5b5b6a31a512d23854cb6fabc9347596bde4106cd3a65dc4f9072bbb0514b4"
 dependencies = [
  "better_scoped_tls",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,7 +149,7 @@ swc                 = { version = "75.0.0", default-features = false }
 swc_atoms           = { version = "10.0.0", default-features = false }
 swc_config          = { version = "6.0.0", default-features = false }
 swc_core            = { version = "77.0.0", default-features = false, features = ["parallel_rayon"] }
-swc_ecma_minifier   = { version = "61.0.0", default-features = false }
+swc_ecma_minifier   = { version = "61.0.4", default-features = false }
 swc_error_reporters = { version = "28.0.0", default-features = false }
 swc_html            = { version = "38.0.0", default-features = false }
 swc_html_minifier   = { version = "61.0.0", default-features = false }

--- a/tests/rspack-test/configCases/plugins/rspack-issue-15335/index.js
+++ b/tests/rspack-test/configCases/plugins/rspack-issue-15335/index.js
@@ -1,0 +1,36 @@
+function sameOwner(requestAccount, currentAccount) {
+	return requestAccount === currentAccount;
+}
+
+function resumeCreateOrder(submitAccount, currentAccount) {
+	$stateMachine: for (;;) {
+		switch (0) {
+			case 0: {
+				const comparator = sameOwner;
+				let requestAccount;
+
+				$checkNotNull: do {
+					if (submitAccount == null) {
+						throw new Error("Required value was null.");
+					}
+
+					requestAccount = submitAccount;
+					break $checkNotNull;
+				} while (false);
+
+				if (comparator(requestAccount, currentAccount)) {
+					return "same";
+				}
+
+				return "changed";
+			}
+
+			default:
+				continue $stateMachine;
+		}
+	}
+}
+
+it("should preserve labeled do-while control flow during minification", () => {
+	expect(resumeCreateOrder("account-a", "account-b")).toBe("changed");
+});

--- a/tests/rspack-test/configCases/plugins/rspack-issue-15335/rspack.config.js
+++ b/tests/rspack-test/configCases/plugins/rspack-issue-15335/rspack.config.js
@@ -1,0 +1,17 @@
+const { rspack } = require('@rspack/core');
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new rspack.SwcJsMinimizerRspackPlugin({
+        minimizerOptions: {
+          compress: true,
+          mangle: true,
+        },
+      }),
+    ],
+  },
+};


### PR DESCRIPTION
## Summary

- Update `swc_ecma_minifier` from `61.0.0` to `61.0.4`.
- Include the required lockfile updates for `swc_ecma_parser` and `swc_ecma_transforms_base`.
- Keep `swc_core` at `77.0.0`.
- Add an Rspack regression case for the labeled `do/while(false)` control-flow issue.

## Related links

- Fixes #15335
- https://github.com/swc-project/swc/pull/12160

## Validation

- `pnpm run build:cli:dev`
- Original #15335 reproduction: `undefined` before, `changed` after
- `pnpm run test -t "configCases/plugins/rspack-issue-15335"` (2 passed)
- `pnpm run test -t "configCases/plugins/minify"` (60 passed)
- `cargo test -p rspack_plugin_swc_js_minimizer`

## Checklist

- [x] Tests updated.
- [x] Documentation updated (not required).