### PR TITLE
perf(bench): collect mimalloc memory in benchmark setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2592,6 +2598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
 dependencies = [
  "cc",
+ "cty",
  "libc",
 ]
 
@@ -3957,6 +3964,7 @@ version = "0.102.0"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
+ "libmimalloc-sys",
  "mimalloc",
  "rayon",
  "rspack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ itoa                = { version = "1.0.18", default-features = false }
 json                = { version = "0.12.4", default-features = false }
 json-escape-simd    = { version = "3.1.1", default-features = false }
 json-strip-comments = { version = "3.1.1", default-features = false }
+libmimalloc-sys     = { version = "0.1.44", default-features = false }
 lightningcss        = { version = "1.0.0-alpha.71", default-features = false, features = ["serde"] }
 linked-hash-map     = { version = "0.5.6", default-features = false }
 md4                 = { version = "0.10.2", default-features = false }

--- a/xtask/benchmark/Cargo.toml
+++ b/xtask/benchmark/Cargo.toml
@@ -14,13 +14,16 @@ tokio     = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # Keep benchmark allocator features aligned with rspack_allocator.
-mimalloc = { workspace = true, features = ["local_dynamic_tls", "v3"] }
+libmimalloc-sys = { workspace = true, features = ["extended", "local_dynamic_tls", "v3"] }
+mimalloc        = { workspace = true, features = ["local_dynamic_tls", "v3"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+libmimalloc-sys = { workspace = true, features = ["extended", "v3"] }
+mimalloc        = { workspace = true, features = ["v3"] }
 
 [target.'cfg(all(not(target_os = "linux"), not(target_os = "macos"), not(target_family = "wasm")))'.dependencies]
-mimalloc = { workspace = true, features = ["v3"] }
+libmimalloc-sys = { workspace = true, features = ["extended", "v3"] }
+mimalloc        = { workspace = true, features = ["v3"] }
 
 [dev-dependencies]
 # Make rust analyzer happy

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -202,6 +202,7 @@ pub fn build_chunk_graph_benchmark_inner(c: &mut Criterion) {
   c.bench_function("rust@build_chunk_graph", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         reset_chunk_graph_state(&mut compiler.compilation);
       },
@@ -261,6 +262,7 @@ fn build_module_graph_case(
   c.bench_function(benchmark_id, |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         reset_compilation_state(&mut compiler);
         let plugin_driver = compiler.plugin_driver.clone();

--- a/xtask/benchmark/benches/groups/bundle.rs
+++ b/xtask/benchmark/benches/groups/bundle.rs
@@ -34,6 +34,7 @@ pub(crate) fn bundle_benchmark_case(c: &mut Criterion, target_id: &str) {
   group.bench_function(format!("bundle@{id}"), |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         let compiler_context = Arc::new(CompilerContext::new());
         (
           compiler_context.clone(),

--- a/xtask/benchmark/benches/groups/compilation_stages.rs
+++ b/xtask/benchmark/benches/groups/compilation_stages.rs
@@ -74,6 +74,7 @@ pub(crate) fn flag_dependency_exports_benchmark(c: &mut Criterion, rt: &Runtime)
   c.bench_function("rust@flag_dependency_exports", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         if should_reset.get() {
           compiler.compilation.exports_info_artifact.reset();
@@ -120,6 +121,7 @@ pub(crate) fn flag_dependency_usage_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@flag_dependency_usage", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         if should_reset.get() {
           compiler
@@ -172,6 +174,7 @@ pub(crate) fn create_module_ids_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_module_ids", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         compiler.compilation.module_ids_artifact.clear();
       },
@@ -208,6 +211,7 @@ pub(crate) fn create_named_module_ids_benchmark(c: &mut Criterion, rt: &Runtime)
   c.bench_function("rust@create_named_module_ids", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         compiler.compilation.module_ids_artifact.clear();
       },
@@ -310,6 +314,7 @@ pub(crate) fn split_chunks_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@split_chunks", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         restore_initial_chunk_state(&mut compiler.compilation);
       },
@@ -357,6 +362,7 @@ pub(crate) fn create_chunk_ids_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_chunk_ids", |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         (
           initial_chunk_by_ukey.clone(),
           ChunkNamedIdArtifact::default(),
@@ -404,6 +410,7 @@ pub(crate) fn create_named_chunk_ids_benchmark(c: &mut Criterion, rt: &Runtime) 
   c.bench_function("rust@create_named_chunk_ids", |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         (
           initial_chunk_by_ukey.clone(),
           ChunkNamedIdArtifact::default(),
@@ -472,6 +479,7 @@ pub(crate) fn mangle_exports_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@mangle_exports", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         if should_reset.get() {
           compiler
@@ -523,6 +531,7 @@ pub(crate) fn create_module_hashes_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_module_hashes", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let _compiler = compiler.borrow();
       },
       |_| {
@@ -590,6 +599,7 @@ pub(crate) fn runtime_requirements_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@runtime_requirements", |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         let fs = Arc::new(MemoryFileSystem::default());
         let random_table = random_table.clone();
         let mut compiler = create_general_stage_compiler(fs.clone());
@@ -662,6 +672,7 @@ pub(crate) fn create_full_hash_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_full_hash", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         compiler.compilation.chunk_hashes_artifact.clear();
         compiler.compilation.runtime_modules_hash.clear();
@@ -726,6 +737,7 @@ pub(crate) fn create_chunk_assets_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_chunk_assets", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
       },
@@ -785,6 +797,7 @@ pub(crate) fn create_module_assets_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@create_module_assets", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
       },
@@ -842,6 +855,7 @@ pub(crate) fn real_content_hash_benchmark(c: &mut Criterion, rt: &Runtime) {
   c.bench_function("rust@real_content_hash", |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         restore_chunk_asset_state(&mut compiler.compilation, &initial_state);
       },
@@ -932,6 +946,7 @@ fn register_create_concatenate_module_benchmark(
   c.bench_function(case.name, |b| {
     b.iter_batched_ref(
       || {
+        rspack_benchmark::collect_memory();
         let mut compiler = compiler.borrow_mut();
         if should_reset.get() {
           compiler

--- a/xtask/benchmark/benches/groups/persistent_cache.rs
+++ b/xtask/benchmark/benches/groups/persistent_cache.rs
@@ -61,6 +61,7 @@ fn persistent_cache_benchmark_case<F>(
   group.bench_function(benchmark_id, |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         // Clear the previous measured workspace outside the next sample's
         // timed region so cleanup cost never lands in benchmark results.
         cleanup_pending_workspaces(&pending_cleanup);

--- a/xtask/benchmark/benches/groups/scan_dependencies.rs
+++ b/xtask/benchmark/benches/groups/scan_dependencies.rs
@@ -97,7 +97,10 @@ fn register_scan_dependencies_benchmark_case(
 ) {
   c.bench_function(benchmark_case.benchmark_id, |b| {
     b.iter_batched_ref(
-      || benchmark_case.build_iteration_state(),
+      || {
+        rspack_benchmark::collect_memory();
+        benchmark_case.build_iteration_state()
+      },
       |iteration_state| {
         let result = benchmark_case.execute_scan_dependencies(iteration_state);
         black_box(result);

--- a/xtask/benchmark/benches/walltime.rs
+++ b/xtask/benchmark/benches/walltime.rs
@@ -39,6 +39,7 @@ fn walltime_bundle_benchmark_case(c: &mut Criterion, target_id: &str) {
   group.bench_function(format!("bundle@{id}"), |b| {
     b.iter_batched(
       || {
+        rspack_benchmark::collect_memory();
         let compiler_context = Arc::new(CompilerContext::new());
         let compiler = within_compiler_context_sync(compiler_context.clone(), || {
           get_compiler().build().unwrap()

--- a/xtask/benchmark/src/lib.rs
+++ b/xtask/benchmark/src/lib.rs
@@ -102,6 +102,24 @@ unsafe impl<A: GlobalAlloc> GlobalAlloc for NeverGrowInPlaceAllocator<A> {
   }
 }
 
+/// Reclaim memory retained by the allocator so that every measured iteration
+/// starts from a comparable heap state.
+///
+/// Between iterations a benchmark leaves behind thread-local free lists and
+/// retired pages whose layout depends on the previous iteration's allocation
+/// and free order. The next iteration then walks a different allocator fast
+/// path, which shows up as run-to-run variance. Collecting in `setup` resets
+/// that state; it is not part of the measured region, since CodSpeed only
+/// instruments the routine passed to `iter_batched`/`iter_batched_ref`.
+pub fn collect_memory() {
+  #[cfg(not(target_family = "wasm"))]
+  // SAFETY: `mi_collect` only touches allocator-internal bookkeeping.
+  #[expect(unsafe_code)]
+  unsafe {
+    libmimalloc_sys::mi_collect(true)
+  }
+}
+
 fn build_multi_thread_tokio_rt(worker_threads: usize, blocking_threads: usize) -> Runtime {
   let mut builder = Builder::new_multi_thread();
   builder


### PR DESCRIPTION
## Why

Between two measured iterations a benchmark leaves the allocator dirty: thread-local free lists and retired pages are laid out according to the *previous* iteration's allocation and free order. The next iteration then walks a different allocator fast path, which was the suspected source of run-to-run variance.

This calls `mi_collect(true)` in every `iter_batched` / `iter_batched_ref` setup closure, so each measured iteration starts from a comparable heap state.

Setup is outside the measured region — `codspeed-criterion-compat` only wraps the routine with `start_benchmark()` / `end_benchmark()` (`src/compat/bencher.rs:127-139`), and criterion's walltime bencher excludes setup from timing — so the collect cost is not counted.

## What

- `rspack_benchmark::collect_memory()` — thin wrapper over `libmimalloc_sys::mi_collect(true)`, no-op on wasm.
- `libmimalloc-sys` added with the `extended` feature (that feature is what exposes the `mi_collect` binding); feature set kept aligned with the existing `mimalloc` dependency.
- Call inserted as the first statement of all 21 setup closures across `compilation_stages`, `build_chunk_graph`, `bundle`, `persistent_cache`, `scan_dependencies` and `walltime`.

## Measured effect: no stability gain

Ran the simulation benchmark 5× on this branch and 5× on its base (`faba242cd6`) as independent CI runs, then read the per-benchmark instruction counts straight out of the uploaded callgrind dumps (50 benchmarks, matching the 50 CodSpeed reports).

| | bit-identical across the 5 runs | CV median | CV mean | CV max |
|---|---|---|---|---|
| with `mi_collect` | 16/50 | 0.0079% | 0.133% | 1.21% |
| base | 16/50 | 0.0065% | 0.134% | 1.93% |

Paired per benchmark: with-collect is tighter on 18, base is tighter on 16, 16 ties. Restricted to the 25 benchmarks that are not already deterministic (`max CV > 0.01%`): 12 vs 13. That is a coin flip, so allocator carry-over is not what drives the residual noise.

The noise that remains is concentrated in the small `rust@<stage>` benchmarks (a few million Ir); every `sources@*`, `bundle@*` and `build_*` benchmark is already deterministic. `rust@create_chunk_assets` is the worst case in both arms (1.21% / 1.93%), which is the benchmark previously traced to glibc `memcpy` ifunc dispatch — something `mi_collect` cannot address.

One real effect did show up: collecting shifts the measured level slightly **down** (22 of the 28 benchmarks that moved by more than 0.01%, up to −0.78%, mean −0.086%). That is a one-off bias absorbed at the next baseline, not a variance reduction.

Wall-clock cost is nil: the `Run benchmark (simulation)` step took 727s here versus a 759s median over the last 22 main runs on the same runner type.
