### PR TITLE
docs: improve BannerPlugin option documentation

### DIFF
--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -45,7 +45,21 @@ The generated chunk begins with this comment:
 
 - **Required:** Yes, when using an options object
 
-Specifies the banner content. A function is called once for each selected chunk file and receives the compilation `hash`, current `chunk`, and emitted `filename`. By default, Rspack wraps the returned string in a comment. You can also pass the string or function directly to `BannerPlugin` instead of using an options object.
+#### String
+
+Pass a string to specify the banner content directly. By default, Rspack wraps the string in a comment. You can set it through the `banner` option or pass it directly to `BannerPlugin`.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Built with Rspack',
+});
+```
+
+#### Function
+
+Pass a function to generate banner content for each selected chunk file. Rspack calls it with the compilation `hash`, current `chunk`, and emitted `filename`.
+
+The returned string is wrapped in a comment by default. You can set the function through the `banner` option or pass it directly to `BannerPlugin`.
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -18,9 +18,16 @@ export default {
 };
 ```
 
+The generated chunk begins with this comment:
+
+```js title="dist/main.js"
+/*! Built with Rspack */
+// ...
+```
+
 ## Options
 
-The constructor accepts a banner string or function directly, or an options object. The examples below assume that `rspack` is imported as shown above. The `test`, `include`, and `exclude` options match emitted chunk filenames, not module source paths. A string condition matches the beginning of a filename, while a regular expression can match any part of it. In an array, any matching condition is sufficient.
+`BannerPlugin` accepts a banner string, function, or options object. The examples below reuse the `rspack` import above.
 
 ### banner
 
@@ -96,7 +103,7 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Adds the banner only to chunk files whose emitted filenames match the condition. When omitted, this option does not restrict the matched files.
+Adds the banner only when a chunk's emitted filename matches `test`. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. When omitted, `test` does not restrict files.
 
 ```js
 new rspack.BannerPlugin({
@@ -110,7 +117,7 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Adds the banner only to chunk files whose emitted filenames match at least one condition. If both `test` and `include` are set, a filename must satisfy both options.
+Adds the banner only when a chunk's emitted filename matches at least one `include` condition. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. If `test` is also set, the filename must match both options.
 
 ```js
 new rspack.BannerPlugin({
@@ -124,7 +131,7 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Skips chunk files whose emitted filenames match at least one condition. `exclude` is applied after `test` and `include`.
+Does not add the banner when a chunk's emitted filename matches at least one `exclude` condition. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. `exclude` is checked after `test` and `include`.
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -1,10 +1,10 @@
 ---
-description: 'Adds a comment or raw text to the beginning or end of generated chunk files'
+description: 'Inserts custom content at the beginning or end of generated chunk files'
 ---
 
 # BannerPlugin
 
-`BannerPlugin` adds a comment or raw text to the beginning or end of generated chunk files. By default, it wraps the configured banner in a comment and adds it to the beginning of every chunk file.
+`BannerPlugin` inserts custom content at the beginning or end of generated chunk files. By default, it wraps the content in a comment and prepends it to every chunk file.
 
 ## Examples
 

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -114,7 +114,11 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Adds the banner only when a chunk's emitted filename matches `test`. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. When omitted, `test` does not restrict files.
+`test` selects the chunk files that receive the banner. The banner is added only when a chunk's emitted filename matches `test`.
+
+Matching is performed against the emitted filename, not a module source path. Strings match the beginning of the filename, regular expressions can match any part, and arrays match when any item does.
+
+If omitted, `test` does not filter chunk files.
 
 ```js
 new rspack.BannerPlugin({
@@ -128,7 +132,11 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Adds the banner only when a chunk's emitted filename matches at least one `include` condition. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. If `test` is also set, the filename must match both options.
+`include` limits the banner to specific chunk files. The banner is added only when a chunk's emitted filename matches `include`.
+
+Matching is performed against the emitted filename, not a module source path. Strings match the beginning of the filename, regular expressions can match any part, and arrays match when any item does.
+
+If `test` is also set, the filename must match both `test` and `include`.
 
 ```js
 new rspack.BannerPlugin({
@@ -142,7 +150,11 @@ new rspack.BannerPlugin({
 - **Type:** `string | RegExp | Array<string | RegExp>`
 - **Default:** `undefined`
 
-Does not add the banner when a chunk's emitted filename matches at least one `exclude` condition. Matching uses the emitted filename, not module source paths: a string matches the beginning of the filename, a regular expression can match any part, and an array matches when any condition does. `exclude` is checked after `test` and `include`.
+`exclude` prevents the banner from being added to specific chunk files. The banner is skipped when a chunk's emitted filename matches `exclude`.
+
+Matching is performed against the emitted filename, not a module source path. Strings match the beginning of the filename, regular expressions can match any part, and arrays match when any item does.
+
+`exclude` is applied after `test` and `include`.
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -1,125 +1,134 @@
 ---
-description: 'Adds a banner to the top or bottom of each generated chunk'
+description: 'Adds a comment or raw text to the beginning or end of generated chunk files'
 ---
-
-import { Table } from '@builtIns';
 
 # BannerPlugin
 
-Adds a banner to the top or bottom of each generated chunk.
+`BannerPlugin` adds a comment or raw text to the beginning or end of generated chunk files. By default, it wraps the configured banner in a comment and adds it to the beginning of every chunk file.
 
 ## Examples
 
-Add a banner to the bottom of each chunk file.
+Add a comment to the beginning of every generated chunk file:
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 
 export default {
-  plugins: [
-    new rspack.BannerPlugin({
-      banner: 'hello world',
-      footer: true,
-    }),
-  ],
+  plugins: [new rspack.BannerPlugin('Built with Rspack')],
 };
 ```
 
 ## Options
 
-- **Type:**
+The constructor accepts a banner string or function directly, or an options object. The examples below assume that `rspack` is imported as shown above. The `test`, `include`, and `exclude` options match emitted chunk filenames, not module source paths. A string condition matches the beginning of a filename, while a regular expression can match any part of it. In an array, any matching condition is sufficient.
 
-```ts
-type BannerFunction = (args: {
-  hash: string;
-  chunk: Chunk;
-  filename: string;
-}) => string;
-type BannerContent = string | BannerFunction;
-type BannerPluginOptions = {
-  banner: BannerContent;
-  entryOnly?: boolean;
-  footer?: boolean;
-  raw?: boolean;
-  stage?: number;
-  test?: BannerRules;
-  include?: BannerRules;
-  exclude?: BannerRules;
-};
-type BannerPluginArgument = BannerContent | BannerPluginOptions;
+### banner
+
+- **Type:** `string | ((args) => string)`
+- **Required:** Yes, when using an options object
+
+Specifies the banner content. A function is called once for each selected chunk file and receives the compilation `hash`, current `chunk`, and emitted `filename`. By default, Rspack wraps the returned string in a comment. You can also pass the string or function directly to `BannerPlugin` instead of using an options object.
+
+```js
+new rspack.BannerPlugin({
+  banner: ({ filename }) => `Built file: ${filename}`,
+});
 ```
 
+### entryOnly
+
+- **Type:** `boolean`
 - **Default:** `undefined`
 
-<Table
-  header={[
-    {
-      name: 'Name',
-      key: 'name',
-    },
-    {
-      name: 'Type',
-      key: 'type',
-    },
-    {
-      name: 'Default',
-      key: 'default',
-    },
-    {
-      name: 'Description',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`banner`',
-      type: '`BannerFunction|string`',
-      default: 'undefined',
-      description: 'Specifies the banner, it will be wrapped in a comment.',
-    },
-    {
-      name: '`entryOnly`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description:
-        'If true, the banner will only be added to the entry chunks.',
-    },
-    {
-      name: '`footer`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description: 'If true, banner will be placed at the end of the output.',
-    },
-    {
-      name: '`raw`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description: 'If true, banner will not be wrapped in a comment.',
-    },
-    {
-      name: '`stage`',
-      type: '`number|undefined`',
-      default: '`PROCESS_ASSETS_STAGE_ADDITIONS`(-100)',
-      description:
-        'The stage of the compilation in which the banner should be injected.',
-    },
-    {
-      name: '`test`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: 'Include all modules that pass test assertion.',
-    },
-    {
-      name: '`include`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: 'Include all modules matching any of these conditions.',
-    },
-    {
-      name: '`exclude`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: 'Exclude all modules matching any of these conditions.',
-    },
-  ]}
-/>
+If `true`, the banner is only added to files that belong to initial chunks. Files for asynchronously loaded chunks are skipped. When omitted, the banner can be added to both initial and async chunk files.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Entry bundle',
+  entryOnly: true,
+});
+```
+
+### footer
+
+- **Type:** `boolean`
+- **Default:** `undefined`
+
+If `true`, appends the banner to each selected chunk file instead of prepending it. When omitted, the banner is added at the beginning.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'End of bundle',
+  footer: true,
+});
+```
+
+### raw
+
+- **Type:** `boolean`
+- **Default:** `undefined`
+
+If `true`, emits the banner without wrapping it in a comment. Ensure that the raw content is valid for every selected output file.
+
+```js
+new rspack.BannerPlugin({
+  banner: '/* Build: production */',
+  raw: true,
+});
+```
+
+### stage
+
+- **Type:** `number`
+- **Default:** `Compilation.PROCESS_ASSETS_STAGE_ADDITIONS` (`-100`)
+
+Controls the [`processAssets`](/api/plugin-api/compilation-hooks#processassets) stage at which the banner is added. Lower stage values run earlier. Change this only when the banner must run before or after another asset-processing plugin.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Optimized bundle',
+  stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+});
+```
+
+### test
+
+- **Type:** `string | RegExp | Array<string | RegExp>`
+- **Default:** `undefined`
+
+Adds the banner only to chunk files whose emitted filenames match the condition. When omitted, this option does not restrict the matched files.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'JavaScript bundle',
+  test: /\.js$/,
+});
+```
+
+### include
+
+- **Type:** `string | RegExp | Array<string | RegExp>`
+- **Default:** `undefined`
+
+Adds the banner only to chunk files whose emitted filenames match at least one condition. If both `test` and `include` are set, a filename must satisfy both options.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Application bundle',
+  include: [/^app/, /^admin/],
+});
+```
+
+### exclude
+
+- **Type:** `string | RegExp | Array<string | RegExp>`
+- **Default:** `undefined`
+
+Skips chunk files whose emitted filenames match at least one condition. `exclude` is applied after `test` and `include`.
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Application bundle',
+  exclude: [/^runtime/, /^vendor/],
+});
+```

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -45,27 +45,23 @@ The generated chunk begins with this comment:
 
 - **Required:** Yes, when using an options object
 
-#### String
+The `banner` option supports:
 
-Pass a string to specify the banner content directly. By default, Rspack wraps the string in a comment. You can set it through the `banner` option or pass it directly to `BannerPlugin`.
+- **String:** Pass a string to specify the banner content directly. By default, Rspack wraps the string in a comment. You can set it through the `banner` option or pass it directly to `BannerPlugin`.
 
-```js
-new rspack.BannerPlugin({
-  banner: 'Built with Rspack',
-});
-```
+  ```js
+  new rspack.BannerPlugin({
+    banner: 'Built with Rspack',
+  });
+  ```
 
-#### Function
+- **Function:** Pass a function to generate banner content for each selected chunk file. Rspack calls it with the compilation `hash`, current `chunk`, and emitted `filename`. The returned string is wrapped in a comment by default. You can set the function through the `banner` option or pass it directly to `BannerPlugin`.
 
-Pass a function to generate banner content for each selected chunk file. Rspack calls it with the compilation `hash`, current `chunk`, and emitted `filename`.
-
-The returned string is wrapped in a comment by default. You can set the function through the `banner` option or pass it directly to `BannerPlugin`.
-
-```js
-new rspack.BannerPlugin({
-  banner: ({ filename }) => `Built file: ${filename}`,
-});
-```
+  ```js
+  new rspack.BannerPlugin({
+    banner: ({ filename }) => `Built file: ${filename}`,
+  });
+  ```
 
 ### entryOnly
 

--- a/website/docs/en/plugins/banner-plugin.mdx
+++ b/website/docs/en/plugins/banner-plugin.mdx
@@ -31,7 +31,18 @@ The generated chunk begins with this comment:
 
 ### banner
 
-- **Type:** `string | ((args) => string)`
+- **Type:**
+
+  ```ts
+  type BannerFunction = (args: {
+    hash: string;
+    chunk: Chunk;
+    filename: string;
+  }) => string;
+
+  type BannerContent = string | BannerFunction;
+  ```
+
 - **Required:** Yes, when using an options object
 
 Specifies the banner content. A function is called once for each selected chunk file and receives the compilation `hash`, current `chunk`, and emitted `filename`. By default, Rspack wraps the returned string in a comment. You can also pass the string or function directly to `BannerPlugin` instead of using an options object.

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -45,27 +45,23 @@ export default {
 
 - **是否必填：** 使用选项对象时必填
 
-#### 字符串
+`banner` 选项支持以下两种形式：
 
-传入字符串可直接指定 banner 内容。默认情况下，Rspack 会将字符串包裹成注释。可以通过 `banner` 选项设置，也可以直接将字符串传给 `BannerPlugin`。
+- **字符串：** 传入字符串可直接指定 banner 内容。默认情况下，Rspack 会将字符串包裹成注释。可以通过 `banner` 选项设置，也可以直接将字符串传给 `BannerPlugin`。
 
-```js
-new rspack.BannerPlugin({
-  banner: 'Built with Rspack',
-});
-```
+  ```js
+  new rspack.BannerPlugin({
+    banner: 'Built with Rspack',
+  });
+  ```
 
-#### 函数
+- **函数：** 需要为每个选中的 chunk 文件动态生成 banner 时，可以传入函数。Rspack 调用函数时会传入本次编译的 `hash`、当前 `chunk` 和产物文件名 `filename`。函数返回的字符串默认会被包裹成注释。可以通过 `banner` 选项设置，也可以直接将函数传给 `BannerPlugin`。
 
-需要为每个选中的 chunk 文件动态生成 banner 时，可以传入函数。Rspack 调用函数时会传入本次编译的 `hash`、当前 `chunk` 和产物文件名 `filename`。
-
-函数返回的字符串默认会被包裹成注释。可以通过 `banner` 选项设置，也可以直接将函数传给 `BannerPlugin`。
-
-```js
-new rspack.BannerPlugin({
-  banner: ({ filename }) => `Built file: ${filename}`,
-});
-```
+  ```js
+  new rspack.BannerPlugin({
+    banner: ({ filename }) => `Built file: ${filename}`,
+  });
+  ```
 
 ### entryOnly
 

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -114,7 +114,11 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-仅当 chunk 的产物文件名与 `test` 匹配时，才添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。省略 `test` 时不限制文件。
+`test` 用于筛选需要添加 banner 的 chunk 文件。仅当 chunk 的产物文件名与 `test` 匹配时，才会添加 banner。
+
+匹配对象是产物文件名，而不是模块源码路径。字符串匹配文件名开头；正则表达式可匹配任意位置；传入数组时，任一条件匹配即可。
+
+省略 `test` 时，不会通过该选项过滤 chunk 文件。
 
 ```js
 new rspack.BannerPlugin({
@@ -128,7 +132,11 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-仅当 chunk 的产物文件名与 `include` 中任一条件匹配时，才添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。如果同时设置 `test`，文件名必须也与 `test` 匹配。
+`include` 用于限定需要添加 banner 的 chunk 文件。仅当 chunk 的产物文件名与 `include` 匹配时，才会添加 banner。
+
+匹配对象是产物文件名，而不是模块源码路径。字符串匹配文件名开头；正则表达式可匹配任意位置；传入数组时，任一条件匹配即可。
+
+如果同时设置 `test`，产物文件名必须同时满足 `test` 和 `include`。
 
 ```js
 new rspack.BannerPlugin({
@@ -142,7 +150,11 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-如果 chunk 的产物文件名与 `exclude` 中任一条件匹配，则不添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。`exclude` 在 `test` 和 `include` 之后检查。
+`exclude` 用于指定不添加 banner 的 chunk 文件。如果 chunk 的产物文件名与 `exclude` 匹配，则不会添加 banner。
+
+匹配对象是产物文件名，而不是模块源码路径。字符串匹配文件名开头；正则表达式可匹配任意位置；传入数组时，任一条件匹配即可。
+
+`exclude` 会在 `test` 和 `include` 完成筛选后应用。
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -31,7 +31,18 @@ export default {
 
 ### banner
 
-- **类型：** `string | ((args) => string)`
+- **类型：**
+
+  ```ts
+  type BannerFunction = (args: {
+    hash: string;
+    chunk: Chunk;
+    filename: string;
+  }) => string;
+
+  type BannerContent = string | BannerFunction;
+  ```
+
 - **是否必填：** 使用选项对象时必填
 
 指定 banner 内容。函数会针对每个选中的 chunk 文件调用一次，并接收本次编译的 `hash`、当前 `chunk` 和生成的 `filename`。默认情况下，Rspack 会将函数返回的字符串包裹成注释。也可以不使用选项对象，直接将字符串或函数传给 `BannerPlugin`。

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -18,9 +18,16 @@ export default {
 };
 ```
 
+生成的 chunk 文件会以这段注释开头：
+
+```js title="dist/main.js"
+/*! Built with Rspack */
+// ...
+```
+
 ## 选项
 
-构造函数可以直接接收 banner 字符串或函数，也可以接收选项对象。下面的示例均假设已按上例导入 `rspack`。`test`、`include` 和 `exclude` 匹配的是生成的 chunk 文件名，而不是模块的源码路径。字符串条件匹配文件名的开头，正则表达式可以匹配文件名的任意部分；使用数组时，满足其中任一条件即可。
+`BannerPlugin` 可以接收 banner 字符串、函数或选项对象。下面的示例沿用上方导入的 `rspack`。
 
 ### banner
 
@@ -96,7 +103,7 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-只为生成文件名满足该条件的 chunk 文件添加 banner。省略时，此选项不会限制匹配的文件。
+仅当 chunk 的产物文件名与 `test` 匹配时，才添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。省略 `test` 时不限制文件。
 
 ```js
 new rspack.BannerPlugin({
@@ -110,7 +117,7 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-只为生成文件名满足至少一个条件的 chunk 文件添加 banner。如果同时设置 `test` 和 `include`，文件名必须同时满足这两个选项。
+仅当 chunk 的产物文件名与 `include` 中任一条件匹配时，才添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。如果同时设置 `test`，文件名必须也与 `test` 匹配。
 
 ```js
 new rspack.BannerPlugin({
@@ -124,7 +131,7 @@ new rspack.BannerPlugin({
 - **类型：** `string | RegExp | Array<string | RegExp>`
 - **默认值：** `undefined`
 
-跳过生成文件名满足至少一个条件的 chunk 文件。`exclude` 在 `test` 和 `include` 之后生效。
+如果 chunk 的产物文件名与 `exclude` 中任一条件匹配，则不添加 banner。匹配对象是产物文件名，而不是模块源码路径：字符串匹配文件名开头，正则表达式可匹配任意位置，数组中任一条件匹配即可。`exclude` 在 `test` 和 `include` 之后检查。
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -1,124 +1,134 @@
 ---
-description: 'Rspack BannerPlugin 插件参考，说明用途、可用选项、典型场景、使用方式与常见集成方式。'
+description: '使用 Rspack BannerPlugin 在生成的 chunk 文件开头或结尾添加注释或原始文本。'
 ---
-
-import { Table } from '@builtIns';
 
 # BannerPlugin
 
-在每个生成的 chunk 顶部或尾部添加一段指定的内容。
+`BannerPlugin` 用于在生成的 chunk 文件开头或结尾添加注释或原始文本。默认情况下，它会将配置的 banner 包裹成注释，并添加到每个 chunk 文件的开头。
 
 ## 示例
 
-在每个 chunk 文件底部添加 banner。
+在每个生成的 chunk 文件开头添加一段注释：
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 
 export default {
-  plugins: [
-    new rspack.BannerPlugin({
-      banner: 'hello world',
-      footer: true,
-    }),
-  ],
+  plugins: [new rspack.BannerPlugin('Built with Rspack')],
 };
 ```
 
 ## 选项
 
-- **类型：**
+构造函数可以直接接收 banner 字符串或函数，也可以接收选项对象。下面的示例均假设已按上例导入 `rspack`。`test`、`include` 和 `exclude` 匹配的是生成的 chunk 文件名，而不是模块的源码路径。字符串条件匹配文件名的开头，正则表达式可以匹配文件名的任意部分；使用数组时，满足其中任一条件即可。
 
-```ts
-type BannerFunction = (args: {
-  hash: string;
-  chunk: Chunk;
-  filename: string;
-}) => string;
-type BannerContent = string | BannerFunction;
-type BannerRules = string | RegExp | Array<string | RegExp>;
-type BannerPluginOptions = {
-  banner: BannerContent;
-  entryOnly?: boolean;
-  footer?: boolean;
-  raw?: boolean;
-  stage?: number;
-  test?: BannerRules;
-  include?: BannerRules;
-  exclude?: BannerRules;
-};
-type BannerPluginArgument = BannerContent | BannerPluginOptions;
+### banner
+
+- **类型：** `string | ((args) => string)`
+- **是否必填：** 使用选项对象时必填
+
+指定 banner 内容。函数会针对每个选中的 chunk 文件调用一次，并接收本次编译的 `hash`、当前 `chunk` 和生成的 `filename`。默认情况下，Rspack 会将函数返回的字符串包裹成注释。也可以不使用选项对象，直接将字符串或函数传给 `BannerPlugin`。
+
+```js
+new rspack.BannerPlugin({
+  banner: ({ filename }) => `Built file: ${filename}`,
+});
 ```
 
+### entryOnly
+
+- **类型：** `boolean`
 - **默认值：** `undefined`
 
-<Table
-  header={[
-    {
-      name: '名称',
-      key: 'name',
-    },
-    {
-      name: '类型',
-      key: 'type',
-    },
-    {
-      name: '默认值',
-      key: 'default',
-    },
-    {
-      name: '描述',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`banner`',
-      type: '`BannerFunction|string`',
-      default: 'undefined',
-      description: '指定 banner 内容（会被包裹成注释）',
-    },
-    {
-      name: '`entryOnly`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description: '如果值为 true，将只在入口 chunks 文件中添加',
-    },
-    {
-      name: '`footer`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description: '如果值为 true，banner 将会位于编译结果的最下方',
-    },
-    {
-      name: '`raw`',
-      type: '`boolean|undefined`',
-      default: 'undefined',
-      description: '如果值为 true，将直接输出，不会被作为注释',
-    },
-    {
-      name: '`stage`',
-      type: '`number|undefined`',
-      default: '`PROCESS_ASSETS_STAGE_ADDITIONS`(-100)',
-      description: 'Banner 应在哪个编译阶段注入',
-    },
-    {
-      name: '`test`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: '包含所有匹配的模块',
-    },
-    {
-      name: '`include`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: '根据条件匹配指定的模块',
-    },
-    {
-      name: '`exclude`',
-      type: '`BannerRules|undefined`',
-      default: 'undefined',
-      description: '根据条件排除指定的模块',
-    },
-  ]}
-/>
+设置为 `true` 时，只在初始 chunk 的文件中添加 banner，并跳过异步加载的 chunk 文件。省略时，初始 chunk 和异步 chunk 的文件均可添加 banner。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Entry bundle',
+  entryOnly: true,
+});
+```
+
+### footer
+
+- **类型：** `boolean`
+- **默认值：** `undefined`
+
+设置为 `true` 时，将 banner 追加到每个选中的 chunk 文件末尾，而不是添加到开头。省略时，banner 会添加到文件开头。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'End of bundle',
+  footer: true,
+});
+```
+
+### raw
+
+- **类型：** `boolean`
+- **默认值：** `undefined`
+
+设置为 `true` 时，输出 banner 时不将其包裹成注释。请确保原始内容对每个选中的输出文件都是有效的。
+
+```js
+new rspack.BannerPlugin({
+  banner: '/* Build: production */',
+  raw: true,
+});
+```
+
+### stage
+
+- **类型：** `number`
+- **默认值：** `Compilation.PROCESS_ASSETS_STAGE_ADDITIONS`（`-100`）
+
+控制添加 banner 时所处的 [`processAssets`](/api/plugin-api/compilation-hooks#processassets) 阶段。数值越小，执行越早。仅当 banner 需要在另一个处理资源的插件之前或之后运行时，才需要修改此选项。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Optimized bundle',
+  stage: rspack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE,
+});
+```
+
+### test
+
+- **类型：** `string | RegExp | Array<string | RegExp>`
+- **默认值：** `undefined`
+
+只为生成文件名满足该条件的 chunk 文件添加 banner。省略时，此选项不会限制匹配的文件。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'JavaScript bundle',
+  test: /\.js$/,
+});
+```
+
+### include
+
+- **类型：** `string | RegExp | Array<string | RegExp>`
+- **默认值：** `undefined`
+
+只为生成文件名满足至少一个条件的 chunk 文件添加 banner。如果同时设置 `test` 和 `include`，文件名必须同时满足这两个选项。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Application bundle',
+  include: [/^app/, /^admin/],
+});
+```
+
+### exclude
+
+- **类型：** `string | RegExp | Array<string | RegExp>`
+- **默认值：** `undefined`
+
+跳过生成文件名满足至少一个条件的 chunk 文件。`exclude` 在 `test` 和 `include` 之后生效。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Application bundle',
+  exclude: [/^runtime/, /^vendor/],
+});
+```

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -45,7 +45,21 @@ export default {
 
 - **是否必填：** 使用选项对象时必填
 
-指定 banner 内容。函数会针对每个选中的 chunk 文件调用一次，并接收本次编译的 `hash`、当前 `chunk` 和生成的 `filename`。默认情况下，Rspack 会将函数返回的字符串包裹成注释。也可以不使用选项对象，直接将字符串或函数传给 `BannerPlugin`。
+#### 字符串
+
+传入字符串可直接指定 banner 内容。默认情况下，Rspack 会将字符串包裹成注释。可以通过 `banner` 选项设置，也可以直接将字符串传给 `BannerPlugin`。
+
+```js
+new rspack.BannerPlugin({
+  banner: 'Built with Rspack',
+});
+```
+
+#### 函数
+
+需要为每个选中的 chunk 文件动态生成 banner 时，可以传入函数。Rspack 调用函数时会传入本次编译的 `hash`、当前 `chunk` 和产物文件名 `filename`。
+
+函数返回的字符串默认会被包裹成注释。可以通过 `banner` 选项设置，也可以直接将函数传给 `BannerPlugin`。
 
 ```js
 new rspack.BannerPlugin({

--- a/website/docs/zh/plugins/banner-plugin.mdx
+++ b/website/docs/zh/plugins/banner-plugin.mdx
@@ -1,10 +1,10 @@
 ---
-description: '使用 Rspack BannerPlugin 在生成的 chunk 文件开头或结尾添加注释或原始文本。'
+description: '使用 Rspack BannerPlugin 在生成的 chunk 文件开头或结尾插入指定内容。'
 ---
 
 # BannerPlugin
 
-`BannerPlugin` 用于在生成的 chunk 文件开头或结尾添加注释或原始文本。默认情况下，它会将配置的 banner 包裹成注释，并添加到每个 chunk 文件的开头。
+`BannerPlugin` 用于在生成的 chunk 文件开头或结尾插入指定内容。默认情况下，它会将指定内容包裹成注释，并插入每个 chunk 文件的开头。
 
 ## 示例
 


### PR DESCRIPTION
## Summary

The BannerPlugin option reference was difficult to scan and did not show how to configure individual options. This PR replaces the option table with dedicated sections and concise examples, and clarifies filename filtering, banner functions, entry-only behavior, raw and footer output, and `processAssets` staging in both English and Chinese.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).