### PR TITLE
refactor(core): remove BuildInfo clone

### DIFF
--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TempModule {
   id: ModuleIdentifier,
   build_info: BuildInfo,
@@ -29,7 +29,10 @@ impl TempModule {
     let m = module.as_ref();
     OwnedOrRef::Owned(BoxModule::new(Box::new(Self {
       id: m.identifier(),
-      build_info: m.build_info().clone(),
+      build_info: BuildInfo {
+        dependencies: m.build_info().dependencies.clone(),
+        ..Default::default()
+      },
       build_meta: m.build_meta().clone(),
       dependencies: m.get_dependencies().to_vec(),
       // clean all of blocks

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -260,7 +260,7 @@ pub struct AssetBuildInfo {
 }
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BuildInfo {
   /// Whether the result is cacheable, i.e shared between builds.
   pub cacheable: bool,

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 pub use rspack_core::legacy_cache::persistent::occasion::make::SCOPE;
 use rspack_core::{
-  DependencyId,
+  BuildInfo, DependencyId,
   build_module_graph::BuildModuleGraphArtifact,
   cache::CacheCodec,
   legacy_cache::persistent::{
@@ -226,8 +226,8 @@ impl<'a> ArtifactComparator<'a> {
   }
 
   /// Compare module's BuildInfo using DependencyId mapping
-  /// We take an extreme approach: clone the BuildInfo, extract all_star_exports connections,
-  /// and serialize the rest for direct comparison.
+  /// We take an extreme approach: extract all_star_exports connections and serialize the rest for
+  /// direct comparison.
   fn compare_module_build_info(
     &self,
     module1: &rspack_core::BoxModule,
@@ -246,19 +246,19 @@ impl<'a> ArtifactComparator<'a> {
       debug_info,
     )?;
 
-    // Clone BuildInfo and clear all_star_exports for serialization comparison
-    let mut normalized_info1 = build_info1.clone();
-    let mut normalized_info2 = build_info2.clone();
-    normalized_info1.all_star_exports.clear();
-    normalized_info2.all_star_exports.clear();
-
     // Serialize and compare the rest of BuildInfo using rspack_cacheable
     let ctx = ();
-    let bytes1 = rspack_cacheable::to_bytes(&normalized_info1, &ctx).map_err(|e| {
-      rspack_error::error!("Failed to serialize BuildInfo 1: {:?}\n{}", e, debug_info)
+    let normalize = |build_info: &BuildInfo| -> rspack_cacheable::Result<Vec<u8>> {
+      let bytes = rspack_cacheable::to_bytes(build_info, &ctx)?;
+      let mut normalized: BuildInfo = rspack_cacheable::from_bytes(&bytes, &ctx)?;
+      normalized.all_star_exports.clear();
+      rspack_cacheable::to_bytes(&normalized, &ctx)
+    };
+    let bytes1 = normalize(build_info1).map_err(|e| {
+      rspack_error::error!("Failed to normalize BuildInfo 1: {:?}\n{}", e, debug_info)
     })?;
-    let bytes2 = rspack_cacheable::to_bytes(&normalized_info2, &ctx).map_err(|e| {
-      rspack_error::error!("Failed to serialize BuildInfo 2: {:?}\n{}", e, debug_info)
+    let bytes2 = normalize(build_info2).map_err(|e| {
+      rspack_error::error!("Failed to normalize BuildInfo 2: {:?}\n{}", e, debug_info)
     })?;
 
     if bytes1 != bytes2 {


### PR DESCRIPTION
## Summary

Remove `Clone` from `BuildInfo`. Keep only loader dependencies when creating `TempModule`, and normalize build info comparisons through cacheable serialization.

## Related links

N/A

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).