### PR TITLE
ci: refresh self-hosted cache action reference

### DIFF
--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Restore cache to local
       id: local-cache
       if: ${{ runner.environment == 'self-hosted' }}
-      uses: lynx-infra/cache/restore@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # codex/refresh-action-archive
+      uses: lynx-infra/cache/restore@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # refresh-action-archive
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}

--- a/.github/actions/cache/restore/action.yml
+++ b/.github/actions/cache/restore/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Restore cache to local
       id: local-cache
       if: ${{ runner.environment == 'self-hosted' }}
-      uses: lynx-infra/cache/restore@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
+      uses: lynx-infra/cache/restore@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # codex/refresh-action-archive
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -21,7 +21,7 @@ runs:
         path: ${{ inputs.path }}
     - name: Save cache to local
       if: ${{ runner.environment == 'self-hosted' }}
-      uses: lynx-infra/cache/save@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # codex/refresh-action-archive
+      uses: lynx-infra/cache/save@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # refresh-action-archive
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}

--- a/.github/actions/cache/save/action.yml
+++ b/.github/actions/cache/save/action.yml
@@ -21,7 +21,7 @@ runs:
         path: ${{ inputs.path }}
     - name: Save cache to local
       if: ${{ runner.environment == 'self-hosted' }}
-      uses: lynx-infra/cache/save@d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba # main
+      uses: lynx-infra/cache/save@3c8b52290f86bc0144a2ea7d695c8d63f4962791 # codex/refresh-action-archive
       with:
         key: ${{ inputs.key }}
         path: ${{ inputs.path }}


### PR DESCRIPTION
## Summary

Updates the self-hosted cache restore/save actions from the codeload-broken commit `d6bd70bf2182b228ff5cfa9539e5f61b0929a1ba` to `3c8b52290f86bc0144a2ea7d695c8d63f4962791`.

The old GitHub codeload `/tar.gz/<sha>` URL consistently returns HTTP 400 and caused Linux build jobs to fail while preparing the Rust toolchain. The replacement commit preserves the previous action implementation and its codeload URL returns HTTP 200.

Related failed job: https://github.com/web-infra-dev/rspack/actions/runs/33370276808/job/99419654957

## Related links

- Cache archive refresh: https://github.com/lynx-infra/cache/tree/codex/refresh-action-archive

## Checklist

- [x] Tests updated (not required; reference-only CI change).
- [x] Documentation updated (not required).