### PR TITLE
perf: share runtimes in flag dependency usage

### DIFF
--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -1,4 +1,7 @@
-use std::collections::{VecDeque, hash_map::Entry};
+use std::{
+  collections::{VecDeque, hash_map::Entry},
+  sync::Arc,
+};
 
 use rayon::prelude::*;
 use rspack_collections::IdentifierMap;
@@ -16,8 +19,9 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_util::queue::Queue;
 use rustc_hash::FxHashMap as HashMap;
 
-type ProcessBlockTask = (ModuleOrAsyncDependenciesBlock, Option<RuntimeSpec>, bool);
-type NonNestedTask = (Option<RuntimeSpec>, bool, Vec<ReferencedExport>);
+type SharedRuntimeSpec = Option<Arc<RuntimeSpec>>;
+type ProcessBlockTask = (ModuleOrAsyncDependenciesBlock, SharedRuntimeSpec, bool);
+type NonNestedTask = (SharedRuntimeSpec, bool, Vec<ReferencedExport>);
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 enum ModuleOrAsyncDependenciesBlock {
@@ -96,9 +100,13 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       let runtime = if self.global {
         None
       } else {
-        Some(get_entry_runtime(entry_name, &entry.options, entries))
+        Some(Arc::new(get_entry_runtime(
+          entry_name,
+          &entry.options,
+          entries,
+        )))
       };
-      if let Some(runtime) = runtime.as_ref() {
+      if let Some(runtime) = runtime.as_deref() {
         global_runtime.get_or_insert_default().extend(runtime);
       }
       for &dep in entry.dependencies.iter() {
@@ -108,6 +116,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         self.process_entry_dependency(dep, runtime.clone(), &side_effects_state_artifact, &mut q);
       }
     }
+    let global_runtime = global_runtime.map(Arc::new);
     for dep in self.compilation.global_entry.dependencies.clone() {
       self.process_entry_dependency(
         dep,
@@ -144,7 +153,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             module_graph,
             &side_effects_state_artifact,
             block_id,
-            runtime.as_ref(),
+            &runtime,
             force_side_effects,
             self.global,
           );
@@ -303,7 +312,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     module_graph: &ModuleGraph,
     side_effects_state_artifact: &SideEffectsStateArtifact,
     block_id: ModuleOrAsyncDependenciesBlock,
-    runtime: Option<&RuntimeSpec>,
+    runtime: &SharedRuntimeSpec,
     force_side_effects: bool,
     global: bool,
   ) -> (
@@ -332,7 +341,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         module_graph,
         &compilation.module_graph_cache_artifact,
         self.exports_info_artifact,
-        runtime,
+        runtime.as_deref(),
       );
 
       compilation
@@ -343,7 +352,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
           compilation,
           &dep_id,
           &referenced_exports_result,
-          runtime,
+          runtime.as_deref(),
           Some(module_graph),
         );
 
@@ -396,7 +405,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
   fn process_entry_dependency(
     &mut self,
     dep: DependencyId,
-    runtime: Option<RuntimeSpec>,
+    runtime: SharedRuntimeSpec,
     side_effects_state_artifact: &SideEffectsStateArtifact,
     queue: &mut Queue<ProcessBlockTask>,
   ) {
@@ -428,7 +437,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
     mgm_exports_info: ExportsInfo,
     module_id: ModuleIdentifier,
     used_exports: Vec<ReferencedExport>,
-    runtime: Option<RuntimeSpec>,
+    runtime: SharedRuntimeSpec,
     force_side_effects: bool,
     side_effects_state_artifact: &SideEffectsStateArtifact,
   ) -> Vec<ProcessBlockTask> {
@@ -446,7 +455,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       if need_insert {
         let flag = mgm_exports_info
           .as_data_mut(self.exports_info_artifact)
-          .set_used_without_info(runtime.as_ref());
+          .set_used_without_info(runtime.as_deref());
         if flag {
           queue.push((
             ModuleOrAsyncDependenciesBlock::Module(module_id),
@@ -465,7 +474,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
         if used_exports.is_empty() {
           let flag = mgm_exports_info
             .as_data_mut(self.exports_info_artifact)
-            .set_used_in_unknown_way(runtime.as_ref());
+            .set_used_in_unknown_way(runtime.as_deref());
 
           if flag {
             queue.push((
@@ -504,7 +513,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               let changed_flag = export_info.set_used_conditionally(
                 |used| used == &UsageState::Unused,
                 UsageState::OnlyPropertiesUsed,
-                runtime.as_ref(),
+                runtime.as_deref(),
               );
               if changed_flag {
                 let current_module = if current_exports_info == mgm_exports_info {
@@ -530,7 +539,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
             let changed_flag = export_info.set_used_conditionally(
               |v| v != &UsageState::Used,
               UsageState::Used,
-              runtime.as_ref(),
+              runtime.as_deref(),
             );
             if changed_flag {
               let current_module = if current_exports_info == mgm_exports_info {
@@ -561,7 +570,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       }
       let changed_flag = mgm_exports_info
         .as_data_mut(self.exports_info_artifact)
-        .set_used_for_side_effects_only(runtime.as_ref());
+        .set_used_for_side_effects_only(runtime.as_deref());
       if changed_flag {
         queue.push((
           ModuleOrAsyncDependenciesBlock::Module(module_id),
@@ -662,7 +671,7 @@ fn merge_referenced_exports(
 
 fn collect_active_dependencies(
   block_id: ModuleOrAsyncDependenciesBlock,
-  runtime: Option<&RuntimeSpec>,
+  runtime: &SharedRuntimeSpec,
   module_graph: &ModuleGraph,
   module_graph_cache: &ModuleGraphCacheArtifact,
   side_effects_state_artifact: &SideEffectsStateArtifact,
@@ -673,6 +682,7 @@ fn collect_active_dependencies(
   let mut queue = VecDeque::new();
   let mut dependencies = vec![];
   queue.push_back(block_id);
+  let runtime_spec = runtime.as_deref();
   while let Some(block_id) = queue.pop_front() {
     let (blocks, block_dependencies) = match block_id {
       ModuleOrAsyncDependenciesBlock::Module(module) => {
@@ -694,7 +704,7 @@ fn collect_active_dependencies(
       };
       let active_state = connection.active_state(
         module_graph,
-        runtime,
+        runtime_spec,
         module_graph_cache,
         side_effects_state_artifact,
         exports_info_artifact,
@@ -707,7 +717,7 @@ fn collect_active_dependencies(
         ConnectionState::TransitiveOnly => {
           q.push((
             ModuleOrAsyncDependenciesBlock::Module(*connection.module_identifier()),
-            runtime.cloned(),
+            runtime.clone(),
             false,
           ));
           continue;
@@ -721,7 +731,7 @@ fn collect_active_dependencies(
         .block_by_id(block_id)
         .expect("should have block");
       if !global && let Some(GroupOptions::Entrypoint(options)) = block.get_group_options() {
-        let runtime = RuntimeSpec::from_entry_options(options);
+        let runtime = RuntimeSpec::from_entry_options(options).map(Arc::new);
         q.push((
           ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(*block_id),
           runtime,
@@ -767,13 +777,13 @@ fn process_referenced_module_without_nested(
   is_side_effect_free: bool,
   exports_info: &mut ExportsInfoData,
   used_exports: Vec<ReferencedExport>,
-  runtime: Option<RuntimeSpec>,
+  runtime: SharedRuntimeSpec,
   force_side_effects: bool,
 ) -> Vec<ProcessBlockTask> {
   let mut queue = vec![];
   if !used_exports.is_empty() {
     if is_exports_type_unset {
-      let flag = exports_info.set_used_without_info(runtime.as_ref());
+      let flag = exports_info.set_used_without_info(runtime.as_deref());
       if flag {
         queue.push((
           ModuleOrAsyncDependenciesBlock::Module(module_id),
@@ -790,7 +800,7 @@ fn process_referenced_module_without_nested(
       let ns_access = used_export_info.ns_access();
       let used_exports = used_export_info.name;
       if used_exports.is_empty() {
-        let flag = exports_info.set_used_in_unknown_way(runtime.as_ref());
+        let flag = exports_info.set_used_in_unknown_way(runtime.as_deref());
 
         if flag {
           queue.push((
@@ -821,7 +831,7 @@ fn process_referenced_module_without_nested(
         let changed_flag = export_info.set_used_conditionally(
           |v| v != &UsageState::Used,
           UsageState::Used,
-          runtime.as_ref(),
+          runtime.as_deref(),
         );
         if changed_flag {
           queue.push((
@@ -836,7 +846,7 @@ fn process_referenced_module_without_nested(
     if !force_side_effects && is_side_effect_free {
       return queue;
     }
-    let changed_flag = exports_info.set_used_for_side_effects_only(runtime.as_ref());
+    let changed_flag = exports_info.set_used_for_side_effects_only(runtime.as_deref());
     if changed_flag {
       queue.push((
         ModuleOrAsyncDependenciesBlock::Module(module_id),


### PR DESCRIPTION
## Summary

- store dependency-usage task runtimes as `Option<Arc<RuntimeSpec>>`
- share immutable runtime sets across queue fan-out instead of deeply cloning each `RuntimeSpec`
- keep existing downstream APIs unchanged by borrowing `&RuntimeSpec` from the shared value

In the frozen React 10k production stage benchmark, changing only the runtime task ownership reduced Valgrind instruction reads for `flag_dependency_usage` from 346,648,209 to 297,675,886 (-14.13%). Two candidate runs produced the same instruction count.

Benchmark environment: Docker `rspack-perf-valgrind:nightly-2026-04-16`, Valgrind 3.19.0.

## Related links

N/A

## Checklist

- [x] Tests updated (not required; behavior is unchanged).
- [x] Documentation updated (not required; no public API change).

## Validation

- `pnpm run build:binding:dev`
- `pnpm run build:js`
- `pnpm run test:unit` (46 files, 9,158 passed, 4 skipped)
- `cargo clippy -p rspack_plugin_javascript --all-targets --all-features --locked`
- `pnpm run format:rs`
- `git diff --check`
