### PR TITLE
fix(types): support all EnvironmentPlugin default values

### DIFF
--- a/packages/rspack/src/lib/EnvironmentPlugin.ts
+++ b/packages/rspack/src/lib/EnvironmentPlugin.ts
@@ -17,18 +17,15 @@ type CodeValue = any;
 
 class EnvironmentPlugin {
   keys: string[];
-  defaultValues: Record<string, string | undefined | null>;
+  defaultValues: Record<string, any>;
 
-  constructor(
-    ...keys:
-      string[] | [Record<string, string | undefined | null> | string | string[]]
-  ) {
+  constructor(...keys: string[] | [Record<string, any> | string | string[]]) {
     if (keys.length === 1 && Array.isArray(keys[0])) {
       this.keys = keys[0];
       this.defaultValues = {};
     } else if (keys.length === 1 && keys[0] && typeof keys[0] === 'object') {
       this.keys = Object.keys(keys[0]);
-      this.defaultValues = keys[0] as Record<string, string | undefined | null>;
+      this.defaultValues = keys[0] as Record<string, any>;
     } else {
       this.keys = keys as string[];
       this.defaultValues = {};

--- a/website/docs/en/plugins/environment-plugin.mdx
+++ b/website/docs/en/plugins/environment-plugin.mdx
@@ -1,24 +1,26 @@
 ---
-description: 'The EnvironmentPlugin is shorthand for using the DefinePlugin on process.env keys'
+description: 'Use EnvironmentPlugin to expose selected process.env values to bundled code with optional defaults'
 ---
 
 import Attribution from '@components/Attribution';
 
 # EnvironmentPlugin
 
-The `EnvironmentPlugin` is shorthand for using the [`DefinePlugin`](/plugins/define-plugin) on [`process.env`](https://nodejs.org/api/process.html#process_process_env) keys.
+`EnvironmentPlugin` is shorthand for defining selected [`process.env`](https://nodejs.org/api/process.html#process_process_env) values with [`DefinePlugin`](/plugins/define-plugin). It reads environment variables when Rspack builds and replaces the corresponding `process.env.*` expressions in your bundled code.
 
 ## Examples
 
-### Basic use case
+### Basic usage
 
-The `EnvironmentPlugin` accepts either an array of keys or an object mapping its keys to their default values.
+Pass environment variable names as separate arguments or as an array. The following calls are equivalent:
 
 ```js
+new rspack.EnvironmentPlugin('NODE_ENV', 'DEBUG');
+
 new rspack.EnvironmentPlugin(['NODE_ENV', 'DEBUG']);
 ```
 
-This is equivalent to the following `DefinePlugin` application:
+Both configurations create definitions equivalent to:
 
 ```js
 new rspack.DefinePlugin({
@@ -27,38 +29,24 @@ new rspack.DefinePlugin({
 });
 ```
 
-:::tip
-Not specifying the environment variable raises an "`EnvironmentPlugin` - `${key}` environment variable is undefined" error.
-:::
+If a requested variable is missing and has no default value, compilation fails with an `EnvVariableNotDefinedError`.
 
-### Usage with default values
+### Using default values
 
-Alternatively, the `EnvironmentPlugin` supports an object, which maps keys to their default values. The default value for a key is taken if the key is undefined in `process.env`.
+Pass an object to provide a default value for each variable. A default is used only when the corresponding key is `undefined` in `process.env` when the build starts.
 
 ```js
 new rspack.EnvironmentPlugin({
-  NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
+  NODE_ENV: 'development',
   DEBUG: false,
 });
 ```
 
-:::warning
-Variables coming from `process.env` are always strings.
-:::
+`EnvironmentPlugin` serializes default values with `JSON.stringify` before passing them to `DefinePlugin`. As a result, JSON-compatible defaults preserve their types: the `false` default above is injected as a boolean rather than a string.
 
-:::tip
-Unlike [`DefinePlugin`](/plugins/define-plugin), default values are applied to `JSON.stringify` by the `EnvironmentPlugin`.
-:::
+Use `undefined` for a variable that must be provided during the build. If it is missing, compilation fails. Use `null` to provide an optional variable with a `null` fallback.
 
-:::tip
-Default values of `null` and `undefined` behave differently. Use `undefined` for variables that must be provided during bundling, or `null` if they are optional.
-:::
-
-:::warning
-If an environment variable is not found during bundling and no default value was provided, Rspack will throw an error instead of a warning.
-:::
-
-Let's investigate the result when running the previous `EnvironmentPlugin` configuration on a test file `entry.js`:
+For example, suppose `entry.js` contains:
 
 ```js
 if (process.env.NODE_ENV === 'production') {
@@ -69,69 +57,84 @@ if (process.env.DEBUG) {
 }
 ```
 
-When executing `NODE_ENV=production` Rspack in the terminal to build, `entry.js` becomes this:
+If `NODE_ENV=production` is set for the build and `DEBUG` is unset, the replacements are equivalent to:
 
 ```js
 if ('production' === 'production') {
-  // <-- 'production' from NODE_ENV is taken
+  // process.env.NODE_ENV comes from the environment
   console.log('Welcome to production');
 }
 if (false) {
-  // <-- default value is taken
+  // process.env.DEBUG uses the default value
   console.log('Debugging output');
 }
 ```
 
-Running `DEBUG=false` Rspack yields:
+If `DEBUG=false` is set and `NODE_ENV` is unset, the replacements are equivalent to:
 
 ```js
 if ('development' === 'production') {
-  // <-- default value is taken
+  // process.env.NODE_ENV uses the default value
   console.log('Welcome to production');
 }
 if ('false') {
-  // <-- 'false' from DEBUG is taken
+  // process.env.DEBUG comes from the environment
   console.log('Debugging output');
 }
 ```
 
-### Git version
+:::tip
+Environment variables read from `process.env` are always strings. Setting `DEBUG=false` injects the string `'false'`, not the boolean `false`.
+:::
 
-The following `EnvironmentPlugin` configuration provides `process.env.GIT_VERSION` (such as "v5.4.0-2-g25139f57f") and `process.env.GIT_AUTHOR_DATE` (such as "2020-11-04T12:25:16+01:00") corresponding to the last Git commit of the repository:
+### Using Git metadata
+
+Default values can also be computed while loading the Rspack configuration. This example exposes the version and author date of the current Git commit:
 
 ```js
-import child_process from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
-function git(command) {
-  return child_process.execSync(`git ${command}`, { encoding: 'utf8' }).trim();
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
 new rspack.EnvironmentPlugin({
-  GIT_VERSION: git('describe --always'),
-  GIT_AUTHOR_DATE: git('log -1 --format=%aI'),
+  GIT_VERSION: git('describe', '--always'),
+  GIT_AUTHOR_DATE: git('log', '-1', '--format=%aI'),
 });
 ```
 
-### DotenvPlugin
+### Loading `.env` files
 
-The third-party [`DotenvPlugin`](https://github.com/mrsteele/dotenv-webpack) (`dotenv-webpack`) allows you to expose (a subset of) [dotenv variables](https://www.npmjs.com/package/dotenv):
+`EnvironmentPlugin` does not read `.env` files by itself. To load variables from a file, use a third-party plugin such as [`dotenv-webpack`](https://github.com/mrsteele/dotenv-webpack):
 
-```js
-// .env
-DB_HOST=127.0.0.1
-DB_PASS=foobar
-S3_API=mysecretkey
+```text title=".env"
+PUBLIC_API_ORIGIN=https://api.example.com
+FEATURE_ENABLED=true
 ```
 
 ```js
+import Dotenv from 'dotenv-webpack';
+
 new Dotenv({
-  path: './.env', // Path to .env file (this is the default)
-  safe: true, // load .env.example (defaults to "false" which does not use dotenv-safe)
+  path: './.env',
 });
 ```
+
+Only load values that are safe to embed in client-side code, because injected values can be read from the generated bundle.
 
 ## Options
 
-- **Type:** `string[] | Record<string, string>`
+- **Type:**
+
+```ts
+declare class EnvironmentPlugin {
+  constructor(...keys: string[]);
+  constructor(keys: string[]);
+  constructor(defaultValues: Record<string, any>);
+}
+```
+
+Use either string form when every selected variable is required. Use the object form to provide default values; assigning `undefined` still marks that variable as required.
 
 <Attribution url="https://webpack.js.org/plugins/environment-plugin/" />

--- a/website/docs/zh/plugins/environment-plugin.mdx
+++ b/website/docs/zh/plugins/environment-plugin.mdx
@@ -135,6 +135,6 @@ declare class EnvironmentPlugin {
 }
 ```
 
-当所有变量都必须提供时，可以使用任一字符串形式；需要设置默认值时，请使用对象形式。对象中的值即使设置为 `undefined`，对应变量仍然是必需的。
+如果所有环境变量都必须在构建时提供，可以逐个传入变量名，也可以传入字符串数组。如果需要设置默认值，请使用对象形式；将某个值设置为 `undefined` 表示不提供默认值，因此对应的环境变量在构建时仍是必需的。
 
 <Attribution url="https://webpack.docschina.org/plugins/environment-plugin/" />

--- a/website/docs/zh/plugins/environment-plugin.mdx
+++ b/website/docs/zh/plugins/environment-plugin.mdx
@@ -1,24 +1,26 @@
 ---
-description: 'EnvironmentPlugin 简化了使用 DefinePlugin 设置 process.env 变量的过程。'
+description: '使用 EnvironmentPlugin 将指定的 process.env 变量注入打包代码，并为其设置可选的默认值。'
 ---
 
 import Attribution from '@components/Attribution';
 
 # EnvironmentPlugin
 
-`EnvironmentPlugin` 简化了使用 [`DefinePlugin`](/plugins/define-plugin) 设置 `process.env` 变量的过程。
+`EnvironmentPlugin` 是通过 [`DefinePlugin`](/plugins/define-plugin) 定义指定 [`process.env`](https://nodejs.org/api/process.html#process_process_env) 变量的简写。它会在 Rspack 执行构建时读取环境变量，并替换打包代码中对应的 `process.env.*` 表达式。
 
 ## 示例
 
 ### 基本使用
 
-`EnvironmentPlugin` 接受一个包含键的数组或者一个键到其默认值的对象映射。
+可以将环境变量名作为多个参数传入，也可以传入一个字符串数组。以下两种写法等价：
 
 ```js
+new rspack.EnvironmentPlugin('NODE_ENV', 'DEBUG');
+
 new rspack.EnvironmentPlugin(['NODE_ENV', 'DEBUG']);
 ```
 
-这等同于以下 `DefinePlugin` 的使用方式：
+这两种写法都等同于以下 `DefinePlugin` 配置：
 
 ```js
 new rspack.DefinePlugin({
@@ -27,38 +29,24 @@ new rspack.DefinePlugin({
 });
 ```
 
-:::tip 提示
-如果没有指定环境变量，将会抛出“`EnvironmentPlugin` - `${key}` environment variable is undefined”错误。
-:::
+如果指定的变量不存在且未提供默认值，编译会失败并报告 `EnvVariableNotDefinedError`。
 
-### 带有默认值的使用
+### 使用默认值
 
-作为替代，`EnvironmentPlugin` 支持一个映射键到其默认值的对象。如果在 `process.env` 中某个键未定义，则采用该键的默认值。
+传入对象可以为每个环境变量设置默认值。只有在构建开始时对应的 `process.env` 变量为 `undefined`，默认值才会生效。
 
 ```js
 new rspack.EnvironmentPlugin({
-  NODE_ENV: 'development', // 除非定义了 process.env.NODE_ENV，否则使用 'development'
+  NODE_ENV: 'development',
   DEBUG: false,
 });
 ```
 
-:::warning 警告
-从 `process.env` 来的变量总是字符串。
-:::
+`EnvironmentPlugin` 会先使用 `JSON.stringify` 序列化默认值，再将其传给 `DefinePlugin`。因此，与 JSON 兼容的默认值会保留自身类型：上述 `false` 会作为布尔值而不是字符串注入。
 
-:::tip 提示
-与 [`DefinePlugin`](/plugins/define-plugin) 不同，`EnvironmentPlugin` 会对默认值使用 `JSON.stringify`。
-:::
+如果变量必须在构建时提供，请将默认值设置为 `undefined`；缺少该变量会导致编译失败。如果变量是可选的，可以使用 `null` 作为后备值。
 
-:::tip 提示
-`null` 和 `undefined` 的默认值有不同的表现。如果变量在打包时必须提供，则使用 `undefined`；如果它们是可选的，则使用 `null`。
-:::
-
-:::warning 警告
-如果在打包过程中找不到环境变量，并且没有提供默认值，Rspack 将抛出错误而不是警告。
-:::
-
-让我们来看看在 test 文件 `entry.js` 上运行前述 `EnvironmentPlugin` 配置的结果：
+例如，假设 `entry.js` 包含以下代码：
 
 ```js
 if (process.env.NODE_ENV === 'production') {
@@ -69,69 +57,84 @@ if (process.env.DEBUG) {
 }
 ```
 
-当在终端执行 `NODE_ENV=production` Rspack 构建时，`entry.js` 变成了这样：
+如果构建时设置了 `NODE_ENV=production`，但没有设置 `DEBUG`，替换结果等同于：
 
 ```js
 if ('production' === 'production') {
-  // <-- 取自 NODE_ENV 的 'production'
+  // process.env.NODE_ENV 取自环境变量
   console.log('Welcome to production');
 }
 if (false) {
-  // <-- 取默认值
+  // process.env.DEBUG 使用默认值
   console.log('Debugging output');
 }
 ```
 
-运行 `DEBUG=false` Rspack 产生：
+如果设置了 `DEBUG=false`，但没有设置 `NODE_ENV`，替换结果等同于：
 
 ```js
 if ('development' === 'production') {
-  // <-- 取默认值
+  // process.env.NODE_ENV 使用默认值
   console.log('Welcome to production');
 }
 if ('false') {
-  // <-- 取自 DEBUG 的 'false'
+  // process.env.DEBUG 取自环境变量
   console.log('Debugging output');
 }
 ```
 
-### Git 版本
+:::tip 提示
+从 `process.env` 读取的环境变量值始终是字符串。即使设置了 `DEBUG=false`，注入代码的仍是字符串 `'false'`，而不是布尔值 `false`。
+:::
 
-下面的 `EnvironmentPlugin` 配置提供了对应于仓库最后一次 Git 提交的 `process.env.GIT_VERSION`（例如 "v5.4.0-2-g25139f57f"）和 `process.env.GIT_AUTHOR_DATE`（例如 "2020-11-04T12:25:16+01:00"）：
+### 使用 Git 元数据
+
+默认值也可以在加载 Rspack 配置时动态计算。以下示例会注入当前 Git 提交的版本和作者日期：
 
 ```js
-import child_process from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
-function git(command) {
-  return child_process.execSync(`git ${command}`, { encoding: 'utf8' }).trim();
+function git(...args) {
+  return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
 new rspack.EnvironmentPlugin({
-  GIT_VERSION: git('describe --always'),
-  GIT_AUTHOR_DATE: git('log -1 --format=%aI'),
+  GIT_VERSION: git('describe', '--always'),
+  GIT_AUTHOR_DATE: git('log', '-1', '--format=%aI'),
 });
 ```
 
-### DotenvPlugin
+### 加载 `.env` 文件
 
-第三方 [`DotenvPlugin`](https://github.com/mrsteele/dotenv-webpack)（`dotenv-webpack`）允许你暴露一部分 [dotenv 变量](https://www.npmjs.com/package/dotenv)：
+`EnvironmentPlugin` 本身不会读取 `.env` 文件。若要从文件中加载变量，可以使用 [`dotenv-webpack`](https://github.com/mrsteele/dotenv-webpack) 等第三方插件：
 
-```js
-// .env
-DB_HOST=127.0.0.1
-DB_PASS=foobar
-S3_API=mysecretkey
+```text title=".env"
+PUBLIC_API_ORIGIN=https://api.example.com
+FEATURE_ENABLED=true
 ```
 
 ```js
+import Dotenv from 'dotenv-webpack';
+
 new Dotenv({
-  path: './.env', // Path to .env file (this is the default)
-  safe: true, // load .env.example (defaults to "false" which does not use dotenv-safe)
+  path: './.env',
 });
 ```
+
+只应加载可以安全嵌入客户端代码的值，因为注入的内容可以从生成的产物中读取。
 
 ## 选项
 
-- **类型：** `string[] | Record<string, string>`
+- **类型：**
+
+```ts
+declare class EnvironmentPlugin {
+  constructor(...keys: string[]);
+  constructor(keys: string[]);
+  constructor(defaultValues: Record<string, any>);
+}
+```
+
+当所有变量都必须提供时，可以使用任一字符串形式；需要设置默认值时，请使用对象形式。对象中的值即使设置为 `undefined`，对应变量仍然是必需的。
 
 <Attribution url="https://webpack.docschina.org/plugins/environment-plugin/" />

--- a/website/docs/zh/plugins/environment-plugin.mdx
+++ b/website/docs/zh/plugins/environment-plugin.mdx
@@ -6,7 +6,7 @@ import Attribution from '@components/Attribution';
 
 # EnvironmentPlugin
 
-`EnvironmentPlugin` 是通过 [`DefinePlugin`](/plugins/define-plugin) 定义指定 [`process.env`](https://nodejs.org/api/process.html#process_process_env) 变量的简写。它会在 Rspack 执行构建时读取环境变量，并替换打包代码中对应的 `process.env.*` 表达式。
+`EnvironmentPlugin` 是通过 [`DefinePlugin`](/plugins/define-plugin) 定义指定 [`process.env`](https://nodejs.org/api/process.html#process_process_env) 变量的简写。它会在 Rspack 创建编译器并应用插件时，从当前 Node.js 进程的 `process.env` 中读取指定变量。读取结果会作为常量写入打包产物，应用运行时不会再次读取这些环境变量。
 
 ## 示例
 
@@ -33,7 +33,7 @@ new rspack.DefinePlugin({
 
 ### 使用默认值
 
-传入对象可以为每个环境变量设置默认值。只有在构建开始时对应的 `process.env` 变量为 `undefined`，默认值才会生效。
+传入对象可以为每个环境变量设置默认值。读取变量时，如果当前 Node.js 进程的 `process.env` 中不存在对应变量，则使用对象中提供的默认值。
 
 ```js
 new rspack.EnvironmentPlugin({
@@ -44,7 +44,9 @@ new rspack.EnvironmentPlugin({
 
 `EnvironmentPlugin` 会先使用 `JSON.stringify` 序列化默认值，再将其传给 `DefinePlugin`。因此，与 JSON 兼容的默认值会保留自身类型：上述 `false` 会作为布尔值而不是字符串注入。
 
-如果变量必须在构建时提供，请将默认值设置为 `undefined`；缺少该变量会导致编译失败。如果变量是可选的，可以使用 `null` 作为后备值。
+将默认值设置为 `undefined` 表示该变量是必需的，缺少该变量会导致编译失败。如果变量是可选的，可以使用 `null` 作为后备值。
+
+使用 CLI 时，应在启动 Rspack 命令前设置环境变量；使用 Node.js API 时，应在调用 `rspack(options)` 前设置。编译器创建后再修改 `process.env`，不会更新 `EnvironmentPlugin` 已生成的定义。
 
 例如，假设 `entry.js` 包含以下代码：
 
@@ -57,7 +59,7 @@ if (process.env.DEBUG) {
 }
 ```
 
-如果构建时设置了 `NODE_ENV=production`，但没有设置 `DEBUG`，替换结果等同于：
+`EnvironmentPlugin` 读取变量时，如果 `process.env.NODE_ENV` 为 `'production'`，而 `process.env.DEBUG` 为 `undefined`，替换结果等同于：
 
 ```js
 if ('production' === 'production') {
@@ -70,7 +72,7 @@ if (false) {
 }
 ```
 
-如果设置了 `DEBUG=false`，但没有设置 `NODE_ENV`，替换结果等同于：
+`EnvironmentPlugin` 读取变量时，如果 `process.env.DEBUG` 为 `'false'`，而 `process.env.NODE_ENV` 为 `undefined`，替换结果等同于：
 
 ```js
 if ('development' === 'production') {
@@ -84,7 +86,7 @@ if ('false') {
 ```
 
 :::tip 提示
-从 `process.env` 读取的环境变量值始终是字符串。即使设置了 `DEBUG=false`，注入代码的仍是字符串 `'false'`，而不是布尔值 `false`。
+`EnvironmentPlugin` 从 `process.env` 读取到的环境变量值始终是字符串。即使将 `DEBUG` 设置为 `false`，注入代码的仍是字符串 `'false'`，而不是布尔值 `false`。
 :::
 
 ### 使用 Git 元数据
@@ -135,6 +137,8 @@ declare class EnvironmentPlugin {
 }
 ```
 
-如果所有环境变量都必须在构建时提供，可以逐个传入变量名，也可以传入字符串数组。如果需要设置默认值，请使用对象形式；将某个值设置为 `undefined` 表示不提供默认值，因此对应的环境变量在构建时仍是必需的。
+如果不需要为任何变量设置默认值，可以逐个传入变量名，也可以传入字符串数组。`EnvironmentPlugin` 读取变量时，`process.env` 中缺少任意指定变量都会导致编译失败。
+
+如果需要设置默认值，请使用对象形式。对象中的值为 `undefined` 同样表示不提供默认值，因此对应变量仍必须存在于 `process.env` 中。
 
 <Attribution url="https://webpack.docschina.org/plugins/environment-plugin/" />


### PR DESCRIPTION
## Summary

`EnvironmentPlugin` currently rejects non-string default values in TypeScript even though its runtime supports them. This PR changes the object-form default-value type to `Record<string, any>`, aligning Rspack with webpack's public `EnvironmentPlugin` type.

It also rewrites the documentation to clearly explain the supported constructor forms, default-value behavior, and environment-value serialization.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).