### PR TITLE
fix(cache): normalize restored paths on Windows

### DIFF
--- a/crates/rspack_cacheable/src/context.rs
+++ b/crates/rspack_cacheable/src/context.rs
@@ -11,6 +11,10 @@ const CONTEXT_ADDR: usize = 0;
 unsafe fn default_drop(_: ErasedPtr) {}
 
 pub trait CacheableContext: Any {
+  /// Returns the project root used for portable path conversion.
+  ///
+  /// `Some` enables portable conversion relative to this root, while `None` keeps paths in their
+  /// native representation.
   fn project_root(&self) -> Option<&Path>;
 }
 

--- a/crates/rspack_cacheable/src/utils/portable_path.rs
+++ b/crates/rspack_cacheable/src/utils/portable_path.rs
@@ -28,31 +28,39 @@ pub struct PortablePath {
 }
 
 impl PortablePath {
-  /// Create a portable path, converting to relative if both path and project_root are absolute
-  pub fn new(path: &Path, project_root: Option<&Path>) -> Self {
+  /// Create a portable path. Passing a root enables portable conversion; otherwise the native
+  /// path representation is preserved.
+  pub fn new(path: &Path, portable_project_root: Option<&Path>) -> Self {
     if path.is_absolute()
-      && let Some(project_root) = project_root
+      && let Some(portable_project_root) = portable_project_root
     {
       return Self {
-        path: path.relative(project_root).to_slash_lossy().into_owned(),
+        path: path
+          .relative(portable_project_root)
+          .to_slash_lossy()
+          .into_owned(),
         transformed: true,
       };
     }
 
     Self {
-      path: path.to_slash_lossy().into_owned(),
+      path: if portable_project_root.is_some() {
+        path.to_slash_lossy().into_owned()
+      } else {
+        path.to_string_lossy().into_owned()
+      },
       transformed: false,
     }
   }
 
-  /// Convert back to path string using project_root if the path was transformed
-  pub fn into_path_string(self, project_root: Option<&Path>) -> String {
+  /// Convert back to a path string using the portable project root if the path was transformed.
+  pub fn into_path_string(self, portable_project_root: Option<&Path>) -> String {
     if self.transformed
-      && let Some(project_root) = project_root
+      && let Some(portable_project_root) = portable_project_root
     {
       return self
         .path
-        .absolutize_with(project_root)
+        .absolutize_with(portable_project_root)
         .to_string_lossy()
         .into_owned();
     }

--- a/crates/rspack_cacheable_test/tests/utils/portable_path.rs
+++ b/crates/rspack_cacheable_test/tests/utils/portable_path.rs
@@ -100,3 +100,41 @@ fn test_windows_path() {
   assert_eq!(new_data.path1, PathBuf::from("D:\\workspace\\src\\main.rs"));
   assert_eq!(new_data.path2, PathBuf::from("D:\\workspace\\src\\lib.rs"));
 }
+
+#[test]
+#[cfg(windows)]
+fn test_windows_path_without_context_uses_native_separators() {
+  let context = TestContext(None);
+  let data = PathData {
+    path1: PathBuf::from("C:\\Users\\test\\project\\src\\main.rs"),
+    path2: Utf8PathBuf::from("C:\\Users\\test\\project\\src\\lib.rs"),
+  };
+
+  let bytes = rspack_cacheable::to_bytes(&data, &context).unwrap();
+  let new_data: PathData = rspack_cacheable::from_bytes(&bytes, &context).unwrap();
+
+  assert_eq!(
+    new_data.path1.to_string_lossy(),
+    "C:\\Users\\test\\project\\src\\main.rs"
+  );
+  assert_eq!(
+    new_data.path2.as_str(),
+    "C:\\Users\\test\\project\\src\\lib.rs"
+  );
+}
+
+#[test]
+#[cfg(windows)]
+fn test_windows_relative_paths_preserve_their_representation() {
+  let context = TestContext(None);
+  let data = PathData {
+    path1: PathBuf::from("./build.txt"),
+    path2: Utf8PathBuf::from("node_modules/"),
+  };
+
+  let bytes = rspack_cacheable::to_bytes(&data, &context).unwrap();
+  let new_data: PathData = rspack_cacheable::from_bytes(&bytes, &context).unwrap();
+
+  assert_eq!(new_data.path1.to_string_lossy(), "./build.txt");
+  assert_eq!(new_data.path2.as_str(), "node_modules/");
+}

--- a/crates/rspack_core/src/cache/codec.rs
+++ b/crates/rspack_core/src/cache/codec.rs
@@ -10,12 +10,12 @@ use rspack_paths::Utf8PathBuf;
 /// Internal cacheable context for serialization
 #[derive(Debug, Clone)]
 struct Context {
-  project_path: Option<Utf8PathBuf>,
+  portable_project_root: Option<Utf8PathBuf>,
 }
 
 impl rspack_cacheable::CacheableContext for Context {
   fn project_root(&self) -> Option<&Path> {
-    self.project_path.as_ref().map(|p| p.as_std_path())
+    self.portable_project_root.as_ref().map(|p| p.as_std_path())
   }
 }
 
@@ -27,7 +27,7 @@ impl rspack_cacheable::CacheableContext for Context {
 /// # Example
 ///
 /// ```ignore
-/// let codec = CacheCodec::new(project_path);
+/// let codec = CacheCodec::new(portable_project_root);
 ///
 /// // Encode data to bytes
 /// let bytes = codec.encode(&my_data)?;
@@ -41,9 +41,11 @@ pub struct CacheCodec {
 }
 
 impl CacheCodec {
-  pub fn new(project_path: Option<Utf8PathBuf>) -> Self {
+  pub fn new(portable_project_root: Option<Utf8PathBuf>) -> Self {
     Self {
-      context: Context { project_path },
+      context: Context {
+        portable_project_root,
+      },
     }
   }
 

--- a/crates/rspack_core/src/legacy_cache/persistent/mod.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/mod.rs
@@ -52,12 +52,12 @@ impl PersistentCache {
     intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
     compilation_logging: CompilationLogging,
   ) -> Self {
-    let project_root = if option.portable {
+    let portable_project_root = if option.portable {
       Some(compiler_options.context.as_path().to_path_buf())
     } else {
       None
     };
-    let codec = Arc::new(CacheCodec::new(project_root));
+    let codec = Arc::new(CacheCodec::new(portable_project_root));
     // Each compiler path owns exactly one storage directory.
     let cache_directory = {
       let mut hasher = DefaultHasher::new();

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -45,12 +45,12 @@ pub fn create_cache(
     crate::CacheOptions::Persistent(options) => options,
   };
 
-  let project_root = if options.portable {
+  let portable_project_root = if options.portable {
     Some(compiler_options.context.as_path().to_path_buf())
   } else {
     None
   };
-  let codec = Arc::new(CacheCodec::new(project_root));
+  let codec = Arc::new(CacheCodec::new(portable_project_root));
   let file_system_info = FileSystemInfo::new(
     input_filesystem.clone(),
     CompilationLogger::new("rspack.FileSystemInfo".to_string(), compilation_logging),

--- a/tests/rspack-test/compilerCases/persistent-cache-watch.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-watch.js
@@ -1,0 +1,211 @@
+const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const CASE_NAME = "persistent-cache-watch";
+const INITIAL_VALUE = "initial value";
+const UPDATED_VALUE = "updated value from watch";
+
+const WARM_CACHE_SCRIPT = String.raw`
+const rspack = require(process.argv[1]);
+const options = JSON.parse(process.argv[2]);
+const compiler = rspack(options);
+
+compiler.run((error, stats) => {
+	const statsError =
+		!error && stats && stats.hasErrors()
+			? new Error(stats.toString({ all: false, errors: true, errorDetails: true }))
+			: null;
+
+	compiler.close(closeError => {
+		const finalError = error || statsError || closeError;
+		if (finalError) {
+			console.error(finalError);
+			process.exitCode = 1;
+		}
+	});
+});
+`;
+
+function write(file, content) {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+function warmPersistentCache(options) {
+	execFileSync(
+		process.execPath,
+		[
+			"-e",
+			WARM_CACHE_SCRIPT,
+			require.resolve("@rspack/core"),
+			JSON.stringify(options)
+		],
+		{
+			cwd: options.context,
+			stdio: "pipe",
+			windowsHide: true
+		}
+	);
+}
+
+function watchAfterCacheRestore(context, compiler, valueFile, outputFile) {
+	return new Promise((resolve, reject) => {
+		let buildCount = 0;
+		let changeTimer;
+		let watching;
+		let settled = false;
+
+		const timeout = setTimeout(
+			() => finish(new Error("Timed out waiting for the restored watcher to rebuild")),
+			process.platform === "win32" ? 15_000 : 10_000
+		);
+
+		const finish = error => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(changeTimer);
+
+			const done = closeError => {
+				const finalError = error || closeError;
+				if (finalError) {
+					reject(finalError);
+				} else {
+					resolve();
+				}
+			};
+
+			if (watching) {
+				watching.close(done);
+			} else {
+				done();
+			}
+		};
+
+		watching = compiler.watch(
+			{
+				aggregateTimeout: 50,
+				ignored: []
+			},
+			(error, stats) => {
+				try {
+					if (error) return finish(error);
+					if (!stats) return finish(new Error("Watch build returned no stats"));
+					if (stats.hasErrors()) {
+						return finish(
+							new Error(
+								stats.toString({ all: false, errors: true, errorDetails: true })
+							)
+						);
+					}
+
+					buildCount++;
+					if (buildCount === 1) {
+						context.setValue(
+							"initialCacheLog",
+							stats.toString({
+								all: false,
+								colors: false,
+								logging: false,
+								loggingDebug: /^rspack\.persistentCache$/
+							})
+						);
+						context.setValue(
+							"restoredValueDependency",
+							[...stats.compilation.fileDependencies].find(
+								dependency => path.basename(dependency) === "value.js"
+							)
+						);
+						context.setValue("initialOutput", fs.readFileSync(outputFile, "utf8"));
+
+						// Watchpack is ready after the initial callback, but Windows may need a little
+						// longer to install the native directory watcher under concurrent CI load.
+						changeTimer = setTimeout(
+							() => write(valueFile, `export default ${JSON.stringify(UPDATED_VALUE)};\n`),
+							process.platform === "win32" ? 500 : 100
+						);
+						return;
+					}
+
+					context.setValue("buildCount", buildCount);
+					context.setValue("updatedOutput", fs.readFileSync(outputFile, "utf8"));
+					finish();
+				} catch (callbackError) {
+					finish(callbackError);
+				}
+			}
+		);
+	});
+}
+
+/** @type {import("@rspack/test-tools").TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should detect native file changes after restoring a persistent cache",
+	options(context) {
+		const root = context.getDist(CASE_NAME);
+		const sourceDirectory = path.join(root, "src");
+		const outputDirectory = path.join(root, "dist");
+		const cacheDirectory = path.join(root, "cache");
+		const valueFile = path.join(sourceDirectory, "value.js");
+
+		fs.rmSync(root, { recursive: true, force: true });
+		write(
+			path.join(sourceDirectory, "index.js"),
+			'import value from "./value.js";\nconsole.log(value);\n'
+		);
+		write(valueFile, `export default ${JSON.stringify(INITIAL_VALUE)};\n`);
+
+		const options = {
+			context: sourceDirectory,
+			mode: "development",
+			devtool: false,
+			target: "node",
+			entry: "./index.js",
+			cache: {
+				type: "persistent",
+				portable: false,
+				version: CASE_NAME,
+				storage: {
+					type: "filesystem",
+					directory: cacheDirectory
+				}
+			},
+			output: {
+				path: outputDirectory,
+				filename: "main.js",
+				clean: true
+			}
+		};
+
+		// Use another process so no native path from the warm build can remain in the
+		// process-wide path interner before the persistent cache is restored.
+		warmPersistentCache(options);
+		context.setValue("valueFile", valueFile);
+		context.setValue("outputFile", path.join(outputDirectory, "main.js"));
+		return options;
+	},
+	compiler(_context, compiler) {
+		compiler.outputFileSystem = fs;
+	},
+	async build(context, compiler) {
+		await watchAfterCacheRestore(
+			context,
+			compiler,
+			context.getValue("valueFile"),
+			context.getValue("outputFile")
+		);
+	},
+	check({ context }) {
+		expect(context.getValue("initialCacheLog")).toContain(
+			"make persistent cache recovery succeeded"
+		);
+		expect(context.getValue("restoredValueDependency")).toBe(
+			context.getValue("valueFile")
+		);
+		expect(context.getValue("buildCount")).toBe(2);
+		expect(context.getValue("initialOutput")).toContain(INITIAL_VALUE);
+		expect(context.getValue("updatedOutput")).toContain(UPDATED_VALUE);
+	}
+};


### PR DESCRIPTION
## Summary

Normalize persistent-cache paths to native Windows separators before exposing them to filesystem watchers. Prevent cache-restored slash paths from becoming the process-wide interned representation.

## Related links

Fixes #15352

## Checklist

- [x] Tests updated.
- [x] Documentation not required.