### PR TITLE
fix: fallback eval devtools for modern-module

### DIFF
--- a/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
@@ -5,10 +5,11 @@ import type {
   RspackOptionsNormalized,
 } from '../config';
 import WebpackError from '../lib/WebpackError';
+import type { Logger } from '../logging/Logger';
 import { RemoveDuplicateModulesPlugin } from './RemoveDuplicateModulesPlugin';
 import { toRawSplitChunksOptions } from './SplitChunksPlugin';
 
-export function applyLimits(options: RspackOptionsNormalized) {
+export function applyLimits(options: RspackOptionsNormalized, logger?: Logger) {
   // concatenateModules is not supported in ESM library mode, it has its own scope hoist algorithm
   options.optimization.concatenateModules = false;
 
@@ -27,6 +28,22 @@ export function applyLimits(options: RspackOptionsNormalized) {
 
   if (options.output.chunkLoading === undefined) {
     options.output.chunkLoading = 'import';
+  }
+
+  // Eval source maps wrap module code in eval(), while modern-module renders it
+  // at the top level. Delay this fallback until options apply so it can warn.
+  if (
+    logger &&
+    typeof options.devtool === 'string' &&
+    options.devtool.startsWith('eval-') &&
+    options.devtool.includes('source-map')
+  ) {
+    const previousDevtool = options.devtool;
+    const fallbackDevtool = previousDevtool.slice('eval-'.length);
+    options.devtool = fallbackDevtool as RspackOptionsNormalized['devtool'];
+    logger.warn(
+      `\`devtool: "${previousDevtool}"\` is not supported with \`library.type: "modern-module"\` because its modules are rendered as top-level code. Rspack has changed \`devtool\` to \`"${fallbackDevtool}"\`.`,
+    );
   }
 
   let { splitChunks } = options.optimization;

--- a/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
+++ b/packages/rspack/src/builtin-plugin/EsmLibraryPlugin.ts
@@ -30,20 +30,29 @@ export function applyLimits(options: RspackOptionsNormalized, logger?: Logger) {
     options.output.chunkLoading = 'import';
   }
 
-  // Eval source maps wrap module code in eval(), while modern-module renders it
-  // at the top level. Delay this fallback until options apply so it can warn.
-  if (
-    logger &&
-    typeof options.devtool === 'string' &&
-    options.devtool.startsWith('eval-') &&
-    options.devtool.includes('source-map')
-  ) {
+  // Eval devtools wrap module code in eval(), while modern-module renders it at
+  // the top level. Delay this fallback until options apply so it can warn.
+  if (logger && typeof options.devtool === 'string') {
     const previousDevtool = options.devtool;
-    const fallbackDevtool = previousDevtool.slice('eval-'.length);
-    options.devtool = fallbackDevtool as RspackOptionsNormalized['devtool'];
-    logger.warn(
-      `\`devtool: "${previousDevtool}"\` is not supported with \`library.type: "modern-module"\` because its modules are rendered as top-level code. Rspack has changed \`devtool\` to \`"${fallbackDevtool}"\`.`,
-    );
+    let fallbackDevtool: RspackOptionsNormalized['devtool'];
+
+    if (previousDevtool === 'eval') {
+      fallbackDevtool = false;
+    } else if (
+      previousDevtool.startsWith('eval-') &&
+      previousDevtool.includes('source-map')
+    ) {
+      fallbackDevtool = previousDevtool.slice(
+        'eval-'.length,
+      ) as RspackOptionsNormalized['devtool'];
+    }
+
+    if (fallbackDevtool !== undefined) {
+      options.devtool = fallbackDevtool;
+      logger.warn(
+        `\`devtool: "${previousDevtool}"\` is not supported with \`library.type: "modern-module"\` because its modules are rendered as top-level code. Rspack has changed \`devtool\` to \`${JSON.stringify(fallbackDevtool)}\`.`,
+      );
+    }
   }
 
   let { splitChunks } = options.optimization;

--- a/packages/rspack/src/rspackOptionsApply.ts
+++ b/packages/rspack/src/rspackOptionsApply.ts
@@ -37,6 +37,7 @@ import {
   EnableLibraryPlugin,
   EnableWasmLoadingPlugin,
   EnsureChunkConditionsPlugin,
+  applyLimits,
   EvalDevToolModulePlugin,
   EvalSourceMapDevToolPlugin,
   ExternalsPlugin,
@@ -93,6 +94,13 @@ export class RspackOptionsApply {
     compiler.outputPath = options.output.path;
     compiler.name = options.name;
     compiler.outputFileSystem = fs;
+
+    if (options.output.enabledLibraryTypes?.includes('modern-module')) {
+      applyLimits(
+        options,
+        compiler.getInfrastructureLogger('rspack.RspackOptionsApply'),
+      );
+    }
 
     if (options.externals) {
       if (!options.externalsType) {

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/__snapshots__/esm.snap.txt
@@ -1,0 +1,8 @@
+```mjs title=main.mjs
+// ./index.js
+it('should fall back to a non-eval source map', () => {});
+
+export {};
+
+//# sourceMappingURL=main.mjs.map
+```

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,8 @@
+```mjs title=main.mjs
+// ./index.js
+it('should fall back to a non-eval source map', () => {});
+
+export {};
+
+//# sourceMappingURL=main.mjs.map
+```

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/index.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/index.js
@@ -1,0 +1,1 @@
+it('should fall back to a non-eval source map', () => {});

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/rspack.config.js
@@ -1,0 +1,29 @@
+const previousDevtool = 'eval-nosources-cheap-module-source-map';
+const fallbackDevtool = 'nosources-cheap-module-source-map';
+const expectedWarning = `\`devtool: "${previousDevtool}"\` is not supported with \`library.type: "modern-module"\` because its modules are rendered as top-level code. Rspack has changed \`devtool\` to \`"${fallbackDevtool}"\`.`;
+
+class AssertEvalSourceMapFallbackPlugin {
+  apply(compiler) {
+    let warning;
+
+    compiler.hooks.infrastructureLog.tap(
+      'AssertEvalSourceMapFallbackPlugin',
+      (name, type, args) => {
+        if (name === 'rspack.RspackOptionsApply' && type === 'warn') {
+          warning = args[0];
+          return true;
+        }
+      },
+    );
+
+    compiler.hooks.afterPlugins.tap('AssertEvalSourceMapFallbackPlugin', () => {
+      expect(compiler.options.devtool).toBe(fallbackDevtool);
+      expect(warning).toBe(expectedWarning);
+    });
+  }
+}
+
+module.exports = {
+  devtool: previousDevtool,
+  plugins: [new AssertEvalSourceMapFallbackPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/test.config.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval-source-map/test.config.js
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = {
+  snapshotFileFilter(file) {
+    return file === 'main.mjs';
+  },
+  afterExecute(options) {
+    const source = fs.readFileSync(
+      path.join(options.output.path, 'main.mjs'),
+      'utf-8',
+    );
+
+    expect(source).not.toContain('eval(');
+    expect(source).toContain('sourceMappingURL=main.mjs.map');
+    expect(fs.existsSync(path.join(options.output.path, 'main.mjs.map'))).toBe(
+      true,
+    );
+  },
+};

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval/__snapshots__/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval/__snapshots__/esm.snap.txt
@@ -1,0 +1,7 @@
+```mjs title=main.mjs
+// ./index.js
+it('should disable eval devtool', () => {});
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval/__snapshots__/runtimeModeSnapshot/esm.snap.txt
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval/__snapshots__/runtimeModeSnapshot/esm.snap.txt
@@ -1,0 +1,7 @@
+```mjs title=main.mjs
+// ./index.js
+it('should disable eval devtool', () => {});
+
+export {};
+
+```

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval/index.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval/index.js
@@ -1,0 +1,1 @@
+it('should disable eval devtool', () => {});

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval/rspack.config.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval/rspack.config.js
@@ -1,0 +1,29 @@
+const previousDevtool = 'eval';
+const fallbackDevtool = false;
+const expectedWarning = `\`devtool: "${previousDevtool}"\` is not supported with \`library.type: "modern-module"\` because its modules are rendered as top-level code. Rspack has changed \`devtool\` to \`${fallbackDevtool}\`.`;
+
+class AssertEvalFallbackPlugin {
+  apply(compiler) {
+    let warning;
+
+    compiler.hooks.infrastructureLog.tap(
+      'AssertEvalFallbackPlugin',
+      (name, type, args) => {
+        if (name === 'rspack.RspackOptionsApply' && type === 'warn') {
+          warning = args[0];
+          return true;
+        }
+      },
+    );
+
+    compiler.hooks.afterPlugins.tap('AssertEvalFallbackPlugin', () => {
+      expect(compiler.options.devtool).toBe(fallbackDevtool);
+      expect(warning).toBe(expectedWarning);
+    });
+  }
+}
+
+module.exports = {
+  devtool: previousDevtool,
+  plugins: [new AssertEvalFallbackPlugin()],
+};

--- a/tests/rspack-test/esmOutputCases/invalid-config/eval/test.config.js
+++ b/tests/rspack-test/esmOutputCases/invalid-config/eval/test.config.js
@@ -1,0 +1,20 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+module.exports = {
+  snapshotFileFilter(file) {
+    return file === 'main.mjs';
+  },
+  afterExecute(options) {
+    const source = fs.readFileSync(
+      path.join(options.output.path, 'main.mjs'),
+      'utf-8',
+    );
+
+    expect(source).not.toContain('eval(');
+    expect(source).not.toContain('sourceMappingURL=');
+    expect(fs.existsSync(path.join(options.output.path, 'main.mjs.map'))).toBe(
+      false,
+    );
+  },
+};


### PR DESCRIPTION
## Summary

- Reject eval-based devtools when `library.type` is `modern-module` before devtool plugin selection.
- Change `eval` to `false`, and strip only the `eval-` prefix from `eval-*-source-map` so modifiers such as `nosources` and `cheap-module` are preserved.
- Emit an infrastructure warning for each automatic fallback.
- Add ESM output coverage for both fallback paths, including normalized options, warnings, emitted top-level code, and source-map artifacts.

## Related links

N/A

## Testing

- `pnpm run build:js`
- `pnpm run build:binding:dev`
- `cd tests/rspack-test && pnpm exec rs test run EsmOutput.test.js` (516 passed)
- `pnpm exec rs check`
- `git diff --check`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).