### PR TITLE
fix(cache): restore cached paths with the native separator on Windows

### DIFF
--- a/crates/rspack_cacheable/src/utils/portable_path.rs
+++ b/crates/rspack_cacheable/src/utils/portable_path.rs
@@ -4,6 +4,18 @@ use sugar_path::SugarPath;
 
 use crate::{ContextGuard, Result, cacheable, with::AsConverter};
 
+#[inline]
+fn to_native_separator(path: String) -> String {
+  #[cfg(windows)]
+  {
+    path.replace('/', std::path::MAIN_SEPARATOR_STR)
+  }
+  #[cfg(not(windows))]
+  {
+    path
+  }
+}
+
 /// A portable path representation that can be serialized and deserialized across different
 /// environments with different project roots.
 ///
@@ -56,7 +68,7 @@ impl PortablePath {
         .to_string_lossy()
         .into_owned();
     }
-    self.path
+    to_native_separator(self.path)
   }
 }
 

--- a/crates/rspack_cacheable_test/tests/utils/portable_path.rs
+++ b/crates/rspack_cacheable_test/tests/utils/portable_path.rs
@@ -83,20 +83,32 @@ fn test_relative_path_outside_project() {
 #[test]
 #[cfg(windows)]
 fn test_windows_path() {
-  let context = TestContext(Some(PathBuf::from("C:\\Users\\test\\project")));
+  let project_root = PathBuf::from("C:\\Users\\test\\project");
+  let new_project_root = PathBuf::from("D:\\workspace");
+  let path = PathBuf::from("C:\\Users\\test\\project\\src\\main.rs");
 
-  let data = PathData {
-    path1: PathBuf::from("C:\\Users\\test\\project\\src\\main.rs"),
-    path2: Utf8PathBuf::from("C:\\Users\\test\\project\\src\\lib.rs"),
-  };
+  let restored =
+    PortablePath::new(&path, Some(&project_root)).into_path_string(Some(&new_project_root));
+  assert_eq!(restored, "D:\\workspace\\src\\main.rs");
 
-  let bytes = rspack_cacheable::to_bytes(&data, &context).unwrap();
+  let restored = PortablePath::new(&path, None).into_path_string(None);
+  assert_eq!(restored, "C:\\Users\\test\\project\\src\\main.rs");
 
-  // Deserialize on different Windows path
-  let new_context = TestContext(Some(PathBuf::from("D:\\workspace")));
-  let new_data: PathData = rspack_cacheable::from_bytes(&bytes, &new_context).unwrap();
+  let outside = PathBuf::from("C:\\Users\\test\\other\\lib.rs");
+  let restored =
+    PortablePath::new(&outside, Some(&project_root)).into_path_string(Some(&project_root));
+  assert_eq!(restored, "C:\\Users\\test\\other\\lib.rs");
+}
 
-  // Path separators should be normalized
-  assert_eq!(new_data.path1, PathBuf::from("D:\\workspace\\src\\main.rs"));
-  assert_eq!(new_data.path2, PathBuf::from("D:\\workspace\\src\\lib.rs"));
+#[test]
+fn test_round_trip_keeps_native_separator() {
+  let project_root = PathBuf::from("a").join("project");
+  let path = project_root.join("src").join("main.rs");
+
+  let restored = PortablePath::new(&path, None).into_path_string(None);
+  assert_eq!(restored, path.to_string_lossy());
+
+  let restored =
+    PortablePath::new(&path, Some(&project_root)).into_path_string(Some(&project_root));
+  assert_eq!(restored, path.to_string_lossy());
 }

--- a/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-0.txt
+++ b/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-0.txt
@@ -1,0 +1,17 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-1.txt
+++ b/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-1.txt
@@ -1,0 +1,6 @@
+DEBUG LOG from rspack.persistentCache
+<t> write make to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-2.txt
+++ b/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-2.txt
@@ -1,0 +1,20 @@
+DEBUG LOG from rspack.persistentCache
+<i> persistent cache enabled
+<i> build dependencies are valid (0 tracked)
+<t> validate build dependencies: xx ms
+<i> meta persistent cache recovery succeeded
+<t> read meta from persistent cache: xx ms
+<t> read snapshot from persistent cache: xx ms
+<i> snapshot restored with detected changed dependencies:
+<i> modified paths (1):
+<i>   - <TEST_ROOT>/js/temp/cacheCases-cacheCases/common/path-separator/file.js
+<i> make persistent cache recovery succeeded
+<t> read make from persistent cache: xx ms
+<t> write make to persistent cache: xx ms
+<i> minimize persistent cache recovery succeeded
+<t> read minimize from persistent cache: xx ms
+<t> write minimize to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-3.txt
+++ b/tests/rspack-test/cacheCases/common/path-separator/__snapshots__/stats-3.txt
@@ -1,0 +1,6 @@
+DEBUG LOG from rspack.persistentCache
+<t> write make to persistent cache: xx ms
+<t> write meta to persistent cache: xx ms
+<t> write snapshot to persistent cache: xx ms
+<t> write build dependencies to persistent cache: xx ms
+<t> stage persistent cache: xx ms

--- a/tests/rspack-test/cacheCases/common/path-separator/file.js
+++ b/tests/rspack-test/cacheCases/common/path-separator/file.js
@@ -1,0 +1,7 @@
+export default 1;
+---
+export default 2;
+---
+export default 3;
+---
+export default 4;

--- a/tests/rspack-test/cacheCases/common/path-separator/index.js
+++ b/tests/rspack-test/cacheCases/common/path-separator/index.js
@@ -1,0 +1,17 @@
+import value from './file';
+
+it('should hot update after a warm start from the persistent cache', async () => {
+	if (COMPILER_INDEX == 0) {
+		expect(value).toBe(1);
+		await NEXT_HMR();
+		expect(value).toBe(2);
+		await NEXT_START();
+	}
+	if (COMPILER_INDEX == 1) {
+		expect(value).toBe(3);
+		await NEXT_HMR();
+		expect(value).toBe(4);
+	}
+});
+
+module.hot.accept('./file');

--- a/tests/rspack-test/cacheCases/common/path-separator/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/path-separator/rspack.config.js
@@ -1,0 +1,37 @@
+const path = require('path');
+
+function findForeignSeparator(paths) {
+  const foreign = path.sep === '\\' ? '/' : '\\';
+  return [...paths].filter((p) => p.includes(foreign));
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  context: __dirname,
+  cache: {
+    type: 'persistent',
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.afterEmit.tap('AssertNativeSeparator', (compilation) => {
+          for (const [kind, paths] of [
+            ['file', compilation.fileDependencies],
+            ['context', compilation.contextDependencies],
+            ['missing', compilation.missingDependencies],
+            ['build', compilation.buildDependencies],
+          ]) {
+            const foreign = findForeignSeparator(paths);
+            if (foreign.length) {
+              compilation.errors.push(
+                new Error(
+                  `${kind} dependencies are not spelled with the native separator: ${foreign.join(', ')}`,
+                ),
+              );
+            }
+          }
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Why

Closes #15352. On Windows, `compiler.watch()` stops detecting file changes once a persistent cache is restored — a cold start watches fine, a warm start never rebuilds. Regressed in 2.2.0; 2.1.10 is fine.

Paths are stored slash-separated, and an untransformed one (`cache.portable: false`, the default) was written back **verbatim**. So a restored cache hands the build `D:/a/b` where everything else produces `D:\a\b`. Watchpack registers watchers under the raw string (`withoutCase(target)`, lower-cased only) but reconstructs incoming fs-event paths with `path.join` (native `\`) — the two never match, so the change is dropped.

The slashing itself predates 2.2.0. What changed is that #15205 made `InternedPath` intern process-wide, and on Windows two spellings of one path collide into a single entry that keeps whichever was interned first. Cache restore runs before resolution, so the slashed spelling wins and every later path is rewritten to it. On 2.1.10 the modules rebuilt during a warm start put native spellings back (measured: `native` 2 → 361, including the edited file); on 2.2.0 it stays at 2.

## What

`PortablePath::into_path_string` now converts back to the platform separator on Windows. Fixing the restore side rather than the store side also repairs caches already on disk — a store-side fix would still let the first warm start after upgrading get poisoned by the old data.

The `transformed: true` branch already came back native (`absolutize_with` normalizes); only the untransformed one was affected.

## Verification

Red/green on a Windows runner in one run — the new tests pass on this branch, and fail with `portable_path.rs` alone reverted to `main`:

```
left:  "D:/workspace/app/src/main.rs"
right: "D:\\workspace\\app\\src\\main.rs"
```

End to end on a Windows runner with the reporter's project, `fileDependencies` after a warm start:

| | build 1 | build 2 | after edit |
|---|---|---|---|
| 2.1.10 | native=2, slash=3994 | native=361, target native | rebuilds |
| 2.2.0 | native=2, slash=3994 | native=2, target slash | no rebuild |

The tests assert on strings, not `Path`s: `Path` equality on Windows compares components, so it reads `D:/a/b` and `D:\a\b` as equal while the consumer that broke compares the spelling.

Workaround for anyone on 2.2.0: `cache: { portable: true }`.
