### PR TITLE
docs: remove version info before Rspack 1.3.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,8 +92,8 @@ catalogs:
       specifier: 2.2.3
       version: 2.2.3
     '@rstackjs/doc-ui':
-      specifier: 1.14.9
-      version: 1.14.9
+      specifier: 1.14.11
+      version: 1.14.11
     '@rstackjs/load-config':
       specifier: ^0.1.2
       version: 0.1.2
@@ -1226,7 +1226,7 @@ importers:
     dependencies:
       '@rstackjs/doc-ui':
         specifier: 'catalog:'
-        version: 1.14.9(@rspress/core@2.0.19)
+        version: 1.14.11(@rspress/core@2.0.19)
       markdown-to-jsx:
         specifier: 'catalog:'
         version: 9.10.2(react@19.2.8)(vue@3.5.41)
@@ -1248,10 +1248,10 @@ importers:
         version: 2.0.1(@rsbuild/core@2.1.13)
       '@rsbuild/plugin-tailwindcss':
         specifier: 'catalog:'
-        version: 2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
+        version: 2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.2.1)
       '@rspress/core':
         specifier: 'catalog:'
-        version: 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+        version: 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rspress/plugin-algolia':
         specifier: 'catalog:'
         version: 2.0.19(@rspress/core@2.0.19)(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
@@ -3005,6 +3005,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.2.1':
+    resolution: {integrity: sha512-Y/Naw/7V76QiUYdYRuBzBZtzRjt/3fjDUuF8GK0+/BO7BP1RrpY4tk1ln+iiqegRUD8u9uGn08fi8No1rwfyUg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@2.1.10':
     resolution: {integrity: sha512-my/0h2LwxCRT6cg3oDDC2e0ZOxQLVajAdIcv0fqnQk5JRNvVuL89PuTutitnSqie1A0/JSL8OQz5XHwmoS3kow==}
     cpu: [x64]
@@ -3012,6 +3017,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.2.0-rc.0':
     resolution: {integrity: sha512-UQO0PgLarsA0lv96uqCTAH1eAnAIPHb+qhMfds5ubWKZgKlr0taGQl253C3DN5pfzbHWfNQgAfVUaVMydm9czw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.2.1':
+    resolution: {integrity: sha512-rTIG/xZIW7RbEEuMR9hnNn5dv3fDBpX0N4FAQUwfhUYy3tN2+3vibTTq/Nj1Sd9Vn4yWydbWIEwBX6m/aGejig==}
     cpu: [x64]
     os: [darwin]
 
@@ -3023,6 +3033,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.2.0-rc.0':
     resolution: {integrity: sha512-ZggL6W9ckpvhqIPi7K3zDRiEaQd5Co2qRnN5J8OMmBkQlvYQek0CE/SZHFcZsDM0//6+0mkI+VjaTeWdvqJsaQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.2.1':
+    resolution: {integrity: sha512-53rAMU6Hqiat21IMU1hTt4Si2F33h+ZbXOt+Y18W39AFjcwmleIBId2u7beqJeGXLJuBgIAm31jcbJj/PN7mWQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -3039,6 +3055,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.2.1':
+    resolution: {integrity: sha512-o7zFiWkt4MqSfSdTbxUdF27fcrWKpRizcuVB8H3yd2G6xW9V2OfYbhVGQnOlbKi+GK74RkCmoJtANB+QboIqKQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-linux-ppc64-gnu@2.1.10':
     resolution: {integrity: sha512-U7HlNzHcDtZ+LYOtOJmtx67kHEybZzUUAaP7aEXjGYO5WTCgh/176sW2UYP0rmZLrgUNFUuzn+B98RLaClNaVg==}
     cpu: [ppc64]
@@ -3047,6 +3069,12 @@ packages:
 
   '@rspack/binding-linux-ppc64-gnu@2.2.0-rc.0':
     resolution: {integrity: sha512-n84s99eIMr/4xQ1XCctxtu4AnchukynuyJ4DaJ4vlcRKVdFAnPSpUH669rAxztsby5xa3ftAASmxwXhMUFzMsg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.1':
+    resolution: {integrity: sha512-pvx1oeg1z7cr8OcNt7PAt1SJTHzdsN/pvu7HkGnfks2fWE7GDs9DLL2KvN7tUkzQvJm6bGgUwqSCOrqV4uSwAg==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -3063,6 +3091,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-riscv64-gnu@2.2.1':
+    resolution: {integrity: sha512-WQ6P94Wz2tgwOsgifTWP2/bV63iZH5+rkxngQwF22FC8KmIXXy/Yug7lyMH1ld8Hzg4p1qXjBBr4i1cCyJTR+w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-musl@2.1.10':
     resolution: {integrity: sha512-rkurnAWc04vIbzG1QCrPBWSJadZvaOt1mazFH3EdiJO8VUiu0I1T9zdiwuDOPrd50lOKIZlcTXbd5aaAkWEnvQ==}
     cpu: [riscv64]
@@ -3071,6 +3105,12 @@ packages:
 
   '@rspack/binding-linux-riscv64-musl@2.2.0-rc.0':
     resolution: {integrity: sha512-XNjEnkrNv67CZ4/IhkPQVfNkz9JHevelgZspzuuJOOyn+Z9b1m8JN+shv5Kq06sSudN9aQpLLa6slbHlKGv9lA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-riscv64-musl@2.2.1':
+    resolution: {integrity: sha512-GEFUFHQkjKU7OYyHXnrIo8wWcUHM7jeKov5z6Lxd3i+3hKo11yBOgb7b+uD94Rx2tPuWF4jyFdWmcNu46Njb/A==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
@@ -3087,6 +3127,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rspack/binding-linux-s390x-gnu@2.2.1':
+    resolution: {integrity: sha512-Cqw2UjSmFGZaw1EjQXClKDud86ThynGEEIazy2PZfPzZG4WjICK1WjdeFCJd7xWsSbUQ3jGyzb7/EHiDVa+sKA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-x64-gnu@2.1.10':
     resolution: {integrity: sha512-Fat09V6jUuyo9qG7Wyj9cQ31VDfLmokXyBtGqKxY5OvSWHereB7QUub5btbPXHwbp6Iq4aAQyUbbLTzvR1YaBw==}
     cpu: [x64]
@@ -3095,6 +3141,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.2.0-rc.0':
     resolution: {integrity: sha512-1QoW+7zjApCgL4v5P14AmnxfvOMCk131abSBCl/+u6h/aIainSwpf+O3ar0FqvkQaSPPOQJrg03ys57WyEwlAQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.2.1':
+    resolution: {integrity: sha512-QX+gRxg2CS9ri2fUG5eNurdsrOCWoJ56SsD2O7kcVGiRm+S2+muNb/QhkdkAdt/u/m++7Ve5TMIpHTnaKYCpCw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -3111,12 +3163,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.2.1':
+    resolution: {integrity: sha512-mBZQl1NdGbEB3y5M9d0tkuF7RL1GLz3Hb3gqFa3QRZBymP9PCV83Jiji8s2PJimNUJIVcdZRIw8+VGYs/35c2A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@2.1.10':
     resolution: {integrity: sha512-KY5YbWbuvYcoaLXnV+vzZOvGRCeb6jt4EpVpKdph1h1IJjwX/ju15EQ+GOe3iecZEdf0OttQcNVcwBkLkFT9ag==}
     cpu: [wasm32]
 
   '@rspack/binding-wasm32-wasi@2.2.0-rc.0':
     resolution: {integrity: sha512-2Vvtckz5DNghQKQKwghfM4j30MOu7t9J7mbUCCi7mTUccpy7Cnr0HPmSV9Jx4sUj6vgQEV+8lIAIxNDNtr0Vhg==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.2.1':
+    resolution: {integrity: sha512-/d2ImKDS+lT+FJ07MxKBeUkTat84tr2Nm2+nIRt8HmZK7/N8odkQml9vb4MHr8E7oYOp4B+jm6W5frdRzKrkJQ==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@2.1.10':
@@ -3126,6 +3188,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.2.0-rc.0':
     resolution: {integrity: sha512-enPqTT2sdt6HgItyk6SA6ubvZ2UXkFIpwhsCuoL83z9vHoDw/Y8obC8L92nIuK6FDP17tokm/r1SFPhDZJIYcg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.2.1':
+    resolution: {integrity: sha512-TfmaKPF3KC7uoZb6A+8ZUbLS8g8P5EdeXFGLCaJ+UgdkJ20TsapcfJXZXWNnKzFEkV8dUO/t5oNxNLYy2URusw==}
     cpu: [arm64]
     os: [win32]
 
@@ -3139,6 +3206,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.2.1':
+    resolution: {integrity: sha512-rdBXayngvpQFMSUIC4b71FDZrSBJszSHNEkln/Nis3a17DMAE7IkgJcqe7SqLWbk2OPF/N920AOWmBEDQQCaMg==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     resolution: {integrity: sha512-pgp23pLrzfhGnKycxzr7ifP17lAbWZEfnx1bX8gXtYrnpJ66DRNyTKSzxB6sa/HBWjS1L8PX5TjMZ44WfPydqQ==}
     cpu: [x64]
@@ -3149,11 +3221,19 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.2.1':
+    resolution: {integrity: sha512-l3K4s7nrQJc+3LacPFjZGjX8Jk1sf8Q4TK6IXAsdSucOjTqYSpD8PMl2NUXCBDXOl8T2V4v323z1LfxwW8BPmA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@2.1.10':
     resolution: {integrity: sha512-vnu/UP5HnrND15lO9+VeG6eUrbTyycHNQNQ3XEiRiFojuoiGZkIZC3Hbzr8qQH44C6vScPODEPvvIVvLcO2LpQ==}
 
   '@rspack/binding@2.2.0-rc.0':
     resolution: {integrity: sha512-/Q9ysTd5ajEbIS+Sv61trElR7pWAa5LvcWNrYT+AKI9APsVwy4Y3CIPjEkd7jYeNHl1PJWSLCOUy+BzRUICDUg==}
+
+  '@rspack/binding@2.2.1':
+    resolution: {integrity: sha512-56TqztuEMd+aHGv1jDXnkJQGSLTb4NoO146flFxJqPG8931UdXPO2pNR9M0Q2Pz+GvmO0fLHGPLYBHoRVrRlHw==}
 
   '@rspack/core@2.1.10':
     resolution: {integrity: sha512-YSS2/Xxz8uiG/KXDkqOoA3dTetNo/vysk7bAexQOrU8iuq7JuzDTTAwLKvWZnwmvME8M8m5wcM4YvfIwYmidHA==}
@@ -3169,6 +3249,18 @@ packages:
 
   '@rspack/core@2.2.0-rc.0':
     resolution: {integrity: sha512-2LAdAFF/ZdnBRltI+IievGhysby9LESxvELxS1ZVkPc1F6ZAJ1skIcCNOLmfZeoYwQ5nXZjdUCbCf9MFDMWJjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.2.1':
+    resolution: {integrity: sha512-EHFX2oWCY1HkHJkG/Ev8HXCcl4gQzgETyairdIlBkKaypuW8i7kowBxUFzpHHg/ObF70vB3focToel9Wwg4MRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -3347,8 +3439,8 @@ packages:
     resolution: {integrity: sha512-0I1U/BGGLXBkvE+C9oDKYfmg1wjFMHCPQlG2BJF+f41kL0BmXZaQMa/m515lo8Q349otqyAEam4A5BMuxetTVw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@rstackjs/doc-ui@1.14.9':
-    resolution: {integrity: sha512-Te7Wx4K9JuvluP7HsH/Dpdju5QhClUe17/9YBzHlul+x2wg63jOkngv79DlMXyYDJgHQ+11vZfz18B+bnPhttw==}
+  '@rstackjs/doc-ui@1.14.11':
+    resolution: {integrity: sha512-VJ7trL69YzClO/zFPIgKu3l6b9pvKcUIurniWyirH5JcELqKcmlH7RAI6esfnJglHFqk7xONyqKa7bqsnBCruA==}
     peerDependencies:
       '@rspress/core': '>=2.0.0'
     peerDependenciesMeta:
@@ -9366,9 +9458,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
 
-  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.2.1)':
     dependencies:
-      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
@@ -9385,9 +9477,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
 
-  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)':
+  '@rsbuild/plugin-tailwindcss@2.0.3(@rsbuild/core@2.1.13)(@rspack/core@2.2.1)':
     dependencies:
-      '@tailwindcss/webpack': 4.3.3(@rspack/core@2.1.10)
+      '@tailwindcss/webpack': 4.3.3(@rspack/core@2.2.1)
     optionalDependencies:
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
     transitivePeerDependencies:
@@ -9449,10 +9541,16 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.2.1':
+    optional: true
+
   '@rspack/binding-darwin-x64@2.1.10':
     optional: true
 
   '@rspack/binding-darwin-x64@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.2.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@2.1.10':
@@ -9461,10 +9559,16 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.2.1':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@2.1.10':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@2.2.1':
     optional: true
 
   '@rspack/binding-linux-ppc64-gnu@2.1.10':
@@ -9473,10 +9577,16 @@ snapshots:
   '@rspack/binding-linux-ppc64-gnu@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-ppc64-gnu@2.2.1':
+    optional: true
+
   '@rspack/binding-linux-riscv64-gnu@2.1.10':
     optional: true
 
   '@rspack/binding-linux-riscv64-gnu@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-riscv64-musl@2.1.10':
@@ -9485,10 +9595,16 @@ snapshots:
   '@rspack/binding-linux-riscv64-musl@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-riscv64-musl@2.2.1':
+    optional: true
+
   '@rspack/binding-linux-s390x-gnu@2.1.10':
     optional: true
 
   '@rspack/binding-linux-s390x-gnu@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.2.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@2.1.10':
@@ -9497,10 +9613,16 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.2.1':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@2.1.10':
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.2.1':
     optional: true
 
   '@rspack/binding-wasm32-wasi@2.1.10':
@@ -9517,10 +9639,20 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.2.1':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@2.1.10':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.2.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@2.1.10':
@@ -9529,10 +9661,16 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.2.0-rc.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.2.1':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@2.1.10':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.2.0-rc.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.2.1':
     optional: true
 
   '@rspack/binding@2.1.10':
@@ -9569,6 +9707,24 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.2.0-rc.0
       '@rspack/binding-win32-x64-msvc': 2.2.0-rc.0
 
+  '@rspack/binding@2.2.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 2.2.1
+      '@rspack/binding-darwin-x64': 2.2.1
+      '@rspack/binding-linux-arm64-gnu': 2.2.1
+      '@rspack/binding-linux-arm64-musl': 2.2.1
+      '@rspack/binding-linux-ppc64-gnu': 2.2.1
+      '@rspack/binding-linux-riscv64-gnu': 2.2.1
+      '@rspack/binding-linux-riscv64-musl': 2.2.1
+      '@rspack/binding-linux-s390x-gnu': 2.2.1
+      '@rspack/binding-linux-x64-gnu': 2.2.1
+      '@rspack/binding-linux-x64-musl': 2.2.1
+      '@rspack/binding-wasm32-wasi': 2.2.1
+      '@rspack/binding-win32-arm64-msvc': 2.2.1
+      '@rspack/binding-win32-ia32-msvc': 2.2.1
+      '@rspack/binding-win32-x64-msvc': 2.2.1
+    optional: true
+
   '@rspack/core@2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
     dependencies:
       '@rspack/binding': 2.1.10
@@ -9582,6 +9738,14 @@ snapshots:
     optionalDependencies:
       '@module-federation/runtime-tools': 2.8.2
       '@swc/helpers': 0.5.23
+
+  '@rspack/core@2.2.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)':
+    dependencies:
+      '@rspack/binding': 2.2.1
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.8.2
+      '@swc/helpers': 0.5.23
+    optional: true
 
   '@rspack/dev-middleware@2.0.3(@rspack/core@packages+rspack)':
     optionalDependencies:
@@ -9603,11 +9767,11 @@ snapshots:
     optionalDependencies:
       '@rspack/core': link:packages/rspack
 
-  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.1.10)(react-refresh@0.18.0)':
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.1)(react-refresh@0.18.0)':
     dependencies:
       react-refresh: 0.18.0
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   '@rspack/plugin-react-refresh@2.0.2(@rspack/core@packages+rspack)(react-refresh@0.18.0)':
     dependencies:
@@ -9615,12 +9779,12 @@ snapshots:
     optionalDependencies:
       '@rspack/core': link:packages/rspack
 
-  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)':
+  '@rspress/core@2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
       '@rsbuild/core': 2.1.13(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
-      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.1.10)
+      '@rsbuild/plugin-react': 2.1.0(@rsbuild/core@2.1.13)(@rspack/core@2.2.1)
       '@rspress/shared': 2.0.19(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)
       '@shikijs/rehype': 4.4.2
       '@types/mdast': 4.0.4
@@ -9667,7 +9831,7 @@ snapshots:
     dependencies:
       '@docsearch/css': 4.6.3
       '@docsearch/react': 4.6.3(@types/react@19.2.18)(react-dom@19.2.8)(react@19.2.8)
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
@@ -9678,16 +9842,16 @@ snapshots:
 
   '@rspress/plugin-client-redirects@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/plugin-rss@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       feed: 5.2.1
 
   '@rspress/plugin-sitemap@2.0.19(@rspress/core@2.0.19)':
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rspress/shared@2.0.19(@module-federation/runtime-tools@2.8.2)(core-js@3.50.0)':
     dependencies:
@@ -9742,9 +9906,9 @@ snapshots:
 
   '@rstackjs/create-toolkit@2.2.3': {}
 
-  '@rstackjs/doc-ui@1.14.9(@rspress/core@2.0.19)':
+  '@rstackjs/doc-ui@1.14.11(@rspress/core@2.0.19)':
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   '@rstackjs/load-config@0.1.2(jiti@2.7.0)':
     optionalDependencies:
@@ -9987,14 +10151,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
 
-  '@tailwindcss/webpack@4.3.3(@rspack/core@2.1.10)':
+  '@tailwindcss/webpack@4.3.3(@rspack/core@2.2.1)':
     dependencies:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
       tailwindcss: 4.3.3
     optionalDependencies:
-      '@rspack/core': 2.1.10(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.1(@module-federation/runtime-tools@2.8.2)(@swc/helpers@0.5.23)
 
   '@taplo/core@0.2.0': {}
 
@@ -13685,7 +13849,7 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.4(@rspress/core@2.0.19):
     dependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
   rstack@0.6.4(@microsoft/api-extractor@7.58.13)(@module-federation/runtime-tools@2.8.2)(@rspress/core@2.0.19)(core-js@3.50.0)(jiti@2.7.0)(jsdom@30.0.1)(typescript@6.0.3):
     dependencies:
@@ -13697,7 +13861,7 @@ snapshots:
       tinypool: 2.1.0
       yuku-parser: 0.9.0
     optionalDependencies:
-      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.1.10)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
+      '@rspress/core': 2.0.19(@module-federation/runtime-tools@2.8.2)(@rspack/core@2.2.1)(core-js@3.50.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
       '@rstackjs/cli-darwin-arm64': 0.6.4
       '@rstackjs/cli-darwin-x64': 0.6.4
       '@rstackjs/cli-linux-arm64-gnu': 0.6.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   '@rspress/plugin-client-redirects': '^2.0.19'
   '@rspress/plugin-rss': '^2.0.19'
   '@rspress/plugin-sitemap': '^2.0.19'
-  '@rstackjs/doc-ui': '1.14.9'
+  '@rstackjs/doc-ui': '1.14.11'
   '@rstackjs/create-toolkit': '2.2.3'
   '@rstackjs/load-config': '^0.1.2'
   '@shikijs/transformers': '^4.4.3'

--- a/website/components/ApiMeta.module.scss
+++ b/website/components/ApiMeta.module.scss
@@ -22,7 +22,7 @@
 
   a {
     color: inherit;
-    text-decoration: none;
+    text-decoration: none !important;
 
     &:hover {
       text-decoration: underline;

--- a/website/components/CommunityCompatibleTable.tsx
+++ b/website/components/CommunityCompatibleTable.tsx
@@ -84,7 +84,6 @@ export const CommunityPluginCompatibleTable: React.FC = () => {
       name: 'moment-locales-webpack-plugin',
       url: 'https://www.npmjs.com/package/moment-locales-webpack-plugin',
       status: CompatibleStatus.Compatible,
-      description: i18n[lang]['moment-locales-webpack-plugin-desc'],
     },
     {
       name: 'copy-webpack-plugin',

--- a/website/components/i18n/en.json
+++ b/website/components/i18n/en.json
@@ -12,7 +12,6 @@
   "tsconfig-paths-webpack-plugin-desc": "Use [resolve.tsConfig](/config/resolve#resolvetsconfig) instead",
   "pnp-webpack-plugin-desc": "Use [resolve.pnp](/config/resolve#resolvepnp) instead",
   "case-sensitive-paths-webpack-plugin-desc": "`useBeforeEmitHook` option not supported",
-  "moment-locales-webpack-plugin-desc": "Support for this plugin was implemented in v0.7.0, please upgrade the Rspack version to use it",
   "resolve-plugin-un-support-desc": "`resolve.plugins` option not supported",
   "progress-plugin-desc": "Use [webpackbar](https://www.npmjs.com/package/webpackbar) instead",
   "webpack-virtual-modules-desc": "Use [VirtualModulesPlugin](/plugins/virtual-modules-plugin) instead",

--- a/website/components/i18n/zh.json
+++ b/website/components/i18n/zh.json
@@ -12,7 +12,6 @@
   "tsconfig-paths-webpack-plugin-desc": "使用 [resolve.tsConfig](/zh/config/resolve#resolvetsconfig) 替代",
   "pnp-webpack-plugin-desc": "使用 [resolve.pnp](/zh/config/resolve#resolvepnp) 替代",
   "case-sensitive-paths-webpack-plugin-desc": "不支持 `useBeforeEmitHook` 选项",
-  "moment-locales-webpack-plugin-desc": "在 v0.7.0 已实现对该插件的支持，请升级 Rspack 版本来使用",
   "resolve-plugin-un-support-desc": "不支持 `resolve.plugins`",
   "progress-plugin-desc": "使用 [webpackbar](https://www.npmjs.com/package/webpackbar) 替代",
   "webpack-virtual-modules-desc": "使用 [VirtualModulesPlugin](/plugins/virtual-modules-plugin) 替代",

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -19,7 +19,6 @@ import RuntimeTemplateType from '../../types/runtime-template.mdx';
 import RspackErrorType from '../../types/rspack-error.mdx';
 import CompilationDependenciesType from '../../types/compilation-dependencies.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
-import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation
 
@@ -433,8 +432,6 @@ compiler.hooks.make.tap('MyPlugin', (compilation) => {
 </Collapse>
 
 ### addRuntimeModule
-
-<ApiMeta addedVersion="1.0.6" />
 
 Add a custom runtime module to the compilation.
 

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -13,7 +13,6 @@ import CompilerType from '../../types/compiler.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
 import Columns from '@components/Columns';
 import { NoSSR } from '@rspress/core/runtime';
-import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation hooks
 
@@ -604,8 +603,6 @@ console.log(__webpack_require__.h);
 ```
 
 ## `runtimeRequirementInTree`
-
-<ApiMeta addedVersion="1.0.6" />
 
 Called during adding runtime modules to the compilation.
 

--- a/website/docs/en/api/runtime-api/module-methods.mdx
+++ b/website/docs/en/api/runtime-api/module-methods.mdx
@@ -256,8 +256,6 @@ The final filename is still determined by [`output.chunkFilename`](/config/outpu
 
 #### rspackFetchPriority \{#rspackfetchpriority}
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **Type:** `"low" | "high" | "auto"`
 - **webpack equivalent:** `webpackFetchPriority`
 
@@ -274,8 +272,6 @@ const hero = await import(
 
 #### rspackInclude \{#rspackinclude}
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **Type:** `RegExp`
 - **webpack equivalent:** `webpackInclude`
 
@@ -291,8 +287,6 @@ const messages = await import(
 ```
 
 #### rspackExclude \{#rspackexclude}
-
-<ApiMeta addedVersion="1.0.0" />
 
 - **Type:** `RegExp`
 - **webpack equivalent:** `webpackExclude`
@@ -313,8 +307,6 @@ const messages = await import(
 :::
 
 #### rspackExports \{#rspackexports}
-
-<ApiMeta addedVersion="1.0.0" />
 
 - **Type:** `string | string[]`
 - **webpack equivalent:** `webpackExports`

--- a/website/docs/en/api/runtime-api/module-variables.mdx
+++ b/website/docs/en/api/runtime-api/module-variables.mdx
@@ -617,7 +617,7 @@ import.meta.rspackUniqueId;
 __webpack_require__.ruid;
 
 // webpack/runtime/rspack_unique_id
-__webpack_require__.ruid = 'bundler=rspack@0.7.4';
+__webpack_require__.ruid = 'bundler=rspack@2.1.2';
 ```
 
 </Columns>
@@ -834,7 +834,7 @@ __resourceQuery
 
 ### \_\_webpack_exports_info\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} />
 
 In modules, `__webpack_exports_info__` is available to allow exports introspection:
 
@@ -938,7 +938,7 @@ import('./module-a').then((moduleA) => {
 
 ### \_\_webpack_get_script_filename\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} />
 
 It provides filename of the chunk by its id.
 
@@ -1001,11 +1001,7 @@ The CommonJS equivalent of [`import.meta.rspackVersion`](#importmetarspackversio
 
 ### \_\_rspack_unique_id\_\_
 
-<ApiMeta
-  addedVersion="1.0.0"
-  specific={['Rspack']}
-  stability={Stability.Deprecated}
-/>
+<ApiMeta specific={['Rspack']} stability={Stability.Deprecated} />
 
 The CommonJS equivalent of [`import.meta.rspackUniqueId`](#importmetarspackuniqueid).
 

--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -3,7 +3,6 @@ description: 'Rspack entry configuration reference covering single and multiple 
 ---
 
 import Attribution from '@components/Attribution';
-import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import PropertyType from '@components/PropertyType';
 
 # Entry
@@ -232,8 +231,6 @@ The default value of [`output.wasmLoading`](/config/output#outputwasmloading) ca
 - Defaults to `'async-node'` if target is set to `'node'`, `'async-node'`, `'electron-main'` or `'electron-preload'`.
 
 #### EntryDescription.layer
-
-<ApiMeta addedVersion={'1.0.0-beta.1'} />
 
 <PropertyType
   type="string | null | undefined"

--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -208,8 +208,6 @@ export default {
 
 ### javascript.dynamicImportFetchPriority
 
-<ApiMeta addedVersion="1.0.0" />
-
 <PropertyType
   type="'low' | 'high' | 'auto'"
   defaultValueList={[{ defaultValue: "'auto'" }]}
@@ -370,8 +368,6 @@ export default {
 ```
 
 ### javascript.importMeta
-
-<ApiMeta addedVersion="1.0.0-alpha.6" />
 
 - **Type:** `boolean | 'preserve-unknown' | ImportMetaParserOptions`
 - **Default:** When using [ESM output](/guide/features/esm), the default value is `'preserve-unknown'`; otherwise, it is `true`
@@ -557,8 +553,6 @@ Please refer to [type reexports presence example](https://github.com/rstackjs/rs
 
 ### javascript.worker
 
-<ApiMeta addedVersion="1.0.0-alpha.0" />
-
 <PropertyType type="string[] | boolean | { alias?: string[], url?: 'new-url-relative' }" />
 
 Provide custom syntax for Worker parsing, commonly used to support Worklet:
@@ -619,8 +613,6 @@ new Worker(new URL('./worker.bundle.js', import.meta.url));
 > See [Web Workers](/guide/features/web-workers) for more details.
 
 ### javascript.overrideStrict
-
-<ApiMeta addedVersion="1.0.0-alpha.4" />
 
 <PropertyType type="'strict' | 'non-strict'" />
 
@@ -1025,8 +1017,6 @@ export default {
 
 ### json
 
-<ApiMeta addedVersion="1.2.0" />
-
 Parser options for `json` modules.
 
 ```js title="rspack.config.mjs"
@@ -1042,8 +1032,6 @@ export default {
 ```
 
 ### json.exportsDepth
-
-<ApiMeta addedVersion="1.2.0" />
 
 - **Type:** `number`
 - **Default:** production mode is `Number.MAX_SAFE_INTEGER`, development mode is `1`

--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -241,8 +241,6 @@ export default {
 
 ## rules[].issuerLayer
 
-<ApiMeta addedVersion="1.0.0-beta.1" />
-
 - **Type:** [`Condition`](#condition)
 - **Default:** `undefined`
 
@@ -443,8 +441,6 @@ export default {
 ```
 
 ## rules[].with
-
-<ApiMeta addedVersion="1.0.0-beta.1" />
 
 - **Type:** `{ [key: string]: Condition }`
 - **Default:** `undefined`
@@ -714,8 +710,6 @@ The meanings of all `type` options are as follows:
 - `'asset' | 'asset/source' | 'asset/resource' | 'asset/inline' | 'asset/bytes'`: Asset module, see [Asset Module](/guide/features/asset-module).
 
 ## rules[].layer
-
-<ApiMeta addedVersion="1.0.0-beta.1" />
 
 - **Type:** `string`
 

--- a/website/docs/en/config/optimization.mdx
+++ b/website/docs/en/config/optimization.mdx
@@ -13,8 +13,6 @@ Rspack will select appropriate optimization configuration based on the [`mode`](
 
 ## optimization.avoidEntryIife
 
-<ApiMeta addedVersion="1.2.0" />
-
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
 
 Use `optimization.avoidEntryIife` to avoid wrapping the entry module in an IIFE when it is required (search for `"This entry needs to be wrapped in an IIFE because"` in [rspack_plugin_javascript](https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_javascript/src/plugin/mod.rs)). This approach helps optimize performance for JavaScript engines and helps tree shaking when building ESM libraries.

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -227,8 +227,6 @@ export default {
 
 ## output.compareBeforeEmit
 
-<ApiMeta addedVersion={'1.1.0'} />
-
 - **Type:** `boolean`
 - **Default:** `true`
 
@@ -650,10 +648,6 @@ export default {
   },
 };
 ```
-
-:::tip
-Rspack uses the faster `xxhash64` algorithm by default since v1.1.
-:::
 
 ## output.hashSalt
 
@@ -1753,8 +1747,6 @@ export default {
 ```
 
 ### output.trustedTypes.onPolicyCreationFailure
-
-<ApiMeta addedVersion={'1.1.6'} />
 
 - **Type:** `"stop" | "continue"`
 - **Default:** `"stop"`

--- a/website/docs/en/config/watch.mdx
+++ b/website/docs/en/config/watch.mdx
@@ -62,7 +62,7 @@ export default {
 
 Use `watchOptions.ignored` to exclude matching files and directories from watch mode. Ignoring directories that do not need to be watched can reduce CPU and memory usage.
 
-Since Rspack v1.2.0, `.git` and `node_modules` directories are ignored by default, so changes inside them do not trigger rebuilds.
+By default, `.git` and `node_modules` directories are ignored, so changes inside them do not trigger rebuilds.
 
 To watch files in `node_modules`, override the default value and ignore only the `.git` directory:
 

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -2,11 +2,7 @@
 description: 'Lightning CSS is a high performance CSS parser, transformer and minifier written in Rust'
 ---
 
-import { ApiMeta, Stability } from '@components/ApiMeta';
-
 # Builtin lightningcss-loader
-
-<ApiMeta addedVersion="1.0.0" />
 
 [Lightning CSS](https://lightningcss.dev) is a high performance CSS parser, transformer and minifier written in Rust. It supports parsing and transforming many modern CSS features into syntax supported by target browsers, and also provides a better compression ratio.
 

--- a/website/docs/en/guide/tech/json.mdx
+++ b/website/docs/en/guide/tech/json.mdx
@@ -2,8 +2,6 @@
 description: 'Use JSON with Rspack, covering setup, configuration, integration details, and framework-specific development patterns.'
 ---
 
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
-
 # JSON
 
 Rspack has built-in support for [JSON](https://en.wikipedia.org/wiki/JSON), and you can import JSON files directly.
@@ -37,8 +35,6 @@ console.log(foo); // "bar"
 ```
 
 ## Import attributes
-
-<ApiMeta addedVersion={'1.0.0-beta.1'} />
 
 Rspack supports [import attributes](https://github.com/tc39/proposal-import-attributes), and you can use import attributes to import JSON:
 

--- a/website/docs/en/guide/tech/preact.mdx
+++ b/website/docs/en/guide/tech/preact.mdx
@@ -64,12 +64,6 @@ The enabling of the [Preact Refresh](https://github.com/preactjs/prefresh) is di
     - Add [`@swc/plugin-prefresh`](https://github.com/swc-project/plugins/tree/main/packages/prefresh) into `jsc.experimental.plugins` to support the specific transformation of preact
   - Use `babel-loader` and add official [babel plugin](https://github.com/preactjs/prefresh/tree/main/packages/babel) of prefresh.
 
-:::warning
-In versions below 1.0.0, Rspack did not support preact refresh with `swc-loader`.
-
-Please use `builtin:swc-loader` and enable preact specific transformation with `rspackExperiments.preact: {}`
-:::
-
 ```js title="rspack.config.mjs"
 import PreactRefreshPlugin from '@rspack/plugin-preact-refresh';
 

--- a/website/docs/en/plugins/case-sensitive-plugin.mdx
+++ b/website/docs/en/plugins/case-sensitive-plugin.mdx
@@ -2,11 +2,7 @@
 description: 'Detect case sensitivity conflicts in referenced module names and emit warnings'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # CaseSensitivePlugin
-
-<ApiMeta addedVersion={'1.2.0'} />
 
 Detect case sensitivity conflicts in referenced module names and emit warnings.
 

--- a/website/docs/en/plugins/javascript-modules-plugin.mdx
+++ b/website/docs/en/plugins/javascript-modules-plugin.mdx
@@ -2,11 +2,7 @@
 description: 'Handles the bundling of JavaScript, usually used to access the hooks of the JavascriptModulesPlugin:'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # JavascriptModulesPlugin
-
-<ApiMeta addedVersion={'1.0.0-alpha.0'} />
 
 Handles the bundling of JavaScript, usually used to access the [hooks of the JavascriptModulesPlugin](/api/plugin-api/javascript-modules-plugin-hooks):
 

--- a/website/docs/en/plugins/no-emit-on-errors-plugin.mdx
+++ b/website/docs/en/plugins/no-emit-on-errors-plugin.mdx
@@ -2,11 +2,7 @@
 description: 'Prevents Rspack from emitting assets when a compilation contains errors.'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # NoEmitOnErrorsPlugin
-
-<ApiMeta addedVersion={'1.0.0'} />
 
 `NoEmitOnErrorsPlugin` prevents Rspack from emitting assets when a compilation contains errors. Setting [`optimization.emitOnErrors`](/config/optimization#optimizationemitonerrors) to `false` applies this plugin internally.
 

--- a/website/docs/en/plugins/split-chunks-plugin.mdx
+++ b/website/docs/en/plugins/split-chunks-plugin.mdx
@@ -3,7 +3,6 @@ description: 'SplitChunksPlugin is a built-in plugin that splits code into multi
 ---
 
 import Attribution from '@components/Attribution';
-import { ApiMeta } from '@components/ApiMeta';
 
 # SplitChunksPlugin
 
@@ -434,8 +433,6 @@ type SplitChunksNameFunction = (
 
 - **Default:** `false`
 
-> where the version of the function type is `>=0.4.1`.
-
 Also available for each cacheGroup: `splitChunks.cacheGroups.{cacheGroup}.name`.
 
 The name of the split chunk. Providing `false` will keep the same name of the chunks so it doesn't change names unnecessarily. It is the recommended value for production builds.
@@ -545,8 +542,6 @@ export default {
 
 ### splitChunks.usedExports
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **Type:** `boolean`
 - **Default:** Value of [optimization.usedExports](/config/optimization#optimizationusedexports)
 
@@ -641,8 +636,6 @@ A module can belong to multiple cache groups. The optimization will prefer the c
 #### splitChunks.cacheGroups.\{cacheGroup\}.test
 
 - **Type:** `RegExp | string | (module: Module, { chunkGraph: ChunkGraph, moduleGraph: ModuleGraph }) => boolean`
-
-> where the version of the function type is `>=0.4.1`.
 
 Controls which modules are selected by this cache group. Omitting it selects all modules. It can match the absolute module resource path or chunk names. When a chunk name is matched, all modules in the chunk are selected.
 

--- a/website/docs/zh/api/javascript-api/compilation.mdx
+++ b/website/docs/zh/api/javascript-api/compilation.mdx
@@ -19,7 +19,6 @@ import RuntimeTemplateType from '../../types/runtime-template.mdx';
 import RspackErrorType from '../../types/rspack-error.mdx';
 import CompilationDependenciesType from '../../types/compilation-dependencies.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
-import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation
 
@@ -433,8 +432,6 @@ compiler.hooks.make.tap('MyPlugin', (compilation) => {
 </Collapse>
 
 ### addRuntimeModule
-
-<ApiMeta addedVersion="1.0.6" />
 
 添加一个自定义的运行时模块。
 

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -13,7 +13,6 @@ import CompilerType from '../../types/compiler.mdx';
 import { Collapse, CollapsePanel } from '@components/Collapse';
 import Columns from '@components/Columns';
 import { NoSSR } from '@rspress/core/runtime';
-import { ApiMeta } from '@components/ApiMeta';
 
 # Compilation 钩子
 
@@ -605,8 +604,6 @@ console.log(__webpack_require__.h);
 ```
 
 ## `runtimeRequirementInTree`
-
-<ApiMeta addedVersion="1.0.6" />
 
 在根据运行时依赖以添加运行时模块时调用。
 

--- a/website/docs/zh/api/runtime-api/module-methods.mdx
+++ b/website/docs/zh/api/runtime-api/module-methods.mdx
@@ -255,8 +255,6 @@ const settings = await import(
 
 #### rspackFetchPriority \{#rspackfetchpriority}
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **类型：** `"low" | "high" | "auto"`
 - **webpack 兼容名称：** `webpackFetchPriority`
 
@@ -273,8 +271,6 @@ const hero = await import(
 
 #### rspackInclude \{#rspackinclude}
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **类型：** `RegExp`
 - **webpack 兼容名称：** `webpackInclude`
 
@@ -290,8 +286,6 @@ const messages = await import(
 ```
 
 #### rspackExclude \{#rspackexclude}
-
-<ApiMeta addedVersion="1.0.0" />
 
 - **类型：** `RegExp`
 - **webpack 兼容名称：** `webpackExclude`
@@ -312,8 +306,6 @@ const messages = await import(
 :::
 
 #### rspackExports \{#rspackexports}
-
-<ApiMeta addedVersion="1.0.0" />
 
 - **类型：** `string | string[]`
 - **webpack 兼容名称：** `webpackExports`

--- a/website/docs/zh/api/runtime-api/module-variables.mdx
+++ b/website/docs/zh/api/runtime-api/module-variables.mdx
@@ -618,7 +618,7 @@ import.meta.rspackUniqueId;
 __webpack_require__.ruid;
 
 // webpack/runtime/rspack_unique_id
-__webpack_require__.ruid = 'bundler=rspack@0.7.4';
+__webpack_require__.ruid = 'bundler=rspack@2.1.2';
 ```
 
 </Columns>
@@ -832,7 +832,7 @@ __resourceQuery
 
 ### \_\_webpack_exports_info\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} />
 
 在模块中通过 `__webpack_exports_info__` 可以读取如下导出信息：
 
@@ -936,7 +936,7 @@ import('./module-a').then((moduleA) => {
 
 ### \_\_webpack_get_script_filename\_\_
 
-<ApiMeta addedVersion="1.0.0" specific={['Rspack', 'Webpack']} />
+<ApiMeta specific={['Rspack', 'Webpack']} />
 
 通过 chunk 的 id 获取 chunk 的文件名。
 
@@ -999,11 +999,7 @@ __webpack_get_script_filename__ = (chunkId) => {
 
 ### \_\_rspack_unique_id\_\_
 
-<ApiMeta
-  addedVersion="1.0.0"
-  specific={['Rspack']}
-  stability={Stability.Deprecated}
-/>
+<ApiMeta specific={['Rspack']} stability={Stability.Deprecated} />
 
 是 [`import.meta.rspackUniqueId`](#importmetarspackuniqueid) 在 CommonJS 下的等价写法。
 

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -3,7 +3,6 @@ description: 'Rspack Entry 配置项参考，涵盖单入口、多入口、动�
 ---
 
 import Attribution from '@components/Attribution';
-import { ApiMeta, Stability } from '../../../components/ApiMeta';
 import PropertyType from '@components/PropertyType';
 
 # Entry
@@ -232,8 +231,6 @@ export default {
 - 如果 target 设置为 `'node'`，`'async-node'`，`'electron-main'` 或 `'electron-preload'`，其默认值为 `'async-node'`。
 
 #### EntryDescription.layer
-
-<ApiMeta addedVersion={'1.0.0-beta.1'} />
 
 <PropertyType
   type="string | null | undefined"

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -208,8 +208,6 @@ export default {
 
 ### javascript.dynamicImportFetchPriority
 
-<ApiMeta addedVersion="1.0.0" />
-
 <PropertyType
   type="'low' | 'high' | 'auto'"
   defaultValueList={[{ defaultValue: "'auto'" }]}
@@ -370,8 +368,6 @@ export default {
 ```
 
 ### javascript.importMeta
-
-<ApiMeta addedVersion="1.0.0-alpha.6" />
 
 - **类型：** `boolean | 'preserve-unknown' | ImportMetaParserOptions`
 - **默认值：** 当输出为 [ESM 格式](/guide/features/esm) 时，默认值为 `'preserve-unknown'`，其他情况默认值为 `true`
@@ -557,8 +553,6 @@ export default {
 
 ### javascript.worker
 
-<ApiMeta addedVersion="1.0.0-alpha.0" />
-
 <PropertyType type="string[] | boolean | { alias?: string[], url?: 'new-url-relative' }" />
 
 为 Worker 解析提供自定义的语法，常用于支持 Worklet：
@@ -618,8 +612,6 @@ new Worker(new URL('./worker.bundle.js', import.meta.url));
 > 查看 [Web Workers](/guide/features/web-workers) 了解更多。
 
 ### javascript.overrideStrict
-
-<ApiMeta addedVersion="1.0.0-alpha.4" />
 
 <PropertyType type="'strict' | 'non-strict'" />
 
@@ -1024,8 +1016,6 @@ export default {
 
 ### json
 
-<ApiMeta addedVersion="1.2.0" />
-
 `json` 模块的解析器选项。
 
 ```js title="rspack.config.mjs"
@@ -1041,8 +1031,6 @@ export default {
 ```
 
 ### json.exportsDepth
-
-<ApiMeta addedVersion="1.2.0" />
 
 - **Type:** `number`
 - **Default:** production 模式为 `Number.MAX_SAFE_INTEGER`, development 模式为 `1`

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -241,8 +241,6 @@ export default {
 
 ## rules[].issuerLayer
 
-<ApiMeta addedVersion="1.0.0-beta.1" />
-
 - **类型：** [`Condition`](#condition)
 - **默认值：** `undefined`
 
@@ -443,8 +441,6 @@ export default {
 ```
 
 ## rules[].with
-
-<ApiMeta addedVersion="1.0.0-beta.1" />
 
 - **类型：** `{ [key: string]: Condition }`
 - **默认值：** `undefined`
@@ -712,8 +708,6 @@ export default {
 - `'asset' | 'asset/source' | 'asset/resource' | 'asset/inline' | 'asset/bytes'`：资源模块，参考 [资源模块](/guide/features/asset-module)。
 
 ## rules[].layer
-
-<ApiMeta addedVersion="1.0.0-beta.1" />
 
 - **类型：** `string`
 - **默认值：** `undefined`

--- a/website/docs/zh/config/optimization.mdx
+++ b/website/docs/zh/config/optimization.mdx
@@ -13,8 +13,6 @@ import Attribution from '@components/Attribution';
 
 ## optimization.avoidEntryIife
 
-<ApiMeta addedVersion="1.2.0" />
-
 <PropertyType type="boolean" defaultValueList={[{ defaultValue: 'false' }]} />
 
 使用 `optimization.avoidEntryIife` 可以避免在需要时将入口模块包装在 IIFE 中（在 [rspack_plugin_javascript](https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_javascript/src/plugin/mod.rs) 中搜索 `"This entry needs to be wrapped in an IIFE because"`）。这种方法有助于优化 JavaScript 引擎的性能，并在构建 ESM 库时保证 tree shaking 生效。

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -223,8 +223,6 @@ export default {
 
 ## output.compareBeforeEmit
 
-<ApiMeta addedVersion={'1.1.0'} />
-
 - **类型：** `boolean`
 - **默认值：** `true`
 
@@ -643,10 +641,6 @@ export default {
   },
 };
 ```
-
-:::tip
-Rspack 从 1.1 版本开始默认使用更快的 `xxhash64` 算法。
-:::
 
 ## output.hashSalt
 
@@ -1744,8 +1738,6 @@ export default {
 ```
 
 ### output.trustedTypes.onPolicyCreationFailure
-
-<ApiMeta addedVersion={'1.1.6'} />
 
 - **类型：** `"stop" | "continue"`
 - **默认值：** `"stop"`

--- a/website/docs/zh/config/watch.mdx
+++ b/website/docs/zh/config/watch.mdx
@@ -62,7 +62,7 @@ export default {
 
 使用 `watchOptions.ignored` 可以从监听范围中排除匹配的文件和目录。忽略不需要监听的目录有助于降低 CPU 和内存占用。
 
-从 Rspack v1.2.0 开始，`.git` 和 `node_modules` 目录会被默认忽略，其中的文件发生变化时不会触发重新构建。
+默认情况下，`.git` 和 `node_modules` 目录会被忽略，其中的文件发生变化时不会触发重新构建。
 
 如果需要监听 `node_modules` 中的文件，可以覆盖默认值，仅忽略 `.git` 目录：
 

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -2,11 +2,7 @@
 description: 'Lightning CSS 是一个基于 Rust 编写的高性能 CSS 解析、转译和压缩工具。它支持将许多现代的 CSS 特性解析并转化为指定浏览器支持的语法，并提供更好的压缩比例。'
 ---
 
-import { ApiMeta, Stability } from '@components/ApiMeta';
-
 # 内置 lightningcss-loader
-
-<ApiMeta addedVersion="1.0.0" />
 
 [Lightning CSS](https://lightningcss.dev) 是一个基于 Rust 编写的高性能 CSS 解析、转译和压缩工具。它支持将许多现代的 CSS 特性解析并转化为指定浏览器支持的语法，并提供更好的压缩比例。
 

--- a/website/docs/zh/guide/tech/json.mdx
+++ b/website/docs/zh/guide/tech/json.mdx
@@ -2,8 +2,6 @@
 description: '在 Rspack 中使用JSON的指南，涵盖环境配置、集成方式、调试要点、开发模式与常见问题处理，帮助快速定位相关信息。'
 ---
 
-import { ApiMeta, Stability } from '@components/ApiMeta.tsx';
-
 # JSON
 
 Rspack 内置了对 [JSON](https://en.wikipedia.org/wiki/JSON) 的支持，你可以直接导入 JSON 文件。
@@ -37,8 +35,6 @@ console.log(foo); // "bar"
 ```
 
 ## 使用 import attributes
-
-<ApiMeta addedVersion={'1.0.0-beta.1'} />
 
 Rspack 支持 [import attributes](https://github.com/tc39/proposal-import-attributes)，你可以通过 import attributes 来引入 JSON：
 

--- a/website/docs/zh/guide/tech/preact.mdx
+++ b/website/docs/zh/guide/tech/preact.mdx
@@ -64,12 +64,6 @@ export default {
     - 在 `jsc.experimental.plugins` 中添加 [`@swc/plugin-prefresh`](https://github.com/swc-project/plugins/tree/main/packages/prefresh) 以支持 preact 特有的转换
   - 使用 `babel-loader` 并接入 prefresh 官方[babel 插件](https://github.com/preactjs/prefresh/tree/main/packages/babel)。
 
-:::warning
-在 1.0.0 以下版本, Rspack 不支持在 `swc-loader` 中使用 preact 特有转换。
-
-请使用 `builtin:swc-loader` 并在配置中添加 `rspackExperiments.preact: {}` 以开启 preact 特有转换。
-:::
-
 ```js title="rspack.config.mjs"
 import PreactRefreshPlugin from '@rspack/plugin-preact-refresh';
 

--- a/website/docs/zh/plugins/case-sensitive-plugin.mdx
+++ b/website/docs/zh/plugins/case-sensitive-plugin.mdx
@@ -2,11 +2,7 @@
 description: '在不同操作系统中，文件系统对大小写的处理方式可能不同。当代码中引用仅大小写不同的模块名称时，可能会导致跨系统编译时出现意外的错误，这个插件用于预防这种情况。'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # CaseSensitivePlugin
-
-<ApiMeta addedVersion={'1.2.0'} />
 
 检测引用的模块名称的大小写冲突，并发出警告。
 

--- a/website/docs/zh/plugins/javascript-modules-plugin.mdx
+++ b/website/docs/zh/plugins/javascript-modules-plugin.mdx
@@ -2,11 +2,7 @@
 description: '处理 JavaScript 的打包，一般用于获取 JavascriptModulesPlugin 的相关钩子：'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # JavascriptModulesPlugin
-
-<ApiMeta addedVersion={'1.0.0-alpha.0'} />
 
 处理 JavaScript 的打包，一般用于获取 [JavascriptModulesPlugin 的相关钩子](/api/plugin-api/javascript-modules-plugin-hooks)：
 

--- a/website/docs/zh/plugins/no-emit-on-errors-plugin.mdx
+++ b/website/docs/zh/plugins/no-emit-on-errors-plugin.mdx
@@ -2,11 +2,7 @@
 description: '当编译中存在错误时，阻止 Rspack 输出构建产物。'
 ---
 
-import { ApiMeta } from '@components/ApiMeta.tsx';
-
 # NoEmitOnErrorsPlugin
-
-<ApiMeta addedVersion={'1.0.0'} />
 
 `NoEmitOnErrorsPlugin` 会在编译中存在错误时阻止 Rspack 输出构建产物。将 [`optimization.emitOnErrors`](/config/optimization#optimizationemitonerrors) 设置为 `false` 会在内部应用此插件。
 

--- a/website/docs/zh/plugins/split-chunks-plugin.mdx
+++ b/website/docs/zh/plugins/split-chunks-plugin.mdx
@@ -3,7 +3,6 @@ description: 'SplitChunksPlugin 是一个内置插件，用于将代码拆分成
 ---
 
 import Attribution from '@components/Attribution';
-import { ApiMeta } from '@components/ApiMeta';
 
 # SplitChunksPlugin
 
@@ -430,8 +429,6 @@ type SplitChunksNameFunction = (
 
 - **默认值：** `false`
 
-> 其中函数类型的版本要求为 `>=0.4.1`
-
 每个 cacheGroup 也可以使用：`splitChunks.cacheGroups.{cacheGroup}.name`。
 
 拆分 chunk 的名称。设为 `false` 将保持 chunk 的相同名称，因此不会不必要地更改名称。这是生产环境下构建的建议值。
@@ -539,8 +536,6 @@ export default {
 
 ### splitChunks.usedExports
 
-<ApiMeta addedVersion="1.0.0" />
-
 - **类型：** `boolean`
 - **默认值：** 默认值为 [optimization.usedExports](/config/optimization#optimizationusedexports)
 
@@ -635,8 +630,6 @@ export default {
 #### splitChunks.cacheGroups.\{cacheGroup\}.test
 
 - **类型：** `RegExp | string | (module: Module, { chunkGraph: ChunkGraph, moduleGraph: ModuleGraph }) => boolean`
-
-> 其中函数类型的版本要求为 `>=0.4.1`
 
 控制此 cacheGroup 选择的模块。省略它会选择所有模块。它可以匹配绝对模块资源路径或 chunk 名称。匹配 chunk 名称时，将选择该 chunk 中的所有模块。
 


### PR DESCRIPTION
## Summary

Rspack versions earlier than 1.3.0 account for less than 2.5% of usage, so keeping their "Added in" labels and compatibility notices adds visual noise without helping most readers.

This removes pre-1.3.0 version metadata from the English and Chinese docs while preserving newer version information, updates the related `ApiMeta` styling, and refreshes `@rstackjs/doc-ui`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).