### PR TITLE
perf(core): optimize module rendering for chunk assets

### DIFF
--- a/crates/rspack_plugin_esm_library/src/render.rs
+++ b/crates/rspack_plugin_esm_library/src/render.rs
@@ -192,6 +192,10 @@ impl EsmLibraryPlugin {
 
     if !chunk_link.decl_modules.is_empty() {
       let hooks = JsPlugin::get_compilation_hooks(compilation.id());
+      let module_runtime_scope = compilation
+        .runtime_template
+        .create_module_code_template()
+        .render_runtime_scope();
 
       let mut decl_inner = ConcatSource::default();
       for m in chunk_link.decl_modules.iter() {
@@ -216,6 +220,7 @@ impl EsmLibraryPlugin {
           &output_path,
           &hooks,
           module_runtime_template,
+          Some(&module_runtime_scope),
         )
         .await?
         else {

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -885,6 +885,7 @@ var {} = {{}};
           output_path,
           &hooks,
           runtime_template,
+          None,
         )
         .await?
         else {
@@ -1108,6 +1109,7 @@ var {} = {{}};
               output_path,
               hooks,
               runtime_template,
+              None,
             )
             .await
           },

--- a/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/runtime_context.rs
@@ -790,6 +790,7 @@ impl JsPlugin {
           output_path,
           &hooks,
           runtime_template,
+          None,
         )
         .await?
         else {

--- a/crates/rspack_plugin_javascript/src/runtime.rs
+++ b/crates/rspack_plugin_javascript/src/runtime.rs
@@ -34,6 +34,10 @@ pub async fn render_chunk_modules(
   hooks: &JavascriptModulesPluginHooks,
   runtime_template: &RuntimeCodeTemplate,
 ) -> Result<Option<(BoxSource, ChunkInitFragments)>> {
+  let module_runtime_scope = compilation
+    .runtime_template
+    .create_module_code_template()
+    .render_runtime_scope();
   let module_sources = rspack_parallel::scope::<_, _>(|token| {
     ordered_modules.iter().for_each(|module| {
       let s = unsafe {
@@ -44,11 +48,21 @@ pub async fn render_chunk_modules(
           all_strict,
           output_path,
           hooks,
-          runtime_template
+          runtime_template,
+          module_runtime_scope.as_str(),
         ))
       };
       s.spawn(
-        |(compilation, chunk_ukey, module, all_strict, output_path, hooks, runtime_template)| async move {
+        |(
+          compilation,
+          chunk_ukey,
+          module,
+          all_strict,
+          output_path,
+          hooks,
+          runtime_template,
+          module_runtime_scope,
+        )| async move {
           render_module(
             compilation,
             chunk_ukey,
@@ -58,12 +72,11 @@ pub async fn render_chunk_modules(
             true,
             output_path,
             hooks,
-            runtime_template
+            runtime_template,
+            Some(module_runtime_scope),
           )
           .await
-          .map(|result| {
-            result.map(|(source, fragments)| (module.identifier(), source, fragments))
-          })
+          .map(|result| result.map(|(source, fragments)| (module.identifier(), source, fragments)))
         },
       );
     });
@@ -73,7 +86,7 @@ pub async fn render_chunk_modules(
   .map(|r| r.to_rspack_result())
   .collect::<Result<Vec<_>>>()?;
 
-  let mut module_code_array = vec![];
+  let mut module_code_array = Vec::with_capacity(module_sources.len());
   for item in module_sources {
     if let Some(i) = item? {
       module_code_array.push(i);
@@ -86,18 +99,12 @@ pub async fn render_chunk_modules(
 
   module_code_array.sort_unstable_by_key(|(module_identifier, _, _)| *module_identifier);
 
-  let chunk_init_fragments = module_code_array.iter().fold(
-    ChunkInitFragments::default(),
-    |mut chunk_init_fragments, (_, _, fragments)| {
-      chunk_init_fragments.extend((*fragments).clone());
-      chunk_init_fragments
-    },
-  );
-
-  let module_sources: Vec<_> = module_code_array
-    .into_iter()
-    .map(|(_, source, _)| source)
-    .collect();
+  let mut chunk_init_fragments = ChunkInitFragments::default();
+  let mut module_sources = Vec::with_capacity(module_code_array.len());
+  for (_, source, fragments) in module_code_array {
+    chunk_init_fragments.extend(fragments);
+    module_sources.push(source);
+  }
   let module_sources = module_sources
     .into_par_iter()
     .fold(ConcatSource::default, |mut output, source| {
@@ -125,14 +132,16 @@ pub async fn render_module(
   output_path: &str,
   hooks: &JavascriptModulesPluginHooks,
   runtime_template: &RuntimeCodeTemplate,
+  module_runtime_scope: Option<&str>,
 ) -> Result<Option<(BoxSource, ChunkInitFragments)>> {
+  let module_identifier = module.identifier();
   let chunk = compilation
     .build_chunk_graph_artifact
     .chunk_by_ukey
     .expect_get(chunk_ukey);
   let code_gen_result = compilation
     .code_generation_results
-    .get(&module.identifier(), Some(chunk.runtime()));
+    .get(&module_identifier, Some(chunk.runtime()));
   let Some(origin_source) = code_gen_result.get(&SourceType::JavaScript) else {
     return Ok(None);
   };
@@ -160,7 +169,7 @@ pub async fn render_module(
       .into_owned();
     let position = compilation
       .get_module_graph()
-      .get_pre_order_index(&module.identifier())
+      .get_pre_order_index(&module_identifier)
       .map_or(0, |index| index as i32);
     module_chunk_init_fragments.push(
       ExternalModuleInitFragment::new(
@@ -237,9 +246,8 @@ pub async fn render_module(
 
   let sources = if factory {
     let mut sources = ConcatSource::default();
-    let module_id =
-      ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())
-        .expect("should have module_id in render_module");
+    let module_id = ChunkGraph::get_module_id(&compilation.module_ids_artifact, module_identifier)
+      .expect("should have module_id in render_module");
     sources.add(RawStringSource::from(rspack_util::json_stringify(
       module_id,
     )));
@@ -247,7 +255,7 @@ pub async fn render_module(
     let mut post_module_container = {
       let runtime_requirements = ChunkGraph::get_module_runtime_requirements(
         compilation,
-        module.identifier(),
+        module_identifier,
         chunk.runtime(),
       );
 
@@ -259,44 +267,47 @@ pub async fn render_module(
           || !render_runtime_requirements
             .renderable_require_scope()
             .is_empty());
-      let module_runtime_scope = compilation
-        .runtime_template
-        .create_module_code_template()
-        .render_runtime_scope();
-
-      let mut args = Vec::new();
+      let mut args = String::with_capacity(64);
+      let mut push_argument = |argument: &str, used: bool| {
+        if !args.is_empty() {
+          args.push_str(", ");
+        }
+        if !used {
+          args.push_str("__unused_rspack_");
+        }
+        args.push_str(argument);
+      };
       if need_module || need_exports || need_require {
         let module_argument = runtime_template.render_module_argument(module.get_module_argument());
-        args.push(if need_module {
-          module_argument
-        } else {
-          format!("__unused_rspack_{module_argument}")
-        });
+        push_argument(&module_argument, need_module);
       }
 
       if need_exports || need_require {
         let exports_argument =
           runtime_template.render_exports_argument(module.get_exports_argument());
-        args.push(if need_exports {
-          exports_argument
-        } else {
-          format!("__unused_rspack_{exports_argument}")
-        });
+        push_argument(&exports_argument, need_exports);
       }
       if need_require {
-        args.push(module_runtime_scope);
+        push_argument(
+          module_runtime_scope
+            .expect("module runtime scope should be provided for factory modules"),
+          true,
+        );
       }
 
       let mut container_sources = ConcatSource::default();
 
+      let mut container_prefix = String::with_capacity(args.len() + 16);
       if use_method_shorthand {
-        container_sources.add(RawStringSource::from(format!("({}) {{\n", args.join(", "))));
+        container_prefix.push('(');
+        container_prefix.push_str(&args);
+        container_prefix.push_str(") {\n");
       } else {
-        container_sources.add(RawStringSource::from(format!(
-          ": (function ({}) {{\n",
-          args.join(", ")
-        )));
+        container_prefix.push_str(": (function (");
+        container_prefix.push_str(&args);
+        container_prefix.push_str(") {\n");
       }
+      container_sources.add(RawStringSource::from(container_prefix));
       if module.build_info().strict && !all_strict {
         container_sources.add(RawStringSource::from_static("\"use strict\";\n"));
       }


### PR DESCRIPTION
## Summary

- reuse the rendered module runtime scope across modules in the same chunk
- build module factory arguments directly instead of allocating and joining temporary strings
- avoid cloning chunk init fragments and preallocate module result containers
- reuse module identifiers across rendering lookups

## Performance

Measured with the React 10k production fixture in Docker using targeted Valgrind Callgrind instrumentation:

- targeted instruction count: 43,894,917 -> 19,396,556 (-55.81%)
- create chunk assets stage median: 10.068 ms -> 9.463 ms (-6.00%)
- all 19 emitted files remained byte-for-byte identical to the baseline

## Related links

N/A

## Checklist

- [x] Tests updated (not required for behavior-preserving refactoring).
- [x] Documentation updated (not required).

## Validation

- cargo fmt --all --check
- cargo check -p rspack_plugin_javascript -p rspack_plugin_esm_library
- pnpm run build:binding:dev
- pnpm run test:unit