### PR TITLE
perf(ids): optimize deterministic module id assignment

### DIFF
--- a/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/deterministic_module_ids_plugin.rs
@@ -1,15 +1,17 @@
 use derive_more::Debug;
 use rayon::prelude::*;
 use rspack_core::{
-  ChunkGraph, Compilation, CompilationModuleIds, ModuleIdsArtifact, Plugin,
+  ChunkGraph, Compilation, CompilationModuleIds, ModuleId, ModuleIdsArtifact, Plugin,
   incremental::IncrementalPasses,
 };
 use rspack_error::{Diagnostic, Result, error};
 use rspack_hook::{plugin, plugin_hook};
+use rspack_util::number_hash::{get_number_hash_combined_from_state, get_number_hash_state};
+use rustc_hash::FxHashSet;
 
 use crate::id_helpers::{
-  ModuleFilterFn, assign_deterministic_ids, compare_modules_by_pre_order_index_or_identifier,
-  get_full_module_name, get_used_module_ids_and_modules_with_artifact,
+  ModuleFilterFn, assign_deterministic_ids_with_hash, compare_by_pre_order_index_or_id,
+  get_deterministic_id_range, get_full_module_name, get_used_module_ids_and_modules_with_artifact,
   get_used_module_ids_and_modules_with_async_filter,
 };
 
@@ -79,7 +81,7 @@ async fn module_ids(
 
   // Use the sync path when no async test filter is provided (the common case),
   // avoiding unnecessary async overhead on the hot path.
-  let (mut used_ids, modules) = if self.test.is_some() {
+  let (used_ids, modules) = if self.test.is_some() {
     get_used_module_ids_and_modules_with_async_filter(compilation, module_ids, self.test.as_ref())
       .await?
   } else {
@@ -96,42 +98,64 @@ async fn module_ids(
   let module_graph = compilation.get_module_graph();
   let modules = modules
     .into_iter()
-    .filter_map(|i| module_graph.module_by_identifier(&i))
+    .filter_map(|identifier| {
+      module_graph
+        .module_by_identifier(&identifier)
+        .map(|module| {
+          (
+            identifier,
+            module,
+            module_graph.get_pre_order_index(&identifier),
+          )
+        })
+    })
     .collect::<Vec<_>>();
   let used_ids_len = used_ids.len();
+  let ranges = [10usize
+    .checked_pow(self.max_length as u32)
+    .unwrap_or(usize::MAX)];
+  let expand_factor = if self.fixed_length { 0 } else { 10 };
+  let range = get_deterministic_id_range(modules.len(), &ranges, expand_factor, used_ids_len);
 
-  let modules_with_names = modules
+  let modules_with_hashes = modules
     .into_par_iter()
-    .map(|m| (m, get_full_module_name(m, context)))
+    .map(|(identifier, module, pre_order_index)| {
+      let full_name = get_full_module_name(module, context);
+      (
+        identifier,
+        pre_order_index,
+        get_number_hash_state(&full_name, range),
+      )
+    })
     .collect::<Vec<_>>();
 
-  assign_deterministic_ids(
-    modules_with_names,
-    |(_, name)| name.as_str(),
-    |(a, _), (b, _)| {
-      compare_modules_by_pre_order_index_or_identifier(
-        module_graph,
-        &a.identifier(),
-        &b.identifier(),
+  let mut used_module_ids = FxHashSet::with_capacity_and_hasher(
+    used_ids_len + modules_with_hashes.len(),
+    Default::default(),
+  );
+  used_module_ids.extend(used_ids.into_iter().map(ModuleId::from));
+  module_ids_map.reserve(modules_with_hashes.len());
+
+  assign_deterministic_ids_with_hash(
+    modules_with_hashes,
+    |(a_identifier, a_pre_order_index, _), (b_identifier, b_pre_order_index, _)| {
+      compare_by_pre_order_index_or_id(
+        *a_pre_order_index,
+        a_identifier,
+        *b_pre_order_index,
+        b_identifier,
       )
     },
-    |(module, _), id| {
-      if !used_ids.insert(id.to_string()) {
+    |(module_identifier, _, _), id| {
+      let module_id: ModuleId = id.to_string().into();
+      if !used_module_ids.insert(module_id.clone()) {
         conflicts += 1;
         return false;
       }
-      ChunkGraph::set_module_id(
-        &mut module_ids_map,
-        module.identifier(),
-        id.to_string().into(),
-      );
+      ChunkGraph::set_module_id(&mut module_ids_map, *module_identifier, module_id);
       true
     },
-    &[10usize
-      .checked_pow(self.max_length as u32)
-      .unwrap_or(usize::MAX)],
-    if self.fixed_length { 0 } else { 10 },
-    used_ids_len,
+    |(_, _, hash_state), suffix| get_number_hash_combined_from_state(*hash_state, suffix),
     self.salt,
   );
   *module_ids = module_ids_map;

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -161,18 +161,32 @@ pub fn get_hash(s: impl Hash, length: usize) -> String {
 
 #[allow(clippy::too_many_arguments)]
 pub fn assign_deterministic_ids<T>(
-  mut items: Vec<T>,
+  items: Vec<T>,
   get_name: impl for<'b> Fn(&'b T) -> &'b str,
   comparator: impl FnMut(&T, &T) -> Ordering,
-  mut assign_id: impl FnMut(&T, usize) -> bool,
+  assign_id: impl FnMut(&T, usize) -> bool,
   ranges: &[usize],
   expand_factor: usize,
   extra_space: usize,
   salt: usize,
 ) {
-  items.sort_unstable_by(comparator);
+  let range = get_deterministic_id_range(items.len(), ranges, expand_factor, extra_space);
+  assign_deterministic_ids_with_hash(
+    items,
+    comparator,
+    assign_id,
+    |item, suffix| get_number_hash_combined(get_name(item), suffix, range),
+    salt,
+  );
+}
 
-  let optimal_range = usize::min(items.len() * 20 + extra_space, usize::MAX);
+pub(crate) fn get_deterministic_id_range(
+  item_count: usize,
+  ranges: &[usize],
+  expand_factor: usize,
+  extra_space: usize,
+) -> usize {
+  let optimal_range = usize::min(item_count * 20 + extra_space, usize::MAX);
   let mut i = 0;
   debug_assert!(!ranges.is_empty());
   let mut range = ranges[i];
@@ -186,14 +200,24 @@ pub fn assign_deterministic_ids<T>(
       break;
     }
   }
+  range
+}
+
+pub(crate) fn assign_deterministic_ids_with_hash<T>(
+  mut items: Vec<T>,
+  comparator: impl FnMut(&T, &T) -> Ordering,
+  mut assign_id: impl FnMut(&T, usize) -> bool,
+  mut get_id: impl FnMut(&T, usize) -> usize,
+  salt: usize,
+) {
+  items.sort_unstable_by(comparator);
 
   for item in items {
-    let ident = get_name(&item);
     let mut i = salt;
-    let mut id = get_number_hash_combined(ident, i, range);
+    let mut id = get_id(&item, i);
     while !assign_id(&item, id) {
       i += 1;
-      id = get_number_hash_combined(ident, i, range);
+      id = get_id(&item, i);
     }
   }
 }
@@ -244,7 +268,7 @@ pub fn compare_modules_by_pre_order_index_or_identifier(
 /// some modules): a numeric edge and an identifier edge can disagree. Use a single
 /// key — pre-order index (missing sorts last via `u32::MAX`) — with the identifier
 /// as a deterministic tiebreak.
-fn compare_by_pre_order_index_or_id(
+pub(crate) fn compare_by_pre_order_index_or_id(
   a_index: Option<u32>,
   a_id: &str,
   b_index: Option<u32>,

--- a/crates/rspack_util/src/number_hash.rs
+++ b/crates/rspack_util/src/number_hash.rs
@@ -19,6 +19,18 @@ const FNV_OFFSET_64: u64 = 0xCBF2_9CE4_8422_2325;
 
 const FNV_PRIME_64: u64 = 0x0100_0000_01B3;
 
+#[derive(Debug, Clone, Copy)]
+pub struct NumberHashState {
+  inner: NumberHashStateInner,
+  range: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum NumberHashStateInner {
+  Fnv32(u32),
+  Fnv64(u64),
+}
+
 fn fnv1a32(s: &str) -> u32 {
   fnv1a32_update(FNV_OFFSET_32, s) & MASK_31
 }
@@ -60,15 +72,31 @@ pub fn get_number_hash(s: &str, range: usize) -> usize {
   }
 }
 
-pub fn get_number_hash_combined(prefix: &str, suffix: usize, range: usize) -> usize {
+pub fn get_number_hash_state(prefix: &str, range: usize) -> NumberHashState {
+  let inner = if range < FNV_64_THRESHOLD {
+    NumberHashStateInner::Fnv32(fnv1a32_update(FNV_OFFSET_32, prefix))
+  } else {
+    NumberHashStateInner::Fnv64(fnv1a64_update(FNV_OFFSET_64, prefix))
+  };
+  NumberHashState { inner, range }
+}
+
+pub fn get_number_hash_combined_from_state(state: NumberHashState, suffix: usize) -> usize {
   let mut suffix_buffer = itoa::Buffer::new();
   let suffix = suffix_buffer.format(suffix);
 
-  if range < FNV_64_THRESHOLD {
-    ((fnv1a32_update(fnv1a32_update(FNV_OFFSET_32, prefix), suffix) & MASK_31) as usize) % range
-  } else {
-    (fnv1a64_update(fnv1a64_update(FNV_OFFSET_64, prefix), suffix) % (range as u64)) as usize
+  match state.inner {
+    NumberHashStateInner::Fnv32(hash) => {
+      ((fnv1a32_update(hash, suffix) & MASK_31) as usize) % state.range
+    }
+    NumberHashStateInner::Fnv64(hash) => {
+      (fnv1a64_update(hash, suffix) % (state.range as u64)) as usize
+    }
   }
+}
+
+pub fn get_number_hash_combined(prefix: &str, suffix: usize, range: usize) -> usize {
+  get_number_hash_combined_from_state(get_number_hash_state(prefix, range), suffix)
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- precompute the webpack-compatible FNV prefix state in the existing parallel full-module-name pass
- cache module pre-order indices before sorting instead of looking them up from the module graph in every comparison
- reserve the module ID collections and materialize each numeric `ModuleId` only once
- preserve the existing range selection, UTF-16 hashing, salt, collision retry, and deterministic ordering behavior

On the React 10k production fixture with a warm persistent cache:

- `DeterministicModuleIdsPlugin`: 11.905 ms -> 6.490 ms median (45.5% reduction)
- complete `module ids` pass: 12.340 ms -> 7.646 ms median (38.0% reduction)
- all 19 cold-build output file names and SHA-256 hashes are unchanged

## Related links

N/A

## Testing

- `cargo test -p rspack_util number_hash`
- `cargo check -p rspack_util -p rspack_ids`
- `pnpm run build:binding:dev`
- `pnpm run test:unit` (9158 passed, 4 skipped; CLI 90 passed, 1 skipped)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
