### PR TITLE
fix(core): align module need_build and FileSystemInfo with webpack

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2830,6 +2830,7 @@ export interface RawOptions {
   module: RawModuleOptions
   optimization: RawOptimizationOptions
   stats: RawStatsOptions
+  snapshot: RawSnapshotOptions
   cache: boolean | { type: "memory" } | ({ type: "persistent" } & RawCacheOptionsPersistent)
   experiments: RawExperiments
 incremental?: false | { [key: string]: boolean }

--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1946,6 +1946,7 @@ export interface RawCacheGroupOptions {
 
 export interface RawCacheOptionsMemory {
   maxGenerations?: number
+  snapshot?: RawSnapshotOptions
 }
 
 export interface RawCacheOptionsPersistent {
@@ -2830,8 +2831,7 @@ export interface RawOptions {
   module: RawModuleOptions
   optimization: RawOptimizationOptions
   stats: RawStatsOptions
-  snapshot: RawSnapshotOptions
-  cache: boolean | { type: "memory" } | ({ type: "persistent" } & RawCacheOptionsPersistent)
+  cache: boolean | { type: "memory", snapshot: RawSnapshotOptions } | ({ type: "persistent" } & RawCacheOptionsPersistent)
   experiments: RawExperiments
 incremental?: false | { [key: string]: boolean }
 node?: RawNodeOption

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -54,8 +54,8 @@ use rspack_core::{
   ModuleType, NewCacheOptions, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption,
   Optimization, OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo,
   PrintlnInfrastructureLogSink, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
-  SideEffectOption, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading, WasmLoadingType,
-  incremental::IncrementalOptions, runtime_mode::RuntimeMode,
+  SideEffectOption, SnapshotOptions, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading,
+  WasmLoadingType, incremental::IncrementalOptions, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
@@ -198,6 +198,14 @@ impl CompilerBuilder {
   /// See [`CompilerOptionsBuilder::cache`] for more details.
   pub fn cache(&mut self, cache: CacheOptions) -> &mut Self {
     self.options_builder.cache(cache);
+    self
+  }
+
+  /// Set the filesystem snapshot options.
+  ///
+  /// See [`CompilerOptionsBuilder::snapshot`] for more details.
+  pub fn snapshot(&mut self, snapshot: SnapshotOptions) -> &mut Self {
+    self.options_builder.snapshot(snapshot);
     self
   }
 
@@ -580,6 +588,8 @@ pub struct CompilerOptionsBuilder {
   context: Option<Context>,
   /// Options for caching.
   cache: Option<CacheOptions>,
+  /// Options for filesystem snapshots.
+  snapshot: Option<SnapshotOptions>,
   /// The mode in which Rspack should operate.
   mode: Option<Mode>,
   /// The type of externals.
@@ -619,6 +629,7 @@ impl From<&mut CompilerOptionsBuilder> for CompilerOptionsBuilder {
       externals_presets: value.externals_presets.take(),
       context: value.context.take(),
       cache: value.cache.take(),
+      snapshot: value.snapshot.take(),
       mode: value.mode.take(),
       resolve: value.resolve.take(),
       resolve_loader: value.resolve_loader.take(),
@@ -694,6 +705,12 @@ impl CompilerOptionsBuilder {
   /// Set options for caching.
   pub fn cache(&mut self, cache: CacheOptions) -> &mut Self {
     self.cache = Some(cache);
+    self
+  }
+
+  /// Set options for filesystem snapshots.
+  pub fn snapshot(&mut self, snapshot: SnapshotOptions) -> &mut Self {
+    self.snapshot = Some(snapshot);
     self
   }
 
@@ -948,6 +965,7 @@ impl CompilerOptionsBuilder {
         CacheOptions::Disabled
       }
     });
+    let snapshot = d!(self.snapshot.take(), SnapshotOptions::default());
 
     // apply experiments defaults
     let mut experiments_builder = f!(self.experiments.take(), Experiments::builder);
@@ -1287,6 +1305,7 @@ impl CompilerOptionsBuilder {
       resolve_loader,
       module,
       stats,
+      snapshot,
       cache,
       experiments,
       incremental,

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -201,14 +201,6 @@ impl CompilerBuilder {
     self
   }
 
-  /// Set the filesystem snapshot options.
-  ///
-  /// See [`CompilerOptionsBuilder::snapshot`] for more details.
-  pub fn snapshot(&mut self, snapshot: SnapshotOptions) -> &mut Self {
-    self.options_builder.snapshot(snapshot);
-    self
-  }
-
   /// Set the source map configuration.
   ///
   /// See [`CompilerOptionsBuilder::devtool`] for more details.
@@ -588,8 +580,6 @@ pub struct CompilerOptionsBuilder {
   context: Option<Context>,
   /// Options for caching.
   cache: Option<CacheOptions>,
-  /// Options for filesystem snapshots.
-  snapshot: Option<SnapshotOptions>,
   /// The mode in which Rspack should operate.
   mode: Option<Mode>,
   /// The type of externals.
@@ -629,7 +619,6 @@ impl From<&mut CompilerOptionsBuilder> for CompilerOptionsBuilder {
       externals_presets: value.externals_presets.take(),
       context: value.context.take(),
       cache: value.cache.take(),
-      snapshot: value.snapshot.take(),
       mode: value.mode.take(),
       resolve: value.resolve.take(),
       resolve_loader: value.resolve_loader.take(),
@@ -705,12 +694,6 @@ impl CompilerOptionsBuilder {
   /// Set options for caching.
   pub fn cache(&mut self, cache: CacheOptions) -> &mut Self {
     self.cache = Some(cache);
-    self
-  }
-
-  /// Set options for filesystem snapshots.
-  pub fn snapshot(&mut self, snapshot: SnapshotOptions) -> &mut Self {
-    self.snapshot = Some(snapshot);
     self
   }
 
@@ -960,12 +943,14 @@ impl CompilerOptionsBuilder {
     let bail = d!(self.bail.take(), false);
     let cache = d!(self.cache.take(), {
       if development {
-        CacheOptions::Memory { max_generations: 1 }
+        CacheOptions::Memory {
+          max_generations: 1,
+          snapshot: SnapshotOptions::default(),
+        }
       } else {
         CacheOptions::Disabled
       }
     });
-    let snapshot = d!(self.snapshot.take(), SnapshotOptions::default());
 
     // apply experiments defaults
     let mut experiments_builder = f!(self.experiments.take(), Experiments::builder);
@@ -1305,7 +1290,6 @@ impl CompilerOptionsBuilder {
       resolve_loader,
       module,
       stats,
-      snapshot,
       cache,
       experiments,
       incremental,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1746,19 +1746,6 @@ CompilerOptions {
     stats: StatsOptions {
         colors: <env-dependent>,
     },
-    snapshot: SnapshotOptions {
-        immutable_paths: [],
-        unmanaged_paths: [],
-        managed_paths: [],
-        dependencies: SnapshotStrategyOptions {
-            hash: true,
-            timestamp: true,
-        },
-        context_dependencies: SnapshotStrategyOptions {
-            hash: false,
-            timestamp: true,
-        },
-    },
     cache: Disabled,
     experiments: Experiments {
         css: false,

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1746,6 +1746,19 @@ CompilerOptions {
     stats: StatsOptions {
         colors: <env-dependent>,
     },
+    snapshot: SnapshotOptions {
+        immutable_paths: [],
+        unmanaged_paths: [],
+        managed_paths: [],
+        dependencies: SnapshotStrategyOptions {
+            hash: true,
+            timestamp: true,
+        },
+        context_dependencies: SnapshotStrategyOptions {
+            hash: false,
+            timestamp: true,
+        },
+    },
     cache: Disabled,
     experiments: Experiments {
         css: false,

--- a/crates/rspack_binding_api/src/raw_options/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/mod.rs
@@ -53,6 +53,7 @@ pub struct RawOptions {
   pub module: RawModuleOptions,
   pub optimization: RawOptimizationOptions,
   pub stats: RawStatsOptions,
+  pub snapshot: RawSnapshotOptions,
   // For now, memory.max_generation will not be exposed to the js side.
   #[napi(
     ts_type = r#"boolean | { type: "memory" } | ({ type: "persistent" } & RawCacheOptionsPersistent)"#
@@ -80,6 +81,7 @@ impl TryFrom<RawOptions> for CompilerOptions {
     let resolve_loader = value.resolve_loader.try_into()?;
     let mode = value.mode.unwrap_or_default().into();
     let module: ModuleOptions = value.module.try_into()?;
+    let snapshot = value.snapshot.into();
     let cache = normalize_raw_cache(value.cache)?;
     let experiments: Experiments = value.experiments.into();
     let incremental: IncrementalOptions = match value.incremental {
@@ -137,6 +139,7 @@ impl TryFrom<RawOptions> for CompilerOptions {
       experiments,
       incremental,
       stats,
+      snapshot,
       cache,
       optimization,
       node,

--- a/crates/rspack_binding_api/src/raw_options/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/mod.rs
@@ -53,10 +53,9 @@ pub struct RawOptions {
   pub module: RawModuleOptions,
   pub optimization: RawOptimizationOptions,
   pub stats: RawStatsOptions,
-  pub snapshot: RawSnapshotOptions,
   // For now, memory.max_generation will not be exposed to the js side.
   #[napi(
-    ts_type = r#"boolean | { type: "memory" } | ({ type: "persistent" } & RawCacheOptionsPersistent)"#
+    ts_type = r#"boolean | { type: "memory", snapshot: RawSnapshotOptions } | ({ type: "persistent" } & RawCacheOptionsPersistent)"#
   )]
   pub cache: RawCacheOptions,
   pub experiments: RawExperiments,
@@ -81,7 +80,6 @@ impl TryFrom<RawOptions> for CompilerOptions {
     let resolve_loader = value.resolve_loader.try_into()?;
     let mode = value.mode.unwrap_or_default().into();
     let module: ModuleOptions = value.module.try_into()?;
-    let snapshot = value.snapshot.into();
     let cache = normalize_raw_cache(value.cache)?;
     let experiments: Experiments = value.experiments.into();
     let incremental: IncrementalOptions = match value.incremental {
@@ -139,7 +137,6 @@ impl TryFrom<RawOptions> for CompilerOptions {
       experiments,
       incremental,
       stats,
-      snapshot,
       cache,
       optimization,
       node,

--- a/crates/rspack_binding_api/src/raw_options/raw_cache/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_cache/mod.rs
@@ -8,7 +8,7 @@ use napi::{
   bindgen_prelude::{FromNapiValue, JsObjectValue, Object, TypeName, ValidateNapiValue},
 };
 use napi_derive::napi;
-use raw_snapshot::RawSnapshotOptions;
+pub use raw_snapshot::RawSnapshotOptions;
 use raw_storage::RawStorageOptions;
 use rspack_core::{CacheOptions, PersistentCacheOptions};
 

--- a/crates/rspack_binding_api/src/raw_options/raw_cache/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_cache/mod.rs
@@ -8,9 +8,9 @@ use napi::{
   bindgen_prelude::{FromNapiValue, JsObjectValue, Object, TypeName, ValidateNapiValue},
 };
 use napi_derive::napi;
-pub use raw_snapshot::RawSnapshotOptions;
+use raw_snapshot::RawSnapshotOptions;
 use raw_storage::RawStorageOptions;
-use rspack_core::{CacheOptions, PersistentCacheOptions};
+use rspack_core::{CacheOptions, PersistentCacheOptions, SnapshotOptions};
 
 #[derive(Debug)]
 #[napi(object)]
@@ -50,6 +50,7 @@ impl TryFrom<RawCacheOptionsPersistent> for PersistentCacheOptions {
 #[napi(object)]
 pub struct RawCacheOptionsMemory {
   pub max_generations: Option<u32>,
+  pub snapshot: Option<RawSnapshotOptions>,
 }
 
 #[derive(Debug)]
@@ -102,7 +103,10 @@ pub fn normalize_raw_cache(options: RawCacheOptions) -> rspack_error::Result<Cac
   Ok(match options {
     Either::A(options) => {
       if options {
-        CacheOptions::Memory { max_generations: 1 }
+        CacheOptions::Memory {
+          max_generations: 1,
+          snapshot: SnapshotOptions::default(),
+        }
       } else {
         CacheOptions::Disabled
       }
@@ -111,6 +115,7 @@ pub fn normalize_raw_cache(options: RawCacheOptions) -> rspack_error::Result<Cac
       InnerCacheOptions::Persistent(options) => CacheOptions::Persistent(options.try_into()?),
       InnerCacheOptions::Memory(options) => CacheOptions::Memory {
         max_generations: options.max_generations.unwrap_or(1),
+        snapshot: options.snapshot.unwrap_or_default().into(),
       },
     },
   })

--- a/crates/rspack_core/src/artifacts/code_generate_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/code_generate_cache_artifact.rs
@@ -28,7 +28,9 @@ impl CodeGenerateCacheArtifact {
   pub fn new(options: &CompilerOptions) -> Self {
     Self {
       storage: match &options.cache {
-        CacheOptions::Memory { max_generations } => Some(MemoryGCStorage::new(*max_generations)),
+        CacheOptions::Memory {
+          max_generations, ..
+        } => Some(MemoryGCStorage::new(*max_generations)),
         CacheOptions::Persistent(_) => Some(MemoryGCStorage::new(1)),
         CacheOptions::Disabled => None,
       },

--- a/crates/rspack_core/src/artifacts/process_runtime_requirements_cache_artifact.rs
+++ b/crates/rspack_core/src/artifacts/process_runtime_requirements_cache_artifact.rs
@@ -26,7 +26,9 @@ impl ProcessRuntimeRequirementsCacheArtifact {
   pub fn new(options: &CompilerOptions) -> Self {
     Self {
       storage: match &options.cache {
-        CacheOptions::Memory { max_generations } => Some(MemoryGCStorage::new(*max_generations)),
+        CacheOptions::Memory {
+          max_generations, ..
+        } => Some(MemoryGCStorage::new(*max_generations)),
         CacheOptions::Persistent(_) => Some(MemoryGCStorage::new(1)),
         CacheOptions::Disabled => None,
       },

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -50,11 +50,14 @@ impl Cutout {
           clean_entry_dependencies = true;
         }
         UpdateParam::CheckNeedBuild => {
-          force_build_modules.extend(module_graph.modules().filter_map(|(_, module)| {
-            module
-              .need_build_for_incremental(&compilation.value_cache_versions)
-              .then(|| module.identifier())
-          }));
+          force_build_modules.extend(
+            module_graph
+              .modules()
+              .filter(|(_, module)| {
+                module.need_build_for_incremental(&compilation.value_cache_versions)
+              })
+              .map(|(_, module)| module.identifier()),
+          );
         }
         UpdateParam::ModifiedFiles(files) | UpdateParam::RemovedFiles(files) => {
           for file in files {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -51,11 +51,9 @@ impl Cutout {
         }
         UpdateParam::CheckNeedBuild => {
           force_build_modules.extend(module_graph.modules().filter_map(|(_, module)| {
-            if module.need_build(&compilation.value_cache_versions) {
-              Some(module.identifier())
-            } else {
-              None
-            }
+            module
+              .need_build_for_incremental(&compilation.value_cache_versions)
+              .then(|| module.identifier())
           }));
         }
         UpdateParam::ModifiedFiles(files) | UpdateParam::RemovedFiles(files) => {

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
@@ -18,7 +18,8 @@ pub enum UpdateParam {
   BuildEntry(FxHashSet<DependencyId>),
   /// Build some entries and clean up the entries that not in this list.
   BuildEntryAndClean(FxHashSet<DependencyId>),
-  /// Build the module which module.need_build is true, i.e. modules where loader.cacheable is false
+  /// Build modules whose incremental rebuild check returns true, for example
+  /// modules where `loader.cacheable` is false.
   CheckNeedBuild,
   /// Build the module and dependency which depend on these modified file.
   ModifiedFiles(InternedPathSet),

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -7,11 +7,9 @@ use rustc_hash::FxHashMap as HashMap;
 use super::BuildModuleGraphArtifact;
 use crate::{
   Compilation, CompilationId, CompilerId, CompilerOptions, CompilerPlatform, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleFactory, ResolverFactory,
-  RuntimeTemplate, SharedPluginDriver,
-  incremental::Incremental,
-  module_graph::ModuleGraph,
-  new_cache::{Cache, FileSystemInfo},
+  DependencyTemplateType, DependencyType, ExportsInfoArtifact, FileSystemInfo, ModuleFactory,
+  ResolverFactory, RuntimeTemplate, SharedPluginDriver, incremental::Incremental,
+  module_graph::ModuleGraph, new_cache::Cache,
 };
 
 #[derive(Debug)]
@@ -22,6 +20,7 @@ pub struct TaskContext {
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
+  pub file_system_info: FileSystemInfo,
   pub intermediate_fs: Arc<dyn IntermediateFileSystem>,
   pub output_fs: Arc<dyn WritableFileSystem>,
   pub compiler_options: Arc<CompilerOptions>,
@@ -32,7 +31,6 @@ pub struct TaskContext {
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
-  pub(crate) file_system_info: FileSystemInfo,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -56,11 +54,11 @@ impl TaskContext {
       dependency_factories: compilation.dependency_factories.clone(),
       dependency_templates: compilation.dependency_templates.clone(),
       fs: compilation.input_filesystem.clone(),
+      file_system_info: compilation.file_system_info.clone(),
       intermediate_fs: compilation.intermediate_filesystem.clone(),
       output_fs: compilation.output_filesystem.clone(),
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       cache: compilation.cache.clone(),
-      file_system_info: compilation.file_system_info(),
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -79,13 +79,14 @@ use crate::{
   CompilationLogging, CompilerOptions, CompilerPlatform, ConcatenationScope,
   DependenciesDiagnosticsArtifact, Dependency, DependencyId, DependencyRef, DependencyTemplate,
   DependencyTemplateType, DependencyType, Entry, EntryData, EntryOptions, EntryRuntime, Entrypoint,
-  ExecuteModuleId, ExportsInfoArtifact, ExternalModuleChunkConditionHook, Filename, ImportPhase,
-  ImportVarMap, ImportedByDeferModulesArtifact, ModuleFactory, ModuleGraph,
+  ExecuteModuleId, ExportsInfoArtifact, ExternalModuleChunkConditionHook, FileSystemInfo, Filename,
+  ImportPhase, ImportVarMap, ImportedByDeferModulesArtifact, ModuleFactory, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, ModuleStaticCache, PathData,
   ProcessRuntimeRequirementsCacheArtifact, ReferencedExport, ResolverFactory, RuntimeGlobals,
   RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeProxyMetadataArtifact, RuntimeSpec,
   RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact,
   SideEffectsStateArtifact, SourceType, Stats, StatsContext, StealCell, ValueCacheVersions,
+  cache::SnapshotOptions,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
@@ -96,7 +97,7 @@ use crate::{
   legacy_cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCache, minimize::MinimizePersistentCache,
   },
-  new_cache::{Cache, CacheFacade, FileSystemInfo},
+  new_cache::{Cache, CacheFacade},
   to_identifier,
 };
 
@@ -238,7 +239,7 @@ pub struct Compilation {
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
   cache: Cache,
-  file_system_info: FileSystemInfo,
+  pub file_system_info: FileSystemInfo,
   pub plugin_driver: SharedPluginDriver,
   pub buildtime_plugin_driver: SharedPluginDriver,
   pub resolver_factory: Arc<ResolverFactory>,
@@ -358,7 +359,17 @@ impl Compilation {
     is_rebuild: bool,
     compiler_context: Arc<CompilerContext>,
   ) -> Self {
-    let file_system_info = cache.file_system_info();
+    let snapshot_options = match &options.cache {
+      CacheOptions::Persistent(options) => options.snapshot.clone(),
+      CacheOptions::Disabled | CacheOptions::Memory { .. } => SnapshotOptions::default(),
+    };
+    let file_system_info = FileSystemInfo::new_for_compilation(
+      input_filesystem.clone(),
+      CompilationLogger::new("rspack.FileSystemInfo", logging.clone()),
+      snapshot_options,
+      options.output.hash_function,
+    );
+
     Self {
       id: CompilationId::new(),
       compiler_id,
@@ -450,10 +461,6 @@ impl Compilation {
 
   pub fn get_cache(&self, name: &str) -> CacheFacade {
     self.cache.facade(name)
-  }
-
-  pub fn file_system_info(&self) -> FileSystemInfo {
-    self.file_system_info.clone()
   }
 
   pub fn id(&self) -> CompilationId {

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -86,7 +86,6 @@ use crate::{
   RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeProxyMetadataArtifact, RuntimeSpec,
   RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact,
   SideEffectsStateArtifact, SourceType, Stats, StatsContext, StealCell, ValueCacheVersions,
-  cache::SnapshotOptions,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
@@ -359,14 +358,10 @@ impl Compilation {
     is_rebuild: bool,
     compiler_context: Arc<CompilerContext>,
   ) -> Self {
-    let snapshot_options = match &options.cache {
-      CacheOptions::Persistent(options) => options.snapshot.clone(),
-      CacheOptions::Disabled | CacheOptions::Memory { .. } => SnapshotOptions::default(),
-    };
     let file_system_info = FileSystemInfo::new(
       input_filesystem.clone(),
       CompilationLogger::new("rspack.FileSystemInfo", logging.clone()),
-      snapshot_options,
+      options.snapshot.clone(),
       options.output.hash_function,
     );
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -86,6 +86,7 @@ use crate::{
   RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeProxyMetadataArtifact, RuntimeSpec,
   RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact,
   SideEffectsStateArtifact, SourceType, Stats, StatsContext, StealCell, ValueCacheVersions,
+  cache::SnapshotOptions,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, update_module_graph,
   },
@@ -358,10 +359,15 @@ impl Compilation {
     is_rebuild: bool,
     compiler_context: Arc<CompilerContext>,
   ) -> Self {
+    let snapshot_options = match &options.cache {
+      CacheOptions::Disabled => SnapshotOptions::default(),
+      CacheOptions::Memory { snapshot, .. } => snapshot.clone(),
+      CacheOptions::Persistent(options) => options.snapshot.clone(),
+    };
     let file_system_info = FileSystemInfo::new(
       input_filesystem.clone(),
       CompilationLogger::new("rspack.FileSystemInfo", logging.clone()),
-      options.snapshot.clone(),
+      snapshot_options,
       options.output.hash_function,
     );
 
@@ -413,7 +419,9 @@ impl Compilation {
       chunk_render_cache_artifact: StealCell::new(ChunkRenderCacheArtifact::new(
         match &options.cache {
           CacheOptions::Disabled => 0, // FIXME: this should be removed in future
-          CacheOptions::Memory { max_generations } => *max_generations,
+          CacheOptions::Memory {
+            max_generations, ..
+          } => *max_generations,
           CacheOptions::Persistent(_) => 1,
         },
       )),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -363,7 +363,7 @@ impl Compilation {
       CacheOptions::Persistent(options) => options.snapshot.clone(),
       CacheOptions::Disabled | CacheOptions::Memory { .. } => SnapshotOptions::default(),
     };
-    let file_system_info = FileSystemInfo::new_for_compilation(
+    let file_system_info = FileSystemInfo::new(
       input_filesystem.clone(),
       CompilationLogger::new("rspack.FileSystemInfo", logging.clone()),
       snapshot_options,

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -307,7 +307,6 @@ impl Compiler {
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
-    self.new_cache.file_system_info().invalidate_all();
     if let Some(restored) = self.new_cache.restore_meta()? {
       let current = self.compiler_context.dependency_id();
       if current < restored.max_dependency_id {

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -68,11 +68,6 @@ impl Compiler {
       let mut removed_files: InternedPathSet = InternedPathSet::default();
       removed_files.extend(deleted_files.iter().map(|files| Path::new(files).into()));
 
-      self
-        .new_cache
-        .file_system_info()
-        .invalidate(modified_files.iter().chain(&removed_files));
-
       let mut all_files = modified_files.clone();
       all_files.extend(removed_files.clone());
 

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -97,7 +97,7 @@ impl Module for TempModule {
     unreachable!()
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build_for_incremental(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
     // return true to make sure this module always rebuild
     true
   }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -16,7 +16,8 @@ pub use compilation::{
 };
 pub use exports::*;
 pub use new_cache::{
-  Cache, CacheFacade, CacheValue, Etag, FileSystemInfo, ItemCacheFacade, MultiItemCache,
+  Cache, CacheFacade, CacheValue, Etag, FileSystemInfo, ItemCacheFacade, MultiItemCache, Snapshot,
+  SnapshotValidationResult,
 };
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -35,7 +35,7 @@ use crate::{
   ExportProvided, ExportsInfoArtifact, ExternalModule, FileSystemInfo, Filename, GetTargetResult,
   ImportPhase, ModuleCodeTemplate, ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer, ModuleType,
   NormalModule, OptimizationBailoutItem, RawModule, Resolve, ResolverFactory, RuntimeSpec,
-  SelfModule, SharedPluginDriver, SideEffectsStateArtifact, SourceType,
+  SelfModule, SharedPluginDriver, SideEffectsStateArtifact, Snapshot, SourceType,
   concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
   get_target, value_cache_versions::ValueCacheVersions,
 };
@@ -50,6 +50,26 @@ pub struct BuildContext {
   pub runtime_template: ModuleCodeTemplate,
   pub plugin_driver: SharedPluginDriver,
   pub fs: Arc<dyn ReadableFileSystem>,
+}
+
+/// Context used to decide whether a previously built module is still valid.
+///
+/// This follows webpack's `NeedBuildContext` shape and provides the shared
+/// filesystem snapshot service used to validate a previous module build.
+pub struct NeedBuildContext<'a> {
+  pub compilation: &'a Compilation,
+  pub file_system_info: &'a FileSystemInfo,
+  pub value_cache_versions: &'a ValueCacheVersions,
+}
+
+impl<'a> NeedBuildContext<'a> {
+  pub fn new(compilation: &'a Compilation) -> Self {
+    Self {
+      compilation,
+      file_system_info: &compilation.file_system_info,
+      value_cache_versions: &compilation.value_cache_versions,
+    }
+  }
 }
 
 #[cacheable]
@@ -269,6 +289,7 @@ pub struct BuildInfo {
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
   pub dependencies: crate::LoaderDependencies,
+  pub file_system_snapshot: Option<Snapshot>,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
   pub esm_named_exports: HashSet<Atom>,
@@ -307,6 +328,7 @@ impl Default for BuildInfo {
       module_argument: Default::default(),
       exports_argument: Default::default(),
       dependencies: Default::default(),
+      file_system_snapshot: None,
       value_dependencies: HashMap::default(),
       esm_named_exports: HashSet::default(),
       all_star_exports: Vec::default(),
@@ -825,7 +847,23 @@ pub trait Module:
     ConnectionState::Active(true)
   }
 
-  fn need_build(&self, value_cache_version: &ValueCacheVersions) -> bool {
+  /// Determines whether a module needs to be rebuilt using the complete build
+  /// context.
+  ///
+  /// Implementations may inspect or mutate module state and perform asynchronous
+  /// work. As in webpack's base `Module`, the default is conservative: module
+  /// types that can prove an existing build is valid should override this.
+  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
+    Ok(true)
+  }
+
+  /// Performs the synchronous rebuild decision used by incremental make.
+  ///
+  /// This preserves the pre-existing incremental-make behavior: it only checks
+  /// cacheability, value dependencies, and build errors. Filesystem changes are
+  /// handled separately by the make artifact. It is intentionally narrower than
+  /// [`Module::need_build`] and must not be used as the general rebuild check.
+  fn need_build_for_incremental(&self, value_cache_version: &ValueCacheVersions) -> bool {
     let build_info = self.build_info();
     !build_info.cacheable
       || value_cache_version.has_diff(&build_info.value_dependencies)

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -289,7 +289,7 @@ pub struct BuildInfo {
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
   pub dependencies: crate::LoaderDependencies,
-  pub snapshot: Option<Snapshot>,
+  pub snapshot: Option<Arc<Snapshot>>,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
   pub esm_named_exports: HashSet<Atom>,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -291,7 +291,7 @@ pub struct BuildInfo {
   pub dependencies: crate::LoaderDependencies,
   /// Reserved for full `need_build` snapshot validation. Module builds do not
   /// populate it yet to avoid adding snapshot creation overhead.
-  pub snapshot: Option<Arc<Snapshot>>,
+  pub snapshot: Option<Snapshot>,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
   pub esm_named_exports: HashSet<Atom>,

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -289,7 +289,7 @@ pub struct BuildInfo {
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
   pub dependencies: crate::LoaderDependencies,
-  pub file_system_snapshot: Option<Snapshot>,
+  pub snapshot: Option<Snapshot>,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]
   pub esm_named_exports: HashSet<Atom>,
@@ -328,7 +328,7 @@ impl Default for BuildInfo {
       module_argument: Default::default(),
       exports_argument: Default::default(),
       dependencies: Default::default(),
-      file_system_snapshot: None,
+      snapshot: None,
       value_dependencies: HashMap::default(),
       esm_named_exports: HashSet::default(),
       all_star_exports: Vec::default(),

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -289,6 +289,8 @@ pub struct BuildInfo {
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
   pub dependencies: crate::LoaderDependencies,
+  /// Reserved for full `need_build` snapshot validation. Module builds do not
+  /// populate it yet to avoid adding snapshot creation overhead.
   pub snapshot: Option<Arc<Snapshot>>,
   pub value_dependencies: HashMap<String, String>,
   #[cacheable(with=AsVec<AsPreset>)]

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -4,8 +4,8 @@ use rspack_error::Result;
 use rspack_paths::InternedPathSet;
 
 use super::{
-  CacheFacade, CacheKey, CacheValue, Etag, FileSystemInfo, IdleFileCache, MemoryCache,
-  MemoryCacheGetResult, Meta, cache_value::CacheValueData,
+  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult, Meta,
+  cache_value::CacheValueData,
 };
 
 /// Cache entry point backed by memory and optional filesystem storage.
@@ -23,7 +23,6 @@ struct CacheStorage {
 struct CacheInner {
   compiler_path: String,
   storage: Option<CacheStorage>,
-  file_system_info: FileSystemInfo,
 }
 
 /// Cheaply cloneable handle to the shared cache state.
@@ -37,7 +36,6 @@ impl Cache {
     compiler_path: String,
     memory_cache: MemoryCache,
     idle_file_cache: Option<IdleFileCache>,
-    file_system_info: FileSystemInfo,
   ) -> Self {
     Self {
       inner: Arc::new(CacheInner {
@@ -46,23 +44,17 @@ impl Cache {
           memory_cache,
           idle_file_cache,
         }),
-        file_system_info,
       }),
     }
   }
 
-  pub fn new_disabled(compiler_path: String, file_system_info: FileSystemInfo) -> Self {
+  pub fn new_disabled(compiler_path: String) -> Self {
     Self {
       inner: Arc::new(CacheInner {
         compiler_path,
         storage: None,
-        file_system_info,
       }),
     }
-  }
-
-  pub(crate) fn file_system_info(&self) -> FileSystemInfo {
-    self.inner.file_system_info.clone()
   }
 
   pub(crate) fn facade(&self, name: &str) -> CacheFacade {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -8,7 +8,7 @@ mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 mod meta;
-mod snapshot;
+pub(crate) mod snapshot;
 mod validator;
 
 use std::sync::Arc;
@@ -23,8 +23,7 @@ pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
 pub use meta::Meta;
 use rspack_fs::ReadableFileSystem;
-pub use snapshot::FileSystemInfo;
-pub(crate) use snapshot::{Snapshot, SnapshotValidationResult};
+pub use snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult};
 
 use crate::{
   CompilerOptions, InfrastructureLogSink, InfrastructureLogger, Logger, cache::CacheCodec,
@@ -36,33 +35,18 @@ pub fn create_cache(
   input_filesystem: Arc<dyn ReadableFileSystem>,
   infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
 ) -> Cache {
-  let logger = Arc::new(InfrastructureLogger::new(
-    "rspack.cache.IdleFileCache",
-    infrastructure_log_sink,
-  ));
-  let snapshot_options = match &compiler_options.cache {
-    crate::CacheOptions::Persistent(options) => options.snapshot.clone(),
-    _ => Default::default(),
-  };
-  let file_system_info = FileSystemInfo::new(
-    input_filesystem.clone(),
-    logger.get_child("rspack.FileSystemInfo"),
-    snapshot_options,
-    compiler_options.output.hash_function,
-  );
-
   if !compiler_options.experiments.new_cache.is_enabled() {
-    return Cache::new_disabled(compiler_path, file_system_info);
+    return Cache::new_disabled(compiler_path);
   }
 
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => {
-      return Cache::new_disabled(compiler_path, file_system_info);
+      return Cache::new_disabled(compiler_path);
     }
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
     } => {
-      return Cache::new(compiler_path, MemoryCache::new(5), None, file_system_info);
+      return Cache::new(compiler_path, MemoryCache::new(5), None);
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -73,6 +57,16 @@ pub fn create_cache(
     None
   };
   let codec = Arc::new(CacheCodec::new(project_root));
+  let logger = Arc::new(InfrastructureLogger::new(
+    "rspack.cache.IdleFileCache",
+    infrastructure_log_sink,
+  ));
+  let file_system_info = FileSystemInfo::new(
+    input_filesystem,
+    logger.get_child("rspack.FileSystemInfo"),
+    options.snapshot.clone(),
+    compiler_options.output.hash_function,
+  );
   let (base_path, database_path) = match &options.storage {
     crate::cache::StorageOptions::FileSystem { directory } => {
       let base_path = directory.parent().unwrap_or_else(|| {
@@ -93,20 +87,10 @@ pub fn create_cache(
     Ok(strategy) => strategy,
     Err(error) => {
       logger.warn(format!("Open cache from {database_path} failed: {error}"));
-      return Cache::new(
-        compiler_path,
-        MemoryCache::default(),
-        None,
-        file_system_info,
-      );
+      return Cache::new(compiler_path, MemoryCache::default(), None);
     }
   };
   let idle_file_cache = IdleFileCache::new(strategy, logger, None, None, None);
 
-  Cache::new(
-    compiler_path,
-    MemoryCache::default(),
-    Some(idle_file_cache),
-    file_system_info,
-  )
+  Cache::new(compiler_path, MemoryCache::default(), Some(idle_file_cache))
 }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -45,6 +45,7 @@ pub fn create_cache(
     }
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
+      ..
     } => {
       return Cache::new(compiler_path, MemoryCache::new(5), None);
     }

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -82,7 +82,7 @@ pub fn create_cache(
     rspack_workspace::rspack_pkg_version!().to_string(),
     options.version.clone(),
     codec,
-    file_system_info.clone(),
+    file_system_info,
     logger.clone(),
   ) {
     Ok(strategy) => strategy,

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -19,9 +19,21 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-enum FileSystemInfoLogger {
+pub(crate) enum FileSystemInfoLogger {
   Compilation(CompilationLogger),
   Infrastructure(InfrastructureLogger),
+}
+
+impl From<CompilationLogger> for FileSystemInfoLogger {
+  fn from(logger: CompilationLogger) -> Self {
+    Self::Compilation(logger)
+  }
+}
+
+impl From<InfrastructureLogger> for FileSystemInfoLogger {
+  fn from(logger: InfrastructureLogger) -> Self {
+    Self::Infrastructure(logger)
+  }
 }
 
 impl Logger for FileSystemInfoLogger {
@@ -123,44 +135,16 @@ impl fmt::Debug for FileSystemInfo {
 }
 
 impl FileSystemInfo {
-  pub fn new(
+  pub(crate) fn new(
     fs: Arc<dyn ReadableFileSystem>,
-    logger: InfrastructureLogger,
-    options: SnapshotOptions,
-    hash_function: HashFunction,
-  ) -> Self {
-    Self::with_logger(
-      fs,
-      FileSystemInfoLogger::Infrastructure(logger),
-      options,
-      hash_function,
-    )
-  }
-
-  pub fn new_for_compilation(
-    fs: Arc<dyn ReadableFileSystem>,
-    logger: CompilationLogger,
-    options: SnapshotOptions,
-    hash_function: HashFunction,
-  ) -> Self {
-    Self::with_logger(
-      fs,
-      FileSystemInfoLogger::Compilation(logger),
-      options,
-      hash_function,
-    )
-  }
-
-  fn with_logger(
-    fs: Arc<dyn ReadableFileSystem>,
-    logger: FileSystemInfoLogger,
+    logger: impl Into<FileSystemInfoLogger>,
     options: SnapshotOptions,
     hash_function: HashFunction,
   ) -> Self {
     Self {
       inner: Arc::new(FileSystemInfoInner {
         fs,
-        logger,
+        logger: logger.into(),
         options,
         hash_function,
         file_timestamps: Default::default(),

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -3,7 +3,6 @@ use std::{collections::VecDeque, fmt, sync::Arc};
 use rspack_error::{Result, error};
 use rspack_fs::{Error as FsError, FileMetadata, ReadableFileSystem};
 use rspack_hash::{HashDigest, HashFunction, RspackHashDigest, RspackHasher};
-use rspack_loader_runner::LoaderDependencies;
 use rspack_parallel::TryFutureConsumer;
 use rspack_paths::{AssertUtf8, InternedPath, InternedPathDashMap, InternedPathSet};
 use rspack_util::time::mtime_accuracy;
@@ -188,25 +187,6 @@ impl FileSystemInfo {
     self.capture_contexts(&mut snapshot, contexts, mode).await?;
     self.capture_missing(&mut snapshot, missing).await?;
     Ok(snapshot)
-  }
-
-  /// Captures the filesystem inputs of a module build.
-  pub async fn create_module_snapshot(
-    &self,
-    start_time: Option<u64>,
-    dependencies: &LoaderDependencies,
-  ) -> Result<Snapshot> {
-    self
-      .create_snapshot(
-        start_time,
-        &dependencies.file,
-        &dependencies.context,
-        &dependencies.missing,
-        // Rspack does not expose webpack's `snapshot.module` option yet, so use
-        // webpack's default module snapshot strategy directly.
-        SnapshotStrategyOptions::timestamp(),
-      )
-      .await
   }
 
   /// See webpack's snapshot merge implementation:

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -3,6 +3,7 @@ use std::{collections::VecDeque, fmt, sync::Arc};
 use rspack_error::{Result, error};
 use rspack_fs::{Error as FsError, FileMetadata, ReadableFileSystem};
 use rspack_hash::{HashDigest, HashFunction, RspackHashDigest, RspackHasher};
+use rspack_loader_runner::LoaderDependencies;
 use rspack_parallel::TryFutureConsumer;
 use rspack_paths::{AssertUtf8, InternedPath, InternedPathDashMap, InternedPathSet};
 use rspack_util::time::mtime_accuracy;
@@ -13,9 +14,24 @@ use super::{
   TimestampAndHash,
 };
 use crate::{
-  InfrastructureLogger,
+  CompilationLogger, InfrastructureLogger, LogType, Logger,
   cache::{BuildDependencyHelper, SnapshotOptions, SnapshotStrategyOptions, is_node_package_path},
 };
+
+#[derive(Debug, Clone)]
+enum FileSystemInfoLogger {
+  Compilation(CompilationLogger),
+  Infrastructure(InfrastructureLogger),
+}
+
+impl Logger for FileSystemInfoLogger {
+  fn raw(&self, log_type: LogType) {
+    match self {
+      Self::Compilation(logger) => logger.raw(log_type),
+      Self::Infrastructure(logger) => logger.raw(log_type),
+    }
+  }
+}
 
 #[derive(Debug, Default)]
 pub struct ResolvedBuildDependencies {
@@ -86,7 +102,7 @@ pub struct FileSystemInfo {
 
 struct FileSystemInfoInner {
   fs: Arc<dyn ReadableFileSystem>,
-  logger: InfrastructureLogger,
+  logger: FileSystemInfoLogger,
   options: SnapshotOptions,
   hash_function: HashFunction,
   file_timestamps: InternedPathDashMap<Option<FileSystemInfoEntry>>,
@@ -110,6 +126,34 @@ impl FileSystemInfo {
   pub fn new(
     fs: Arc<dyn ReadableFileSystem>,
     logger: InfrastructureLogger,
+    options: SnapshotOptions,
+    hash_function: HashFunction,
+  ) -> Self {
+    Self::with_logger(
+      fs,
+      FileSystemInfoLogger::Infrastructure(logger),
+      options,
+      hash_function,
+    )
+  }
+
+  pub fn new_for_compilation(
+    fs: Arc<dyn ReadableFileSystem>,
+    logger: CompilationLogger,
+    options: SnapshotOptions,
+    hash_function: HashFunction,
+  ) -> Self {
+    Self::with_logger(
+      fs,
+      FileSystemInfoLogger::Compilation(logger),
+      options,
+      hash_function,
+    )
+  }
+
+  fn with_logger(
+    fs: Arc<dyn ReadableFileSystem>,
+    logger: FileSystemInfoLogger,
     options: SnapshotOptions,
     hash_function: HashFunction,
   ) -> Self {
@@ -162,6 +206,25 @@ impl FileSystemInfo {
     Ok(snapshot)
   }
 
+  /// Captures the filesystem inputs of a module build.
+  pub async fn create_module_snapshot(
+    &self,
+    start_time: Option<u64>,
+    dependencies: &LoaderDependencies,
+  ) -> Result<Snapshot> {
+    self
+      .create_snapshot(
+        start_time,
+        &dependencies.file,
+        &dependencies.context,
+        &dependencies.missing,
+        // Rspack does not expose webpack's `snapshot.module` option yet, so use
+        // webpack's default module snapshot strategy directly.
+        SnapshotStrategyOptions::timestamp(),
+      )
+      .await
+  }
+
   /// See webpack's snapshot merge implementation:
   /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L3081-L3166
   pub fn merge_snapshots(&self, mut first: Snapshot, second: Snapshot) -> Snapshot {
@@ -171,35 +234,6 @@ impl FileSystemInfo {
 
   pub fn build_dependencies_strategy(&self) -> SnapshotStrategyOptions {
     self.inner.options.dependencies_strategy()
-  }
-
-  pub(crate) fn invalidate<'a>(&self, paths: impl Iterator<Item = &'a InternedPath>) {
-    let mut has_invalidated_path = false;
-    for path in paths {
-      has_invalidated_path = true;
-      self.inner.file_timestamps.remove(path);
-      self.inner.file_hashes.remove(path);
-      self.inner.file_timestamp_hashes.remove(path);
-    }
-    if has_invalidated_path {
-      // A changed path can affect any cached ancestor context, including one
-      // reached through a symlink. Clear context and managed-item caches when
-      // the watcher reports a change instead of trying to infer every owner.
-      self.inner.context_timestamps.clear();
-      self.inner.context_hashes.clear();
-      self.inner.context_timestamp_hashes.clear();
-      self.inner.managed_items.clear();
-    }
-  }
-
-  pub(crate) fn invalidate_all(&self) {
-    self.inner.file_timestamps.clear();
-    self.inner.file_hashes.clear();
-    self.inner.file_timestamp_hashes.clear();
-    self.inner.context_timestamps.clear();
-    self.inner.context_hashes.clear();
-    self.inner.context_timestamp_hashes.clear();
-    self.inner.managed_items.clear();
   }
 
   /// See webpack's snapshot validation implementation:

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -61,7 +61,7 @@ pub struct ContextTimestampAndHash {
 /// See webpack's `Snapshot` data structure:
 /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L303-L665
 #[cacheable]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct Snapshot {
   pub(super) start_time: Option<u64>,
   pub(super) file_timestamps: Option<InternedPathMap<Option<FileSystemInfoEntry>>>,

--- a/crates/rspack_core/src/new_cache/snapshot/mod.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/mod.rs
@@ -61,7 +61,7 @@ pub struct ContextTimestampAndHash {
 /// See webpack's `Snapshot` data structure:
 /// https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FileSystemInfo.js#L303-L665
 #[cacheable]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Snapshot {
   pub(super) start_time: Option<u64>,
   pub(super) file_timestamps: Option<InternedPathMap<Option<FileSystemInfoEntry>>>,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -39,6 +39,7 @@ use crate::{
   OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
   ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext,
   RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SnapshotValidationResult, SourceType,
+  cache::SnapshotStrategyOptions,
   contextify,
   diagnostics::ModuleBuildError,
   get_context,
@@ -545,11 +546,17 @@ impl Module for NormalModule {
       self.presentational_dependencies = Some(Vec::new());
 
       if let Some(file_system_info) = &file_system_info {
-        self.build_info.snapshot = Some(
+        self.build_info.snapshot = Some(Arc::new(
           file_system_info
-            .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
+            .create_snapshot(
+              Some(build_start_time),
+              &self.build_info.dependencies.file,
+              &self.build_info.dependencies.context,
+              &self.build_info.dependencies.missing,
+              SnapshotStrategyOptions::timestamp(),
+            )
             .await?,
-        );
+        ));
       }
 
       self.build_info.hash =
@@ -621,11 +628,17 @@ impl Module for NormalModule {
     self.presentational_dependencies = Some(presentational_dependencies);
 
     if let Some(file_system_info) = &file_system_info {
-      self.build_info.snapshot = Some(
+      self.build_info.snapshot = Some(Arc::new(
         file_system_info
-          .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
+          .create_snapshot(
+            Some(build_start_time),
+            &self.build_info.dependencies.file,
+            &self.build_info.dependencies.context,
+            &self.build_info.dependencies.missing,
+            SnapshotStrategyOptions::timestamp(),
+          )
           .await?,
-      );
+      ));
     }
 
     self.build_info.hash =

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -389,7 +389,7 @@ impl Module for NormalModule {
       return Ok(true);
     }
 
-    let Some(snapshot) = &self.build_info.file_system_snapshot else {
+    let Some(snapshot) = &self.build_info.snapshot else {
       return Ok(true);
     };
 
@@ -422,7 +422,7 @@ impl Module for NormalModule {
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
     self.force_build = false;
-    self.build_info.file_system_snapshot = None;
+    self.build_info.snapshot = None;
     let build_start_time = current_time();
     let file_system_info = (!build_context
       .compiler_options
@@ -545,7 +545,7 @@ impl Module for NormalModule {
       self.presentational_dependencies = Some(Vec::new());
 
       if let Some(file_system_info) = &file_system_info {
-        self.build_info.file_system_snapshot = Some(
+        self.build_info.snapshot = Some(
           file_system_info
             .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
             .await?,
@@ -621,7 +621,7 @@ impl Module for NormalModule {
     self.presentational_dependencies = Some(presentational_dependencies);
 
     if let Some(file_system_info) = &file_system_info {
-      self.build_info.file_system_snapshot = Some(
+      self.build_info.snapshot = Some(
         file_system_info
           .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
           .await?,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -23,10 +23,7 @@ use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
 };
-use rspack_util::{
-  source_map::{ModuleSourceMapConfig, SourceMapKind},
-  time::current_time,
-};
+use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 use serde_json::json;
 use tracing::{Instrument, info_span};
 
@@ -39,12 +36,10 @@ use crate::{
   OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
   ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext,
   RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SnapshotValidationResult, SourceType,
-  cache::SnapshotStrategyOptions,
   contextify,
   diagnostics::ModuleBuildError,
-  get_context,
-  incremental::IncrementalPasses,
-  module_analyzed_side_effect_free, module_declared_side_effect_free, module_update_hash,
+  get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
+  module_update_hash,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -424,13 +419,6 @@ impl Module for NormalModule {
   ) -> Result<BuildResult> {
     self.force_build = false;
     self.build_info.snapshot = None;
-    let build_start_time = current_time();
-    let file_system_info = (!build_context
-      .compiler_options
-      .incremental
-      .passes
-      .contains(IncrementalPasses::BUILD_MODULE_GRAPH))
-    .then(|| build_context.file_system_info.clone());
 
     // so does webpack
     self.parsed = true;
@@ -545,20 +533,6 @@ impl Module for NormalModule {
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
-      if let Some(file_system_info) = &file_system_info {
-        self.build_info.snapshot = Some(Arc::new(
-          file_system_info
-            .create_snapshot(
-              Some(build_start_time),
-              &self.build_info.dependencies.file,
-              &self.build_info.dependencies.context,
-              &self.build_info.dependencies.missing,
-              SnapshotStrategyOptions::timestamp(),
-            )
-            .await?,
-        ));
-      }
-
       self.build_info.hash =
         Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
@@ -626,20 +600,6 @@ impl Module for NormalModule {
     self.source = Some(source);
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
-
-    if let Some(file_system_info) = &file_system_info {
-      self.build_info.snapshot = Some(Arc::new(
-        file_system_info
-          .create_snapshot(
-            Some(build_start_time),
-            &self.build_info.dependencies.file,
-            &self.build_info.dependencies.context,
-            &self.build_info.dependencies.missing,
-            SnapshotStrategyOptions::timestamp(),
-          )
-          .await?,
-      ));
-    }
 
     self.build_info.hash =
       Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -23,7 +23,10 @@ use rspack_sources::{
   BoxSource, CachedSource, OriginalSource, RawBufferSource, RawStringSource, SourceExt, SourceMap,
   SourceMapSource, WithoutOriginalOptions,
 };
-use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
+use rspack_util::{
+  source_map::{ModuleSourceMapConfig, SourceMapKind},
+  time::current_time,
+};
 use serde_json::json;
 use tracing::{Instrument, info_span};
 
@@ -32,13 +35,15 @@ use crate::{
   BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, ConnectionState, Context,
   DependenciesBlock, DependencyCodeGenerationRef, DependencyId, FactoryMeta, GenerateContext,
   GeneratorOptions, ImportPhase, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem,
-  OutputOptions, ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve,
-  ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType, contextify,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, NeedBuildContext,
+  OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
+  ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext,
+  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SnapshotValidationResult, SourceType,
+  contextify,
   diagnostics::ModuleBuildError,
-  get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
-  module_update_hash,
+  get_context,
+  incremental::IncrementalPasses,
+  module_analyzed_side_effect_free, module_declared_side_effect_free, module_update_hash,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -148,6 +153,9 @@ pub struct NormalModule {
   build_info: BuildInfo,
   build_meta: BuildMeta,
   parsed: bool,
+  /// Mirrors webpack's `_forceBuild`: a new module has no reusable build until
+  /// its first build starts.
+  force_build: bool,
 
   source_map_kind: SourceMapKind,
 }
@@ -230,6 +238,7 @@ impl NormalModule {
       build_info,
       build_meta: Default::default(),
       parsed: false,
+      force_build: true,
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -363,6 +372,43 @@ impl Module for NormalModule {
     }
   }
 
+  async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
+    if self.force_build {
+      return Ok(true);
+    }
+
+    if self
+      .diagnostics
+      .iter()
+      .any(|diagnostic| diagnostic.is_error())
+    {
+      return Ok(true);
+    }
+
+    if !self.build_info.cacheable {
+      return Ok(true);
+    }
+
+    let Some(snapshot) = &self.build_info.file_system_snapshot else {
+      return Ok(true);
+    };
+
+    if context
+      .value_cache_versions
+      .has_diff(&self.build_info.value_dependencies)
+    {
+      return Ok(true);
+    }
+
+    Ok(matches!(
+      context
+        .file_system_info
+        .check_snapshot_valid(snapshot)
+        .await?,
+      SnapshotValidationResult::Invalid { .. }
+    ))
+  }
+
   #[tracing::instrument("NormalModule:build", skip_all, fields(
     perfetto.track_name = format!("Module Build"),
     perfetto.process_name = format!("Rspack Build Detail"),
@@ -375,6 +421,16 @@ impl Module for NormalModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.force_build = false;
+    self.build_info.file_system_snapshot = None;
+    let build_start_time = current_time();
+    let file_system_info = (!build_context
+      .compiler_options
+      .incremental
+      .passes
+      .contains(IncrementalPasses::BUILD_MODULE_GRAPH))
+    .then(|| build_context.file_system_info.clone());
+
     // so does webpack
     self.parsed = true;
 
@@ -488,6 +544,14 @@ impl Module for NormalModule {
       self.code_generation_dependencies = Some(Vec::new());
       self.presentational_dependencies = Some(Vec::new());
 
+      if let Some(file_system_info) = &file_system_info {
+        self.build_info.file_system_snapshot = Some(
+          file_system_info
+            .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
+            .await?,
+        );
+      }
+
       self.build_info.hash =
         Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
@@ -555,6 +619,14 @@ impl Module for NormalModule {
     self.source = Some(source);
     self.code_generation_dependencies = Some(code_generation_dependencies);
     self.presentational_dependencies = Some(presentational_dependencies);
+
+    if let Some(file_system_info) = &file_system_info {
+      self.build_info.file_system_snapshot = Some(
+        file_system_info
+          .create_module_snapshot(Some(build_start_time), &self.build_info.dependencies)
+          .await?,
+      );
+    }
 
     self.build_info.hash =
       Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));

--- a/crates/rspack_core/src/options/cache.rs
+++ b/crates/rspack_core/src/options/cache.rs
@@ -12,6 +12,7 @@ pub enum CacheOptions {
     /// For example, if `max_generations` is set to 1,
     /// the cache will be removed if it's not accessed for 1 compilation generation.
     max_generations: u32,
+    snapshot: SnapshotOptions,
   },
   Persistent(PersistentCacheOptions),
 }

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -1,6 +1,6 @@
 use crate::{
   CacheOptions, Context, Experiments, Mode, ModuleOptions, NodeOption, Optimization, OutputOptions,
-  Resolve, StatsOptions, incremental::IncrementalOptions,
+  Resolve, SnapshotOptions, StatsOptions, incremental::IncrementalOptions,
 };
 
 #[derive(Debug)]
@@ -13,6 +13,7 @@ pub struct CompilerOptions {
   pub resolve_loader: Resolve,
   pub module: ModuleOptions,
   pub stats: StatsOptions,
+  pub snapshot: SnapshotOptions,
   pub cache: CacheOptions,
   pub experiments: Experiments,
   pub incremental: IncrementalOptions,

--- a/crates/rspack_core/src/options/compiler_options.rs
+++ b/crates/rspack_core/src/options/compiler_options.rs
@@ -1,6 +1,6 @@
 use crate::{
   CacheOptions, Context, Experiments, Mode, ModuleOptions, NodeOption, Optimization, OutputOptions,
-  Resolve, SnapshotOptions, StatsOptions, incremental::IncrementalOptions,
+  Resolve, StatsOptions, incremental::IncrementalOptions,
 };
 
 #[derive(Debug)]
@@ -13,7 +13,6 @@ pub struct CompilerOptions {
   pub resolve_loader: Resolve,
   pub module: ModuleOptions,
   pub stats: StatsOptions,
-  pub snapshot: SnapshotOptions,
   pub cache: CacheOptions,
   pub experiments: Experiments,
   pub incremental: IncrementalOptions,

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -7,8 +7,8 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
   BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
   EntryDependency, FactoryMeta, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  ModuleType, NeedBuildContext, RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions,
+  impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -120,8 +120,12 @@ impl Module for DllModule {
     Ok(code_generation_result)
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build_for_incremental(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
     false
+  }
+
+  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
+    Ok(false)
   }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
   BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
   FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleDependency, ModuleGraph, ModuleId, ModuleType, RuntimeSpec, SourceType,
+  ModuleDependency, ModuleGraph, ModuleId, ModuleType, NeedBuildContext, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec, ValueCacheVersions, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
@@ -184,8 +184,12 @@ impl Module for DelegatedModule {
     Ok(code_generation_result)
   }
 
-  fn need_build(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build_for_incremental(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
     false
+  }
+
+  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
+    Ok(false)
   }
 
   async fn get_runtime_hash(

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1788,7 +1788,7 @@ async fn create_concatenated_module(
         plugin_driver: compilation.plugin_driver.clone(),
         compiler_options: compilation.options.clone(),
         loader_cache: compilation.get_cache("loader"),
-        file_system_info: compilation.file_system_info(),
+        file_system_info: compilation.file_system_info.clone(),
         fs: compilation.input_filesystem.clone(),
         runtime_template: compilation.runtime_template.create_module_code_template(),
       },

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -7,8 +7,8 @@ use rspack_core::{
   BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, Context,
   DependenciesBlock, DependencyId, DependencyRange, FactoryMeta, ImportPhase, LibIdentOptions,
   Module, ModuleArgument, ModuleCodeGenerationContext, ModuleFactoryCreateData, ModuleGraph,
-  ModuleIdentifier, ModuleLayer, ModuleType, OutputOptions, RuntimeGlobals, RuntimeSpec,
-  SourceType, ValueCacheVersions, impl_module_meta_info, module_update_hash,
+  ModuleIdentifier, ModuleLayer, ModuleType, NeedBuildContext, OutputOptions, RuntimeGlobals,
+  RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -170,7 +170,7 @@ impl Module for LazyCompilationProxyModule {
     self.lib_ident.as_ref().map(|s| Cow::Borrowed(s.as_str()))
   }
 
-  fn need_build(&self, value_cache_versions: &ValueCacheVersions) -> bool {
+  fn need_build_for_incremental(&self, value_cache_versions: &ValueCacheVersions) -> bool {
     if self.need_build {
       return true;
     }
@@ -183,6 +183,10 @@ impl Module for LazyCompilationProxyModule {
     } else {
       true
     }
+  }
+
+  async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
+    Ok(self.need_build_for_incremental(context.value_cache_versions))
   }
 
   async fn build(

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -41,6 +41,7 @@ import {
 } from './adapterRuleUse';
 import type {
   CacheNormalized,
+  CacheSnapshotNormalized,
   ExperimentsNormalized,
   ModuleOptionsNormalized,
   OutputNormalized,
@@ -83,6 +84,12 @@ export type {
 
 const MAX_U32 = 0xffffffff;
 
+const EMPTY_CACHE_SNAPSHOT: Required<CacheSnapshotNormalized> = {
+  immutablePaths: [],
+  unmanagedPaths: [],
+  managedPaths: [],
+};
+
 type ExperimentsWithDefaults = Omit<
   Required<ExperimentsNormalized>,
   'newCache'
@@ -97,6 +104,12 @@ export const getRawOptions = (
 ): RawOptions => {
   const mode = options.mode;
   const experiments = options.experiments as ExperimentsWithDefaults;
+  const cache = options.cache!;
+  const cacheSnapshot =
+    cache !== false && cache.type === 'persistent'
+      ? cache.snapshot
+      : EMPTY_CACHE_SNAPSHOT;
+  const snapshot = getRawSnapshot(cacheSnapshot);
   return {
     name: options.name,
     mode,
@@ -112,7 +125,8 @@ export const getRawOptions = (
     }),
     optimization: options.optimization as Required<Optimization>,
     stats: getRawStats(options.stats),
-    cache: getRawCache(options.cache!),
+    snapshot,
+    cache: getRawCache(cache, snapshot),
     experiments,
     incremental: mode === 'development' && options.incremental,
     node: getRawNode(options.node),
@@ -122,7 +136,20 @@ export const getRawOptions = (
   };
 };
 
-function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
+function getRawSnapshot(
+  snapshot: CacheSnapshotNormalized,
+): RawOptions['snapshot'] {
+  return {
+    immutablePaths: snapshot.immutablePaths!,
+    unmanagedPaths: snapshot.unmanagedPaths!,
+    managedPaths: snapshot.managedPaths!,
+  };
+}
+
+function getRawCache(
+  cache: CacheNormalized,
+  snapshot: RawOptions['snapshot'],
+): RawOptions['cache'] {
   if (cache === false) return false;
   if (cache.type === 'memory') return cache;
   const toRawStorageLimit = (name: string, value: number) => {
@@ -144,11 +171,7 @@ function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
       // Raw `directory` expects the final cache path; normalized `directory` is only the base.
       directory: cache.storage.location!,
     },
-    snapshot: {
-      immutablePaths: cache.snapshot.immutablePaths!,
-      unmanagedPaths: cache.snapshot.unmanagedPaths!,
-      managedPaths: cache.snapshot.managedPaths!,
-    },
+    snapshot,
     portable: cache.portable,
     readonly: cache.readonly,
   };

--- a/packages/rspack/src/config/adapter.ts
+++ b/packages/rspack/src/config/adapter.ts
@@ -24,6 +24,7 @@ import {
   type RawRuleSetCondition,
   RawRuleSetConditionType,
   type RawRuleSetLogicalConditions,
+  type RawSnapshotOptions,
 } from '@rspack/binding';
 
 import type { Compiler } from '../Compiler';
@@ -84,12 +85,6 @@ export type {
 
 const MAX_U32 = 0xffffffff;
 
-const EMPTY_CACHE_SNAPSHOT: Required<CacheSnapshotNormalized> = {
-  immutablePaths: [],
-  unmanagedPaths: [],
-  managedPaths: [],
-};
-
 type ExperimentsWithDefaults = Omit<
   Required<ExperimentsNormalized>,
   'newCache'
@@ -105,11 +100,6 @@ export const getRawOptions = (
   const mode = options.mode;
   const experiments = options.experiments as ExperimentsWithDefaults;
   const cache = options.cache!;
-  const cacheSnapshot =
-    cache !== false && cache.type === 'persistent'
-      ? cache.snapshot
-      : EMPTY_CACHE_SNAPSHOT;
-  const snapshot = getRawSnapshot(cacheSnapshot);
   return {
     name: options.name,
     mode,
@@ -125,8 +115,7 @@ export const getRawOptions = (
     }),
     optimization: options.optimization as Required<Optimization>,
     stats: getRawStats(options.stats),
-    snapshot,
-    cache: getRawCache(cache, snapshot),
+    cache: getRawCache(cache),
     experiments,
     incremental: mode === 'development' && options.incremental,
     node: getRawNode(options.node),
@@ -136,9 +125,7 @@ export const getRawOptions = (
   };
 };
 
-function getRawSnapshot(
-  snapshot: CacheSnapshotNormalized,
-): RawOptions['snapshot'] {
+function getRawSnapshot(snapshot: CacheSnapshotNormalized): RawSnapshotOptions {
   return {
     immutablePaths: snapshot.immutablePaths!,
     unmanagedPaths: snapshot.unmanagedPaths!,
@@ -146,12 +133,15 @@ function getRawSnapshot(
   };
 }
 
-function getRawCache(
-  cache: CacheNormalized,
-  snapshot: RawOptions['snapshot'],
-): RawOptions['cache'] {
+function getRawCache(cache: CacheNormalized): RawOptions['cache'] {
   if (cache === false) return false;
-  if (cache.type === 'memory') return cache;
+  const snapshot = getRawSnapshot(cache.snapshot);
+  if (cache.type === 'memory') {
+    return {
+      type: cache.type,
+      snapshot,
+    };
+  }
   const toRawStorageLimit = (name: string, value: number) => {
     if (value === Infinity) return 0;
     if (!Number.isSafeInteger(value) || value < 1 || value > MAX_U32) {

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -101,7 +101,7 @@ export const applyRspackOptionsDefaults = (
   D(options, 'bail', false);
 
   F(options, 'cache', () =>
-    development ? { type: 'memory' as const } : false,
+    development ? { type: 'memory' as const, snapshot: {} } : false,
   );
   applyCacheDefaults(options.cache!, {
     context: options.context!,
@@ -226,6 +226,9 @@ const applyCacheDefaults = (
   },
 ) => {
   if (cache === false) return;
+  F(cache.snapshot, 'immutablePaths', () => []);
+  F(cache.snapshot, 'unmanagedPaths', () => []);
+  F(cache.snapshot, 'managedPaths', () => [/[\\/]node_modules[\\/][^.]/]);
   switch (cache.type) {
     case 'memory':
       break;
@@ -246,9 +249,6 @@ const applyCacheDefaults = (
       D(cache, 'version', '');
       D(cache, 'maxAge', DEFAULT_FILESYSTEM_CACHE_MAX_AGE_SECONDS);
       F(cache, 'buildDependencies', () => []);
-      F(cache.snapshot, 'immutablePaths', () => []);
-      F(cache.snapshot, 'unmanagedPaths', () => []);
-      F(cache.snapshot, 'managedPaths', () => [/[\\/]node_modules[\\/][^.]/]);
       D(cache, 'portable', false);
       D(cache, 'readonly', false);
       break;

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -635,6 +635,12 @@ export interface ModuleOptionsNormalized {
   noParse?: NoParseOption;
 }
 
+export type CacheSnapshotNormalized = {
+  immutablePaths?: (string | RegExp)[];
+  unmanagedPaths?: (string | RegExp)[];
+  managedPaths?: (string | RegExp)[];
+};
+
 export type CacheNormalized =
   | false
   | {
@@ -647,11 +653,7 @@ export type CacheNormalized =
       version?: string;
       maxAge?: number;
       maxVersions?: number;
-      snapshot: {
-        immutablePaths?: (string | RegExp)[];
-        unmanagedPaths?: (string | RegExp)[];
-        managedPaths?: (string | RegExp)[];
-      };
+      snapshot: CacheSnapshotNormalized;
       storage: {
         type: 'filesystem';
         directory?: string;

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -18,6 +18,7 @@ import type {
   AssetModuleFilename,
   Bail,
   BundlerInfoOptions,
+  CacheSnapshotOptions,
   ChunkFilename,
   ChunkLoading,
   ChunkLoadingGlobal,
@@ -280,6 +281,7 @@ export const getNormalizedRspackOptions = (
       if (cache === true) {
         return {
           type: 'memory',
+          snapshot: getNormalizedCacheSnapshot(),
         };
       }
       switch (cache.type) {
@@ -288,6 +290,7 @@ export const getNormalizedRspackOptions = (
           return {
             ...cache,
             type: 'memory',
+            snapshot: getNormalizedCacheSnapshot(cache.snapshot),
           };
         case 'persistent': {
           const hasMaxVersions = Object.hasOwn(cache, 'maxVersions');
@@ -308,19 +311,7 @@ export const getNormalizedRspackOptions = (
             buildDependencies: nestedArray(cache.buildDependencies, (deps) =>
               deps.map((d) => path.resolve(context, d)),
             ),
-            snapshot: nestedConfig(cache.snapshot, (snapshot) => ({
-              immutablePaths: optionalNestedArray(
-                snapshot.immutablePaths,
-                (p) => [...p],
-              ),
-              unmanagedPaths: optionalNestedArray(
-                snapshot.unmanagedPaths,
-                (p) => [...p],
-              ),
-              managedPaths: optionalNestedArray(snapshot.managedPaths, (p) => [
-                ...p,
-              ]),
-            })),
+            snapshot: getNormalizedCacheSnapshot(cache.snapshot),
             storage: nestedConfig(cache.storage, (storage) => ({
               type: storage.type,
               directory: optionalNestedConfig(storage.directory, (directory) =>
@@ -510,6 +501,15 @@ const getNormalizedNewCacheOptions = (
   return newCache;
 };
 
+const getNormalizedCacheSnapshot = (
+  snapshot?: CacheSnapshotOptions,
+): CacheSnapshotNormalized =>
+  nestedConfig(snapshot, (snapshot) => ({
+    immutablePaths: optionalNestedArray(snapshot.immutablePaths, (p) => [...p]),
+    unmanagedPaths: optionalNestedArray(snapshot.unmanagedPaths, (p) => [...p]),
+    managedPaths: optionalNestedArray(snapshot.managedPaths, (p) => [...p]),
+  }));
+
 const nestedConfig = <T, R>(value: T | undefined, fn: (value: T) => R) =>
   value === undefined ? fn({} as T) : fn(value);
 
@@ -645,6 +645,7 @@ export type CacheNormalized =
   | false
   | {
       type: 'memory';
+      snapshot: CacheSnapshotNormalized;
     }
   | {
       type: 'persistent';

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -2170,6 +2170,10 @@ export type MemoryCacheOptions = {
    * Cache type.
    */
   type: 'memory';
+  /**
+   * Snapshot options for determining which files have been modified.
+   */
+  snapshot?: CacheSnapshotOptions;
 };
 
 /**

--- a/tests/rspack-test/defaultsCases/cache/cache.js
+++ b/tests/rspack-test/defaultsCases/cache/cache.js
@@ -10,6 +10,13 @@ module.exports = {
 			@@ ... @@
 			-   "cache": false,
 			+   "cache": Object {
+			+     "snapshot": Object {
+			+       "immutablePaths": Array [],
+			+       "managedPaths": Array [
+			+         /[\\\\/]node_modules[\\\\/][^.]/,
+			+       ],
+			+       "unmanagedPaths": Array [],
+			+     },
 			+     "type": "memory",
 			+   },
 		`)

--- a/tests/rspack-test/defaultsCases/mode/development.js
+++ b/tests/rspack-test/defaultsCases/mode/development.js
@@ -10,6 +10,13 @@ module.exports = {
 			@@ ... @@
 			-   "cache": false,
 			+   "cache": Object {
+			+     "snapshot": Object {
+			+       "immutablePaths": Array [],
+			+       "managedPaths": Array [
+			+         /[\\\\/]node_modules[\\\\/][^.]/,
+			+       ],
+			+       "unmanagedPaths": Array [],
+			+     },
 			+     "type": "memory",
 			+   },
 			@@ ... @@

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -368,10 +368,7 @@ fn reset_compilation_state(compiler: &mut Compiler) {
 
   let compiler_id = compiler.id();
   let compiler_context = CURRENT_COMPILER_CONTEXT.get();
-  let cache = Cache::new_disabled(
-    compiler.compiler_path.clone(),
-    compiler.compilation.file_system_info(),
-  );
+  let cache = Cache::new_disabled(compiler.compiler_path.clone());
   fast_set(
     &mut compiler.compilation,
     Compilation::new(


### PR DESCRIPTION
## Summary

- Align `Module::need_build` and `NormalModule` snapshot validation with webpack.
- Align the `FileSystemInfo` lifecycle and ownership with webpack by keeping it compilation-scoped.
- Preserve the existing incremental make behavior through `need_build_for_incremental`.
- Keep the build snapshot field reserved while deferring snapshot capture to avoid a performance regression.

## Related links

- Stacked follow-up: #15380