### PR TITLE
docs: remove extra code block spacing in collapse panels

### DIFF
--- a/website/components/Collapse.scss
+++ b/website/components/Collapse.scss
@@ -11,6 +11,13 @@
     margin: 0 !important;
     border-radius: 0 !important;
   }
+
+  .rp-codeblock:only-child {
+    margin: 0 -1rem;
+    border: none;
+    border-radius: 0;
+    box-shadow: none;
+  }
 }
 
 .dark {

--- a/website/docs/en/plugins/javascript-modules-plugin.mdx
+++ b/website/docs/en/plugins/javascript-modules-plugin.mdx
@@ -2,6 +2,8 @@
 description: 'Handles the bundling of JavaScript, usually used to access the hooks of the JavascriptModulesPlugin:'
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # JavascriptModulesPlugin
 
 Handles the bundling of JavaScript, usually used to access the [hooks of the JavascriptModulesPlugin](/api/plugin-api/javascript-modules-plugin-hooks):

--- a/website/docs/zh/plugins/javascript-modules-plugin.mdx
+++ b/website/docs/zh/plugins/javascript-modules-plugin.mdx
@@ -2,6 +2,8 @@
 description: '处理 JavaScript 的打包，一般用于获取 JavascriptModulesPlugin 的相关钩子：'
 ---
 
+import { ApiMeta } from '@components/ApiMeta';
+
 # JavascriptModulesPlugin
 
 处理 JavaScript 的打包，一般用于获取 [JavascriptModulesPlugin 的相关钩子](/api/plugin-api/javascript-modules-plugin-hooks)：


### PR DESCRIPTION
## Summary

- remove the extra code block spacing, border, radius, and shadow inside collapse code panels
- scope the override to code blocks that are the only child so regular collapse content and code blocks remain unchanged
- import `ApiMeta` in the English and Chinese JavascriptModulesPlugin docs so full-site SSG succeeds

## Testing

- `pnpm exec rs fmt --check website/components/Collapse.scss website/docs/en/plugins/javascript-modules-plugin.mdx website/docs/zh/plugins/javascript-modules-plugin.mdx`
- started the website locally and verified the expanded code block on `/zh/api/plugin-api/javascript-modules-plugin-hooks`
- `pnpm --dir website build`

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).