### PR TITLE
fix(cache): skip non-serializable entries during filesystem cache writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4271,6 +4271,7 @@ dependencies = [
  "swc_experimental_ecma_ast",
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
+ "tempfile",
  "tokio",
  "tracing",
  "triomphe",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -85,6 +85,7 @@ turbo-persistence = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile          = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -222,16 +222,14 @@ impl FileCacheStrategy {
       let pending_items = entries.len()
         + if validator.is_some() { 1 } else { 0 }
         + if meta.is_some() { 1 } else { 0 };
-      let logger = &self.logger;
-      let skipped_items = &AtomicUsize::new(0);
+      let skipped = AtomicUsize::new(0);
+      let skipped_items = &skipped;
       let result = self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {
           let value = match (pending.encoder)(&pending.entry, codec) {
             Ok(value) => value,
             Err(error) => {
-              logger.warn(format!(
-                "Skipping cache item {key}, it can't be stored: {error}"
-              ));
+              tracing::warn!("Storing cache item {key} failed: {error}");
               skipped_items.fetch_add(1, Ordering::Relaxed);
               return Ok(());
             }
@@ -249,10 +247,16 @@ impl FileCacheStrategy {
       self.logger.time_end(start);
       result?;
 
-      let stored_items = pending_items - skipped_items.load(Ordering::Relaxed);
+      let skipped_items = skipped.load(Ordering::Relaxed);
+      let stored_items = pending_items - skipped_items;
       self.pending_writes.entries.clear();
       self.pending_writes.new_build_dependencies = None;
       self.pending_writes.meta = None;
+      if skipped_items > 0 {
+        self.logger.warn(format!(
+          "Skipped {skipped_items} cache items that can't be stored"
+        ));
+      }
       self
         .logger
         .log(format!("Stored cache ({stored_items} items)"));
@@ -289,6 +293,7 @@ impl FileCacheStrategy {
 mod tests {
   use rspack_fs::MemoryFileSystem;
   use rspack_hash::HashFunction;
+  use rspack_paths::AssertUtf8;
 
   use super::*;
   use crate::{PrintlnInfrastructureLogSink, cache::SnapshotOptions, new_cache::CacheValue};
@@ -297,7 +302,7 @@ mod tests {
     Err(rspack_error::error!("value can't be serialized"))
   }
 
-  fn strategy(directory: &Utf8PathBuf) -> FileCacheStrategy {
+  fn new_strategy(directory: &Utf8PathBuf) -> FileCacheStrategy {
     let logger = Arc::new(InfrastructureLogger::new(
       "rspack.cache.IdleFileCache",
       Arc::new(PrintlnInfrastructureLogSink),
@@ -317,14 +322,13 @@ mod tests {
       file_system_info,
       logger,
     )
-    .unwrap()
+    .expect("should open the cache database")
   }
 
   #[tokio::test]
-  async fn a_non_encodable_entry_does_not_discard_the_batch() {
-    let directory = tempfile::tempdir().unwrap();
-    let mut strategy =
-      strategy(&Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).unwrap());
+  async fn non_encodable_entry_does_not_discard_the_batch() {
+    let directory = tempfile::tempdir().expect("should create a temporary directory");
+    let mut strategy = new_strategy(&directory.path().to_path_buf().assert_utf8());
 
     strategy.store(
       CacheKey::new("encodable"),
@@ -338,21 +342,26 @@ mod tests {
       CacheValue::new("value".to_string()).erase(),
       failing_encoder,
     );
+    strategy.store_meta(Meta {
+      max_dependency_id: 7,
+    });
 
-    strategy.after_all_stored(0, || false).await.unwrap();
+    strategy
+      .after_all_stored(0, || false)
+      .await
+      .expect("should store the encodable items");
 
     let decoder = CacheValue::<String>::decoder();
-    assert!(
-      strategy
-        .restore(&CacheKey::new("encodable"), None, decoder)
-        .unwrap()
-        .is_some()
-    );
-    assert!(
-      strategy
-        .restore(&CacheKey::new("non-encodable"), None, decoder)
-        .unwrap()
-        .is_none()
-    );
+    let encodable = strategy
+      .restore(&CacheKey::new("encodable"), None, decoder)
+      .expect("should read the encodable item");
+    let non_encodable = strategy
+      .restore(&CacheKey::new("non-encodable"), None, decoder)
+      .expect("should read the non encodable item");
+    let meta = strategy.restore_meta().expect("should read the meta");
+
+    assert!(encodable.is_some());
+    assert!(non_encodable.is_none());
+    assert_eq!(meta.expect("meta should be stored").max_dependency_id, 7);
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -1,4 +1,10 @@
-use std::{fmt, sync::Arc};
+use std::{
+  fmt,
+  sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+  },
+};
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use rspack_error::Result;
@@ -213,12 +219,23 @@ impl FileCacheStrategy {
         .as_ref()
         .map(|meta| codec.encode(meta))
         .transpose()?;
-      let stored_items = entries.len()
+      let pending_items = entries.len()
         + if validator.is_some() { 1 } else { 0 }
         + if meta.is_some() { 1 } else { 0 };
+      let logger = &self.logger;
+      let skipped_items = &AtomicUsize::new(0);
       let result = self.database.write_batch(move |batch| {
         entries.par_iter().try_for_each(|(key, pending)| {
-          let value = (pending.encoder)(&pending.entry, codec)?;
+          let value = match (pending.encoder)(&pending.entry, codec) {
+            Ok(value) => value,
+            Err(error) => {
+              logger.warn(format!(
+                "Skipping cache item {key}, it can't be stored: {error}"
+              ));
+              skipped_items.fetch_add(1, Ordering::Relaxed);
+              return Ok(());
+            }
+          };
           batch.put(DatabaseFamily::Cache, key.as_bytes(), value)
         })?;
         if let Some(validator) = validator {
@@ -232,6 +249,7 @@ impl FileCacheStrategy {
       self.logger.time_end(start);
       result?;
 
+      let stored_items = pending_items - skipped_items.load(Ordering::Relaxed);
       self.pending_writes.entries.clear();
       self.pending_writes.new_build_dependencies = None;
       self.pending_writes.meta = None;
@@ -264,5 +282,77 @@ impl FileCacheStrategy {
     !self.pending_writes.entries.is_empty()
       || self.pending_writes.new_build_dependencies.is_some()
       || self.pending_writes.meta.is_some()
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rspack_fs::MemoryFileSystem;
+  use rspack_hash::HashFunction;
+
+  use super::*;
+  use crate::{PrintlnInfrastructureLogSink, cache::SnapshotOptions, new_cache::CacheValue};
+
+  fn failing_encoder(_entry: &CacheEntry, _codec: &CacheCodec) -> Result<Vec<u8>> {
+    Err(rspack_error::error!("value can't be serialized"))
+  }
+
+  fn strategy(directory: &Utf8PathBuf) -> FileCacheStrategy {
+    let logger = Arc::new(InfrastructureLogger::new(
+      "rspack.cache.IdleFileCache",
+      Arc::new(PrintlnInfrastructureLogSink),
+    ));
+    let file_system_info = FileSystemInfo::new(
+      Arc::new(MemoryFileSystem::default()),
+      logger.get_child("rspack.FileSystemInfo"),
+      SnapshotOptions::default(),
+      HashFunction::Xxhash64,
+    );
+    FileCacheStrategy::new(
+      (directory.clone(), directory.join("database")),
+      false,
+      "0.0.0".to_string(),
+      "test".to_string(),
+      Arc::new(CacheCodec::new(None)),
+      file_system_info,
+      logger,
+    )
+    .unwrap()
+  }
+
+  #[tokio::test]
+  async fn a_non_encodable_entry_does_not_discard_the_batch() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut strategy =
+      strategy(&Utf8PathBuf::from_path_buf(directory.path().to_path_buf()).unwrap());
+
+    strategy.store(
+      CacheKey::new("encodable"),
+      None,
+      CacheValue::new("value".to_string()).erase(),
+      CacheValue::<String>::encoder(),
+    );
+    strategy.store(
+      CacheKey::new("non-encodable"),
+      None,
+      CacheValue::new("value".to_string()).erase(),
+      failing_encoder,
+    );
+
+    strategy.after_all_stored(0, || false).await.unwrap();
+
+    let decoder = CacheValue::<String>::decoder();
+    assert!(
+      strategy
+        .restore(&CacheKey::new("encodable"), None, decoder)
+        .unwrap()
+        .is_some()
+    );
+    assert!(
+      strategy
+        .restore(&CacheKey::new("non-encodable"), None, decoder)
+        .unwrap()
+        .is_none()
+    );
   }
 }


### PR DESCRIPTION
## Summary

`FileCacheStrategy::after_all_stored` encodes every pending entry inside a `try_for_each` over the write batch, so one entry whose encoder fails aborts the whole batch: the valid entries, the validator data and the metadata are all dropped, and the next idle store retries the same batch and fails again. Before module cache moved its encoding behind the generic cache boundary it encoded its own value and skipped just that module, and that recovery path went away with the refactor.

Each entry is now encoded independently. A failing encoder is traced with the key that caused it and the entry is dropped; everything else in the batch is written as before. The skipped entries are counted so `after_all_stored` can warn once with the total and report an accurate `Stored cache (N items)`, rather than warning per entry inside the rayon loop. Errors from `batch.put` still propagate, since those are real database failures rather than a single unserializable value.

## Test

`non_encodable_entry_does_not_discard_the_batch` in `crates/rspack_core/src/new_cache/file_cache_strategy.rs` stores one entry with a working encoder, one with an encoder that always errors, and some metadata, then checks the good entry and the metadata are readable from the database afterwards. Without the change it fails on `after_all_stored` returning the encoder error.

`cargo test -p rspack_core --lib` is 120 passed, `cargo clippy -p rspack_core --all-targets` and `cargo fmt --check` are clean.

## Related links

Closes #15406

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
