### PR TITLE
chore(ci): validate website builds for fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,26 @@ jobs:
       profile: 'ci'
       runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
 
+  build-website-for-fork:
+    name: Build Website for Fork PR
+    needs: [check-changed]
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && needs.check-changed.outputs.document_changed == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Pnpm Setup
+        uses: ./.github/actions/pnpm/setup
+
+      - name: Pnpm Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Website
+        run: pnpm --dir website run build
+
   test-linux:
     name: Test Linux
     needs: [check-changed, build-linux]
@@ -197,11 +217,12 @@ jobs:
   test_required_check:
     # this job will be used for GitHub actions to determine required job success or not;
     # When code changed, it will check if any of the test jobs failed.
-    # When *only* doc changed, it will run as success directly
+    # For fork PRs that change the website, it also requires the website build to pass.
     name: Test Required Check
     needs:
       [
         build-linux,
+        build-website-for-fork,
         test-linux,
         test-windows,
         test-mac,
@@ -219,9 +240,32 @@ jobs:
       - name: Log
         run: echo ${{ join(needs.*.result, ',') }}
       - name: Test check
-        if: ${{ needs.check-changed.outputs.code_changed == 'true'
-          && join(needs.*.result, ',')!='success,success,success,success,success,success,success,success,success,success,skipped' }}
+        if: >-
+          ${{
+            needs.check-changed.result != 'success' ||
+            (needs.check-changed.outputs.code_changed == 'true' &&
+              (needs.build-linux.result != 'success' ||
+                needs.test-linux.result != 'success' ||
+                needs.test-windows.result != 'success' ||
+                needs.test-mac.result != 'success' ||
+                needs.build-wasm.result != 'success' ||
+                needs.build-riscv64.result != 'success' ||
+                needs.build-ppc64.result != 'success' ||
+                needs.build-s390x.result != 'success' ||
+                needs.test-wasm.result != 'success' ||
+                needs.check-cache.result != 'skipped'))
+          }}
         run: echo "Test Failed" && exit 1
+
+      - name: Website check
+        if: >-
+          ${{
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.fork &&
+            needs.check-changed.outputs.document_changed == 'true' &&
+            needs.build-website-for-fork.result != 'success'
+          }}
+        run: echo "Website Build Failed" && exit 1
 
       - name: No check to Run test
         run: echo "Success"


### PR DESCRIPTION
## Summary

- build the Rspress website when a pull request from a fork changes `website/**`
- run the untrusted build on `ubuntu-latest` with read-only repository access and no secrets
- feed the website build result into the existing `Test Required Check`
- replace the required-check result string comparison with explicit job result checks

This covers fork pull requests that do not receive a Cloudflare Pages preview deployment.

## Related links

- [Cloudflare Pages preview URL behavior](https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/#preview-urls)

## Validation

- `pnpm --dir website run build`
- workflow YAML parsing
- Rstack formatting check
- actionlint expression validation
- `git diff --check`

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).
