### PR TITLE
docs: improve low-level plugin documentation

### DIFF
--- a/website/docs/en/plugins/low-level-plugins.mdx
+++ b/website/docs/en/plugins/low-level-plugins.mdx
@@ -28,7 +28,9 @@ Plugins affecting the compiler environment and runtime target.
 
 ### ElectronTargetPlugin \{#electron-target-plugin}
 
-`electron.ElectronTargetPlugin(context)`
+```js
+new rspack.electron.ElectronTargetPlugin(context);
+```
 
 `ElectronTargetPlugin` keeps Electron built-in modules external so Electron can load them at runtime. Pass `'main'`, `'preload'`, or `'renderer'` to externalize the additional modules available in that process.
 
@@ -51,7 +53,9 @@ new compiler.rspack.electron.ElectronTargetPlugin('main').apply(childCompiler);
 
 ### NodeEnvironmentPlugin
 
-`node.NodeEnvironmentPlugin(options)`
+```js
+new rspack.node.NodeEnvironmentPlugin(options);
+```
 
 `NodeEnvironmentPlugin` installs infrastructure logging, a cached Node.js input file system, the Node.js `fs` module as the output file system, and a watch file system on a compiler. The `rspack()` API applies it automatically to the root compiler.
 
@@ -67,7 +71,9 @@ This plugin configures compiler I/O and logging; it does not set the JavaScript 
 
 ### NodeTargetPlugin \{#node-target-plugin}
 
-`node.NodeTargetPlugin()`
+```js
+new rspack.node.NodeTargetPlugin();
+```
 
 `NodeTargetPlugin` keeps Node.js built-in modules and requests using the `node:` scheme external so the Node.js runtime loads them instead of Rspack bundling them. The [`externalsPresets.node`](/config/externals#externalspresetsnode) option applies this plugin internally.
 
@@ -92,7 +98,9 @@ Plugins that add entry chunks to the compilation.
 
 ### DynamicEntryPlugin
 
-`DynamicEntryPlugin(context, entry)`
+```js
+new rspack.DynamicEntryPlugin(context, entry);
+```
 
 `DynamicEntryPlugin` calls an entry function during every `make` event and adds the returned entries to the compilation. This allows the entry list to change between watch rebuilds.
 
@@ -120,7 +128,9 @@ For a regular build, prefer an [`entry` function](/config/entry#entry), which Rs
 
 ### EntryOptionPlugin
 
-`EntryOptionPlugin()`
+```js
+new rspack.EntryOptionPlugin();
+```
 
 `EntryOptionPlugin` handles the `entryOption` compiler hook. It applies an `EntryPlugin` for each static entry request or a `DynamicEntryPlugin` for a function entry. Rspack applies it automatically to the root compiler.
 
@@ -146,7 +156,9 @@ Plugins affecting generated modules, chunks, and runtime loading.
 
 ### EnableChunkLoadingPlugin \{#enable-chunk-loading-plugin}
 
-`javascript.EnableChunkLoadingPlugin(type)`
+```js
+new rspack.javascript.EnableChunkLoadingPlugin(type);
+```
 
 `EnableChunkLoadingPlugin` enables the runtime modules required by a chunk-loading type. Rspack normally applies it for the types collected in [`output.enabledChunkLoadingTypes`](/config/output#outputenabledchunkloadingtypes).
 
@@ -175,7 +187,9 @@ For a custom chunk-loading implementation, call `EnableChunkLoadingPlugin.setEna
 
 ### EnableLibraryPlugin \{#enable-library-plugin}
 
-`library.EnableLibraryPlugin(type)`
+```js
+new rspack.library.EnableLibraryPlugin(type);
+```
 
 `EnableLibraryPlugin` registers a library output type with the compiler. Rspack normally applies it for the types collected in [`output.enabledLibraryTypes`](/config/output#outputenabledlibrarytypes).
 
@@ -206,7 +220,9 @@ For a regular library build, prefer [`output.library`](/config/output#outputlibr
 
 ### EnableWasmLoadingPlugin \{#enable-wasm-loading-plugin}
 
-`wasm.EnableWasmLoadingPlugin(type)`
+```js
+new rspack.wasm.EnableWasmLoadingPlugin(type);
+```
 
 `EnableWasmLoadingPlugin` enables the runtime modules required by a WebAssembly loading type. Rspack normally applies it for the types collected in [`output.enabledWasmLoadingTypes`](/config/output#outputenabledwasmloadingtypes).
 
@@ -240,7 +256,9 @@ For a regular build, prefer [`output.wasmLoading`](/config/output#outputwasmload
 
 ### EvalDevToolModulePlugin
 
-`EvalDevToolModulePlugin(options)`
+```js
+new rspack.EvalDevToolModulePlugin(options);
+```
 
 `EvalDevToolModulePlugin` wraps each non-external JavaScript module in `eval` and appends a `sourceURL`, allowing browser developer tools to display the original module name. Setting `devtool: 'eval'` applies this plugin automatically.
 
@@ -264,7 +282,9 @@ The `moduleFilenameTemplate` and `sourceUrlComment` options can customize the ge
 
 ### FetchCompileAsyncWasmPlugin
 
-`web.FetchCompileAsyncWasmPlugin()`
+```js
+new rspack.web.FetchCompileAsyncWasmPlugin();
+```
 
 `FetchCompileAsyncWasmPlugin` adds the browser runtime that fetches and compiles asynchronous WebAssembly modules. `EnableWasmLoadingPlugin('fetch')` applies this implementation internally.
 
@@ -296,7 +316,9 @@ For a regular web build, prefer `output.wasmLoading: 'fetch'`, which enables the
 
 ### JsonpTemplatePlugin \{#jsonp-template-plugin}
 
-`web.JsonpTemplatePlugin()`
+```js
+new rspack.web.JsonpTemplatePlugin();
+```
 
 `JsonpTemplatePlugin` configures browser output for child compilers. It sets [`output.chunkLoading`](/config/output#outputchunkloading) to `'jsonp'`, applies the [`'array-push'` chunk format](/config/output#outputchunkformat), and enables the required JSONP chunk-loading runtime.
 
@@ -354,7 +376,9 @@ For a regular web build, prefer `target: 'web'`. It selects the `'array-push'` c
 
 ### NodeTemplatePlugin \{#node-template-plugin}
 
-`node.NodeTemplatePlugin(options)`
+```js
+new rspack.node.NodeTemplatePlugin(options);
+```
 
 `NodeTemplatePlugin` configures Node.js output for child compilers. It applies the [`'commonjs'` chunk format](/config/output#outputchunkformat), sets [`output.chunkLoading`](/config/output#outputchunkloading) to `'require'` by default, and enables the required chunk-loading runtime.
 
@@ -423,7 +447,9 @@ For a regular Node.js build, prefer `target: 'node'`. It selects the `'commonjs'
 
 ### WebWorkerTemplatePlugin \{#web-worker-template-plugin}
 
-`webworker.WebWorkerTemplatePlugin()`
+```js
+new rspack.webworker.WebWorkerTemplatePlugin();
+```
 
 `WebWorkerTemplatePlugin` configures Web Worker output for child compilers. It sets [`output.chunkLoading`](/config/output#outputchunkloading) to `'import-scripts'`, applies the [`'array-push'` chunk format](/config/output#outputchunkformat), and enables the required `importScripts` chunk-loading runtime.
 
@@ -485,7 +511,9 @@ Plugins that customize the context in which loaders execute.
 
 ### LoaderOptionsPlugin
 
-`LoaderOptionsPlugin(options)`
+```js
+new rspack.LoaderOptionsPlugin(options);
+```
 
 `LoaderOptionsPlugin` copies custom option fields onto the loader context for resources matching `test`, `include`, and `exclude`. The matching fields themselves are used only as filters and are not copied.
 
@@ -525,7 +553,9 @@ This plugin mainly supports loaders that read custom properties from `this`. New
 
 ### LoaderTargetPlugin
 
-`LoaderTargetPlugin(target)`
+```js
+new rspack.LoaderTargetPlugin(target);
+```
 
 `LoaderTargetPlugin` assigns `target` to `this.target` in every loader context. It is useful when a custom compiler needs loaders to observe a target that differs from the compiler's configured target.
 
@@ -565,7 +595,9 @@ These plugins implement the `exposes`, `remotes`, and `shared` parts of Module F
 
 ### ContainerPlugin
 
-`container.ContainerPlugin(options)`
+```js
+new rspack.container.ContainerPlugin(options);
+```
 
 `ContainerPlugin` creates a container entry that exposes local modules through the Module Federation `get` and `init` interface. It is the low-level implementation of the `exposes` option.
 
@@ -590,7 +622,9 @@ export default {
 
 ### ContainerReferencePlugin
 
-`container.ContainerReferencePlugin(options)`
+```js
+new rspack.container.ContainerReferencePlugin(options);
+```
 
 `ContainerReferencePlugin` registers remote containers as externals and adds the runtime needed to load modules from them. It is the low-level implementation of the `remotes` option.
 
@@ -614,7 +648,9 @@ export default {
 
 ### ConsumeSharedPlugin
 
-`sharing.ConsumeSharedPlugin(options)`
+```js
+new rspack.sharing.ConsumeSharedPlugin(options);
+```
 
 `ConsumeSharedPlugin` resolves configured module requests from a share scope. It can enforce version and singleton requirements and use a local module as a fallback when no suitable provider is available.
 
@@ -641,7 +677,9 @@ export default {
 
 ### ProvideSharedPlugin
 
-`sharing.ProvideSharedPlugin(options)`
+```js
+new rspack.sharing.ProvideSharedPlugin(options);
+```
 
 `ProvideSharedPlugin` registers local modules and their versions in a share scope so other builds can consume them. It is the provider half of the `shared` option.
 
@@ -661,7 +699,9 @@ export default {
 
 ### SharePlugin
 
-`sharing.SharePlugin(options)`
+```js
+new rspack.sharing.SharePlugin(options);
+```
 
 `SharePlugin` applies both `ConsumeSharedPlugin` and `ProvideSharedPlugin` for the same `shared` configuration. It is the low-level equivalent of `ModuleFederationPlugin`'s `shared` option.
 
@@ -687,7 +727,9 @@ export default {
 
 ### TreeShakingSharedPlugin \{#tree-shaking-shared-plugin}
 
-`sharing.TreeShakingSharedPlugin(options)`
+```js
+new rspack.sharing.TreeShakingSharedPlugin(options);
+```
 
 <ApiMeta stability={Stability.Experimental} />
 
@@ -727,7 +769,9 @@ The plugin creates an independent build only for shared dependencies that enable
 
 ### RemoveDuplicateModulesPlugin
 
-`experiments.RemoveDuplicateModulesPlugin()`
+```js
+new rspack.experiments.RemoveDuplicateModulesPlugin();
+```
 
 <ApiMeta stability={Stability.Experimental} />
 

--- a/website/docs/en/plugins/low-level-plugins.mdx
+++ b/website/docs/en/plugins/low-level-plugins.mdx
@@ -741,29 +741,41 @@ new rspack.sharing.TreeShakingSharedPlugin(options);
 - `secondary`: Whether to perform a second tree-shaking pass during the independent build. The default is `false`.
 - `onBuildAssets`: A callback invoked with the generated shared fallback assets.
 
-Direct application is mainly intended for deployment integrations that perform a secondary build after collecting complete dependency information:
+Direct application is mainly intended for deployment integrations that perform a secondary build. It must be combined with a sharing plugin so `TreeShakingSharedPlugin` can collect the shared modules to build:
+
+```js title="src/index.js"
+import { add } from 'lodash-es';
+
+console.log(add(1, 2));
+```
 
 ```js title="rspack.config.mjs"
 import { sharing } from '@rspack/core';
 
+const shared = {
+  'lodash-es': { treeShaking: { mode: 'server-calc' } },
+};
+
 export default {
+  entry: './src/index.js',
   plugins: [
+    new sharing.SharePlugin({
+      enhanced: true,
+      shared,
+    }),
     new sharing.TreeShakingSharedPlugin({
       secondary: true,
       mfConfig: {
         name: 'app',
-        shared: {
-          'lodash-es': { treeShaking: { mode: 'server-calc' } },
-        },
+        shared,
         library: { type: 'var', name: 'App' },
-        manifest: true,
       },
     }),
   ],
 };
 ```
 
-The plugin creates an independent build only for shared dependencies that enable `treeShaking` and retain a local implementation. When `mfConfig.manifest` is enabled, it records the generated fallback assets in the stats and manifest.
+The plugin creates an independent build only for shared dependencies that enable `treeShaking` and retain a local implementation. Direct use does not generate Module Federation stats or manifest files. When `ModuleFederationPlugin` applies it internally with manifest generation enabled, the plugin writes the generated fallback asset information into those files.
 
 ## experiments
 

--- a/website/docs/en/plugins/low-level-plugins.mdx
+++ b/website/docs/en/plugins/low-level-plugins.mdx
@@ -51,9 +51,19 @@ new compiler.rspack.electron.ElectronTargetPlugin('main').apply(childCompiler);
 
 ### NodeEnvironmentPlugin
 
-`node.NodeEnvironmentPlugin()`
+`node.NodeEnvironmentPlugin(options)`
 
-Applies a Node.js-style filesystem to the compiler.
+`NodeEnvironmentPlugin` installs infrastructure logging, a cached Node.js input file system, the Node.js `fs` module as the output file system, and a watch file system on a compiler. The `rspack()` API applies it automatically to the root compiler.
+
+When a custom compiler needs its own Node.js file-system environment, pass its normalized infrastructure logging options and apply the plugin directly:
+
+```js
+new compiler.rspack.node.NodeEnvironmentPlugin({
+  infrastructureLogging: childCompiler.options.infrastructureLogging,
+}).apply(childCompiler);
+```
+
+This plugin configures compiler I/O and logging; it does not set the JavaScript runtime target. Use `NodeTargetPlugin` when Node.js built-in modules should remain external.
 
 ### NodeTargetPlugin \{#node-target-plugin}
 
@@ -84,11 +94,51 @@ Plugins that add entry chunks to the compilation.
 
 `DynamicEntryPlugin(context, entry)`
 
-Similar to `EntryPlugin` but accepts a function as the `entry` argument. This function is called during each `make` event to determine the entry points dynamically.
+`DynamicEntryPlugin` calls an entry function during every `make` event and adds the returned entries to the compilation. This allows the entry list to change between watch rebuilds.
+
+The direct API receives normalized entry descriptions, so each `import` value is an array:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+const context = process.cwd();
+
+export default {
+  context,
+  entry: {},
+  plugins: [
+    new rspack.DynamicEntryPlugin(context, async () => ({
+      main: {
+        import: ['./src/index.js'],
+      },
+    })),
+  ],
+};
+```
+
+For a regular build, prefer an [`entry` function](/config/entry#entry), which Rspack normalizes and passes to this plugin automatically.
 
 ### EntryOptionPlugin
 
 `EntryOptionPlugin()`
+
+`EntryOptionPlugin` handles the `entryOption` compiler hook. It applies an `EntryPlugin` for each static entry request or a `DynamicEntryPlugin` for a function entry. Rspack applies it automatically to the root compiler.
+
+The static `applyEntryOption` helper is useful when adding normalized entries to a child compiler:
+
+```js
+const childOptions = compiler.rspack.config.getNormalizedRspackOptions({
+  entry: {
+    child: './src/child.js',
+  },
+});
+
+compiler.rspack.EntryOptionPlugin.applyEntryOption(
+  childCompiler,
+  compiler.context,
+  childOptions.entry,
+);
+```
 
 ## output
 
@@ -192,13 +242,57 @@ For a regular build, prefer [`output.wasmLoading`](/config/output#outputwasmload
 
 `EvalDevToolModulePlugin(options)`
 
-Decorates the module template by wrapping each module in an `eval` annotated with `// @sourceURL`.
+`EvalDevToolModulePlugin` wraps each non-external JavaScript module in `eval` and appends a `sourceURL`, allowing browser developer tools to display the original module name. Setting `devtool: 'eval'` applies this plugin automatically.
+
+The following configuration applies it directly and uses `dashboard` as the source URL namespace:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  mode: 'development',
+  devtool: false,
+  plugins: [
+    new rspack.EvalDevToolModulePlugin({
+      namespace: 'dashboard',
+    }),
+  ],
+};
+```
+
+The `moduleFilenameTemplate` and `sourceUrlComment` options can customize the generated module URL and comment format.
 
 ### FetchCompileAsyncWasmPlugin
 
 `web.FetchCompileAsyncWasmPlugin()`
 
-Provides runtime code for fetching and compiling asynchronous WebAssembly modules, and is often used with a child compiler.
+`FetchCompileAsyncWasmPlugin` adds the browser runtime that fetches and compiles asynchronous WebAssembly modules. `EnableWasmLoadingPlugin('fetch')` applies this implementation internally.
+
+This example disables automatic WebAssembly loading setup and installs the fetch implementation directly:
+
+```js title="src/index.js"
+import { add } from './add.wasm';
+
+console.log(add(1, 2));
+```
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  target: 'web',
+  entry: './src/index.js',
+  experiments: {
+    asyncWebAssembly: true,
+  },
+  output: {
+    wasmLoading: false,
+  },
+  plugins: [new rspack.web.FetchCompileAsyncWasmPlugin()],
+};
+```
+
+For a regular web build, prefer `output.wasmLoading: 'fetch'`, which enables the same runtime automatically.
 
 ### JsonpTemplatePlugin \{#jsonp-template-plugin}
 
@@ -387,37 +481,209 @@ For a regular Web Worker build, prefer `target: 'webworker'`. It selects the `'a
 
 ## loader
 
+Plugins that customize the context in which loaders execute.
+
 ### LoaderOptionsPlugin
 
 `LoaderOptionsPlugin(options)`
+
+`LoaderOptionsPlugin` copies custom option fields onto the loader context for resources matching `test`, `include`, and `exclude`. The matching fields themselves are used only as filters and are not copied.
+
+This loader reads a custom `message` property from its context:
+
+```js title="loaders/message-loader.cjs"
+module.exports = function () {
+  return `export default ${JSON.stringify(this.message)};`;
+};
+```
+
+The plugin provides that property only while processing `.message` files:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  entry: './src/welcome.message',
+  module: {
+    rules: [
+      {
+        test: /\.message$/,
+        use: './loaders/message-loader.cjs',
+      },
+    ],
+  },
+  plugins: [
+    new rspack.LoaderOptionsPlugin({
+      test: /\.message$/,
+      message: 'Hello from the loader',
+    }),
+  ],
+};
+```
+
+This plugin mainly supports loaders that read custom properties from `this`. New loaders should usually receive values through their own loader options.
 
 ### LoaderTargetPlugin
 
 `LoaderTargetPlugin(target)`
 
+`LoaderTargetPlugin` assigns `target` to `this.target` in every loader context. It is useful when a custom compiler needs loaders to observe a target that differs from the compiler's configured target.
+
+The following loader replaces its input with the target it observes:
+
+```js title="loaders/target-loader.cjs"
+module.exports = function () {
+  return `console.log(${JSON.stringify(this.target)});`;
+};
+```
+
+Although the build target is `web`, this plugin makes the loader receive `'node'`:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  target: 'web',
+  entry: './src/index.js',
+  module: {
+    rules: [
+      {
+        test: /index\.js$/,
+        use: './loaders/target-loader.cjs',
+      },
+    ],
+  },
+  plugins: [new rspack.LoaderTargetPlugin('node')],
+};
+```
+
+For a regular build, prefer the top-level [`target`](/config/target) option.
+
 ## module federation
 
-Low-level plugins used by `ModuleFederationPlugin`.
+These plugins implement the `exposes`, `remotes`, and `shared` parts of Module Federation. For regular application builds, prefer [`ModuleFederationPlugin`](/plugins/module-federation-plugin), which configures these low-level plugins together.
 
 ### ContainerPlugin
 
 `container.ContainerPlugin(options)`
 
+`ContainerPlugin` creates a container entry that exposes local modules through the Module Federation `get` and `init` interface. It is the low-level implementation of the `exposes` option.
+
+This configuration emits `remoteEntry.js` and exposes `src/Button.js` as `./Button`:
+
+```js title="rspack.config.mjs"
+import { container } from '@rspack/core';
+
+export default {
+  entry: {},
+  plugins: [
+    new container.ContainerPlugin({
+      name: 'catalog',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './Button': './src/Button.js',
+      },
+    }),
+  ],
+};
+```
+
 ### ContainerReferencePlugin
 
 `container.ContainerReferencePlugin(options)`
+
+`ContainerReferencePlugin` registers remote containers as externals and adds the runtime needed to load modules from them. It is the low-level implementation of the `remotes` option.
+
+With the following configuration, an import such as `import('catalog/Button')` loads `./Button` from the remote container:
+
+```js title="rspack.config.mjs"
+import { container } from '@rspack/core';
+
+export default {
+  entry: './src/index.js',
+  plugins: [
+    new container.ContainerReferencePlugin({
+      remoteType: 'script',
+      remotes: {
+        catalog: 'catalog@http://localhost:3001/remoteEntry.js',
+      },
+    }),
+  ],
+};
+```
 
 ### ConsumeSharedPlugin
 
 `sharing.ConsumeSharedPlugin(options)`
 
+`ConsumeSharedPlugin` resolves configured module requests from a share scope. It can enforce version and singleton requirements and use a local module as a fallback when no suitable provider is available.
+
+This example consumes `react` as a singleton from the default share scope and falls back to the locally installed package without checking its version:
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  entry: './src/index.js',
+  plugins: [
+    new sharing.ConsumeSharedPlugin({
+      consumes: {
+        react: {
+          import: 'react',
+          requiredVersion: false,
+          singleton: true,
+        },
+      },
+    }),
+  ],
+};
+```
+
 ### ProvideSharedPlugin
 
 `sharing.ProvideSharedPlugin(options)`
 
+`ProvideSharedPlugin` registers local modules and their versions in a share scope so other builds can consume them. It is the provider half of the `shared` option.
+
+The shorthand form below provides the locally installed `react` package under the `react` share key and infers its version from the package metadata:
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  plugins: [
+    new sharing.ProvideSharedPlugin({
+      provides: ['react'],
+    }),
+  ],
+};
+```
+
 ### SharePlugin
 
 `sharing.SharePlugin(options)`
+
+`SharePlugin` applies both `ConsumeSharedPlugin` and `ProvideSharedPlugin` for the same `shared` configuration. It is the low-level equivalent of `ModuleFederationPlugin`'s `shared` option.
+
+This example provides the local `react` package as a fallback and consumes a singleton instance from the default share scope:
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  plugins: [
+    new sharing.SharePlugin({
+      enhanced: false,
+      shared: {
+        react: {
+          requiredVersion: false,
+          singleton: true,
+        },
+      },
+    }),
+  ],
+};
+```
 
 ### TreeShakingSharedPlugin \{#tree-shaking-shared-plugin}
 
@@ -462,5 +728,26 @@ The plugin creates an independent build only for shared dependencies that enable
 ### RemoveDuplicateModulesPlugin
 
 `experiments.RemoveDuplicateModulesPlugin()`
+
+<ApiMeta stability={Stability.Experimental} />
+
+`RemoveDuplicateModulesPlugin` finds modules that occur in the same set of multiple chunks and moves them into one reusable or newly created shared chunk. Rspack uses it internally for `modern-module` library output.
+
+In this example, both entries import the same `src/shared.js` module. Disabling `splitChunks` makes `RemoveDuplicateModulesPlugin` responsible for extracting that duplicated module:
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  entry: {
+    admin: './src/admin.js',
+    store: './src/store.js',
+  },
+  optimization: {
+    splitChunks: false,
+  },
+  plugins: [new rspack.experiments.RemoveDuplicateModulesPlugin()],
+};
+```
 
 <Attribution url="https://webpack.js.org/plugins/internal-plugins/" />

--- a/website/docs/zh/plugins/low-level-plugins.mdx
+++ b/website/docs/zh/plugins/low-level-plugins.mdx
@@ -741,29 +741,41 @@ new rspack.sharing.TreeShakingSharedPlugin(options);
 - `secondary`：是否在独立构建中执行第二次 tree shaking，默认值为 `false`。
 - `onBuildAssets`：生成共享 fallback 产物后调用的回调函数。
 
-直接应用该插件主要适用于部署平台在收集完整依赖信息后执行二次构建的场景：
+直接应用该插件主要适用于部署平台执行二次构建的场景。它必须配合共享插件使用，以便 `TreeShakingSharedPlugin` 收集需要构建的共享模块：
+
+```js title="src/index.js"
+import { add } from 'lodash-es';
+
+console.log(add(1, 2));
+```
 
 ```js title="rspack.config.mjs"
 import { sharing } from '@rspack/core';
 
+const shared = {
+  'lodash-es': { treeShaking: { mode: 'server-calc' } },
+};
+
 export default {
+  entry: './src/index.js',
   plugins: [
+    new sharing.SharePlugin({
+      enhanced: true,
+      shared,
+    }),
     new sharing.TreeShakingSharedPlugin({
       secondary: true,
       mfConfig: {
         name: 'app',
-        shared: {
-          'lodash-es': { treeShaking: { mode: 'server-calc' } },
-        },
+        shared,
         library: { type: 'var', name: 'App' },
-        manifest: true,
       },
     }),
   ],
 };
 ```
 
-该插件只会为启用了 `treeShaking` 且保留本地实现的共享依赖创建独立构建。启用 `mfConfig.manifest` 后，生成的 fallback 产物信息会写入 stats 和 manifest。
+该插件只会为启用了 `treeShaking` 且保留本地实现的共享依赖创建独立构建。单独使用时，它不会生成 Module Federation stats 或 manifest 文件。当 `ModuleFederationPlugin` 在启用 manifest 生成的情况下在内部应用该插件时，生成的 fallback 产物信息会被写入这些文件。
 
 ## experiments
 

--- a/website/docs/zh/plugins/low-level-plugins.mdx
+++ b/website/docs/zh/plugins/low-level-plugins.mdx
@@ -51,9 +51,19 @@ new compiler.rspack.electron.ElectronTargetPlugin('main').apply(childCompiler);
 
 ### NodeEnvironmentPlugin
 
-`node.NodeEnvironmentPlugin()`
+`node.NodeEnvironmentPlugin(options)`
 
-将 Node.js 风格的文件系统应用到编译器。
+`NodeEnvironmentPlugin` 会为编译器安装 infrastructure logger、带缓存的 Node.js 输入文件系统、作为输出文件系统的 Node.js `fs` 模块以及 watch 文件系统。`rspack()` API 会自动将它应用到根编译器。
+
+当自定义编译器需要独立的 Node.js 文件系统环境时，可以传入该编译器标准化后的 infrastructure logging 选项并直接应用插件：
+
+```js
+new compiler.rspack.node.NodeEnvironmentPlugin({
+  infrastructureLogging: childCompiler.options.infrastructureLogging,
+}).apply(childCompiler);
+```
+
+该插件只配置编译器 I/O 和日志，不会设置 JavaScript 运行目标。需要将 Node.js 内置模块保留为外部依赖时，应使用 `NodeTargetPlugin`。
 
 ### NodeTargetPlugin \{#node-target-plugin}
 
@@ -84,11 +94,51 @@ new compiler.rspack.node.NodeTargetPlugin().apply(childCompiler);
 
 `DynamicEntryPlugin(context, entry)`
 
-与 `EntryPlugin` 类似，但接受一个函数作为 `entry` 参数。该函数会在每次触发 `make` 事件时调用，以动态决定入口点。
+`DynamicEntryPlugin` 会在每次触发 `make` 事件时调用入口函数，并将函数返回的入口添加到 compilation 中，因此入口列表可以在 watch 重新构建之间发生变化。
+
+直接调用该 API 时需要传入标准化后的入口描述，因此每个 `import` 的值都是数组：
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+const context = process.cwd();
+
+export default {
+  context,
+  entry: {},
+  plugins: [
+    new rspack.DynamicEntryPlugin(context, async () => ({
+      main: {
+        import: ['./src/index.js'],
+      },
+    })),
+  ],
+};
+```
+
+常规构建应优先使用 [`entry` 函数](/config/entry#entry)，Rspack 会自动将它标准化并传给该插件。
 
 ### EntryOptionPlugin
 
 `EntryOptionPlugin()`
+
+`EntryOptionPlugin` 用于处理 compiler 的 `entryOption` hook。对于静态入口，它会为每个入口请求应用 `EntryPlugin`；对于函数入口，则会应用 `DynamicEntryPlugin`。Rspack 会自动将它应用到根编译器。
+
+为子编译器添加标准化后的入口时，可以使用静态的 `applyEntryOption` 方法：
+
+```js
+const childOptions = compiler.rspack.config.getNormalizedRspackOptions({
+  entry: {
+    child: './src/child.js',
+  },
+});
+
+compiler.rspack.EntryOptionPlugin.applyEntryOption(
+  childCompiler,
+  compiler.context,
+  childOptions.entry,
+);
+```
 
 ## output
 
@@ -192,13 +242,57 @@ export default {
 
 `EvalDevToolModulePlugin(options)`
 
-使用带有 `// @sourceURL` 注释的 `eval` 包裹每个模块，以装饰模块模板。
+`EvalDevToolModulePlugin` 会使用 `eval` 包裹每个非 external JavaScript 模块并添加 `sourceURL`，使浏览器开发者工具可以显示原始模块名称。设置 `devtool: 'eval'` 时，Rspack 会自动应用该插件。
+
+下面的配置直接应用该插件，并使用 `dashboard` 作为 source URL 的 namespace：
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  mode: 'development',
+  devtool: false,
+  plugins: [
+    new rspack.EvalDevToolModulePlugin({
+      namespace: 'dashboard',
+    }),
+  ],
+};
+```
+
+可以通过 `moduleFilenameTemplate` 和 `sourceUrlComment` 选项自定义生成的模块 URL 和注释格式。
 
 ### FetchCompileAsyncWasmPlugin
 
 `web.FetchCompileAsyncWasmPlugin()`
 
-为异步获取和编译 WebAssembly 模块提供运行时代码，通常配合子编译器使用。
+`FetchCompileAsyncWasmPlugin` 会添加在浏览器中获取并编译异步 WebAssembly 模块的运行时代码。`EnableWasmLoadingPlugin('fetch')` 会在内部应用这个实现。
+
+下面的示例关闭 WebAssembly loading 的自动配置，并直接安装 fetch 实现：
+
+```js title="src/index.js"
+import { add } from './add.wasm';
+
+console.log(add(1, 2));
+```
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  target: 'web',
+  entry: './src/index.js',
+  experiments: {
+    asyncWebAssembly: true,
+  },
+  output: {
+    wasmLoading: false,
+  },
+  plugins: [new rspack.web.FetchCompileAsyncWasmPlugin()],
+};
+```
+
+常规 web 构建应优先使用 `output.wasmLoading: 'fetch'`，Rspack 会自动启用相同的运行时实现。
 
 ### JsonpTemplatePlugin \{#jsonp-template-plugin}
 
@@ -387,37 +481,209 @@ export default {
 
 ## loader
 
+用于自定义 loader 执行上下文的插件。
+
 ### LoaderOptionsPlugin
 
 `LoaderOptionsPlugin(options)`
+
+`LoaderOptionsPlugin` 会将自定义选项字段复制到匹配 `test`、`include` 和 `exclude` 的资源所对应的 loader context 上。匹配字段本身只用于过滤，不会被复制。
+
+下面的 loader 会从 context 中读取自定义的 `message` 属性：
+
+```js title="loaders/message-loader.cjs"
+module.exports = function () {
+  return `export default ${JSON.stringify(this.message)};`;
+};
+```
+
+插件只在处理 `.message` 文件时提供该属性：
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  entry: './src/welcome.message',
+  module: {
+    rules: [
+      {
+        test: /\.message$/,
+        use: './loaders/message-loader.cjs',
+      },
+    ],
+  },
+  plugins: [
+    new rspack.LoaderOptionsPlugin({
+      test: /\.message$/,
+      message: 'Hello from the loader',
+    }),
+  ],
+};
+```
+
+该插件主要用于兼容从 `this` 读取自定义属性的 loader。新编写的 loader 通常应通过自身的 loader options 接收参数。
 
 ### LoaderTargetPlugin
 
 `LoaderTargetPlugin(target)`
 
+`LoaderTargetPlugin` 会将 `target` 赋值给每个 loader context 的 `this.target`。当自定义编译器需要让 loader 读取到与编译器配置不同的 target 时，可以使用该插件。
+
+下面的 loader 会将输入替换为它读取到的 target：
+
+```js title="loaders/target-loader.cjs"
+module.exports = function () {
+  return `console.log(${JSON.stringify(this.target)});`;
+};
+```
+
+虽然构建的 target 是 `web`，下面的插件会让 loader 读取到 `'node'`：
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  target: 'web',
+  entry: './src/index.js',
+  module: {
+    rules: [
+      {
+        test: /index\.js$/,
+        use: './loaders/target-loader.cjs',
+      },
+    ],
+  },
+  plugins: [new rspack.LoaderTargetPlugin('node')],
+};
+```
+
+常规构建应优先使用顶层的 [`target`](/config/target) 配置。
+
 ## module federation
 
-`ModuleFederationPlugin` 使用的底层插件。
+这些插件实现了 Module Federation 的 `exposes`、`remotes` 和 `shared` 能力。常规应用构建应优先使用 [`ModuleFederationPlugin`](/plugins/module-federation-plugin)，由它统一配置这些底层插件。
 
 ### ContainerPlugin
 
 `container.ContainerPlugin(options)`
 
+`ContainerPlugin` 会创建一个 container 入口，通过 Module Federation 的 `get` 和 `init` 接口暴露本地模块。它是 `exposes` 配置的底层实现。
+
+下面的配置会生成 `remoteEntry.js`，并将 `src/Button.js` 暴露为 `./Button`：
+
+```js title="rspack.config.mjs"
+import { container } from '@rspack/core';
+
+export default {
+  entry: {},
+  plugins: [
+    new container.ContainerPlugin({
+      name: 'catalog',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './Button': './src/Button.js',
+      },
+    }),
+  ],
+};
+```
+
 ### ContainerReferencePlugin
 
 `container.ContainerReferencePlugin(options)`
+
+`ContainerReferencePlugin` 会将远程 container 注册为 external，并添加从远程加载模块所需的运行时代码。它是 `remotes` 配置的底层实现。
+
+使用下面的配置后，`import('catalog/Button')` 这样的导入会从远程 container 加载 `./Button`：
+
+```js title="rspack.config.mjs"
+import { container } from '@rspack/core';
+
+export default {
+  entry: './src/index.js',
+  plugins: [
+    new container.ContainerReferencePlugin({
+      remoteType: 'script',
+      remotes: {
+        catalog: 'catalog@http://localhost:3001/remoteEntry.js',
+      },
+    }),
+  ],
+};
+```
 
 ### ConsumeSharedPlugin
 
 `sharing.ConsumeSharedPlugin(options)`
 
+`ConsumeSharedPlugin` 会从 share scope 中解析配置的模块请求。它可以检查版本与 singleton 要求，并在没有合适 provider 时使用本地模块作为 fallback。
+
+下面的示例会从默认 share scope 中消费 singleton `react`，不检查版本，并在需要时回退到本地安装的 package：
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  entry: './src/index.js',
+  plugins: [
+    new sharing.ConsumeSharedPlugin({
+      consumes: {
+        react: {
+          import: 'react',
+          requiredVersion: false,
+          singleton: true,
+        },
+      },
+    }),
+  ],
+};
+```
+
 ### ProvideSharedPlugin
 
 `sharing.ProvideSharedPlugin(options)`
 
+`ProvideSharedPlugin` 会将本地模块及其版本注册到 share scope 中，供其他构建消费。它是 `shared` 配置中 provider 部分的底层实现。
+
+下面的简写形式会使用 `react` 作为 share key 提供本地安装的 `react` package，并从 package metadata 中推断版本：
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  plugins: [
+    new sharing.ProvideSharedPlugin({
+      provides: ['react'],
+    }),
+  ],
+};
+```
+
 ### SharePlugin
 
 `sharing.SharePlugin(options)`
+
+`SharePlugin` 会根据同一份 `shared` 配置同时应用 `ConsumeSharedPlugin` 和 `ProvideSharedPlugin`。它等价于 `ModuleFederationPlugin` 中 `shared` 配置的底层实现。
+
+下面的示例会将本地 `react` package 作为 fallback 提供，同时从默认 share scope 中消费 singleton 实例：
+
+```js title="rspack.config.mjs"
+import { sharing } from '@rspack/core';
+
+export default {
+  plugins: [
+    new sharing.SharePlugin({
+      enhanced: false,
+      shared: {
+        react: {
+          requiredVersion: false,
+          singleton: true,
+        },
+      },
+    }),
+  ],
+};
+```
 
 ### TreeShakingSharedPlugin \{#tree-shaking-shared-plugin}
 
@@ -462,5 +728,26 @@ export default {
 ### RemoveDuplicateModulesPlugin
 
 `experiments.RemoveDuplicateModulesPlugin()`
+
+<ApiMeta stability={Stability.Experimental} />
+
+`RemoveDuplicateModulesPlugin` 会查找同时出现在同一组多个 chunk 中的模块，并将它们移动到一个可复用或新创建的共享 chunk 中。Rspack 会在生成 `modern-module` library 产物时在内部使用该插件。
+
+下面的两个入口都导入了同一个 `src/shared.js` 模块。关闭 `splitChunks` 后，将由 `RemoveDuplicateModulesPlugin` 提取这个重复模块：
+
+```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
+export default {
+  entry: {
+    admin: './src/admin.js',
+    store: './src/store.js',
+  },
+  optimization: {
+    splitChunks: false,
+  },
+  plugins: [new rspack.experiments.RemoveDuplicateModulesPlugin()],
+};
+```
 
 <Attribution url="https://webpack.docschina.org/plugins/internal-plugins/" />

--- a/website/docs/zh/plugins/low-level-plugins.mdx
+++ b/website/docs/zh/plugins/low-level-plugins.mdx
@@ -28,7 +28,9 @@ import { ApiMeta, Stability } from '@components/ApiMeta';
 
 ### ElectronTargetPlugin \{#electron-target-plugin}
 
-`electron.ElectronTargetPlugin(context)`
+```js
+new rspack.electron.ElectronTargetPlugin(context);
+```
 
 `ElectronTargetPlugin` 会将 Electron 内置模块保留为外部依赖，使其在运行时由 Electron 加载。传入 `'main'`、`'preload'` 或 `'renderer'`，可以额外外置对应进程中可用的模块。
 
@@ -51,7 +53,9 @@ new compiler.rspack.electron.ElectronTargetPlugin('main').apply(childCompiler);
 
 ### NodeEnvironmentPlugin
 
-`node.NodeEnvironmentPlugin(options)`
+```js
+new rspack.node.NodeEnvironmentPlugin(options);
+```
 
 `NodeEnvironmentPlugin` 会为编译器安装 infrastructure logger、带缓存的 Node.js 输入文件系统、作为输出文件系统的 Node.js `fs` 模块以及 watch 文件系统。`rspack()` API 会自动将它应用到根编译器。
 
@@ -67,7 +71,9 @@ new compiler.rspack.node.NodeEnvironmentPlugin({
 
 ### NodeTargetPlugin \{#node-target-plugin}
 
-`node.NodeTargetPlugin()`
+```js
+new rspack.node.NodeTargetPlugin();
+```
 
 `NodeTargetPlugin` 会将 Node.js 内置模块和使用 `node:` scheme 的请求保留为外部依赖，使其由 Node.js 运行时加载，而不是被 Rspack 打进 bundle。[`externalsPresets.node`](/config/externals#externalspresetsnode) 配置会在内部应用该插件。
 
@@ -92,7 +98,9 @@ new compiler.rspack.node.NodeTargetPlugin().apply(childCompiler);
 
 ### DynamicEntryPlugin
 
-`DynamicEntryPlugin(context, entry)`
+```js
+new rspack.DynamicEntryPlugin(context, entry);
+```
 
 `DynamicEntryPlugin` 会在每次触发 `make` 事件时调用入口函数，并将函数返回的入口添加到 compilation 中，因此入口列表可以在 watch 重新构建之间发生变化。
 
@@ -120,7 +128,9 @@ export default {
 
 ### EntryOptionPlugin
 
-`EntryOptionPlugin()`
+```js
+new rspack.EntryOptionPlugin();
+```
 
 `EntryOptionPlugin` 用于处理 compiler 的 `entryOption` hook。对于静态入口，它会为每个入口请求应用 `EntryPlugin`；对于函数入口，则会应用 `DynamicEntryPlugin`。Rspack 会自动将它应用到根编译器。
 
@@ -146,7 +156,9 @@ compiler.rspack.EntryOptionPlugin.applyEntryOption(
 
 ### EnableChunkLoadingPlugin \{#enable-chunk-loading-plugin}
 
-`javascript.EnableChunkLoadingPlugin(type)`
+```js
+new rspack.javascript.EnableChunkLoadingPlugin(type);
+```
 
 `EnableChunkLoadingPlugin` 会启用指定 chunk loading 类型所需的运行时模块。Rspack 通常会根据 [`output.enabledChunkLoadingTypes`](/config/output#outputenabledchunkloadingtypes) 收集到的类型应用该插件。
 
@@ -175,7 +187,9 @@ export default {
 
 ### EnableLibraryPlugin \{#enable-library-plugin}
 
-`library.EnableLibraryPlugin(type)`
+```js
+new rspack.library.EnableLibraryPlugin(type);
+```
 
 `EnableLibraryPlugin` 会向编译器注册一种 library 输出类型。Rspack 通常会根据 [`output.enabledLibraryTypes`](/config/output#outputenabledlibrarytypes) 收集到的类型应用该插件。
 
@@ -206,7 +220,9 @@ export default {
 
 ### EnableWasmLoadingPlugin \{#enable-wasm-loading-plugin}
 
-`wasm.EnableWasmLoadingPlugin(type)`
+```js
+new rspack.wasm.EnableWasmLoadingPlugin(type);
+```
 
 `EnableWasmLoadingPlugin` 会启用指定 WebAssembly 加载类型所需的运行时模块。Rspack 通常会根据 [`output.enabledWasmLoadingTypes`](/config/output#outputenabledwasmloadingtypes) 收集到的类型应用该插件。
 
@@ -240,7 +256,9 @@ export default {
 
 ### EvalDevToolModulePlugin
 
-`EvalDevToolModulePlugin(options)`
+```js
+new rspack.EvalDevToolModulePlugin(options);
+```
 
 `EvalDevToolModulePlugin` 会使用 `eval` 包裹每个非 external JavaScript 模块并添加 `sourceURL`，使浏览器开发者工具可以显示原始模块名称。设置 `devtool: 'eval'` 时，Rspack 会自动应用该插件。
 
@@ -264,7 +282,9 @@ export default {
 
 ### FetchCompileAsyncWasmPlugin
 
-`web.FetchCompileAsyncWasmPlugin()`
+```js
+new rspack.web.FetchCompileAsyncWasmPlugin();
+```
 
 `FetchCompileAsyncWasmPlugin` 会添加在浏览器中获取并编译异步 WebAssembly 模块的运行时代码。`EnableWasmLoadingPlugin('fetch')` 会在内部应用这个实现。
 
@@ -296,7 +316,9 @@ export default {
 
 ### JsonpTemplatePlugin \{#jsonp-template-plugin}
 
-`web.JsonpTemplatePlugin()`
+```js
+new rspack.web.JsonpTemplatePlugin();
+```
 
 `JsonpTemplatePlugin` 用于配置子编译器的浏览器产物。它会将 [`output.chunkLoading`](/config/output#outputchunkloading) 设置为 `'jsonp'`，应用 [`'array-push'` chunk format](/config/output#outputchunkformat)，并启用 JSONP chunk loading 所需的运行时代码。
 
@@ -354,7 +376,9 @@ export default {
 
 ### NodeTemplatePlugin \{#node-template-plugin}
 
-`node.NodeTemplatePlugin(options)`
+```js
+new rspack.node.NodeTemplatePlugin(options);
+```
 
 `NodeTemplatePlugin` 用于配置子编译器的 Node.js 产物。它会应用 [`'commonjs'` chunk format](/config/output#outputchunkformat)，默认将 [`output.chunkLoading`](/config/output#outputchunkloading) 设置为 `'require'`，并启用所需的 chunk loading 运行时代码。
 
@@ -423,7 +447,9 @@ export default {
 
 ### WebWorkerTemplatePlugin \{#web-worker-template-plugin}
 
-`webworker.WebWorkerTemplatePlugin()`
+```js
+new rspack.webworker.WebWorkerTemplatePlugin();
+```
 
 `WebWorkerTemplatePlugin` 用于配置子编译器的 Web Worker 产物。它会将 [`output.chunkLoading`](/config/output#outputchunkloading) 设置为 `'import-scripts'`，应用 [`'array-push'` chunk format](/config/output#outputchunkformat)，并启用基于 `importScripts` 的 chunk loading 运行时代码。
 
@@ -485,7 +511,9 @@ export default {
 
 ### LoaderOptionsPlugin
 
-`LoaderOptionsPlugin(options)`
+```js
+new rspack.LoaderOptionsPlugin(options);
+```
 
 `LoaderOptionsPlugin` 会将自定义选项字段复制到匹配 `test`、`include` 和 `exclude` 的资源所对应的 loader context 上。匹配字段本身只用于过滤，不会被复制。
 
@@ -525,7 +553,9 @@ export default {
 
 ### LoaderTargetPlugin
 
-`LoaderTargetPlugin(target)`
+```js
+new rspack.LoaderTargetPlugin(target);
+```
 
 `LoaderTargetPlugin` 会将 `target` 赋值给每个 loader context 的 `this.target`。当自定义编译器需要让 loader 读取到与编译器配置不同的 target 时，可以使用该插件。
 
@@ -565,7 +595,9 @@ export default {
 
 ### ContainerPlugin
 
-`container.ContainerPlugin(options)`
+```js
+new rspack.container.ContainerPlugin(options);
+```
 
 `ContainerPlugin` 会创建一个 container 入口，通过 Module Federation 的 `get` 和 `init` 接口暴露本地模块。它是 `exposes` 配置的底层实现。
 
@@ -590,7 +622,9 @@ export default {
 
 ### ContainerReferencePlugin
 
-`container.ContainerReferencePlugin(options)`
+```js
+new rspack.container.ContainerReferencePlugin(options);
+```
 
 `ContainerReferencePlugin` 会将远程 container 注册为 external，并添加从远程加载模块所需的运行时代码。它是 `remotes` 配置的底层实现。
 
@@ -614,7 +648,9 @@ export default {
 
 ### ConsumeSharedPlugin
 
-`sharing.ConsumeSharedPlugin(options)`
+```js
+new rspack.sharing.ConsumeSharedPlugin(options);
+```
 
 `ConsumeSharedPlugin` 会从 share scope 中解析配置的模块请求。它可以检查版本与 singleton 要求，并在没有合适 provider 时使用本地模块作为 fallback。
 
@@ -641,7 +677,9 @@ export default {
 
 ### ProvideSharedPlugin
 
-`sharing.ProvideSharedPlugin(options)`
+```js
+new rspack.sharing.ProvideSharedPlugin(options);
+```
 
 `ProvideSharedPlugin` 会将本地模块及其版本注册到 share scope 中，供其他构建消费。它是 `shared` 配置中 provider 部分的底层实现。
 
@@ -661,7 +699,9 @@ export default {
 
 ### SharePlugin
 
-`sharing.SharePlugin(options)`
+```js
+new rspack.sharing.SharePlugin(options);
+```
 
 `SharePlugin` 会根据同一份 `shared` 配置同时应用 `ConsumeSharedPlugin` 和 `ProvideSharedPlugin`。它等价于 `ModuleFederationPlugin` 中 `shared` 配置的底层实现。
 
@@ -687,7 +727,9 @@ export default {
 
 ### TreeShakingSharedPlugin \{#tree-shaking-shared-plugin}
 
-`sharing.TreeShakingSharedPlugin(options)`
+```js
+new rspack.sharing.TreeShakingSharedPlugin(options);
+```
 
 <ApiMeta stability={Stability.Experimental} />
 
@@ -727,7 +769,9 @@ export default {
 
 ### RemoveDuplicateModulesPlugin
 
-`experiments.RemoveDuplicateModulesPlugin()`
+```js
+new rspack.experiments.RemoveDuplicateModulesPlugin();
+```
 
 <ApiMeta stability={Stability.Experimental} />
 


### PR DESCRIPTION
## Summary

This PR improves the low-level plugin reference so advanced users can understand when and how to use these publicly exposed building blocks. It adds source-backed descriptions and minimal examples for every listed plugin in English and Chinese, and formats constructor signatures consistently with standalone plugin pages.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).