### PR TITLE
fix: improve incremental chunk graph reuse

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -1,7 +1,7 @@
 use std::mem;
 
 use futures::Future;
-use rspack_collections::{IdentifierIndexMap, IdentifierMap};
+use rspack_collections::IdentifierMap;
 use rspack_error::Result;
 use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
 use rustc_hash::FxHashMap as HashMap;
@@ -9,8 +9,8 @@ use tracing::instrument;
 
 use crate::{
   ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
-  Logger, ModuleIdentifier,
-  build_chunk_graph::code_splitter::{CodeSplitter, DependenciesBlockIdentifier},
+  Logger,
+  build_chunk_graph::code_splitter::CodeSplitter,
   fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
@@ -73,7 +73,6 @@ impl BuildChunkGraphArtifact {
     }
 
     let module_graph = this_compilation.get_module_graph();
-    let module_graph_cache = &this_compilation.module_graph_cache_artifact;
     let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
     let previous_modules_map = &this_compilation
       .build_chunk_graph_artifact
@@ -86,91 +85,11 @@ impl BuildChunkGraphArtifact {
     }
 
     for module in affected_modules {
-      let outgoings: Vec<ModuleIdentifier> = {
-        let mut res = vec![];
-        let mut active_modules = IdentifierIndexMap::<Vec<_>>::default();
-        let module = module_graph
-          .module_graph_module_by_identifier(&module)
-          .expect("should have module");
-        module
-          .all_dependencies()
-          .iter()
-          .filter(|dep_id| {
-            module_graph
-              .dependency_by_id(dep_id)
-              .as_module_dependency()
-              .is_none_or(|module_dep| !module_dep.weak())
-          })
-          .filter_map(|dep| module_graph.connection_by_dependency_id(dep))
-          .for_each(|conn| {
-            let m = *conn.module_identifier();
-            active_modules.entry(m).or_default().push(conn);
-          });
-
-        'outer: for (m, connections) in active_modules {
-          let side_effects_state_artifact = &this_compilation
-            .build_module_graph_artifact
-            .side_effects_state_artifact;
-          for conn in connections {
-            if conn
-              .active_state(
-                module_graph,
-                None,
-                module_graph_cache,
-                side_effects_state_artifact,
-                &this_compilation.exports_info_artifact,
-              )
-              .is_not_false()
-            {
-              res.push(m);
-              continue 'outer;
-            }
-          }
-        }
-
-        res
-      };
-
-      // get outgoings from all runtimes in the previous compilation
-      let mut previous_modules = IdentifierIndexMap::default();
-      let all_runtimes = previous_modules_map.values();
-      let mut miss_in_previous = true;
-
-      all_runtimes.for_each(|modules| {
-        let Some(outgoings) = modules.get(&DependenciesBlockIdentifier::Module(module)) else {
-          return;
-        };
-        miss_in_previous = false;
-
-        for (outgoing, state, _) in outgoings.iter() {
-          // we must insert module even if state is false
-          // because we need to keep the import order
-          previous_modules
-            .entry(*outgoing)
-            .and_modify(|v| {
-              if state.is_not_false() {
-                *v = *state;
-              }
-            })
-            .or_insert(*state);
-        }
-      });
-
-      if miss_in_previous {
-        logger.log("new module detected, rebuilding chunk graph");
-        return false;
-      }
-
-      if previous_modules
-        .iter()
-        .filter(|(_, conn_state)| conn_state.is_not_false())
-        .map(|(m, _)| *m)
-        .collect::<Vec<_>>()
-        != outgoings.clone()
+      if !self
+        .code_splitter
+        .can_reuse_affected_module(module, this_compilation)
       {
-        // we find one module's outgoings has changed
-        // we cannot skip rebuilding
-        logger.log(format!("module outgoings change detected: {module}"));
+        logger.log(format!("module topology change detected: {module}"));
         return false;
       }
     }

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -87,6 +87,76 @@ fn finalize_prepared_connection_map(
   groups
 }
 
+fn prepare_module_connection_map(
+  module: ModuleIdentifier,
+  module_graph: &ModuleGraph,
+) -> Option<PreparedBlockConnectionMap> {
+  let all_dependencies = module_graph
+    .module_graph_module_by_identifier(&module)
+    .map(|module| module.all_dependencies())
+    .unwrap_or_default();
+  let dependency_count = all_dependencies.len();
+  if dependency_count == 0 {
+    return None;
+  }
+
+  let mut ordered_dependencies = Vec::new();
+  let mut unordered_dependencies = Vec::with_capacity(dependency_count);
+  let mut ordered_dependencies_sorted = true;
+  let mut last_source_order = None;
+  for dependency_id in all_dependencies {
+    let dependency = module_graph.dependency_by_id(dependency_id);
+    let module_dependency = dependency.as_module_dependency();
+    if module_dependency.is_none() && dependency.as_context_dependency().is_none() {
+      continue;
+    }
+    if module_dependency.is_some_and(|dependency| dependency.weak()) {
+      continue;
+    }
+    let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
+      continue;
+    };
+
+    let block = module_graph
+      .get_parent_block(dependency_id)
+      .map_or(DependenciesBlockIdentifier::Module(module), |block| {
+        DependenciesBlockIdentifier::AsyncDependenciesBlock(*block)
+      });
+    let connection = PreparedBlockConnectionBuilder {
+      block,
+      module: *connection.module_identifier(),
+      dependency: *dependency_id,
+    };
+    if let Some(source_order) = dependency.source_order() {
+      if let Some(previous) = last_source_order
+        && source_order < previous
+      {
+        ordered_dependencies_sorted = false;
+      }
+      last_source_order = Some(source_order);
+      ordered_dependencies.push((source_order, connection));
+    } else {
+      unordered_dependencies.push(connection);
+    }
+  }
+  if !ordered_dependencies_sorted {
+    ordered_dependencies.sort_by_key(|(source_order, _)| *source_order);
+  }
+
+  let connection_count = ordered_dependencies.len() + unordered_dependencies.len();
+  if connection_count == 0 {
+    return None;
+  }
+
+  Some(finalize_prepared_connection_map(
+    ordered_dependencies
+      .into_iter()
+      .map(|(_, connection)| connection)
+      .chain(unordered_dependencies),
+    connection_count,
+  ))
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ChunkGroupInfo {
   pub initialized: bool,
@@ -308,6 +378,8 @@ pub(crate) struct CodeSplitter {
   prepared_connection_map: IdentifierMap<PreparedBlockConnectionMap>,
 
   prepared_blocks_map: DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
+
+  prepared_block_group_options: AsyncDependenciesBlockIdentifierMap<GroupOptions>,
 }
 
 fn add_chunk_in_group(
@@ -379,6 +451,117 @@ fn get_active_state_of_connections(
 }
 
 impl CodeSplitter {
+  pub(crate) fn can_reuse_affected_module(
+    &self,
+    module: ModuleIdentifier,
+    compilation: &Compilation,
+  ) -> bool {
+    let module_block = DependenciesBlockIdentifier::Module(module);
+    let current_blocks = compilation
+      .get_module_graph()
+      .module_by_identifier(&module)
+      .expect("should have module")
+      .get_blocks();
+    let cached_blocks = self
+      .prepared_blocks_map
+      .get(&module_block)
+      .map(Vec::as_slice)
+      .unwrap_or_default();
+
+    if current_blocks != cached_blocks {
+      return false;
+    }
+
+    let module_graph = compilation.get_module_graph();
+    for block_id in current_blocks {
+      let block = module_graph.block_by_id_expect(block_id);
+      // Nested async blocks are not constructed today. Keep the reuse path
+      // conservative if that changes.
+      if !block.get_blocks().is_empty() {
+        return false;
+      }
+
+      if block.get_group_options() != self.prepared_block_group_options.get(block_id) {
+        return false;
+      }
+    }
+
+    let mut current_connections_by_block = DependenciesBlockIdentifierMap::default();
+    for connection in prepare_module_connection_map(module, module_graph).unwrap_or_default() {
+      current_connections_by_block
+        .entry(connection.block)
+        .or_insert_with(Vec::new)
+        .push(connection);
+    }
+
+    let module_graph_cache = &compilation.module_graph_cache_artifact;
+    let side_effects_state_artifact = &compilation
+      .build_module_graph_artifact
+      .side_effects_state_artifact;
+    let exports_info_artifact = &compilation.exports_info_artifact;
+    // Connectionless modules deliberately use `EMPTY_BLOCK_MODULES` and are
+    // not inserted into `block_modules_runtime_map`. An existing leaf module
+    // can still be reused when both its cached chunk membership and an incoming
+    // module connection prove that its placement is derived from a stable
+    // parent topology. Entry-only and isolated modules stay conservative since
+    // their placement is not represented by the cached connection map.
+    let mut found_cached_root = current_blocks.is_empty()
+      && current_connections_by_block.is_empty()
+      && module_graph
+        .get_incoming_connections(&module)
+        .any(|connection| connection.original_module_identifier.is_some())
+      && compilation
+        .build_chunk_graph_artifact
+        .chunk_graph
+        .get_number_of_module_chunks(module)
+        > 0;
+
+    for (runtime, block_modules) in &self.block_modules_runtime_map {
+      if !block_modules.contains_key(&module_block) {
+        continue;
+      }
+
+      for block in std::iter::once(module_block).chain(
+        current_blocks
+          .iter()
+          .copied()
+          .map(DependenciesBlockIdentifier::AsyncDependenciesBlock),
+      ) {
+        let Some(cached_modules) = block_modules.get(&block) else {
+          return false;
+        };
+        found_cached_root |= block == module_block;
+
+        let current_connections = current_connections_by_block
+          .get(&block)
+          .map(Vec::as_slice)
+          .unwrap_or_default();
+        if current_connections.len() != cached_modules.len() {
+          return false;
+        }
+
+        for (current, (cached_module, cached_state, _)) in
+          current_connections.iter().zip(cached_modules.iter())
+        {
+          if current.module != *cached_module
+            || get_active_state_of_connections(
+              &current.connections,
+              runtime.as_deref(),
+              module_graph,
+              module_graph_cache,
+              side_effects_state_artifact,
+              exports_info_artifact,
+            ) != *cached_state
+          {
+            return false;
+          }
+        }
+      }
+    }
+
+    found_cached_root
+  }
+
   pub(crate) fn chunk_group_info(&self, ukey: &CgiUkey) -> &ChunkGroupInfo {
     self
       .chunk_group_infos
@@ -2371,83 +2554,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     let mg = compilation.get_module_graph();
     self.prepared_connection_map = all_modules
       .par_iter()
-      .filter_map(|module| {
-        let all_dependencies = mg
-          .module_graph_module_by_identifier(module)
-          .map(|mgm| mgm.all_dependencies())
-          .unwrap_or_default();
-        let dependency_count = all_dependencies.len();
-        if dependency_count == 0 {
-          return None;
-        }
-
-        let mut ordered_deps = Vec::new();
-        let mut unordered_deps = Vec::with_capacity(dependency_count);
-        let mut ordered_deps_sorted = true;
-        let mut last_source_order = None;
-        for dep_id in all_dependencies {
-          let dep = mg.dependency_by_id(dep_id);
-          let module_dep = dep.as_module_dependency();
-          if module_dep.is_none() && dep.as_context_dependency().is_none() {
-            continue;
-          }
-          if matches!(module_dep.map(|d| d.weak()), Some(true)) {
-            continue;
-          }
-          let Some(connection) = mg.connection_by_dependency_id(dep_id) else {
-            continue;
-          };
-
-          let module_identifier = *connection.module_identifier();
-          let block_id = if let Some(block) = mg.get_parent_block(dep_id) {
-            (*block).into()
-          } else {
-            (*module).into()
-          };
-          if let Some(source_order) = dep.source_order() {
-            if let Some(last_source_order) = last_source_order
-              && source_order < last_source_order
-            {
-              ordered_deps_sorted = false;
-            }
-            last_source_order = Some(source_order);
-            ordered_deps.push((source_order, block_id, *dep_id, module_identifier));
-          } else {
-            unordered_deps.push((block_id, *dep_id, module_identifier));
-          }
-        }
-        if !ordered_deps_sorted {
-          ordered_deps.sort_by_key(|(source_order, _, _, _)| *source_order);
-        }
-
-        let connection_count = ordered_deps.len() + unordered_deps.len();
-        if connection_count == 0 {
-          return None;
-        }
-        let ordered_deps = ordered_deps
-          .into_iter()
-          .map(
-            |(_, block, dependency, module)| PreparedBlockConnectionBuilder {
-              block,
-              module,
-              dependency,
-            },
-          );
-        let unordered_deps = unordered_deps
-          .into_iter()
-          .map(
-            |(block, dependency, module)| PreparedBlockConnectionBuilder {
-              block,
-              module,
-              dependency,
-            },
-          );
-
-        Some((
-          *module,
-          finalize_prepared_connection_map(ordered_deps.chain(unordered_deps), connection_count),
-        ))
-      })
+      .filter_map(|module| prepare_module_connection_map(*module, mg).map(|map| (*module, map)))
       .collect::<IdentifierMap<_>>();
 
     let mut prepared_blocks_map = DependenciesBlockIdentifierMap::<
@@ -2455,6 +2562,8 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
     >::with_capacity_and_hasher(
       all_modules.len(), Default::default()
     );
+    let mut prepared_block_group_options =
+      AsyncDependenciesBlockIdentifierMap::<GroupOptions>::default();
 
     for module in all_modules {
       let blocks = compilation
@@ -2474,9 +2583,14 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       if !blocks.is_empty() {
         prepared_blocks_map.insert((*block_id).into(), blocks.to_vec());
       }
+
+      if let Some(group_options) = block.get_group_options() {
+        prepared_block_group_options.insert(*block_id, group_options.clone());
+      }
     }
 
     self.prepared_blocks_map = prepared_blocks_map;
+    self.prepared_block_group_options = prepared_block_group_options;
 
     Ok(())
   }

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/connectionless.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/connectionless.js
@@ -1,0 +1,1 @@
+globalThis.connectionlessValue = "before";

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/index.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/index.js
@@ -1,0 +1,11 @@
+import "./connectionless";
+import { load, loadSecond, value } from "./route";
+
+it("should reuse stable async outgoings for a transitively affected module", async () => {
+	expect(value).toBe(WATCH_STEP === "0" ? "before:stable" : "after:stable");
+	expect(globalThis.connectionlessValue).toBe(
+		WATCH_STEP === "0" ? "before" : "after"
+	);
+	expect((await load()).lazy).toBe(true);
+	expect((await loadSecond()).lazySecond).toBe(true);
+});

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/lazy-second.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/lazy-second.js
@@ -1,0 +1,1 @@
+export const lazySecond = true;

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/lazy.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/lazy.js
@@ -1,0 +1,1 @@
+export const lazy = true;

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/leaf.js
@@ -1,0 +1,3 @@
+import { suffix } from "./terminal";
+
+export const value = `before:${suffix}`;

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/route.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/route.js
@@ -1,0 +1,11 @@
+export { value } from "./leaf";
+
+export const load = () =>
+	import(
+		/* webpackChunkName: "lazy", webpackPrefetch: 1 */ "./lazy"
+	);
+
+export const loadSecond = () =>
+	import(
+		/* webpackChunkName: "lazy", webpackPrefetch: 2 */ "./lazy-second"
+	);

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/terminal.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/0/terminal.js
@@ -1,0 +1,1 @@
+export const suffix = "stable";

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/1/connectionless.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/1/connectionless.js
@@ -1,0 +1,1 @@
+globalThis.connectionlessValue = "after";

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/1/leaf.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/1/leaf.js
@@ -1,0 +1,3 @@
+import { suffix } from "./terminal";
+
+export const value = `after:${suffix}`;

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/2/route.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/2/route.js
@@ -1,0 +1,11 @@
+export { value } from "./leaf";
+
+export const load = () =>
+	import(
+		/* webpackChunkName: "next", webpackPrefetch: 1 */ "./lazy"
+	);
+
+export const loadSecond = () =>
+	import(
+		/* webpackChunkName: "lazy", webpackPrefetch: 2 */ "./lazy-second"
+	);

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/rspack.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/rspack.config.js
@@ -1,0 +1,9 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    splitChunks: false,
+  },
+  incremental: {
+    buildChunkGraph: true,
+  },
+};

--- a/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/test.config.js
+++ b/tests/rspack-test/watchCases/build-chunk-graph/transitive-async-outgoings/test.config.js
@@ -1,0 +1,37 @@
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(`Assertion failed: ${message}`);
+	}
+}
+
+module.exports = {
+	checkStats(stepName, _, stats) {
+		if (stepName === "0") {
+			assert(
+				stats.includes("<t> rebuild chunk graph"),
+				"cold build must build the chunk graph"
+			);
+		} else if (stepName === "1") {
+			assert(
+				!stats.includes("<t> rebuild chunk graph"),
+				"a stable transitive async topology must reuse the chunk graph"
+			);
+			assert(
+				!stats.includes("module topology change detected"),
+				"stable async outgoings must pass the topology guard"
+			);
+		} else if (stepName === "2") {
+			assert(
+				stats.includes("<t> rebuild chunk graph"),
+				"changing async chunk options must rebuild the chunk graph"
+			);
+			assert(
+				stats.includes("module topology change detected"),
+				"the topology guard must reject changed async chunk options"
+			);
+		} else {
+			throw new Error(`Unexpected watch step: ${stepName}`);
+		}
+		return true;
+	}
+};


### PR DESCRIPTION
## Summary

- reuse the incremental chunk graph only after comparing affected modules' current code-splitting topology with the cached `CodeSplitter` data
- preserve dependency-block boundaries, source order, runtime-specific connection state, and async chunk group options during validation
- recognize previously connected zero-dependency leaf modules that intentionally have no `block_modules_runtime_map` entry, while keeping entry-only and isolated modules on the conservative rebuild path
- keep conservative rebuilds for new or removed modules, changed async blocks or chunk group options, nested async blocks, and changed per-runtime connections

The previous check flattened cached connections across runtimes and compared them with the current runtime-independent outgoing modules. This could produce false cache misses for content-only edits and rebuild the full chunk graph.

### Real-world benchmark

Measured in a real-world project with approximately 27.6k modules. The comparison used the same JavaScript core and configuration; only the native binding changed. Measurements used a baseline → this PR → baseline order and edited the same already-built module without changing its dependency topology.

| Case | Baseline | This PR |
| --- | ---: | ---: |
| Chunk graph phase | 1.244–1.265 s | 44 ms |
| Full rebuild | 11.022 s / 13.528 s | 9.965 s |

The chunk graph phase was reduced by about 96.5%, avoiding roughly 1.2 seconds of work per content-only rebuild in this project. Full rebuild time improved by 9.6%–26.3%, but it also includes noise from unrelated phases such as chunk optimization, so the phase-level result is the directly attributable measurement.

As a correctness control, changing an actual async chunk name caused the topology guard to reject reuse and rebuild the chunk graph (1.334 s).

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test:unit` (Rspack: 9167 passed, 4 skipped; CLI: 90 passed, 1 skipped)
- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- `cargo fmt --all -- --check`
- targeted watch and incremental-watch coverage for unchanged transitive async topology and topology-changing edits

## Related links

- Fixes #14769

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
