### PR TITLE
fix(cache): persist dependency id in metadata

### DIFF
--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -258,14 +258,14 @@ impl Compiler {
     } else {
       Ok(())
     };
-    let record_dependency_id = self
-      .new_cache
-      .store_dependency_id(self.compiler_context.dependency_id());
+    let store_meta = self.new_cache.store_meta(Meta {
+      max_dependency_id: self.compiler_context.dependency_id(),
+    });
     let begin_idle = self.new_cache.begin_idle();
 
     record_build_time
       .and(store_build_dependencies)
-      .and(record_dependency_id)
+      .and(store_meta)
       .and(begin_idle)
   }
 
@@ -302,10 +302,12 @@ impl Compiler {
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
-    if let Some(restored) = self.new_cache.restore_dependency_id()? {
+    if let Some(restored) = self.new_cache.restore_meta()? {
       let current = self.compiler_context.dependency_id();
-      if current < restored {
-        self.compiler_context.set_dependency_id(restored);
+      if current < restored.max_dependency_id {
+        self
+          .compiler_context
+          .set_dependency_id(restored.max_dependency_id);
       }
     }
     // TODO: clear the outdated cache entries in resolver,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -27,7 +27,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{Cache, CacheFacade, create_cache},
+  new_cache::{Cache, CacheFacade, Meta, create_cache},
   trim_dir,
 };
 

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -258,10 +258,14 @@ impl Compiler {
     } else {
       Ok(())
     };
+    let record_dependency_id = self
+      .new_cache
+      .store_dependency_id(self.compiler_context.dependency_id());
     let begin_idle = self.new_cache.begin_idle();
 
     record_build_time
       .and(store_build_dependencies)
+      .and(record_dependency_id)
       .and(begin_idle)
   }
 
@@ -298,6 +302,12 @@ impl Compiler {
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
+    if let Some(restored) = self.new_cache.restore_dependency_id()? {
+      let current = self.compiler_context.dependency_id();
+      if current < restored {
+        self.compiler_context.set_dependency_id(restored);
+      }
+    }
     // TODO: clear the outdated cache entries in resolver,
     // TODO: maybe it's better to use external entries.
     let plugin_driver_clone = self.plugin_driver.clone();

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -4,7 +4,7 @@ use rspack_error::Result;
 use rspack_paths::InternedPathSet;
 
 use super::{
-  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
+  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult, Meta,
   cache_value::CacheValueData,
 };
 
@@ -126,26 +126,26 @@ impl Cache {
     }
   }
 
-  pub fn store_dependency_id(&self, dependency_id: u32) -> Result<()> {
+  pub fn store_meta(&self, meta: Meta) -> Result<()> {
     let Some(storage) = &self.inner.storage else {
       return Ok(());
     };
     if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.store_dependency_id(dependency_id)
+      file_cache.store_meta(meta)
     } else {
       Ok(())
     }
   }
 
-  pub fn restore_dependency_id(&self) -> Result<Option<u32>> {
+  pub fn restore_meta(&self) -> Result<Option<Meta>> {
     let Some(storage) = &self.inner.storage else {
       return Ok(None);
     };
-    storage
-      .idle_file_cache
-      .as_ref()
-      .map(IdleFileCache::restore_dependency_id)
-      .transpose()
+    if let Some(file_cache) = &storage.idle_file_cache {
+      file_cache.restore_meta()
+    } else {
+      Ok(None)
+    }
   }
 
   pub fn has_file_cache(&self) -> bool {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -126,6 +126,28 @@ impl Cache {
     }
   }
 
+  pub fn store_dependency_id(&self, dependency_id: u32) -> Result<()> {
+    let Some(storage) = &self.inner.storage else {
+      return Ok(());
+    };
+    if let Some(file_cache) = &storage.idle_file_cache {
+      file_cache.store_dependency_id(dependency_id)
+    } else {
+      Ok(())
+    }
+  }
+
+  pub fn restore_dependency_id(&self) -> Result<Option<u32>> {
+    let Some(storage) = &self.inner.storage else {
+      return Ok(None);
+    };
+    storage
+      .idle_file_cache
+      .as_ref()
+      .map(IdleFileCache::restore_dependency_id)
+      .transpose()
+  }
+
   pub fn has_file_cache(&self) -> bool {
     self
       .inner

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -12,15 +12,17 @@ pub use turbo::{Database, DatabaseValue};
 pub enum DatabaseFamily {
   Cache,
   Validator,
+  Meta,
 }
 
 impl DatabaseFamily {
-  pub const COUNT: usize = 2;
+  pub const COUNT: usize = 3;
 
   pub const fn index(self) -> usize {
     match self {
       Self::Cache => 0,
       Self::Validator => 1,
+      Self::Meta => 2,
     }
   }
 }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -338,6 +338,10 @@ fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
         name: "validator",
         kind: FamilyKind::SingleValue,
       },
+      FamilyConfig {
+        name: "meta",
+        kind: FamilyKind::SingleValue,
+      },
     ],
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -6,7 +6,7 @@ use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use rustc_hash::FxHashMap;
 
 use super::{
-  CacheKey, Etag,
+  CacheKey, Etag, Meta,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
   db::{Database, DatabaseFamily, DatabaseValue},
   snapshot::FileSystemInfo,
@@ -15,13 +15,13 @@ use super::{
 use crate::cache::CacheCodec;
 
 const VALIDATOR_KEY: &[u8] = b"validator";
-const MAX_DEPENDENCY_ID_KEY: &[u8] = b"max_dependency_id";
+const META_KEY: &[u8] = b"meta";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   new_build_dependencies: Option<InternedPathSet>,
-  max_dependency_id_dirty: bool,
+  meta: Option<Meta>,
 }
 
 #[derive(Debug)]
@@ -36,7 +36,6 @@ pub struct FileCacheStrategy {
   codec: Arc<CacheCodec>,
   database: Database,
   pending_writes: PendingWrites,
-  max_dependency_id: u32,
   readonly: bool,
 }
 
@@ -71,7 +70,6 @@ impl FileCacheStrategy {
       codec,
       database,
       pending_writes: PendingWrites::default(),
-      max_dependency_id: 0,
       readonly,
     })
   }
@@ -113,12 +111,6 @@ impl FileCacheStrategy {
         self.database.reset()?;
       }
     }
-    self.max_dependency_id = self
-      .database
-      .get(DatabaseFamily::Meta, MAX_DEPENDENCY_ID_KEY)?
-      .map(|data| self.codec.decode::<u32>(&data))
-      .transpose()?
-      .unwrap_or_default();
     Ok(())
   }
 
@@ -152,16 +144,21 @@ impl FileCacheStrategy {
       .extend(dependencies);
   }
 
-  pub fn store_dependency_id(&mut self, dependency_id: u32) {
-    if self.readonly || dependency_id <= self.max_dependency_id {
+  pub fn store_meta(&mut self, meta: Meta) {
+    if self.readonly {
       return;
     }
-    self.max_dependency_id = dependency_id;
-    self.pending_writes.max_dependency_id_dirty = true;
+    self.pending_writes.meta = Some(meta);
   }
 
-  pub fn restore_dependency_id(&self) -> u32 {
-    self.max_dependency_id
+  pub fn restore_meta(&self) -> Result<Option<Meta>> {
+    if let Some(pending) = self.pending_writes.meta.as_ref() {
+      return Ok(Some(pending.clone()));
+    }
+    let Some(entry) = self.database.get(DatabaseFamily::Meta, META_KEY)? else {
+      return Ok(None);
+    };
+    Ok(Some(self.codec.decode(&entry)?))
   }
 
   pub(super) fn restore(
@@ -195,17 +192,17 @@ impl FileCacheStrategy {
     }
 
     if self.has_pending_writes() {
+      let codec = &self.codec;
+      let entries = &self.pending_writes.entries;
       let validator = if let Some(dependencies) = &self.pending_writes.new_build_dependencies {
         self.validator.update(dependencies.iter().cloned()).await?
       } else {
         None
       };
-      let entries = &self.pending_writes.entries;
-      let codec = &self.codec;
-      let encoded_max_dependency_id = self
+      let meta = self
         .pending_writes
-        .max_dependency_id_dirty
-        .then(|| codec.encode(&self.max_dependency_id))
+        .meta
+        .map(|meta| codec.encode(&meta))
         .transpose()?;
       self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {
@@ -215,19 +212,15 @@ impl FileCacheStrategy {
         if let Some(validator) = validator {
           batch.put(DatabaseFamily::Validator, VALIDATOR_KEY, validator)?;
         }
-        if let Some(max_dependency_id) = encoded_max_dependency_id {
-          batch.put(
-            DatabaseFamily::Meta,
-            MAX_DEPENDENCY_ID_KEY,
-            max_dependency_id,
-          )?;
+        if let Some(meta) = meta {
+          batch.put(DatabaseFamily::Meta, META_KEY, meta)?;
         }
         Ok(())
       })?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.new_build_dependencies = None;
-      self.pending_writes.max_dependency_id_dirty = false;
+      self.pending_writes.meta = None;
     }
 
     for _ in 0..max_compaction_passes {
@@ -253,6 +246,6 @@ impl FileCacheStrategy {
   pub fn has_pending_writes(&self) -> bool {
     !self.pending_writes.entries.is_empty()
       || self.pending_writes.new_build_dependencies.is_some()
-      || self.pending_writes.max_dependency_id_dirty
+      || self.pending_writes.meta.is_some()
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -15,11 +15,13 @@ use super::{
 use crate::cache::CacheCodec;
 
 const VALIDATOR_KEY: &[u8] = b"validator";
+const MAX_DEPENDENCY_ID_KEY: &[u8] = b"max_dependency_id";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxHashMap<CacheKey, PendingWrite>,
   new_build_dependencies: Option<InternedPathSet>,
+  max_dependency_id_dirty: bool,
 }
 
 #[derive(Debug)]
@@ -34,6 +36,7 @@ pub struct FileCacheStrategy {
   codec: Arc<CacheCodec>,
   database: Database,
   pending_writes: PendingWrites,
+  max_dependency_id: u32,
   readonly: bool,
 }
 
@@ -68,6 +71,7 @@ impl FileCacheStrategy {
       codec,
       database,
       pending_writes: PendingWrites::default(),
+      max_dependency_id: 0,
       readonly,
     })
   }
@@ -109,6 +113,12 @@ impl FileCacheStrategy {
         self.database.reset()?;
       }
     }
+    self.max_dependency_id = self
+      .database
+      .get(DatabaseFamily::Meta, MAX_DEPENDENCY_ID_KEY)?
+      .map(|data| self.codec.decode::<u32>(&data))
+      .transpose()?
+      .unwrap_or_default();
     Ok(())
   }
 
@@ -140,6 +150,18 @@ impl FileCacheStrategy {
       .new_build_dependencies
       .get_or_insert_default()
       .extend(dependencies);
+  }
+
+  pub fn store_dependency_id(&mut self, dependency_id: u32) {
+    if self.readonly || dependency_id <= self.max_dependency_id {
+      return;
+    }
+    self.max_dependency_id = dependency_id;
+    self.pending_writes.max_dependency_id_dirty = true;
+  }
+
+  pub fn restore_dependency_id(&self) -> u32 {
+    self.max_dependency_id
   }
 
   pub(super) fn restore(
@@ -180,6 +202,11 @@ impl FileCacheStrategy {
       };
       let entries = &self.pending_writes.entries;
       let codec = &self.codec;
+      let encoded_max_dependency_id = self
+        .pending_writes
+        .max_dependency_id_dirty
+        .then(|| codec.encode(&self.max_dependency_id))
+        .transpose()?;
       self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {
           let value = (pending.encoder)(&pending.entry, codec)?;
@@ -188,11 +215,19 @@ impl FileCacheStrategy {
         if let Some(validator) = validator {
           batch.put(DatabaseFamily::Validator, VALIDATOR_KEY, validator)?;
         }
+        if let Some(max_dependency_id) = encoded_max_dependency_id {
+          batch.put(
+            DatabaseFamily::Meta,
+            MAX_DEPENDENCY_ID_KEY,
+            max_dependency_id,
+          )?;
+        }
         Ok(())
       })?;
 
       self.pending_writes.entries.clear();
       self.pending_writes.new_build_dependencies = None;
+      self.pending_writes.max_dependency_id_dirty = false;
     }
 
     for _ in 0..max_compaction_passes {
@@ -216,6 +251,8 @@ impl FileCacheStrategy {
   }
 
   pub fn has_pending_writes(&self) -> bool {
-    !self.pending_writes.entries.is_empty() || self.pending_writes.new_build_dependencies.is_some()
+    !self.pending_writes.entries.is_empty()
+      || self.pending_writes.new_build_dependencies.is_some()
+      || self.pending_writes.max_dependency_id_dirty
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -202,7 +202,8 @@ impl FileCacheStrategy {
       let meta = self
         .pending_writes
         .meta
-        .map(|meta| codec.encode(&meta))
+        .as_ref()
+        .map(|meta| codec.encode(meta))
         .transpose()?;
       self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -16,7 +16,7 @@ use tokio::{
 };
 
 use super::{
-  CacheKey, CacheValue, Etag, FileCacheStrategy,
+  CacheKey, CacheValue, Etag, FileCacheStrategy, Meta,
   cache_value::{CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
 };
 
@@ -33,13 +33,16 @@ enum Command {
     value: ErasedCacheValue,
     encoder: CacheValueEncoder,
   },
-  StoreBuildDependencies(InternedPathSet),
-  StoreDependencyId(u32),
   Restore {
     key: CacheKey,
     etag: Option<Etag>,
     decoder: CacheValueDecoder,
     result: sync_mpsc::SyncSender<Result<Option<ErasedCacheValue>>>,
+  },
+  StoreBuildDependencies(InternedPathSet),
+  StoreMeta(Meta),
+  RestoreMeta {
+    result: sync_mpsc::SyncSender<Result<Option<Meta>>>,
   },
   RecordBuildTime(Duration),
   BeginIdle {
@@ -47,9 +50,6 @@ enum Command {
   },
   EndIdle,
   Shutdown(oneshot::Sender<Result<()>>),
-  RestoreDependencyId {
-    result: sync_mpsc::SyncSender<u32>,
-  },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -126,8 +126,8 @@ impl BackgroundJob {
       Command::StoreBuildDependencies(dependencies) => {
         self.strategy.store_build_dependencies(dependencies);
       }
-      Command::StoreDependencyId(dependency_id) => {
-        self.strategy.store_dependency_id(dependency_id);
+      Command::StoreMeta(meta) => {
+        self.strategy.store_meta(meta);
       }
       Command::Restore {
         key,
@@ -172,8 +172,8 @@ impl BackgroundJob {
         let _ = result.send(self.strategy.shutdown().await);
         return true;
       }
-      Command::RestoreDependencyId { result } => {
-        let _ = result.send(self.strategy.restore_dependency_id());
+      Command::RestoreMeta { result } => {
+        let _ = result.send(self.strategy.restore_meta());
       }
     }
     false
@@ -296,16 +296,16 @@ impl IdleFileCache {
     self.send(Command::StoreBuildDependencies(dependencies))
   }
 
-  pub fn store_dependency_id(&self, dependency_id: u32) -> Result<()> {
-    self.send(Command::StoreDependencyId(dependency_id))
+  pub fn store_meta(&self, meta: Meta) -> Result<()> {
+    self.send(Command::StoreMeta(meta))
   }
 
-  pub fn restore_dependency_id(&self) -> Result<u32> {
+  pub fn restore_meta(&self) -> Result<Option<Meta>> {
     let (result, result_receiver) = sync_mpsc::sync_channel(1);
-    self.send(Command::RestoreDependencyId { result })?;
+    self.send(Command::RestoreMeta { result })?;
     result_receiver
       .recv()
-      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -34,6 +34,7 @@ enum Command {
     encoder: CacheValueEncoder,
   },
   StoreBuildDependencies(InternedPathSet),
+  StoreDependencyId(u32),
   Restore {
     key: CacheKey,
     etag: Option<Etag>,
@@ -46,6 +47,9 @@ enum Command {
   },
   EndIdle,
   Shutdown(oneshot::Sender<Result<()>>),
+  RestoreDependencyId {
+    result: sync_mpsc::SyncSender<u32>,
+  },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -122,6 +126,9 @@ impl BackgroundJob {
       Command::StoreBuildDependencies(dependencies) => {
         self.strategy.store_build_dependencies(dependencies);
       }
+      Command::StoreDependencyId(dependency_id) => {
+        self.strategy.store_dependency_id(dependency_id);
+      }
       Command::Restore {
         key,
         etag,
@@ -164,6 +171,9 @@ impl BackgroundJob {
         self.idle_deadline = None;
         let _ = result.send(self.strategy.shutdown().await);
         return true;
+      }
+      Command::RestoreDependencyId { result } => {
+        let _ = result.send(self.strategy.restore_dependency_id());
       }
     }
     false
@@ -284,6 +294,18 @@ impl IdleFileCache {
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) -> Result<()> {
     self.send(Command::StoreBuildDependencies(dependencies))
+  }
+
+  pub fn store_dependency_id(&self, dependency_id: u32) -> Result<()> {
+    self.send(Command::StoreDependencyId(dependency_id))
+  }
+
+  pub fn restore_dependency_id(&self) -> Result<u32> {
+    let (result, result_receiver) = sync_mpsc::sync_channel(1);
+    self.send(Command::RestoreDependencyId { result })?;
+    result_receiver
+      .recv()
+      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
   }
 
   pub fn record_build_time(&self, build_time: Duration) -> Result<()> {

--- a/crates/rspack_core/src/new_cache/meta.rs
+++ b/crates/rspack_core/src/new_cache/meta.rs
@@ -1,0 +1,7 @@
+use rspack_cacheable::cacheable;
+
+#[cacheable]
+#[derive(Debug, Clone)]
+pub struct Meta {
+  pub max_dependency_id: u32,
+}

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -7,6 +7,7 @@ mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
+mod meta;
 mod snapshot;
 mod validator;
 
@@ -20,6 +21,7 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
+pub use meta::Meta;
 use rspack_fs::ReadableFileSystem;
 
 use self::snapshot::FileSystemInfo;


### PR DESCRIPTION
## Summary

- Persist the maximum dependency ID in a dedicated new-cache `meta` database family.
- Restore the counter before compilation and record it before idle flushing, including failed builds.
- Keep dependency ID metadata separate from validator data and module-cache ownership.