### PR TITLE
chore(release): bump all published crates in crate-version

### DIFF
--- a/scripts/x.mjs
+++ b/scripts/x.mjs
@@ -178,7 +178,7 @@ program
       '--no-git-push', // Do not push generated commit and tags to git remote
       '--no-git-tag', // Do not tag versions in git, we will tag them in `crate-publish`
       '--force',
-      'rspack*', // Always include targeted crates matched by glob even when there are no changes
+      '*', // Every member inherits `[workspace.package].version`, so all published crates must be bumped together
       '--yes', // Skip confirmation prompt
       bump, // Bump type
     ];

--- a/scripts/x.mjs
+++ b/scripts/x.mjs
@@ -178,7 +178,7 @@ program
       '--no-git-push', // Do not push generated commit and tags to git remote
       '--no-git-tag', // Do not tag versions in git, we will tag them in `crate-publish`
       '--force',
-      '*', // Every member inherits `[workspace.package].version`, so all published crates must be bumped together
+      '*', // Published crates share `[workspace.package].version`; include them all so `[workspace.dependencies]` exact pins stay in sync
       '--yes', // Skip confirmation prompt
       bump, // Bump type
     ];


### PR DESCRIPTION
## Why

`./x version <bump>` fails on `cargo codegen`:

```
error: failed to select a version for the requirement `css-module-lexer = "=0.102.1"`
candidate versions found which didn't match: 0.102.2
required by package `rspack_plugin_css v0.102.2`
```

Every workspace member declares `version.workspace = true`, so bumping `[workspace.package].version` moves **all** crate versions at once. But `cargo workspaces version` only rewrites the `=X.Y.Z` pins in `[workspace.dependencies]` for the crates it includes in the version set, and `--force 'rspack*'` excludes `css-module-lexer` (name does not match the glob, and it had no changes since the last tag).

The result is a root `Cargo.toml` that cannot resolve: the pin still demands `=0.102.1` while the crate itself is already `0.102.2`. Note `cargo workspaces version` exits 0 and commits `Release <version>` anyway, so the repo is left half-released when the next `cargo` call dies.

This is not new — the 2.2.1 release hit the same thing (`Release 0.102.1` left `css-module-lexer = "=0.102.0"`) and it was patched by hand in the follow-up commit.

## Before / after

| `--force` | result |
| --- | --- |
| omitted | 75 crates bumped, `rspack_binding_build = "=0.102.1"` becomes the stale pin |
| `'rspack*'` | 86 crates bumped, `css-module-lexer = "=0.102.1"` stale |
| `'*'` | all published crates bumped, `./x version patch` exits 0 |

Since versions move together, the "only bump what changed" selection has no meaning in this workspace — it just decides which pins get left behind. `'*'` turns it off.

Private crates (`xtask`, `rspack_benchmark`) are still skipped: `cargo workspaces version` needs `-a/--all` to touch them, which we do not pass.
