### PR TITLE
fix(binding): preserve function-valued chunk filename templates

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -125,7 +125,7 @@ export declare class Chunk {
   get id(): string | number | undefined
   get ids(): Array<string | number>
   get idNameHints(): Array<string>
-  get filenameTemplate(): string | undefined
+  get filenameTemplate(): JsFilename | undefined
   get cssFilenameTemplate(): string | undefined
   get _files(): Array<string>
   get _runtime(): Array<string>

--- a/crates/rspack_binding_api/src/chunk.rs
+++ b/crates/rspack_binding_api/src/chunk.rs
@@ -8,17 +8,22 @@ use napi::{
   sys,
 };
 use napi_derive::napi;
-use rspack_core::{Compilation, CompilationId, chunk_graph_chunk::ChunkId};
+use rspack_core::{Compilation, CompilationId, CompilerId, chunk_graph_chunk::ChunkId};
 use rspack_napi::OneShotRef;
 use rustc_hash::FxHashMap;
 
 use crate::{
-  chunk_group::ChunkGroupWrapper, compilation::entries::EntryOptionsDTO, with_compilation,
+  COMPILER_REFERENCES,
+  chunk_group::ChunkGroupWrapper,
+  compilation::entries::EntryOptionsDTO,
+  filename::{CompilerScopedFilenameTsFnManager, JsFilenameFunction},
+  with_compilation,
 };
 
 #[napi]
 pub struct Chunk {
   pub(crate) chunk_ukey: rspack_core::ChunkUkey,
+  compiler_id: CompilerId,
   compilation_id: CompilationId,
 }
 
@@ -48,6 +53,49 @@ impl Chunk {
         )))
       }
     })
+  }
+
+  fn with_ref_and_filename_tsfn_manager<R>(
+    &self,
+    f: impl FnOnce(
+      &Compilation,
+      &rspack_core::Chunk,
+      &CompilerScopedFilenameTsFnManager,
+    ) -> napi::Result<R>,
+  ) -> napi::Result<R> {
+    let compiler_reference = COMPILER_REFERENCES.with(|ref_cell| {
+      let references = ref_cell.borrow();
+      references.get(&self.compiler_id).cloned()
+    });
+
+    let Some(compiler) = compiler_reference
+      .as_ref()
+      .and_then(|compiler_reference| compiler_reference.get())
+      .filter(|compiler| compiler.compiler.compilation.id() == self.compilation_id)
+    else {
+      return Err(napi::Error::from_reason(format!(
+        "Unable to access compilation with id = {:?} now. The Compilation has been removed on the Rust side or the Compiler has been garbage collected by JavaScript.",
+        self.compilation_id
+      )));
+    };
+
+    let compilation = &compiler.compiler.compilation;
+    let Some(chunk) = compilation
+      .build_chunk_graph_artifact
+      .chunk_by_ukey
+      .get(&self.chunk_ukey)
+    else {
+      return Err(napi::Error::from_reason(format!(
+        "Unable to access chunk with id = {:?} now. The chunk have been removed on the Rust side.",
+        self.chunk_ukey
+      )));
+    };
+
+    f(
+      compilation,
+      chunk,
+      &compiler.compiler_scoped_filename_tsfn_manager,
+    )
   }
 }
 
@@ -103,12 +151,27 @@ impl Chunk {
     })
   }
 
-  #[napi(getter)]
-  pub fn filename_template<'a>(&self, env: &'a Env) -> napi::Result<Either<JsString<'a>, ()>> {
-    self.with_ref(|_, chunk| {
-      Ok(match chunk.filename_template().and_then(|f| f.template()) {
-        Some(tpl) => Either::A(env.create_string(tpl)?),
-        None => Either::B(()),
+  #[napi(getter, ts_return_type = "JsFilename | undefined")]
+  pub fn filename_template<'a>(
+    &self,
+    env: &'a Env,
+  ) -> napi::Result<Either3<JsString<'a>, JsFilenameFunction<'a>, ()>> {
+    self.with_ref_and_filename_tsfn_manager(|_, chunk, manager| {
+      let Some(filename) = chunk.filename_template() else {
+        return Ok(Either3::C(()));
+      };
+      if let Some(template) = filename.template() {
+        return Ok(Either3::A(env.create_string(template)?));
+      }
+      let function = manager.get(filename, env)?;
+      debug_assert!(
+        function.is_some(),
+        "chunk.filenameTemplate for chunk {:?} contains a filename function that is not backed by JavaScript",
+        self.chunk_ukey
+      );
+      Ok(match function {
+        Some(function) => Either3::B(function),
+        None => Either3::C(()),
       })
     })
   }
@@ -318,6 +381,7 @@ thread_local! {
 
 pub struct ChunkWrapper {
   pub chunk_ukey: rspack_core::ChunkUkey,
+  pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
 }
 
@@ -326,6 +390,7 @@ impl FromNapiValue for ChunkWrapper {
     let chunk: &Chunk = unsafe { FromNapiValue::from_napi_value(env, napi_val)? };
     Ok(Self {
       chunk_ukey: chunk.chunk_ukey,
+      compiler_id: chunk.compiler_id,
       compilation_id: chunk.compilation_id,
     })
   }
@@ -335,13 +400,19 @@ impl ChunkWrapper {
   pub fn new(chunk_ukey: rspack_core::ChunkUkey, compilation: &Compilation) -> Self {
     Self {
       chunk_ukey,
+      compiler_id: compilation.compiler_id(),
       compilation_id: compilation.id(),
     }
   }
 
-  pub fn new_by_id(chunk_ukey: rspack_core::ChunkUkey, compilation_id: CompilationId) -> Self {
+  pub fn new_by_id(
+    chunk_ukey: rspack_core::ChunkUkey,
+    compiler_id: CompilerId,
+    compilation_id: CompilationId,
+  ) -> Self {
     Self {
       chunk_ukey,
+      compiler_id,
       compilation_id,
     }
   }
@@ -398,6 +469,7 @@ impl ToNapiValue for ChunkWrapper {
           std::collections::hash_map::Entry::Vacant(entry) => {
             let js_chunk = Chunk {
               chunk_ukey: val.chunk_ukey,
+              compiler_id: val.compiler_id,
               compilation_id: val.compilation_id,
             };
             let r = entry.insert(OneShotRef::new(env, js_chunk)?);

--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -784,8 +784,9 @@ impl JsCompilation {
   )]
   pub fn add_entry(
     &mut self,
+    env: &Env,
     reference: Reference<JsCompilation>,
-    js_args: Vec<(String, &mut EntryDependency, Option<JsEntryOptions>)>,
+    raw_js_args: Unknown<'static>,
     f: Function<'static>,
   ) -> napi::Result<(), ErrorCode> {
     let compilation = self
@@ -808,6 +809,17 @@ impl JsCompilation {
           "Unable to addEntry now. The Compiler has been garbage collected by JavaScript.",
         ));
       };
+      let js_args = js_compiler
+        .compiler_scoped_filename_tsfn_manager
+        .scope(|| {
+          js_compiler.compiler_scoped_tsfn_manager.scope(|| unsafe {
+            Vec::<(String, &mut EntryDependency, Option<JsEntryOptions>)>::from_napi_value(
+              env.raw(),
+              raw_js_args.raw(),
+            )
+          })
+        })
+        .map_err(|err| napi::Error::new(err.status.into(), err.reason))?;
       let entry_dependencies_map = &mut js_compiler.entry_dependencies_map;
 
       let args = js_args
@@ -888,8 +900,9 @@ impl JsCompilation {
   )]
   pub fn add_include(
     &mut self,
+    env: &Env,
     reference: Reference<JsCompilation>,
-    js_args: Vec<(String, &mut EntryDependency, Option<JsEntryOptions>)>,
+    raw_js_args: Unknown<'static>,
     f: Function<'static>,
   ) -> napi::Result<(), ErrorCode> {
     let compilation = self
@@ -912,6 +925,17 @@ impl JsCompilation {
       ));
     };
     within_compiler_context_sync(js_compiler.compiler_context.clone(), || {
+      let js_args = js_compiler
+        .compiler_scoped_filename_tsfn_manager
+        .scope(|| {
+          js_compiler.compiler_scoped_tsfn_manager.scope(|| unsafe {
+            Vec::<(String, &mut EntryDependency, Option<JsEntryOptions>)>::from_napi_value(
+              env.raw(),
+              raw_js_args.raw(),
+            )
+          })
+        })
+        .map_err(|err| napi::Error::new(err.status.into(), err.reason))?;
       let include_dependencies_map = &mut js_compiler.include_dependencies_map;
 
       let args = js_args

--- a/crates/rspack_binding_api/src/filename.rs
+++ b/crates/rspack_binding_api/src/filename.rs
@@ -1,9 +1,14 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{
+  cell::RefCell,
+  fmt::Debug,
+  rc::{Rc, Weak as RcWeak},
+  sync::{Arc, Weak as SyncWeak},
+};
 
 use futures::future::BoxFuture;
 use napi::{
   Either,
-  bindgen_prelude::{FnArgs, FromNapiValue, TypeName},
+  bindgen_prelude::{FnArgs, FromNapiValue, Function, FunctionRef, TypeName},
 };
 use rspack_core::{Filename, FilenameFn, LocalFilenameFn, PathData, PublicPath};
 
@@ -12,13 +17,162 @@ use crate::{
   path_data::JsPathData,
 };
 
-type FilenameValue =
+thread_local! {
+  static CURRENT_FILENAME_TSFN_MANAGER: RefCell<Option<RcWeak<CompilerScopedFilenameTsFnManagerInner>>> = Default::default();
+}
+
+type RawFilenameValue =
   Either<String, ThreadsafeFunction<FnArgs<(JsPathData, Option<AssetInfo>)>, String>>;
+type JsFilenameFnArgs = FnArgs<(JsPathData, Option<AssetInfo>)>;
+pub(crate) type JsFilenameFunctionRef = FunctionRef<JsFilenameFnArgs, String>;
+
+pub(crate) type JsFilenameFunction<'env> = Function<'env, JsFilenameFnArgs, String>;
+
+#[derive(Debug)]
+enum FilenameValue {
+  Template(String),
+  Function(Filename),
+}
+
+struct CompilerScopedFilenameTsFnReference {
+  filename_fn: SyncWeak<dyn FilenameFn>,
+  function_ref: JsFilenameFunctionRef,
+}
+
+#[derive(Default)]
+struct CompilerScopedFilenameTsFnManagerInner {
+  references: RefCell<Vec<CompilerScopedFilenameTsFnReference>>,
+}
+
+/// Maintains the compiler-scoped identity mapping between JavaScript filename
+/// functions and their Rust `FilenameFn` counterparts.
+///
+/// # Why the mapping exists
+///
+/// Converting a JavaScript filename function creates two representations of the
+/// same callback:
+///
+/// - a `CompilerScopedTsFnHandle`, wrapped by `ThreadSafeFilenameFn` and stored
+///   in Rust as an `Arc<dyn FilenameFn>`, so the compiler can render filenames;
+/// - a `FunctionRef` to the original JavaScript function, so binding APIs such
+///   as `Chunk::filename_template` can return that exact function object.
+///
+/// A Rust `Filename` cannot reconstruct the original JavaScript function by
+/// itself. Creating a new JavaScript wrapper around the Rust `FilenameFn` would
+/// introduce a nested boundary crossing:
+///
+/// ```text
+/// JavaScript wrapper -> Rust FilenameFn -> TSFN -> original JavaScript function
+/// ```
+///
+/// Besides adding calls and error/lifetime handling, that wrapper would have a
+/// different JavaScript identity. Keeping this mapping lets the binding borrow
+/// back the original function directly, preserving identity and avoiding the
+/// nested JavaScript -> Rust -> JavaScript call path.
+///
+/// # Filename sources
+///
+/// Filename functions are not limited to initial compiler options. They can be
+/// introduced through:
+///
+/// - compiler options such as entry and output filename settings;
+/// - built-in plugin options, including entry and split-chunks configuration;
+/// - compilation-time APIs such as `addEntry` and `addInclude`.
+///
+/// Consequently, every conversion path that can create a compiler-owned
+/// `JsFilename` must run inside `CompilerScopedFilenameTsFnManager::scope`.
+/// The thread-local scope supplies the owning manager because `FromNapiValue`
+/// cannot receive the compiler as explicit conversion context.
+///
+/// # Ownership and cleanup
+///
+/// Each mapping owns the JavaScript `FunctionRef`, but holds only a `Weak` to
+/// the Rust `FilenameFn`. A strong Rust reference here would keep filenames
+/// alive after their compilation data had been discarded and could retain the
+/// TSFN and its JavaScript closure indefinitely.
+///
+/// Once the last real Rust owner drops a filename function, `sweep` observes
+/// that its `Weak` can no longer be upgraded and removes the mapping, which also
+/// drops the corresponding `FunctionRef`. Sweeping occurs after each
+/// compilation and lazily before lookup. `release` removes every remaining
+/// mapping when the compiler is closed.
+#[derive(Clone, Default)]
+pub(crate) struct CompilerScopedFilenameTsFnManager {
+  inner: Rc<CompilerScopedFilenameTsFnManagerInner>,
+}
+
+impl CompilerScopedFilenameTsFnManager {
+  pub fn scope<R>(&self, f: impl FnOnce() -> R) -> R {
+    struct ManagerGuard(Option<RcWeak<CompilerScopedFilenameTsFnManagerInner>>);
+
+    impl Drop for ManagerGuard {
+      fn drop(&mut self) {
+        CURRENT_FILENAME_TSFN_MANAGER.with(|current| {
+          current.replace(self.0.take());
+        });
+      }
+    }
+
+    let previous = CURRENT_FILENAME_TSFN_MANAGER
+      .with(|current| current.replace(Some(Rc::downgrade(&self.inner))));
+    let _guard = ManagerGuard(previous);
+    f()
+  }
+
+  fn current_context() -> Option<Self> {
+    CURRENT_FILENAME_TSFN_MANAGER
+      .with(|current| current.borrow().clone())
+      .and_then(|manager| manager.upgrade().map(|inner| Self { inner }))
+  }
+
+  fn register(&self, filename_fn: SyncWeak<dyn FilenameFn>, function_ref: JsFilenameFunctionRef) {
+    self
+      .inner
+      .references
+      .borrow_mut()
+      .push(CompilerScopedFilenameTsFnReference {
+        filename_fn,
+        function_ref,
+      });
+  }
+
+  pub fn get<'env>(
+    &self,
+    filename: &Filename,
+    env: &'env napi::Env,
+  ) -> napi::Result<Option<JsFilenameFunction<'env>>> {
+    self.sweep();
+    let references = self.inner.references.borrow();
+
+    for reference in references.iter() {
+      let Some(filename_fn) = reference.filename_fn.upgrade() else {
+        continue;
+      };
+      if Filename::from(filename_fn).eq(filename) {
+        return reference.function_ref.borrow_back(env).map(Some);
+      }
+    }
+
+    Ok(None)
+  }
+
+  pub fn sweep(&self) {
+    self
+      .inner
+      .references
+      .borrow_mut()
+      .retain(|reference| reference.filename_fn.strong_count() > 0);
+  }
+
+  pub fn release(&self) {
+    self.inner.references.borrow_mut().clear();
+  }
+}
 
 /// A js filename value. Either a string or a function
 #[derive(Debug)]
 pub struct JsFilename {
-  pub filename: FilenameValue,
+  filename: FilenameValue,
 }
 
 impl FromNapiValue for JsFilename {
@@ -27,9 +181,25 @@ impl FromNapiValue for JsFilename {
     napi_val: napi::sys::napi_value,
   ) -> napi::Result<Self> {
     unsafe {
-      Ok(Self {
-        filename: Either::from_napi_value(env, napi_val)?,
-      })
+      let filename = match RawFilenameValue::from_napi_value(env, napi_val)? {
+        Either::A(template) => FilenameValue::Template(template),
+        Either::B(f) => {
+          let filename_fn = Arc::new(ThreadSafeFilenameFn(Arc::new(
+            move |path_data, asset_info| {
+              let f = f.clone();
+              Box::pin(async move { f.call_with_sync((path_data, asset_info).into()).await })
+            },
+          ))) as Arc<dyn FilenameFn>;
+
+          if let Some(manager) = CompilerScopedFilenameTsFnManager::current_context() {
+            let function_ref = JsFilenameFunctionRef::from_napi_value(env, napi_val)?;
+            manager.register(Arc::downgrade(&filename_fn), function_ref);
+          }
+
+          FilenameValue::Function(Filename::from(filename_fn))
+        }
+      };
+      Ok(Self { filename })
     }
   }
 }
@@ -47,13 +217,8 @@ impl TypeName for JsFilename {
 impl From<JsFilename> for Filename {
   fn from(value: JsFilename) -> Self {
     match value.filename {
-      Either::A(template) => Filename::from(template),
-      Either::B(f) => Filename::from(Arc::new(ThreadSafeFilenameFn(Arc::new(
-        move |path_data, asset_info| {
-          let f = f.clone();
-          Box::pin(async move { f.call_with_sync((path_data, asset_info).into()).await })
-        },
-      ))) as Arc<dyn FilenameFn>),
+      FilenameValue::Template(template) => Filename::from(template),
+      FilenameValue::Function(filename) => filename,
     }
   }
 }
@@ -61,13 +226,8 @@ impl From<JsFilename> for Filename {
 impl From<JsFilename> for PublicPath {
   fn from(value: JsFilename) -> Self {
     match value.filename {
-      Either::A(template) => template.into(),
-      Either::B(f) => PublicPath::Filename(Filename::from(Arc::new(ThreadSafeFilenameFn(Arc::new(
-        move |path_data, asset_info| {
-          let f = f.clone();
-          Box::pin(async move { f.call_with_sync((path_data, asset_info).into()).await })
-        },
-      ))) as Arc<dyn FilenameFn>)),
+      FilenameValue::Template(template) => template.into(),
+      FilenameValue::Function(filename) => PublicPath::Filename(filename),
     }
   }
 }

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -130,6 +130,7 @@ use crate::{
   compiler_scoped_tsfn::{CompilerScopedTsFnHandle, CompilerScopedTsFnManager},
   dependency::DependencyWrapper,
   error::{ErrorCode, RspackResultToNapiResultExt},
+  filename::CompilerScopedFilenameTsFnManager,
   fs_node::{HybridFileSystem, NodeFileSystem, ThreadsafeNodeFS},
   logging::{InfrastructureLogDispatcher, JsLog},
   module::ModuleObject,
@@ -230,6 +231,7 @@ struct JsCompiler {
   unsafe_fast_drop: bool,
   infrastructure_log_dispatcher: Arc<InfrastructureLogDispatcher>,
   compiler_scoped_tsfn_manager: CompilerScopedTsFnManager,
+  compiler_scoped_filename_tsfn_manager: CompilerScopedFilenameTsFnManager,
   js_hooks_plugin: JsHooksAdapterPlugin,
   // call drop manually to avoid unnecessary drop overhead in cli build
   compiler: ManuallyDrop<Compiler>,
@@ -265,15 +267,22 @@ impl JsCompiler {
     tracing::info!(name:"rspack_version", version = rspack_workspace::rspack_pkg_version!());
 
     let compiler_scoped_tsfn_manager = CompilerScopedTsFnManager::new();
-    // Parse constructor inputs inside the manager scope so any nested callback fields in
-    // options, builtin plugins, or hook registrations become compiler-scoped TSFNs.
-    let mut options: RawOptions = compiler_scoped_tsfn_manager
-      .scope(|| unsafe { RawOptions::from_napi_value(env.raw(), raw_options.raw()) })?;
-    let builtin_plugins: Vec<BuiltinPlugin> = compiler_scoped_tsfn_manager.scope(|| unsafe {
-      Vec::<BuiltinPlugin>::from_napi_value(env.raw(), raw_builtin_plugins.raw())
+    let compiler_scoped_filename_tsfn_manager = CompilerScopedFilenameTsFnManager::default();
+    // Parse constructor inputs inside both compiler-owned scopes so nested callbacks become
+    // compiler-scoped TSFNs and filename functions retain their original JavaScript handles.
+    let mut options: RawOptions = compiler_scoped_filename_tsfn_manager.scope(|| {
+      compiler_scoped_tsfn_manager
+        .scope(|| unsafe { RawOptions::from_napi_value(env.raw(), raw_options.raw()) })
     })?;
-    let register_js_taps: RegisterJsTaps = compiler_scoped_tsfn_manager.scope(|| unsafe {
-      RegisterJsTaps::from_napi_value(env.raw(), raw_register_js_taps.raw())
+    let builtin_plugins: Vec<BuiltinPlugin> =
+      compiler_scoped_filename_tsfn_manager.scope(|| {
+        compiler_scoped_tsfn_manager.scope(|| unsafe {
+          Vec::<BuiltinPlugin>::from_napi_value(env.raw(), raw_builtin_plugins.raw())
+        })
+      })?;
+    let register_js_taps: RegisterJsTaps = compiler_scoped_filename_tsfn_manager.scope(|| {
+      compiler_scoped_tsfn_manager
+        .scope(|| unsafe { RegisterJsTaps::from_napi_value(env.raw(), raw_register_js_taps.raw()) })
     })?;
     let infrastructure_log_callback: CompilerScopedTsFnHandle<Vec<JsLog>, ()> =
       compiler_scoped_tsfn_manager.scope(|| unsafe {
@@ -313,7 +322,9 @@ impl JsCompiler {
       plugins.push(js_cleanup_plugin.boxed());
 
       for bp in builtin_plugins {
-        compiler_scoped_tsfn_manager.scope(|| bp.append_to(env, &mut this, &mut plugins))?;
+        compiler_scoped_filename_tsfn_manager.scope(|| {
+          compiler_scoped_tsfn_manager.scope(|| bp.append_to(env, &mut this, &mut plugins))
+        })?;
       }
 
       let pnp = options.resolve.pnp.unwrap_or(false);
@@ -413,6 +424,7 @@ impl JsCompiler {
       Ok(Self {
         infrastructure_log_dispatcher,
         compiler_scoped_tsfn_manager,
+        compiler_scoped_filename_tsfn_manager,
         compiler: ManuallyDrop::new(Compiler::from(rspack)),
         state: CompilerState::init(),
         js_hooks_plugin,
@@ -524,11 +536,13 @@ impl JsCompiler {
     });
     let Ok(mut promise) = spawn_future_result else {
       self.compiler_scoped_tsfn_manager.release();
+      self.compiler_scoped_filename_tsfn_manager.release();
       drop(reference);
       return spawn_future_result;
     };
     promise.finally(|_env| {
       self.compiler_scoped_tsfn_manager.release();
+      self.compiler_scoped_filename_tsfn_manager.release();
       drop(reference);
       Ok(())
     })
@@ -551,6 +565,13 @@ impl JsCompiler {
 struct RunGuard {
   _compiler_state_guard: CompilerStateGuard,
   _reference: Reference<JsCompiler>,
+  filename_tsfn_manager: CompilerScopedFilenameTsFnManager,
+}
+
+impl Drop for RunGuard {
+  fn drop(&mut self) {
+    self.filename_tsfn_manager.sweep();
+  }
 }
 
 impl JsCompiler {
@@ -587,6 +608,7 @@ impl JsCompiler {
     let guard = RunGuard {
       _compiler_state_guard: compiler_state_guard,
       _reference: reference,
+      filename_tsfn_manager: self.compiler_scoped_filename_tsfn_manager.clone(),
     };
 
     self.cleanup_last_compilation(&compiler.compilation);

--- a/crates/rspack_binding_api/src/runtime.rs
+++ b/crates/rspack_binding_api/src/runtime.rs
@@ -147,7 +147,7 @@ impl JsLinkPrefetchData {
 
 impl From<RuntimeModuleChunkWrapper> for ChunkWrapper {
   fn from(value: RuntimeModuleChunkWrapper) -> Self {
-    ChunkWrapper::new_by_id(value.chunk_ukey, value.compilation_id)
+    ChunkWrapper::new_by_id(value.chunk_ukey, value.compiler_id, value.compilation_id)
   }
 }
 

--- a/crates/rspack_plugin_runtime/src/drive.rs
+++ b/crates/rspack_plugin_runtime/src/drive.rs
@@ -1,4 +1,4 @@
-use rspack_core::{Chunk, ChunkUkey, Compilation, CompilationId};
+use rspack_core::{Chunk, ChunkUkey, Compilation, CompilationId, CompilerId};
 use rspack_hook::define_hook;
 #[cfg(allocative)]
 use rspack_util::allocative;
@@ -30,6 +30,7 @@ pub struct LinkPrefetchData<'a> {
 #[derive(Debug, Clone)]
 pub struct RuntimeModuleChunkWrapper {
   pub chunk_ukey: ChunkUkey,
+  pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,
 }
 

--- a/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs
@@ -132,6 +132,7 @@ impl RuntimeModule for LoadScriptRuntimeModule {
         code: create_script_code,
         chunk: RuntimeModuleChunkWrapper {
           chunk_ukey,
+          compiler_id: compilation.compiler_id(),
           compilation_id: compilation.id(),
         },
       })

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/add-entry.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/add-entry.js
@@ -1,0 +1,1 @@
+module.exports = 'add-entry';

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/add-include.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/add-include.js
@@ -1,0 +1,1 @@
+module.exports = 'add-include';

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/async.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/async.js
@@ -1,0 +1,2 @@
+require('./shared');
+module.exports = 'async';

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/index.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/index.js
@@ -1,0 +1,6 @@
+require('./shared');
+
+it('should execute chunks whose filename templates are functions', async () => {
+	const result = await import(/* webpackChunkName: "async" */ './async');
+	expect(result.default).toBe('async');
+});

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/rspack.config.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/rspack.config.js
@@ -1,0 +1,103 @@
+const path = require('path');
+
+const entryFilename = () => 'entry-[name].js';
+const sharedFilename = () => 'shared-[name].js';
+const addEntryFilename = () => 'add-entry-[name].js';
+const addIncludeFilename = () => 'add-include-[name].js';
+
+const pluginName = 'chunk-filename-template-function';
+
+class Plugin {
+  apply(compiler) {
+    const { EntryPlugin } = compiler.rspack;
+    const addEntryDependency = EntryPlugin.createDependency(
+      path.resolve(__dirname, './add-entry.js'),
+    );
+    const addIncludeDependency = EntryPlugin.createDependency(
+      path.resolve(__dirname, './add-include.js'),
+    );
+
+    compiler.hooks.make.tapPromise(
+      pluginName,
+      (compilation) =>
+        new Promise((resolve, reject) => {
+          compilation.addEntry(
+            compiler.context,
+            addEntryDependency,
+            {
+              name: 'add-entry',
+              filename: addEntryFilename,
+            },
+            (error) => (error ? reject(error) : resolve()),
+          );
+        }),
+    );
+    compiler.hooks.finishMake.tapPromise(
+      pluginName,
+      (compilation) =>
+        new Promise((resolve, reject) => {
+          compilation.addInclude(
+            compiler.context,
+            addIncludeDependency,
+            {
+              name: 'add-include',
+              filename: addIncludeFilename,
+            },
+            (error) => (error ? reject(error) : resolve()),
+          );
+        }),
+    );
+
+    let checked = false;
+    compiler.hooks.compilation.tap(pluginName, (compilation) => {
+      compilation.hooks.afterSeal.tap(pluginName, () => {
+        const chunks = Object.fromEntries(
+          [...compilation.chunks].map((chunk) => [chunk.name, chunk]),
+        );
+
+        expect(chunks.main.filenameTemplate).toBe(entryFilename);
+        expect(chunks.shared.filenameTemplate).toBe(sharedFilename);
+        expect(chunks['add-entry'].filenameTemplate).toBe(addEntryFilename);
+        expect(chunks['add-include'].filenameTemplate).toBe(addIncludeFilename);
+        expect(chunks.async.filenameTemplate).toBeUndefined();
+
+        checked = true;
+      });
+    });
+    compiler.hooks.done.tap(pluginName, (stats) => {
+      expect(stats.toJson().errors).toHaveLength(0);
+      expect(checked).toBe(true);
+    });
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  context: __dirname,
+  mode: 'development',
+  target: 'node',
+  entry: {
+    main: {
+      import: './index.js',
+      filename: entryFilename,
+    },
+  },
+  output: {
+    chunkFilename: 'async-[name].js',
+  },
+  optimization: {
+    chunkIds: 'named',
+    splitChunks: {
+      cacheGroups: {
+        shared: {
+          chunks: 'all',
+          test: /shared/,
+          name: 'shared',
+          filename: sharedFilename,
+          enforce: true,
+        },
+      },
+    },
+  },
+  plugins: [new Plugin()],
+};

--- a/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/shared.js
+++ b/tests/rspack-test/configCases/filename-template/chunk-filename-template-function/shared.js
@@ -1,0 +1,1 @@
+module.exports = 'shared';

--- a/website/docs/en/types/chunk.mdx
+++ b/website/docs/en/types/chunk.mdx
@@ -7,7 +7,7 @@ type Chunk = {
   chunkReason?: Readonly<string>;
   contentHash: Readonly<Record<string, string>>;
   cssFilenameTemplate?: Readonly<string>;
-  filenameTemplate?: Readonly<string>;
+  filenameTemplate?: Filename;
   files: ReadonlySet<string>;
   getAllAsyncChunks(): Iterable<Chunk>;
   getAllInitialChunks(): Iterable<Chunk>;

--- a/website/docs/zh/types/chunk.mdx
+++ b/website/docs/zh/types/chunk.mdx
@@ -7,7 +7,7 @@ type Chunk = {
   chunkReason?: Readonly<string>;
   contentHash: Readonly<Record<string, string>>;
   cssFilenameTemplate?: Readonly<string>;
-  filenameTemplate?: Readonly<string>;
+  filenameTemplate?: Filename;
   files: ReadonlySet<string>;
   getAllAsyncChunks(): Iterable<Chunk>;
   getAllInitialChunks(): Iterable<Chunk>;


### PR DESCRIPTION
## Summary

<!-- Describe what this PR does and why. -->

- Return the original JavaScript filename function from `Chunk.filenameTemplate` while preserving existing string and `undefined` behavior.
- Track filename function references per compiler with weak Rust ownership, cleaning up expired references after compilation and releasing them when the compiler closes.
- Support filename functions originating from entry options, split chunks, `addEntry`, and `addInclude`, with updated types, documentation, and integration coverage.

## Related links

<!-- Related issues or discussions. -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
