### PR TITLE
fix: limit concurrent asset emission

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -14,6 +14,7 @@ use rspack_sources::BoxSource;
 use rspack_tasks::{CompilerContext, within_compiler_context};
 use rspack_util::{node_path::NodePath, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::FxHashMap as HashMap;
+use tokio::sync::Semaphore;
 use tracing::instrument;
 
 pub use self::rebuild::CompilationRecords;
@@ -67,6 +68,7 @@ pub struct CompilerHooks {
 }
 
 static COMPILER_ID: AtomicU32 = AtomicU32::new(0);
+const MAX_CONCURRENT_ASSET_EMITS: usize = 15;
 
 #[cacheable]
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
@@ -446,6 +448,7 @@ impl Compiler {
       .compilation
       .incremental
       .passes_enabled(IncrementalPasses::EMIT_ASSETS);
+    let emit_assets_semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_ASSET_EMITS));
 
     let emit_results = rspack_parallel::scope(|token| {
       self
@@ -468,9 +471,14 @@ impl Compiler {
 
           // SAFETY: await immediately and trust caller to poll future entirely
           let s = unsafe { token.used((&self, filename, asset, output_path)) };
+          let emit_assets_semaphore = Arc::clone(&emit_assets_semaphore);
 
-          s.spawn(|(this, filename, asset, output_path)| {
-            this.emit_asset(output_path, filename, asset)
+          s.spawn(move |(this, filename, asset, output_path)| async move {
+            let _permit = emit_assets_semaphore
+              .acquire_owned()
+              .await
+              .expect("asset emit semaphore should not be closed");
+            this.emit_asset(output_path, filename, asset).await
           });
         })
     })

--- a/tests/rspack-test/compilerCases/emit-assets-concurrency.js
+++ b/tests/rspack-test/compilerCases/emit-assets-concurrency.js
@@ -1,0 +1,82 @@
+const { createFsFromVolume, Volume } = require("memfs");
+
+const ADDITIONAL_ASSET_COUNT = 30;
+const MAX_CONCURRENT_ASSET_EMITS = 15;
+
+let activeWrites;
+let buildError;
+let buildStats;
+let maxActiveWrites;
+let outputFileSystem;
+let writeCount;
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should limit concurrent asset emits",
+	options(context) {
+		return {
+			entry: "./a",
+			output: {
+				path: context.getDist(),
+				filename: "main.js"
+			},
+			plugins: [
+				{
+					apply(compiler) {
+						compiler.hooks.compilation.tap("EmitAssetsPlugin", compilation => {
+							compilation.hooks.processAssets.tap("EmitAssetsPlugin", () => {
+								const { RawSource } = require("webpack-sources");
+								for (let i = 0; i < ADDITIONAL_ASSET_COUNT; i++) {
+									compilation.emitAsset(
+										`asset-${i}.txt`,
+										new RawSource(`asset ${i}`)
+									);
+								}
+							});
+						});
+					}
+				}
+			]
+		};
+	},
+	compiler(context, compiler) {
+		activeWrites = 0;
+		buildError = undefined;
+		buildStats = undefined;
+		maxActiveWrites = 0;
+		writeCount = 0;
+		outputFileSystem = createFsFromVolume(new Volume());
+		const writeFile = outputFileSystem.writeFile.bind(outputFileSystem);
+
+		outputFileSystem.writeFile = (filename, content, callback) => {
+			activeWrites++;
+			writeCount++;
+			maxActiveWrites = Math.max(maxActiveWrites, activeWrites);
+
+			writeFile(filename, content, error => {
+				setTimeout(() => {
+					activeWrites--;
+					callback(error);
+				}, 10);
+			});
+		};
+
+		compiler.outputFileSystem = outputFileSystem;
+	},
+	build(context, compiler) {
+		return new Promise(resolve => {
+			compiler.run((error, stats) => {
+				buildError = error;
+				buildStats = stats;
+				resolve();
+			});
+		});
+	},
+	check() {
+		expect(buildError).toBeFalsy();
+		expect(buildStats).toBeTruthy();
+		expect(activeWrites).toBe(0);
+		expect(writeCount).toBe(ADDITIONAL_ASSET_COUNT + 1);
+		expect(maxActiveWrites).toBe(MAX_CONCURRENT_ASSET_EMITS);
+	}
+};


### PR DESCRIPTION
## Summary

- Limit concurrent asset emission to 15, matching webpack behavior.
- Prevent large asset sets from exhausting available file descriptors during output.
- Add a compiler regression case that verifies the concurrent write peak.

## Related links

Fixes #15340

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).