### PR TITLE
perf(core): optimize create module hashes

### DIFF
--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -2089,14 +2089,14 @@ impl Module for ConcatenatedModule {
                 .expect("should have module")
                 .get_runtime_hash(compilation, generation_runtime)
                 .await?;
-              Ok(Some(digest.encoded().to_string()))
+              Ok(Some(digest))
             }
             ConcatenationEntry::External(e) => Ok(
               ChunkGraph::get_module_id(
                 &compilation.module_ids_artifact,
                 e.module(compilation.get_module_graph()),
               )
-              .map(|id| id.to_string()),
+              .map(|id| RspackHashDigest::from(id.as_str())),
             ),
           }
         })

--- a/crates/rspack_core/src/exports/exports_info.rs
+++ b/crates/rspack_core/src/exports/exports_info.rs
@@ -107,7 +107,8 @@ impl ExportsInfoData {
       exports_info_artifact: &ExportsInfoArtifact,
       hasher: &mut dyn std::hash::Hasher,
       runtime: Option<&RuntimeSpec>,
-      visited: &mut FxHashSet<ExportsInfo>,
+      root_exports_info: ExportsInfo,
+      visited: &mut Option<FxHashSet<ExportsInfo>>,
     ) {
       if let Some(used_name) = export_info.used_name() {
         used_name.dyn_hash(hasher);
@@ -118,16 +119,20 @@ impl ExportsInfoData {
       export_info.provided().dyn_hash(hasher);
       export_info.terminal_binding().dyn_hash(hasher);
       export_info.ns_access().dyn_hash(hasher);
-      if let Some(exports_info) = export_info.exports_info()
-        && !visited.contains(&exports_info)
-      {
-        exports_info_update_hash(
-          exports_info.as_data(exports_info_artifact),
-          exports_info_artifact,
-          hasher,
-          runtime,
-          visited,
-        );
+      if let Some(exports_info) = export_info.exports_info() {
+        let should_visit = visited
+          .get_or_insert_with(|| FxHashSet::from_iter([root_exports_info]))
+          .insert(exports_info);
+        if should_visit {
+          exports_info_update_hash(
+            exports_info.as_data(exports_info_artifact),
+            exports_info_artifact,
+            hasher,
+            runtime,
+            root_exports_info,
+            visited,
+          );
+        }
       }
     }
 
@@ -136,15 +141,22 @@ impl ExportsInfoData {
       exports_info_artifact: &ExportsInfoArtifact,
       hasher: &mut dyn std::hash::Hasher,
       runtime: Option<&RuntimeSpec>,
-      visited: &mut FxHashSet<ExportsInfo>,
+      root_exports_info: ExportsInfo,
+      visited: &mut Option<FxHashSet<ExportsInfo>>,
     ) {
-      visited.insert(exports_info.id());
       let other_export_info = exports_info.other_exports_info();
       let side_effects_only_info = exports_info.side_effects_only_info();
 
       for export_info in exports_info.exports().values() {
         if export_info.has_info(other_export_info, runtime) {
-          export_info_update_hash(export_info, exports_info_artifact, hasher, runtime, visited);
+          export_info_update_hash(
+            export_info,
+            exports_info_artifact,
+            hasher,
+            runtime,
+            root_exports_info,
+            visited,
+          );
         }
       }
 
@@ -153,6 +165,7 @@ impl ExportsInfoData {
         exports_info_artifact,
         hasher,
         runtime,
+        root_exports_info,
         visited,
       );
       export_info_update_hash(
@@ -160,11 +173,19 @@ impl ExportsInfoData {
         exports_info_artifact,
         hasher,
         runtime,
+        root_exports_info,
         visited,
       );
     }
 
-    let mut visited = FxHashSet::default();
-    exports_info_update_hash(self, exports_info_artifact, hasher, runtime, &mut visited);
+    let mut visited = None;
+    exports_info_update_hash(
+      self,
+      exports_info_artifact,
+      hasher,
+      runtime,
+      self.id(),
+      &mut visited,
+    );
   }
 }

--- a/crates/rspack_core/src/runtime.rs
+++ b/crates/rspack_core/src/runtime.rs
@@ -231,6 +231,7 @@ pub fn filter_runtime(
 ) -> RuntimeCondition {
   match runtime {
     None => RuntimeCondition::Boolean(filter(None)),
+    Some(runtime) if runtime.len() == 1 => RuntimeCondition::Boolean(filter(Some(runtime))),
     Some(runtime) => {
       let mut some = false;
       let mut every = true;


### PR DESCRIPTION
## Summary

- avoid constructing a temporary `RuntimeSpec` when filtering a singleton runtime
- lazily allocate the exports-info cycle-detection set only when nested exports are traversed
- keep concatenated module hash inputs as `RspackHashDigest` values instead of converting them to owned strings
- preserve generated output while reducing allocation and hashing overhead in create module hashes

Callgrind measurement on the React 10k production fixture without minification reduced the create module hashes stage from 705,923,691 IR to 557,307,083 IR, a 21.05% reduction. The baseline and optimized builds produced byte-identical output across all 19 emitted files.

## Related links

N/A

## Verification

- `cargo fmt --all -- --check`
- `pnpm run build:binding:dev`
- `pnpm run test:unit`
- byte-for-byte comparison of the React 10k production output

## Checklist

- [x] Tests updated (not required; existing unit coverage and output comparison verify the behavior).
- [x] Documentation updated (not required; no user-facing behavior changes).