### PR TITLE
chore: refine webpack gap tracker workflow

### DIFF
--- a/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
+++ b/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
@@ -20,11 +20,21 @@ Keep the issue and comments as lists, not prose-only summaries.
 - Completed feature comment: webpack compatibility features that Rspack has completed.
 - Missing test comment: webpack tests missing from Rspack that are not already covered by a missing feature or PR-specific feature gap.
 
+Keep workflow and update rules in this skill only. Do not add an `Update Rules` section or other agent instructions to the GitHub issue body or placeholder comments.
+
 Every update to the issue body or either placeholder comment must include a visible update time, using the local timezone when possible:
 
 ```text
 Last updated: YYYY-MM-DD HH:mm:ss Z
 ```
+
+## Preview and Approval Gate
+
+Before every GitHub update, generate a local Markdown preview containing the exact replacement body for the tracking issue and every placeholder comment that would be changed. Clearly mark the file as a preview, include its local path in the response, and do not call any GitHub write operation yet.
+
+Wait for the user to explicitly approve that preview before updating GitHub. After approval, re-read the current issue and comments and compare them with the state used to generate the preview. If GitHub changed in the meantime, do not apply the stale preview; generate a refreshed local preview and request approval again.
+
+Apply only the approved preview content. Do not add, remove, reclassify, or reword entries during the write step. A request that both approves the current preview and asks to update the issue satisfies this gate for that preview.
 
 ## Audit Workflow
 
@@ -38,13 +48,12 @@ Last updated: YYYY-MM-DD HH:mm:ss Z
    - Differences between Rspack built-in plugins and webpack built-in plugins, plus commonly-used webpack ecosystem plugins that Rspack provides built-in alternatives for.
    - Rspack PRs merged since the last recorded update, especially large changes and PRs labeled or titled as features.
    - Existing issue entries and completed entries, to avoid re-recording already tracked work.
-6. Classify each missing feature into one of these recommendation buckets:
-   - Recommended to implement in Rspack: gaps in config or plugin functionality that Rspack already exposes, or features that need native Rust/compiler integration for correctness or performance.
-   - Pending evaluation: gaps where the right home is unclear, or where webpack support may be experimental, low priority, or partially covered by existing Rspack/Rsbuild behavior.
-   - Not recommended to implement in Rspack: plugin or integration features that can be implemented outside Rspack without native Rust work or performance impact; prefer a third-party package or an independent plugin under https://github.com/rstackjs when the compatibility layer should be maintained by the Rstack ecosystem.
-7. Before marking a feature as not recommended or pending, inspect the corresponding webpack feature or plugin implementation. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin.
-8. If the gap is native CSS-related, record it in #14002 instead of #14556.
-9. For missing tests:
+6. Put every missing feature in **Pending evaluation** by default, except for the DLL-specific rule below. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, or whether the feature could live in an external package.
+7. Put DLL plugins and DLL-related functionality in **Not recommended to implement in Rspack** by default. State that users should use Module Federation instead.
+8. Put or move any non-DLL gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording or reasoning does not count as a manual annotation; when the provenance is unclear, leave the gap in **Pending evaluation**. Do not add other new gaps to **Not recommended to implement in Rspack** automatically.
+9. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep non-DLL gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
+10. If the gap is native CSS-related, record it in #14002 instead of #14556.
+11. For missing tests:
    - If a missing webpack test maps clearly to a tracked feature gap or a specific PR gap, mention it under that feature instead of adding it to the standalone missing-test comment.
    - Otherwise, list missing tests by webpack test directory.
    - Include older missing tests directly; do not hide them just because they predate the last update.
@@ -54,7 +63,7 @@ Last updated: YYYY-MM-DD HH:mm:ss Z
 - Webpack releases and changelog for new feature candidates.
 - Webpack config schema/types and Rspack config schema/types for option-level gaps.
 - Webpack built-in plugin docs/source, Rspack built-in plugin exports/source, and webpack ecosystem plugin docs/source for plugin-compatibility gaps.
-- Webpack feature/plugin implementation details when deciding whether the gap belongs in Rspack, an external package, or an Rstack ecosystem plugin.
+- Webpack feature/plugin implementation details for accurate compatibility notes; this investigation does not change the default **Pending evaluation** classification.
 - GitHub merged PRs in `web-infra-dev/rspack` since the last update.
 - Existing Rspack issues, linked issues, subtask issues, and the completed-feature comment for deduplication.
 - Rsbuild docs/source and https://github.com/rstackjs packages for existing compatibility solutions.
@@ -98,7 +107,7 @@ Use concise checklist entries. Prefer one feature or test group per item.
 Missing feature entry:
 
 ```markdown
-- [ ] `<feature or option>` - Short compatibility note. Recommendation: recommended/pending/not recommended, with a short reason. Source: webpack release/config/PR link.
+- [ ] `<feature or option>` - Short compatibility note. Recommendation: pending by default; use recommended only when preserving an explicit manual annotation already present in the tracking issue; classify DLL-related gaps as not recommended and direct users to Module Federation. Source: webpack release/config/PR link.
 ```
 
 Completed feature entry:

--- a/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
+++ b/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
@@ -55,9 +55,10 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
 8. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
 9. If the gap is native CSS-related, record it in #14002 instead of #14556.
 10. For missing tests:
-   - If a missing webpack test maps clearly to a tracked feature gap or a specific PR gap, mention it under that feature instead of adding it to the standalone missing-test comment.
-   - Otherwise, list missing tests by webpack test directory.
-   - Include older missing tests directly; do not hide them just because they predate the last update.
+
+- If a missing webpack test maps clearly to a tracked feature gap or a specific PR gap, mention it under that feature instead of adding it to the standalone missing-test comment.
+- Otherwise, list missing tests by webpack test directory.
+- Include older missing tests directly; do not hide them just because they predate the last update.
 
 ## Suggested Investigation Sources
 

--- a/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
+++ b/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
@@ -8,6 +8,7 @@ description: Use when tracking, auditing, or updating Rspack compatibility gaps 
 ## Tracking Targets
 
 - Main tracking issue: https://github.com/web-infra-dev/rspack/issues/14556
+- Pending evaluation comment ID: `5437977419`
 - Completed feature comment ID: `4785525873`
 - Missing test comment ID: `4785526309`
 - Native CSS tracking issue: https://github.com/web-infra-dev/rspack/issues/14002
@@ -16,13 +17,14 @@ description: Use when tracking, auditing, or updating Rspack compatibility gaps 
 
 Keep the issue and comments as lists, not prose-only summaries.
 
-- Main issue body: missing Rspack features compared with webpack, grouped by implementation recommendation.
+- Main issue body: only missing Rspack features explicitly recommended for implementation.
+- Pending evaluation comment: missing Rspack features compared with webpack that have not been explicitly recommended for implementation.
 - Completed feature comment: webpack compatibility features that Rspack has completed.
 - Missing test comment: webpack tests missing from Rspack that are not already covered by a missing feature or PR-specific feature gap.
 
-Keep workflow and update rules in this skill only. Do not add an `Update Rules` section or other agent instructions to the GitHub issue body or placeholder comments.
+Keep workflow and update rules in this skill only. Do not add an `Update Rules` section or other agent instructions to the GitHub issue body or tracked comments.
 
-Every update to the issue body or either placeholder comment must include a visible update time, using the local timezone when possible:
+Every update to the issue body or a tracked comment must include a visible update time, using the local timezone when possible:
 
 ```text
 Last updated: YYYY-MM-DD HH:mm:ss Z
@@ -30,7 +32,7 @@ Last updated: YYYY-MM-DD HH:mm:ss Z
 
 ## Preview and Approval Gate
 
-Before every GitHub update, generate a local Markdown preview containing the exact replacement body for the tracking issue and every placeholder comment that would be changed. Clearly mark the file as a preview, include its local path in the response, and do not call any GitHub write operation yet.
+Before every GitHub update, generate a local Markdown preview containing the exact replacement body for the tracking issue and every tracked comment that would be changed. Clearly mark the file as a preview, include its local path in the response, and do not call any GitHub write operation yet.
 
 Wait for the user to explicitly approve that preview before updating GitHub. After approval, re-read the current issue and comments and compare them with the state used to generate the preview. If GitHub changed in the meantime, do not apply the stale preview; generate a refreshed local preview and request approval again.
 
@@ -39,17 +41,17 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
 ## Audit Workflow
 
 1. Read the current tracking issue and its comments before adding anything.
-2. Preserve the existing issue and comment format when updating; only change the relevant timestamp and list entries.
-3. Check associated, linked, or subtask issues for each candidate gap. If a related issue or subtask already records the same content, do not duplicate it in the main tracking issue.
-4. Compare new findings with both missing and completed lists to avoid duplicates.
+2. Preserve the existing issue and comment format when updating; only change the relevant timestamp and list entries. Keep the main issue limited to explicitly recommended features and keep all other unresolved gaps in the Pending evaluation comment.
+3. Check associated, linked, or subtask issues for each candidate gap. If a related issue or subtask already records the same content, do not duplicate it in the main issue or Pending evaluation comment.
+4. Compare new findings with the main issue, Pending evaluation comment, and completed list to avoid duplicates.
 5. Search for missing functionality from these directions:
    - New webpack release features since the last recorded update.
    - Differences between webpack's config object and Rspack's config object.
    - Differences between Rspack built-in plugins and webpack built-in plugins, plus commonly-used webpack ecosystem plugins that Rspack provides built-in alternatives for.
    - Rspack PRs merged since the last recorded update, especially large changes and PRs labeled or titled as features.
    - Existing issue entries and completed entries, to avoid re-recording already tracked work.
-6. Put every missing feature in **Pending evaluation** by default. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, user-demand evidence, or whether the feature could live in an external package.
-7. Put or move any gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording or reasoning does not count as a manual recommendation; when the provenance is unclear, leave the gap in **Pending evaluation**. Do not add new gaps to **Not recommended to implement in Rspack** automatically; preserve existing manual classifications.
+6. Put every missing feature in the **Pending evaluation** comment by default. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, user-demand evidence, or whether the feature could live in an external package.
+7. Put or move a gap into the main issue's **Recommended to implement in Rspack** list only when an explicit manual annotation marks that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording or reasoning does not count as a manual recommendation; when the provenance is unclear, leave the gap in the **Pending evaluation** comment. When moving a gap to the main issue, remove its Pending evaluation entry in the same approved update.
 8. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
 9. If the gap is native CSS-related, record it in #14002 instead of #14556.
 10. For missing tests:

--- a/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
+++ b/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
@@ -48,12 +48,11 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
    - Differences between Rspack built-in plugins and webpack built-in plugins, plus commonly-used webpack ecosystem plugins that Rspack provides built-in alternatives for.
    - Rspack PRs merged since the last recorded update, especially large changes and PRs labeled or titled as features.
    - Existing issue entries and completed entries, to avoid re-recording already tracked work.
-6. Put every missing feature in **Pending evaluation** by default, except for the DLL-specific rule below. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, or whether the feature could live in an external package.
-7. Treat DLL plugins and DLL-related functionality as legacy webpack features. Put them in **Not recommended to implement in Rspack** by default, do not plan implementation work for them, and state that users should migrate to Module Federation instead. Move a DLL gap to **Pending evaluation** only when the issue records explicit, evidence-backed strong user demand, such as concrete adoption or migration blockers. Strong demand alone does not make the gap recommended.
-8. Put or move any gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording, reasoning, or user-demand evidence does not count as a manual recommendation; when the provenance is unclear, leave non-DLL gaps in **Pending evaluation** and DLL gaps in **Not recommended to implement in Rspack**. Do not add other new gaps to **Not recommended to implement in Rspack** automatically.
-9. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep non-DLL gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
-10. If the gap is native CSS-related, record it in #14002 instead of #14556.
-11. For missing tests:
+6. Put every missing feature in **Pending evaluation** by default. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, user-demand evidence, or whether the feature could live in an external package.
+7. Put or move any gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording or reasoning does not count as a manual recommendation; when the provenance is unclear, leave the gap in **Pending evaluation**. Do not add new gaps to **Not recommended to implement in Rspack** automatically; preserve existing manual classifications.
+8. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
+9. If the gap is native CSS-related, record it in #14002 instead of #14556.
+10. For missing tests:
    - If a missing webpack test maps clearly to a tracked feature gap or a specific PR gap, mention it under that feature instead of adding it to the standalone missing-test comment.
    - Otherwise, list missing tests by webpack test directory.
    - Include older missing tests directly; do not hide them just because they predate the last update.
@@ -63,7 +62,7 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
 - Webpack releases and changelog for new feature candidates.
 - Webpack config schema/types and Rspack config schema/types for option-level gaps.
 - Webpack built-in plugin docs/source, Rspack built-in plugin exports/source, and webpack ecosystem plugin docs/source for plugin-compatibility gaps.
-- Webpack feature/plugin implementation details for accurate compatibility notes; this investigation does not change the default **Pending evaluation** classification or the DLL-specific **Not recommended to implement in Rspack** classification.
+- Webpack feature/plugin implementation details for accurate compatibility notes; this investigation does not change the default **Pending evaluation** classification.
 - GitHub merged PRs in `web-infra-dev/rspack` since the last update.
 - Existing Rspack issues, linked issues, subtask issues, and the completed-feature comment for deduplication.
 - Rsbuild docs/source and https://github.com/rstackjs packages for existing compatibility solutions.
@@ -107,7 +106,7 @@ Use concise checklist entries. Prefer one feature or test group per item.
 Missing feature entry:
 
 ```markdown
-- [ ] `<feature or option>` - Short compatibility note. Recommendation: pending by default; use recommended only when preserving an explicit manual annotation already present in the tracking issue; classify DLL-related gaps as legacy and not recommended, direct users to Module Federation, and move them to pending only for explicit evidence-backed strong user demand. Source: webpack release/config/PR link.
+- [ ] `<feature or option>` - Short compatibility note. Recommendation: pending by default; use recommended only when preserving an explicit manual annotation already present in the tracking issue. Source: webpack release/config/PR link.
 ```
 
 Completed feature entry:

--- a/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
+++ b/.agents/skills/rspack-webpack-gap-tracker/SKILL.md
@@ -49,8 +49,8 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
    - Rspack PRs merged since the last recorded update, especially large changes and PRs labeled or titled as features.
    - Existing issue entries and completed entries, to avoid re-recording already tracked work.
 6. Put every missing feature in **Pending evaluation** by default, except for the DLL-specific rule below. Do not infer a recommendation from implementation details, performance considerations, existing Rspack APIs, or whether the feature could live in an external package.
-7. Put DLL plugins and DLL-related functionality in **Not recommended to implement in Rspack** by default. State that users should use Module Federation instead.
-8. Put or move any non-DLL gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording or reasoning does not count as a manual annotation; when the provenance is unclear, leave the gap in **Pending evaluation**. Do not add other new gaps to **Not recommended to implement in Rspack** automatically.
+7. Treat DLL plugins and DLL-related functionality as legacy webpack features. Put them in **Not recommended to implement in Rspack** by default, do not plan implementation work for them, and state that users should migrate to Module Federation instead. Move a DLL gap to **Pending evaluation** only when the issue records explicit, evidence-backed strong user demand, such as concrete adoption or migration blockers. Strong demand alone does not make the gap recommended.
+8. Put or move any gap into **Recommended to implement in Rspack** only when the tracking issue already contains an explicit manual annotation marking that gap as recommended. Preserve that manual classification on later audits. The audit's own proposed wording, reasoning, or user-demand evidence does not count as a manual recommendation; when the provenance is unclear, leave non-DLL gaps in **Pending evaluation** and DLL gaps in **Not recommended to implement in Rspack**. Do not add other new gaps to **Not recommended to implement in Rspack** automatically.
 9. Inspect the corresponding webpack feature or plugin implementation for accurate compatibility notes. Check whether Rsbuild already provides a solution, and whether https://github.com/rstackjs already has a compatible package or plugin, but keep non-DLL gaps in **Pending evaluation** unless the issue has the manual recommendation annotation described above.
 10. If the gap is native CSS-related, record it in #14002 instead of #14556.
 11. For missing tests:
@@ -63,7 +63,7 @@ Apply only the approved preview content. Do not add, remove, reclassify, or rewo
 - Webpack releases and changelog for new feature candidates.
 - Webpack config schema/types and Rspack config schema/types for option-level gaps.
 - Webpack built-in plugin docs/source, Rspack built-in plugin exports/source, and webpack ecosystem plugin docs/source for plugin-compatibility gaps.
-- Webpack feature/plugin implementation details for accurate compatibility notes; this investigation does not change the default **Pending evaluation** classification.
+- Webpack feature/plugin implementation details for accurate compatibility notes; this investigation does not change the default **Pending evaluation** classification or the DLL-specific **Not recommended to implement in Rspack** classification.
 - GitHub merged PRs in `web-infra-dev/rspack` since the last update.
 - Existing Rspack issues, linked issues, subtask issues, and the completed-feature comment for deduplication.
 - Rsbuild docs/source and https://github.com/rstackjs packages for existing compatibility solutions.
@@ -107,7 +107,7 @@ Use concise checklist entries. Prefer one feature or test group per item.
 Missing feature entry:
 
 ```markdown
-- [ ] `<feature or option>` - Short compatibility note. Recommendation: pending by default; use recommended only when preserving an explicit manual annotation already present in the tracking issue; classify DLL-related gaps as not recommended and direct users to Module Federation. Source: webpack release/config/PR link.
+- [ ] `<feature or option>` - Short compatibility note. Recommendation: pending by default; use recommended only when preserving an explicit manual annotation already present in the tracking issue; classify DLL-related gaps as legacy and not recommended, direct users to Module Federation, and move them to pending only for explicit evidence-backed strong user demand. Source: webpack release/config/PR link.
 ```
 
 Completed feature entry:


### PR DESCRIPTION
## Summary

- Keep the main compatibility tracking issue limited to features explicitly recommended for implementation.
- Route every other unresolved compatibility gap to the dedicated `Pending evaluation` comment by default.
- Record the Pending evaluation comment ID in the skill and move entries between the comment and main issue without duplication.
- Require an exact local Markdown preview and explicit approval before any GitHub issue update, then re-read the issue to detect stale previews.
- Keep workflow and update rules in the skill instead of writing them into the tracked issue or comments.

### Examples

- A newly discovered `module.rules.glob` gap is added to the Pending evaluation comment.
- A gap moves to the main issue only after an explicit manual recommendation, and its Pending entry is removed in the same approved update.
- Before updating the tracking issue or comments, the skill writes the exact proposed Markdown to a local preview file, shows its path, waits for approval, and applies only that approved content.

## Related links

- Tracking issue: #14556
- Pending evaluation comment: https://github.com/web-infra-dev/rspack/issues/14556#issuecomment-5437977419

## Checklist

- [x] Tests updated (not required; instruction-only change).
- [x] Documentation updated.

---
_by OpenAI Codex_