### PR TITLE
docs: update webpack plugin compatibility

### DIFF
--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -4,8 +4,6 @@ import { Link } from '@rspress/core/theme';
 import { useI18nUrl } from '@theme/i18n';
 import type React from 'react';
 
-// cspell:ignore evaldevtoolmoduleplugin
-
 enum SupportStatus {
   NotSupported = 0,
   PartiallySupported = 1,

--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -490,7 +490,11 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'ReadFileCompileAsyncWasmPlugin',
-    status: SupportStatus.NotSupported,
+    status: SupportStatus.PartiallySupported,
+    notes: {
+      en: 'Used internally, but not exposed through the JavaScript API',
+      zh: '已在内部使用，但未通过 JavaScript API 导出',
+    },
   },
   {
     name: 'ReadFileCompileWasmPlugin',

--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -512,10 +512,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     status: SupportStatus.FullySupported,
   },
 ].sort((a, b) => {
-  return (
-    b.status - a.status ||
-    (b.url && a.url ? 0 : (b.url?.length || 0) - (a.url?.length || 0))
-  );
+  return b.status - a.status || a.name.localeCompare(b.name);
 });
 
 const getNotesText = (

--- a/website/components/PluginSupportStatusTable.tsx
+++ b/website/components/PluginSupportStatusTable.tsx
@@ -4,6 +4,8 @@ import { Link } from '@rspress/core/theme';
 import { useI18nUrl } from '@theme/i18n';
 import type React from 'react';
 
+// cspell:ignore evaldevtoolmoduleplugin
+
 enum SupportStatus {
   NotSupported = 0,
   PartiallySupported = 1,
@@ -13,7 +15,7 @@ enum SupportStatus {
 const SUPPORT_STATUS_LOCALIZED = {
   [SupportStatus.NotSupported]: {
     symbol: '🔴',
-    en: 'Unsupported yet',
+    en: 'Not supported',
     zh: '暂未支持',
   },
   [SupportStatus.PartiallySupported]: {
@@ -44,16 +46,40 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     status: SupportStatus.NotSupported,
   },
   {
+    name: 'AsyncWebAssemblyModulesPlugin',
+    status: SupportStatus.PartiallySupported,
+    notes: {
+      en: 'Used internally, but not exposed through the JavaScript API',
+      zh: '已在内部使用，但未通过 JavaScript API 导出',
+    },
+  },
+  {
     name: 'BannerPlugin',
     url: '/plugins/banner-plugin',
     status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'ChunkPrefetchPreloadPlugin',
+    status: SupportStatus.PartiallySupported,
+    notes: {
+      en: 'Used internally, but not exposed through the JavaScript API',
+      zh: '已在内部使用，但未通过 JavaScript API 导出',
+    },
+  },
+  {
+    name: 'CssModulesPlugin',
+    status: SupportStatus.PartiallySupported,
+    notes: {
+      en: 'Used internally, but not exposed through the JavaScript API',
+      zh: '已在内部使用，但未通过 JavaScript API 导出',
+    },
   },
   {
     name: 'DefinePlugin',
     url: '/plugins/define-plugin',
     status: SupportStatus.PartiallySupported,
     notes: {
-      en: '`rspack.DefinePlugin.runtimeValue` function not supported',
+      en: '`rspack.DefinePlugin.runtimeValue` is not supported',
       zh: '不支持 `rspack.DefinePlugin.runtimeValue` 函数',
     },
   },
@@ -61,6 +87,10 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     name: 'DllPlugin',
     url: '/plugins/dll-plugin',
     status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'DotenvPlugin',
+    status: SupportStatus.NotSupported,
   },
   {
     name: 'EnvironmentPlugin',
@@ -82,6 +112,10 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     status: SupportStatus.FullySupported,
   },
   {
+    name: 'HtmlModulesPlugin',
+    status: SupportStatus.NotSupported,
+  },
+  {
     name: 'IgnorePlugin',
     url: '/plugins/ignore-plugin',
     status: SupportStatus.FullySupported,
@@ -90,6 +124,10 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     name: 'LimitChunkCountPlugin',
     url: '/plugins/limit-chunk-count-plugin',
     status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'ManifestPlugin',
+    status: SupportStatus.NotSupported,
   },
   {
     name: 'MinChunkSizePlugin',
@@ -106,12 +144,17 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'NoEmitOnErrorsPlugin',
+    url: '/plugins/no-emit-on-errors-plugin',
     status: SupportStatus.FullySupported,
   },
   {
     name: 'NormalModuleReplacementPlugin',
     url: '/plugins/normal-module-replacement-plugin',
     status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'PlatformPlugin',
+    status: SupportStatus.NotSupported,
   },
   {
     name: 'PrefetchPlugin',
@@ -127,13 +170,21 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     status: SupportStatus.PartiallySupported,
     notes: {
       zh: '仅支持部分选项',
-      en: 'Only partial options supported',
+      en: 'Only some options are supported',
     },
   },
   {
     name: 'ProvidePlugin',
     url: '/plugins/provide-plugin',
     status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'SingleEntryPlugin',
+    status: SupportStatus.PartiallySupported,
+    notes: {
+      en: 'Use `EntryPlugin` instead',
+      zh: '请改用 `EntryPlugin`',
+    },
   },
   {
     name: 'SourceMapDevToolPlugin',
@@ -146,13 +197,18 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     status: SupportStatus.FullySupported,
   },
   {
+    name: 'VirtualUrlPlugin',
+    status: SupportStatus.NotSupported,
+  },
+  {
     name: 'WatchIgnorePlugin',
     status: SupportStatus.NotSupported,
   },
 
-  // internal Rspack plugins
+  // internal webpack plugins
   {
     name: 'NodeEnvironmentPlugin',
+    url: '/plugins/low-level-plugins#nodeenvironmentplugin',
     status: SupportStatus.FullySupported,
   },
   {
@@ -166,11 +222,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   {
     name: 'EntryPlugin',
     url: '/plugins/entry-plugin',
-    status: SupportStatus.PartiallySupported,
-    notes: {
-      en: '`wasmLoading` option is not supported',
-      zh: '不支持 `wasmLoading` 选项',
-    },
+    status: SupportStatus.FullySupported,
   },
   {
     name: 'JsonpTemplatePlugin',
@@ -193,6 +245,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'EvalDevToolModulePlugin',
+    url: '/plugins/low-level-plugins#evaldevtoolmoduleplugin',
     status: SupportStatus.FullySupported,
   },
   {
@@ -257,7 +310,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     },
   },
 
-  // not write in webpack docs
+  // other webpack plugins
   {
     name: 'AbstractLibraryPlugin',
     status: SupportStatus.NotSupported,
@@ -280,14 +333,17 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'ConsumeSharedPlugin',
+    url: '/plugins/low-level-plugins#consumesharedplugin',
     status: SupportStatus.FullySupported,
   },
   {
     name: 'ContainerPlugin',
+    url: '/plugins/low-level-plugins#containerplugin',
     status: SupportStatus.FullySupported,
   },
   {
     name: 'ContainerReferencePlugin',
+    url: '/plugins/low-level-plugins#containerreferenceplugin',
     status: SupportStatus.FullySupported,
   },
   {
@@ -313,11 +369,8 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'DeterministicModuleIdsPlugin',
-    status: SupportStatus.PartiallySupported,
-    notes: {
-      en: '`context`, `test`, `maxLength`, `salt`, `fixedLength`, `failOnConflict` options are not supported',
-      zh: '不支持 `context`、`test`、`maxLength`、`salt`、`fixedLength`、`failOnConflict` 选项',
-    },
+    url: '/plugins/deterministic-module-ids-plugin',
+    status: SupportStatus.FullySupported,
   },
   {
     name: 'DllReferencePlugin',
@@ -326,11 +379,8 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'DynamicEntryPlugin',
-    status: SupportStatus.PartiallySupported,
-    notes: {
-      en: '`wasmLoading` option is not supported',
-      zh: '不支持 `wasmLoading` 选项',
-    },
+    url: '/plugins/low-level-plugins#dynamicentryplugin',
+    status: SupportStatus.FullySupported,
   },
   {
     name: 'ElectronTargetPlugin',
@@ -354,6 +404,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'EntryOptionPlugin',
+    url: '/plugins/low-level-plugins#entryoptionplugin',
     status: SupportStatus.FullySupported,
   },
   {
@@ -376,10 +427,11 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'JavascriptModulesPlugin',
+    url: '/plugins/javascript-modules-plugin',
     status: SupportStatus.PartiallySupported,
     notes: {
       zh: '静态方法 `getCompilationHooks()` 的返回值未支持所有 hook',
-      en: 'Static `getCompilationHooks()` method does not return all hooks',
+      en: 'Static `getCompilationHooks()` does not expose all hooks',
     },
   },
   {
@@ -388,6 +440,12 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'LoaderOptionsPlugin',
+    url: '/plugins/low-level-plugins#loaderoptionsplugin',
+    status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'LoaderTargetPlugin',
+    url: '/plugins/low-level-plugins#loadertargetplugin',
     status: SupportStatus.FullySupported,
   },
   {
@@ -406,7 +464,7 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
     name: 'NamedModuleIdsPlugin',
     status: SupportStatus.PartiallySupported,
     notes: {
-      en: '`context` options are not supported',
+      en: '`context` is not supported',
       zh: '不支持 `context` 选项',
     },
   },
@@ -424,11 +482,17 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'ProvideSharedPlugin',
-    status: SupportStatus.PartiallySupported,
-    notes: {
-      en: 'Temporarily not exported from the JavaScript side',
-      zh: '暂时未从 JavaScript 侧导出',
-    },
+    url: '/plugins/low-level-plugins#providesharedplugin',
+    status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'SharePlugin',
+    url: '/plugins/low-level-plugins#shareplugin',
+    status: SupportStatus.FullySupported,
+  },
+  {
+    name: 'ReadFileCompileAsyncWasmPlugin',
+    status: SupportStatus.NotSupported,
   },
   {
     name: 'ReadFileCompileWasmPlugin',
@@ -445,11 +509,6 @@ const pluginSupportStatusList: PluginSupportStatus[] = [
   },
   {
     name: 'SyncModuleIdsPlugin',
-    status: SupportStatus.NotSupported,
-  },
-  {
-    name: 'CaseSensitivePlugin',
-    url: '/plugins/case-sensitive-plugin',
     status: SupportStatus.FullySupported,
   },
 ].sort((a, b) => {
@@ -468,7 +527,7 @@ const getNotesText = (
     return lang === 'zh' ? notes.zh : notes.en;
   }
   if (status === SupportStatus.NotSupported) {
-    return lang === 'zh' ? '待实现' : 'To be implemented';
+    return lang === 'zh' ? '待实现' : 'Not implemented';
   }
 };
 

--- a/website/docs/en/guide/compatibility/plugin.mdx
+++ b/website/docs/en/guide/compatibility/plugin.mdx
@@ -8,7 +8,7 @@ import { CommunityPluginCompatibleTable } from '@components/CommunityCompatibleT
 
 This page lists the compatibility status of common community plugins in Rspack.
 
-For details on Rspack's support for webpack built-in plugins, see [webpack built-in plugin support](/plugins/webpack-built-in-plugin-support).
+For webpack built-in plugins and selected internal plugins, see [webpack plugin compatibility](/plugins/webpack-built-in-plugin-support).
 
 The table only covers common community plugins. For others, you can verify their functionality yourself, and you're welcome to add them to this page.
 

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -239,7 +239,7 @@ module.exports = {
 }
 ```
 
-See [webpack built-in plugin support](/plugins/webpack-built-in-plugin-support) for more information about supported webpack plugins in Rspack.
+See [webpack plugin compatibility](/plugins/webpack-built-in-plugin-support) for Rspack's compatibility status with webpack built-in plugins and selected internal plugins.
 
 ## Community plugins
 

--- a/website/docs/en/plugins/index.mdx
+++ b/website/docs/en/plugins/index.mdx
@@ -58,7 +58,7 @@ To learn how to use plugins, see the [plugin guide](/guide/features/plugin).
 ## Reference
 
 - [Low-level plugins](/plugins/low-level-plugins): Catalogs publicly exposed building blocks for target presets, runtime templates, child compilers, and higher-level plugins.
-- [webpack built-in plugin support](/plugins/webpack-built-in-plugin-support): Summarizes Rspack's support for webpack built-in plugins.
+- [webpack plugin compatibility](/plugins/webpack-built-in-plugin-support): Summarizes Rspack's compatibility with webpack built-in plugins and selected internal plugins.
 
 ## Community plugins
 

--- a/website/docs/en/plugins/webpack-built-in-plugin-support.mdx
+++ b/website/docs/en/plugins/webpack-built-in-plugin-support.mdx
@@ -1,11 +1,13 @@
 ---
-description: 'Check Rspack support for webpack built-in plugins and open the available plugin reference pages.'
+description: 'Check Rspack compatibility with webpack built-in plugin APIs and selected internal plugins.'
 ---
 
 import { PluginSupportStatusTable } from '@components/PluginSupportStatusTable';
 
-# webpack built-in plugin support
+# webpack plugin compatibility
 
-The table below shows the support status of Rspack for the built-in plugins in webpack. If you are interested in participating in the development of plugins or features that have not yet been implemented, we would be very happy to have you join us.
+The table below shows Rspack compatibility with webpack [built-in plugin APIs](https://webpack.js.org/plugins/) and selected [internal plugins](https://webpack.js.org/plugins/internal-plugins/). Linked plugin names open the corresponding Rspack reference documentation.
+
+Contributions for plugins or features that have not yet been implemented are welcome.
 
 <PluginSupportStatusTable />

--- a/website/docs/zh/guide/compatibility/plugin.mdx
+++ b/website/docs/zh/guide/compatibility/plugin.mdx
@@ -8,7 +8,7 @@ import { CommunityPluginCompatibleTable } from '@components/CommunityCompatibleT
 
 该索引列出了 Rspack 对一些常见的社区插件的兼容状态。
 
-Rspack 对 webpack 内置插件的支持情况可以参考 [webpack 内置插件支持情况](/plugins/webpack-built-in-plugin-support)。
+Rspack 对 webpack 内置插件和部分内部插件的兼容状态可以参考 [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)。
 
 注意表格中仅列出了一些常见的社区插件，对于未列出的插件，你可以自行验证其功能的可用性。欢迎补充更多插件到当前文档中。
 

--- a/website/docs/zh/guide/compatibility/plugin.mdx
+++ b/website/docs/zh/guide/compatibility/plugin.mdx
@@ -8,7 +8,7 @@ import { CommunityPluginCompatibleTable } from '@components/CommunityCompatibleT
 
 该索引列出了 Rspack 对一些常见的社区插件的兼容状态。
 
-Rspack 对 webpack 内置插件和部分内部插件的兼容状态可以参考 [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)。
+Rspack 对 webpack 内置插件的兼容状态可以参考 [webpack 内置插件兼容性](/plugins/webpack-built-in-plugin-support)。
 
 注意表格中仅列出了一些常见的社区插件，对于未列出的插件，你可以自行验证其功能的可用性。欢迎补充更多插件到当前文档中。
 

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -235,7 +235,7 @@ module.exports = {
 }
 ```
 
-查看 [webpack 内置插件支持情况](/plugins/webpack-built-in-plugin-support)，了解 Rspack 对 webpack 所有内置插件的支持情况。
+查看 [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)，了解 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
 
 ## 社区插件
 

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -235,7 +235,7 @@ module.exports = {
 }
 ```
 
-查看 [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)，了解 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
+查看 [webpack 内置插件兼容性](/plugins/webpack-built-in-plugin-support)，了解 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
 
 ## 社区插件
 

--- a/website/docs/zh/plugins/index.mdx
+++ b/website/docs/zh/plugins/index.mdx
@@ -58,7 +58,7 @@ description: '按功能浏览所有 Rspack 插件文档，并通过简短介绍�
 ## 参考
 
 - [底层插件](/plugins/low-level-plugins)：汇总用于目标预设、运行时模板、子编译器和上层插件的底层构件。
-- [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)：汇总 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
+- [webpack 内置插件兼容性](/plugins/webpack-built-in-plugin-support)：汇总 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
 
 ## 社区插件
 

--- a/website/docs/zh/plugins/index.mdx
+++ b/website/docs/zh/plugins/index.mdx
@@ -58,7 +58,7 @@ description: '按功能浏览所有 Rspack 插件文档，并通过简短介绍�
 ## 参考
 
 - [底层插件](/plugins/low-level-plugins)：汇总用于目标预设、运行时模板、子编译器和上层插件的底层构件。
-- [webpack 内置插件支持情况](/plugins/webpack-built-in-plugin-support)：汇总 Rspack 对 webpack 内置插件的支持情况。
+- [webpack 插件兼容性](/plugins/webpack-built-in-plugin-support)：汇总 Rspack 对 webpack 内置插件和部分内部插件的兼容状态。
 
 ## 社区插件
 

--- a/website/docs/zh/plugins/webpack-built-in-plugin-support.mdx
+++ b/website/docs/zh/plugins/webpack-built-in-plugin-support.mdx
@@ -4,7 +4,7 @@ description: '查看 Rspack 对 webpack 内置插件 API 和部分内部插件�
 
 import { PluginSupportStatusTable } from '@components/PluginSupportStatusTable';
 
-# webpack 插件兼容性
+# webpack 内置插件兼容性
 
 下表列出了 Rspack 对 webpack [内置插件 API](https://webpack.js.org/plugins/)和部分[内部插件](https://webpack.js.org/plugins/internal-plugins/)的兼容状态。插件名称带有链接时，可点击查看对应的 Rspack 参考文档。
 

--- a/website/docs/zh/plugins/webpack-built-in-plugin-support.mdx
+++ b/website/docs/zh/plugins/webpack-built-in-plugin-support.mdx
@@ -1,11 +1,13 @@
 ---
-description: '查看 Rspack 对 webpack 内置插件的支持情况，并前往已有的插件参考页面。'
+description: '查看 Rspack 对 webpack 内置插件 API 和部分内部插件的兼容状态。'
 ---
 
 import { PluginSupportStatusTable } from '@components/PluginSupportStatusTable';
 
-# webpack 内置插件支持情况
+# webpack 插件兼容性
 
-以下表格展示了 Rspack 相对于 webpack 内置插件的支持情况。对于尚未实现的插件或功能，如果你有兴趣参与开发，我们非常欢迎你来参与。
+下表列出了 Rspack 对 webpack [内置插件 API](https://webpack.js.org/plugins/)和部分[内部插件](https://webpack.js.org/plugins/internal-plugins/)的兼容状态。插件名称带有链接时，可点击查看对应的 Rspack 参考文档。
+
+对于尚未实现的插件或功能，欢迎参与贡献。
 
 <PluginSupportStatusTable />

--- a/website/project-words.txt
+++ b/website/project-words.txt
@@ -53,6 +53,7 @@ elecmonkeyjs
 emnapi
 esbuild
 etags
+evaldevtoolmoduleplugin
 evanw
 experimentscss
 externalstypecommonjs


### PR DESCRIPTION
## Summary

This PR refreshes the webpack plugin compatibility page so its title and scope are clearer and its support matrix reflects the current Rspack implementation.

It adds recently introduced webpack plugins to the matrix, corrects stale Rspack support statuses, links supported low-level plugins to their references, and keeps the English and Chinese entry points consistent.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
