### PR TITLE
docs: improve CssExtractRspackPlugin documentation

### DIFF
--- a/website/docs/en/plugins/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/css-extract-rspack-plugin.mdx
@@ -54,6 +54,8 @@ dist/
 `CssExtractRspackPlugin` emits CSS imported by an entry, but does not add a link for it to HTML. Register [HtmlRspackPlugin](/plugins/html-rspack-plugin) alongside it to generate `index.html` and inject the corresponding stylesheet `<link>` tags:
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
 export default {
   entry: './src/index.js',
   plugins: [new rspack.HtmlRspackPlugin(), new rspack.CssExtractRspackPlugin()],
@@ -79,6 +81,8 @@ The configuration above generates `dist/index.html` with a link to `main.css`:
 `CssExtractRspackPlugin` represents extracted styles as modules of type `css/mini-extract`. Use [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) to select only CSS extracted by this plugin, without selecting JavaScript modules or modules handled by Rspack's built-in CSS support.
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
 export default {
   plugins: [new rspack.CssExtractRspackPlugin()],
   module: {

--- a/website/docs/en/plugins/css-extract-rspack-plugin.mdx
+++ b/website/docs/en/plugins/css-extract-rspack-plugin.mdx
@@ -1,53 +1,90 @@
 ---
-description: 'Rspack is currently incompatible with mini-css-extract-plugin, but you can use the CssExtractRspackPlugin as a replacement'
+description: 'Extracts CSS processed by css-loader into separate CSS files'
 ---
 
-import { Table } from '@builtIns';
 import { ApiMeta } from '@components/ApiMeta.tsx';
 
 # CssExtractRspackPlugin
 
 <ApiMeta specific={['Rspack']} />
 
-Rspack is currently incompatible with [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin), but you can use the CssExtractRspackPlugin as a replacement. It can be used with css-loader to extract CSS into separate files.
+`CssExtractRspackPlugin` works with [css-loader](https://github.com/webpack/css-loader) to extract CSS imported by JavaScript modules into separate files. In Rspack, use it as an alternative to [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin), or whenever your project needs css-loader features.
 
-> If your project does not depend on css-loader and mini-css-extract-plugin, it is recommended to use Rspack's built-in CSS solution, which offers better performance.
+By default, CSS in entry chunks is emitted as `[name].css`. CSS loaded through dynamic `import()` is handled by runtime code injected by the plugin.
+
+If your project does not need css-loader, prefer Rspack's [built-in CSS support](/guide/tech/css) to avoid the extra loader and plugin processing.
+
+:::warning
+`CssExtractRspackPlugin.loader` cannot be used with Rspack's built-in CSS module types: `css`, `css/auto`, `css/global`, or `css/module`. The default module type is `javascript/auto`, so `type` can normally be omitted. If a module uses one of the built-in CSS types, the loader skips it and emits a warning; the plugin does not extract its CSS.
+:::
 
 ## Examples
 
-When using CssExtractRspackPlugin, you need to register the plugin in the `plugins` section and register `CssExtractRspackPlugin.loader` in [module.rules](/config/module#modulerules).
+### Basic usage
 
-```ts title="rspack.config.mjs"
+Register the plugin and place `CssExtractRspackPlugin.loader` before `css-loader` in the CSS rule:
+
+```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 
 export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
+  entry: './src/index.js',
+  plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
         test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
-        type: 'javascript/auto',
       },
     ],
   },
 };
 ```
 
-### Split extracted CSS with splitChunks
+If the `main` entry imports CSS, the default output includes:
 
-`CssExtractRspackPlugin` adds extracted CSS modules with the `css/mini-extract` module type. You can use [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) to create a cache group that only matches CSS extracted by `CssExtractRspackPlugin`, without matching JavaScript modules or native CSS modules.
+```text
+dist/
+├── main.js
+└── main.css
+```
 
-```ts title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
+### With the HTML plugin
 
+`CssExtractRspackPlugin` emits CSS imported by an entry, but does not add a link for it to HTML. Register [HtmlRspackPlugin](/plugins/html-rspack-plugin) alongside it to generate `index.html` and inject the corresponding stylesheet `<link>` tags:
+
+```js title="rspack.config.mjs"
 export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
+  entry: './src/index.js',
+  plugins: [new rspack.HtmlRspackPlugin(), new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
         test: /\.css$/i,
-        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+};
+```
+
+The configuration above generates `dist/index.html` with a link to `main.css`:
+
+```html
+<link href="main.css" rel="stylesheet" />
+```
+
+### Split CSS
+
+`CssExtractRspackPlugin` represents extracted styles as modules of type `css/mini-extract`. Use [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) to select only CSS extracted by this plugin, without selecting JavaScript modules or modules handled by Rspack's built-in CSS support.
+
+```js title="rspack.config.mjs"
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin()],
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
       },
     ],
@@ -68,195 +105,392 @@ export default {
 };
 ```
 
-In this example, `extractedCss` only selects modules whose module type is `css/mini-extract`. `enforce: true` makes the CSS chunk be created even when the normal `minSize` or request-limit heuristics would skip it; remove `enforce` if you want the cache group to follow the normal splitChunks heuristics.
+Here, `extractedCss` selects only modules whose type is `css/mini-extract`. For details about `enforce`, see [`splitChunks.cacheGroups.{cacheGroup}.enforce`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegroupenforce).
 
-## Plugin options
+## Options
 
-Options for `CssExtractRspackPlugin`.
+Pass these options to `new rspack.CssExtractRspackPlugin()`.
 
-- **Types:**
+### filename
 
-```ts
-interface PluginOptions {
-  filename?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
-  chunkFilename?:
-    string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
-  ignoreOrder?: boolean;
-  insert?: string | ((linkTag: HTMLLinkElement) => void);
-  attributes?: Record<string, string>;
-  linkType?: string | 'text/css' | false;
-  runtime?: boolean;
-  pathinfo?: boolean;
-  enforceRelative?: boolean;
-}
+- **Type:**
+
+  ```ts
+  type CssFilenameFunction = (
+    pathData: PathData,
+    assetInfo?: AssetInfo,
+  ) => string;
+
+  type CssFilename = string | CssFilenameFunction;
+  ```
+
+- **Default:** `'[name].css'`
+
+Sets the filename of extracted CSS assets for chunks loaded with an entry. The value supports the placeholders documented for [`output.filename`](/config/output#outputfilename). When omitted or set to an empty string, Rspack uses `[name].css`. CSS assets for on-demand chunks use [`chunkFilename`](#chunkfilename).
+
+- **String:** Uses a non-empty value as the filename template for every CSS chunk loaded with an entry.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    filename: 'css/[name].[contenthash].css',
+  });
+  ```
+
+- **Function:** For each CSS chunk loaded with an entry, Rspack calls the function with its `PathData` and optional `AssetInfo`, then uses the returned string as the filename.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    filename: ({ chunk }) => `css/${chunk?.name ?? 'styles'}.css`,
+  });
+  ```
+
+When `filename` is a function and `chunkFilename` is omitted, on-demand CSS chunks use `[id].css`; Rspack does not reuse the function for them.
+
+### chunkFilename
+
+- **Type:**
+
+  ```ts
+  type CssChunkFilenameFunction = (
+    pathData: PathData,
+    assetInfo?: AssetInfo,
+  ) => string;
+
+  type CssChunkFilename = string | CssChunkFilenameFunction;
+  ```
+
+- **Default:** Derived from `filename`
+
+Sets the filename of extracted CSS assets for on-demand chunks, including chunks created by dynamic `import()`. An explicitly configured non-empty string or function overrides the value derived from `filename`. The value supports the placeholders documented for [`output.chunkFilename`](/config/output#outputchunkfilename).
+
+When omitted, Rspack derives the value as follows:
+
+- If a string `filename` contains `[name]`, `[id]`, `[chunkhash]`, or `[contenthash]`, Rspack reuses it.
+- If a string `filename` contains none of those placeholders, Rspack adds `[id].` before its basename. For example, `css/styles.css` produces `css/[id].styles.css` for async chunks.
+- If `filename` is a function, Rspack uses `[id].css`.
+
+- **String:** Uses a non-empty value as the filename template for every on-demand CSS chunk.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    chunkFilename: 'css/[id].[contenthash].chunk.css',
+  });
+  ```
+
+- **Function:** Rspack calls the function for each on-demand CSS chunk with its `PathData` and optional `AssetInfo`, then uses the returned string as the filename.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    chunkFilename: ({ chunk }) =>
+      `css/${chunk?.name ?? chunk?.id ?? 'chunk'}.chunk.css`,
+  });
+  ```
+
+### ignoreOrder
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Controls whether Rspack reports CSS order conflicts. By default, Rspack warns when different chunk groups require incompatible CSS orders, then emits the CSS using a fallback order.
+
+Set `ignoreOrder` to `true` to suppress these warnings. This does not change the order Rspack chooses and does not resolve order-dependent styling conflicts.
+
+```js
+new rspack.CssExtractRspackPlugin({
+  ignoreOrder: true,
+});
 ```
 
-<Table
-  header={[
-    {
-      name: 'Name',
-      key: 'name',
+### insert
+
+- **Type:**
+
+  ```ts
+  type InsertFunction = (linkTag: HTMLLinkElement) => void;
+
+  type Insert = string | InsertFunction;
+  ```
+
+- **Default:** `undefined`
+
+Sets the insertion position of stylesheet `<link>` elements created by the plugin runtime for async CSS chunks and HMR updates. It does not affect stylesheet links already present in HTML.
+
+When omitted, the runtime appends a new async stylesheet to `document.head`. During a hot update, it inserts the replacement after the previous stylesheet.
+
+- **String:** Treats the value as a selector passed to `document.querySelector()` and inserts the stylesheet immediately after the first matching element. The selector must match an element at runtime.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    insert: '#css-anchor',
+  });
+  ```
+
+- **Function:** Serializes the function into the generated runtime and calls it in the browser with the new `<link>` element. The function must insert the element itself and cannot use variables from the Rspack configuration's scope.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    insert: (linkTag) => {
+      document.head.appendChild(linkTag);
     },
-    {
-      name: 'Type',
-      key: 'type',
-    },
-    {
-      name: 'Default Value',
-      key: 'default',
-    },
-    {
-      name: 'Description',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`filename`',
-      type: '`string`',
-      default: '"[name].css"',
-      description:
-        'The name of each CSS output file, please refer to `output.filename`',
-    },
-    {
-      name: '`chunkFilename`',
-      type: '`string`',
-      default: '"[name].css"',
-      description:
-        'The name of the asynchronously loaded CSS files. If not set, it will use `filename`; please refer to `output.chunkFilename`',
-    },
-    {
-      name: '`ignoreOrder`',
-      type: '`boolean`',
-      default: 'false',
-      description:
-        'Whether to issue a warning if there are conflicts in the order of some CSS in different chunks. For example, entryA introduces a.css and b.css, entryB introduces b.css and a.css, and the order of a.css and b.css cannot be determined',
-    },
-    {
-      name: '`insert`',
-      type: '`string | ((linkTag: HTMLLinkElement) => void)`',
-      default: 'undefined',
-      description:
-        'Decide how the link tag is inserted into the page. If passed as a string type, it will be regarded as DOM selector, and the link tag will be inserted after element corresponding to that selector. If passed as function type, the function will be converted into a string at runtime for invocation, with link tag as parameter',
-    },
-    {
-      name: '`attributes`',
-      type: '`Record<string, string>`',
-      default: 'undefined',
-      description:
-        'Adds custom attributes to the `link` tag for async CSS chunks',
-    },
-    {
-      name: '`linkType`',
-      type: "`string | 'text/css' | false`",
-      default: '"text/css"',
-      description:
-        'Set the `type` attribute value for link tags to load async CSS chunks',
-    },
-    {
-      name: '`runtime`',
-      type: '`boolean`',
-      default: 'true',
-      description: `Whether to inject runtime code for CSS loading. If disabled, CSS will be still extracted and can be used for a custom loading methods`,
-    },
-    {
-      name: '`pathinfo`',
-      type: '`boolean`',
-      default: 'false',
-      description:
-        'Whether to include comments in CSS bundles with more detailed path information',
-    },
-    {
-      name: '`enforceRelative`',
-      type: '`boolean`',
-      default: 'false',
-      description:
-        'Whether to preserve "\.\/" when generated CSS `url()` is relative',
-    },
-  ]}
-/>
+  });
+  ```
+
+The `insert` option has no effect when [`runtime`](#runtime) is `false`.
+
+### attributes
+
+- **Type:** `Record<string, string>`
+- **Default:** `undefined`
+
+Adds custom attributes to stylesheet `<link>` elements created by the plugin runtime. These elements are used when loading async CSS chunks and applying HMR updates; stylesheet links already present in HTML are not affected. When omitted, the runtime adds no custom attributes.
+
+```js
+new rspack.CssExtractRspackPlugin({
+  attributes: {
+    'data-source': 'rspack',
+  },
+});
+```
+
+Use [`linkType`](#linktype) to control the `type` attribute. When both options set `type`, a string `linkType` takes precedence. The `attributes` option has no effect when [`runtime`](#runtime) is `false`.
+
+### linkType
+
+- **Type:** `string | false`
+- **Default:** `'text/css'`
+
+Sets the `type` attribute on stylesheet `<link>` elements created by the plugin runtime. These elements are used when loading async CSS chunks and applying HMR updates; stylesheet links already present in HTML are not affected.
+
+When omitted, the runtime sets the attribute to `text/css`.
+
+- **String:** Sets the `type` attribute to the provided value.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    linkType: 'text/css',
+  });
+  ```
+
+- **`false`:** Disables the plugin's default `type` assignment. The attribute is omitted unless `attributes` supplies a custom `type` value.
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    linkType: false,
+  });
+  ```
+
+The `linkType` option has no effect when [`runtime`](#runtime) is `false`.
+
+### runtime
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls whether the plugin injects code that loads CSS for async chunks at runtime. Setting it to `false` still emits extracted CSS assets, but your application must load CSS for on-demand chunks itself.
+
+When omitted, the plugin includes the CSS-loading runtime.
+
+When disabled, [`insert`](#insert), [`attributes`](#attributes), and [`linkType`](#linktype) cannot affect async CSS loading because the plugin does not create those `<link>` elements.
+
+```js
+new rspack.CssExtractRspackPlugin({
+  runtime: false,
+});
+```
+
+### pathinfo
+
+- **Type:** `boolean`
+- **Default:** `true` when [`output.pathinfo`](/config/output#outputpathinfo) is enabled, otherwise `false`
+
+Controls whether the plugin adds a comment containing the readable module path before each extracted module. These comments make CSS assets easier to inspect, but increase their size and can expose source paths.
+
+An explicit `pathinfo` value takes precedence over `output.pathinfo`. When omitted, the option inherits the value of `output.pathinfo`.
+
+```js
+new rspack.CssExtractRspackPlugin({
+  pathinfo: true,
+});
+```
+
+### enforceRelative
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+When the effective loader [`publicPath`](#publicpath) is `'auto'`, Rspack calculates asset URLs relative to the emitted CSS file. If the calculated prefix is empty, this option controls whether the URL starts with `./`. The default produces `url(assets/icon.svg)`; setting it to `true` produces `url(./assets/icon.svg)`.
+
+An explicitly configured loader `publicPath` other than `'auto'` takes precedence, so `enforceRelative` has no effect in that case.
+
+```js
+new rspack.CssExtractRspackPlugin({
+  enforceRelative: true,
+});
+```
 
 ## Loader options
 
-Options for `CssExtractRspackPlugin.loader`.
+Set these options on `CssExtractRspackPlugin.loader` in [`module.rules`](/config/module#modulerules).
 
-- **Types:**
+### publicPath
 
-```ts
-interface LoaderOptions {
-  publicPath?: string | ((resourcePath: string, context: string) => string);
-  emit?: boolean;
-  esModule?: boolean;
-}
+- **Type:**
+
+  ```ts
+  type PublicPathFunction = (resourcePath: string, context: string) => string;
+
+  type PublicPath = string | PublicPathFunction;
+  ```
+
+- **Default:** [`output.publicPath`](/config/output#outputpublicpath)
+
+Sets the public path used for assets referenced in CSS, such as images and fonts. It does not affect the URL of the emitted CSS file itself.
+
+An explicit loader `publicPath` takes precedence over `output.publicPath` for the CSS resource being processed.
+
+When omitted, the loader uses `output.publicPath`.
+
+- **String:** Uses the same public path for every matching CSS resource.
+
+  ```js
+  const cssRule = {
+    test: /\.css$/i,
+    use: [
+      {
+        loader: rspack.CssExtractRspackPlugin.loader,
+        options: {
+          publicPath: '/assets/',
+        },
+      },
+      'css-loader',
+    ],
+  };
+  ```
+
+- **Function:** Calls the function at build time with the absolute CSS `resourcePath` and the compiler root `context`. The returned string becomes the public path for that resource.
+
+  ```js
+  const cssRule = {
+    test: /\.css$/i,
+    use: [
+      {
+        loader: rspack.CssExtractRspackPlugin.loader,
+        options: {
+          publicPath: (resourcePath, context) =>
+            resourcePath.startsWith(context) ? '/assets/' : '/external-assets/',
+        },
+      },
+      'css-loader',
+    ],
+  };
+  ```
+
+### emit
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Controls whether CSS from the processed resource is included in extracted CSS assets. Setting it to `false` still processes the resource and preserves any CSS Modules exports in JavaScript, but omits its CSS from emitted files.
+
+When omitted, the resource's CSS is included in an emitted CSS asset.
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        emit: false,
+      },
+    },
+    'css-loader',
+  ],
+};
 ```
 
-<Table
-  header={[
-    {
-      name: 'Name',
-      key: 'name',
-    },
-    {
-      name: 'Type',
-      key: 'type',
-    },
-    {
-      name: 'Default Value',
-      key: 'default',
-    },
-    {
-      name: 'Description',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`publicPath`',
-      type: '`string | ((resourcePath: string, context: string) => string)`',
-      default: 'output.publicPath',
-      description:
-        'Specifies a custom public path for the external resources like images, files, etc inside CSS',
-    },
-    {
-      name: '`emit`',
-      type: '`boolean`',
-      default: 'true',
-      description:
-        'If true, emits CSS files. If false, the plugin will extract the CSS but will not emit files',
-    },
-    {
-      name: '`esModule`',
-      type: '`boolean`',
-      default: 'true',
-      description:
-        'whether to use ES modules syntax for CSS Modules class name exports in the generated JavaScript module',
-    },
-  ]}
-/>
+### esModule
 
-## Note
+- **Type:** `boolean`
+- **Default:** `true`
 
-Please note that if you want to use this plugin and css together, it's recommended to explicitly set type to `javascript/auto`.
+Controls whether the JavaScript module generated by `CssExtractRspackPlugin.loader` uses ES module or CommonJS syntax. Setting it to `false` uses CommonJS. For consistent output, set css-loader's `esModule` option to the same value.
 
-For example:
+When omitted, `CssExtractRspackPlugin.loader` uses ES module syntax.
 
-```ts title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
+When css-loader generates named CSS Modules exports, those exports remain ES modules. In that case, use [`defaultExport`](#defaultexport) to control whether the loader also generates a default export.
 
-export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
-  module: {
-    rules: [
-      {
-        test: /src\/legacy-project\/.*\.css$/,
-        type: 'javascript/auto', // Cover the default CSS module type and treat it as a regular JS file.
-        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        esModule: false,
       },
-      {
-        test: /src\/new-project\/.*\.css$/,
-        type: 'css/auto', // Handle with built-in CSS
+    },
+    {
+      loader: 'css-loader',
+      options: {
+        esModule: false,
       },
-    ],
-  },
+    },
+  ],
+};
+```
+
+### layer
+
+- **Type:** `string`
+- **Default:** `undefined`
+
+Assigns the processed CSS resource to the specified Rspack module layer. This is a module-graph layer, not a CSS cascade `@layer`. Use it with options such as [`splitChunks.cacheGroups.{cacheGroup}.layer`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouplayer) to select extracted CSS by layer.
+
+When omitted, this loader does not assign an explicit module layer.
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        layer: 'theme',
+      },
+    },
+    'css-loader',
+  ],
+};
+```
+
+### defaultExport
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+When css-loader generates named CSS Modules exports, this option controls whether `CssExtractRspackPlugin.loader` also generates a default object containing all local class names. The named exports are always preserved.
+
+This option has no effect when css-loader does not generate named exports. When omitted, only the named exports are generated in that mode.
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        defaultExport: true,
+      },
+    },
+    {
+      loader: 'css-loader',
+      options: {
+        modules: {
+          namedExport: true,
+        },
+      },
+    },
+  ],
 };
 ```

--- a/website/docs/zh/plugins/css-extract-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/css-extract-rspack-plugin.mdx
@@ -54,6 +54,8 @@ dist/
 `CssExtractRspackPlugin` 会输出入口中导入的 CSS，但不会自动在 HTML 中添加对应链接。将 [HtmlRspackPlugin](/plugins/html-rspack-plugin) 与它一起注册，可以生成 `index.html` 并注入对应的样式表 `<link>` 标签：
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
 export default {
   entry: './src/index.js',
   plugins: [new rspack.HtmlRspackPlugin(), new rspack.CssExtractRspackPlugin()],
@@ -79,6 +81,8 @@ export default {
 `CssExtractRspackPlugin` 会将提取出的样式表示为类型为 `css/mini-extract` 的模块。通过 [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) 可以只选择该插件提取的 CSS，而不会选择 JavaScript 模块或由 Rspack 内置 CSS 支持处理的模块。
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+
 export default {
   plugins: [new rspack.CssExtractRspackPlugin()],
   module: {

--- a/website/docs/zh/plugins/css-extract-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/css-extract-rspack-plugin.mdx
@@ -1,53 +1,90 @@
 ---
-description: 'Rspack 目前不兼容 mini-css-extract-plugin，但可以使用 CssExtractRspackPlugin 替代，它可以和 css-loader 搭配使用，用于将 CSS 提取成单独文件。'
+description: '将 css-loader 处理的 CSS 提取为独立的 CSS 文件'
 ---
 
-import { Table } from '@builtIns';
 import { ApiMeta } from '@components/ApiMeta.tsx';
 
 # CssExtractRspackPlugin
 
 <ApiMeta specific={['Rspack']} />
 
-Rspack 目前不兼容 [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin)，但可以使用 CssExtractRspackPlugin 替代，它可以和 css-loader 搭配使用，用于将 CSS 提取成单独文件。
+`CssExtractRspackPlugin` 与 [css-loader](https://github.com/webpack/css-loader) 配合，将 JavaScript 模块导入的 CSS 提取为独立文件。在 Rspack 中，它可替代 [mini-css-extract-plugin](https://github.com/webpack/mini-css-extract-plugin)，也可用于需要 css-loader 功能的项目。
 
-> 如果你的项目不依赖于 css-loader 和 mini-css-extract-plugin，我们更推荐使用 Rspack [内置的 CSS 解决方案](/guide/tech/css)，它的性能更好。
+默认情况下，入口 chunk 中的 CSS 输出为 `[name].css`，通过动态 `import()` 加载的 CSS 则由插件注入的运行时代码处理。
+
+如果项目不需要 css-loader，建议优先使用 Rspack 的[内置 CSS 支持](/guide/tech/css)，省去额外的 loader 和插件处理。
+
+:::warning
+`CssExtractRspackPlugin.loader` 不能与 Rspack 的内置 CSS 模块类型 `css`、`css/auto`、`css/global` 或 `css/module` 同时使用。默认模块类型是 `javascript/auto`，因此通常可以省略 `type`。如果模块使用了上述任一内置 CSS 类型，该 loader 会跳过该模块并输出警告，插件也不会提取其中的 CSS。
+:::
 
 ## 示例
 
-使用 CssExtractRspackPlugin 时，需要在 `plugins` 中注册插件，并在 [module.rules](/config/module#modulerules) 中注册 `CssExtractRspackPlugin.loader`。
+### 基本用法
 
-```ts title="rspack.config.mjs"
+注册插件，并在 CSS 规则中将 `CssExtractRspackPlugin.loader` 放在 `css-loader` 之前：
+
+```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 
 export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
+  entry: './src/index.js',
+  plugins: [new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
         test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
-        type: 'javascript/auto',
       },
     ],
   },
 };
 ```
 
-### 通过 splitChunks 拆分提取出的 CSS
+如果 `main` 入口导入了 CSS，默认产物中会包含：
 
-`CssExtractRspackPlugin` 会为提取出的 CSS 模块添加 `css/mini-extract` 模块类型。你可以使用 [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) 创建一个只命中 `CssExtractRspackPlugin` 提取出的 CSS 的 cache group，而不会命中 JavaScript 模块或内置 CSS 模块。
+```text
+dist/
+├── main.js
+└── main.css
+```
 
-```ts title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
+### 配合 HTML 插件
 
+`CssExtractRspackPlugin` 会输出入口中导入的 CSS，但不会自动在 HTML 中添加对应链接。将 [HtmlRspackPlugin](/plugins/html-rspack-plugin) 与它一起注册，可以生成 `index.html` 并注入对应的样式表 `<link>` 标签：
+
+```js title="rspack.config.mjs"
 export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
+  entry: './src/index.js',
+  plugins: [new rspack.HtmlRspackPlugin(), new rspack.CssExtractRspackPlugin()],
   module: {
     rules: [
       {
         test: /\.css$/i,
-        type: 'javascript/auto',
+        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+};
+```
+
+上述配置会生成 `dist/index.html`，其中包含指向 `main.css` 的链接：
+
+```html
+<link href="main.css" rel="stylesheet" />
+```
+
+### 拆分 CSS
+
+`CssExtractRspackPlugin` 会将提取出的样式表示为类型为 `css/mini-extract` 的模块。通过 [`splitChunks.cacheGroups.{cacheGroup}.type`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouptype) 可以只选择该插件提取的 CSS，而不会选择 JavaScript 模块或由 Rspack 内置 CSS 支持处理的模块。
+
+```js title="rspack.config.mjs"
+export default {
+  plugins: [new rspack.CssExtractRspackPlugin()],
+  module: {
+    rules: [
+      {
+        test: /\.css$/i,
         use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
       },
     ],
@@ -68,195 +105,392 @@ export default {
 };
 ```
 
-在这个例子中，`extractedCss` 只会选择模块类型为 `css/mini-extract` 的模块。`enforce: true` 会让 CSS chunk 即使在普通 `minSize` 或请求数限制启发式规则下会被跳过时也被创建；如果希望该 cache group 遵循普通 splitChunks 启发式规则，可以移除 `enforce`。
+这里的 `extractedCss` 只选择类型为 `css/mini-extract` 的模块。有关 `enforce` 的行为，请参考 [`splitChunks.cacheGroups.{cacheGroup}.enforce`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegroupenforce)。
 
-## Plugin 选项
+## 选项
 
-CssExtractRspackPlugin 插件的选项。
+以下选项传给 `new rspack.CssExtractRspackPlugin()`。
 
-- **Types:**
+### filename
 
-```ts
-interface PluginOptions {
-  filename?: string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
-  chunkFilename?:
-    string | ((pathData: PathData, assetInfo?: AssetInfo) => string);
-  ignoreOrder?: boolean;
-  insert?: string | ((linkTag: HTMLLinkElement) => void);
-  attributes?: Record<string, string>;
-  linkType?: string | 'text/css' | false;
-  runtime?: boolean;
-  pathinfo?: boolean;
-  enforceRelative?: boolean;
-}
+- **类型：**
+
+  ```ts
+  type CssFilenameFunction = (
+    pathData: PathData,
+    assetInfo?: AssetInfo,
+  ) => string;
+
+  type CssFilename = string | CssFilenameFunction;
+  ```
+
+- **默认值：** `'[name].css'`
+
+设置随入口一起加载的 chunk 所对应的 CSS 产物文件名。该值支持 [`output.filename`](/config/output#outputfilename) 中说明的占位符。省略或设为空字符串时，Rspack 使用 `[name].css`。按需加载 chunk 的 CSS 产物使用 [`chunkFilename`](#chunkfilename)。
+
+- **字符串：** 将非空字符串作为所有随入口一起加载的 CSS chunk 的文件名模板。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    filename: 'css/[name].[contenthash].css',
+  });
+  ```
+
+- **函数：** Rspack 会为每个随入口一起加载的 CSS chunk 调用该函数，传入对应的 `PathData` 和可选的 `AssetInfo`，并将返回值用作文件名。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    filename: ({ chunk }) => `css/${chunk?.name ?? 'styles'}.css`,
+  });
+  ```
+
+如果 `filename` 是函数且省略了 `chunkFilename`，按需加载的 CSS chunk 会使用 `[id].css`；Rspack 不会为它们复用该函数。
+
+### chunkFilename
+
+- **类型：**
+
+  ```ts
+  type CssChunkFilenameFunction = (
+    pathData: PathData,
+    assetInfo?: AssetInfo,
+  ) => string;
+
+  type CssChunkFilename = string | CssChunkFilenameFunction;
+  ```
+
+- **默认值：** 根据 `filename` 推导
+
+设置按需加载的 CSS chunk 的产物文件名，包括动态 `import()` 创建的 chunk。显式设置的非空字符串或函数优先级高于根据 `filename` 推导出的值。该值支持 [`output.chunkFilename`](/config/output#outputchunkfilename) 中说明的占位符。
+
+省略该选项时，Rspack 按以下规则推导：
+
+- 如果字符串形式的 `filename` 包含 `[name]`、`[id]`、`[chunkhash]` 或 `[contenthash]`，则直接复用该值。
+- 如果字符串形式的 `filename` 不包含上述占位符，则在文件名主体前添加 `[id].`。例如，`css/styles.css` 对应的异步 chunk 文件名为 `css/[id].styles.css`。
+- 如果 `filename` 是函数，则使用 `[id].css`。
+
+- **字符串：** 将非空字符串作为所有按需加载的 CSS chunk 的文件名模板。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    chunkFilename: 'css/[id].[contenthash].chunk.css',
+  });
+  ```
+
+- **函数：** Rspack 会为每个按需加载的 CSS chunk 调用该函数，传入对应的 `PathData` 和可选的 `AssetInfo`，并将返回的字符串用作文件名。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    chunkFilename: ({ chunk }) =>
+      `css/${chunk?.name ?? chunk?.id ?? 'chunk'}.chunk.css`,
+  });
+  ```
+
+### ignoreOrder
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+控制 Rspack 是否报告 CSS 顺序冲突。默认情况下，如果不同 chunk group 要求的 CSS 顺序无法同时满足，Rspack 会输出警告，然后使用一个回退顺序生成 CSS。
+
+将 `ignoreOrder` 设为 `true` 只会隐藏这些警告，不会改变 Rspack 最终选择的顺序，也不会解决依赖顺序的样式冲突。
+
+```js
+new rspack.CssExtractRspackPlugin({
+  ignoreOrder: true,
+});
 ```
 
-<Table
-  header={[
-    {
-      name: '名称',
-      key: 'name',
+### insert
+
+- **类型：**
+
+  ```ts
+  type InsertFunction = (linkTag: HTMLLinkElement) => void;
+
+  type Insert = string | InsertFunction;
+  ```
+
+- **默认值：** `undefined`
+
+设置插件运行时为异步 CSS chunk 和 HMR 更新创建的样式表 `<link>` 元素的插入位置。该选项不会影响 HTML 中已有的样式表链接。
+
+省略该选项时，运行时会将新加载的异步样式表追加到 `document.head`。热更新时，替换用的样式表会插入到旧样式表之后。
+
+- **字符串：** 作为选择器传给 `document.querySelector()`，并将样式表插入到第一个匹配元素之后。运行时必须能匹配到对应元素。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    insert: '#css-anchor',
+  });
+  ```
+
+- **函数：** 函数会被序列化到生成的运行时代码中，并在浏览器中调用，参数是新建的 `<link>` 元素。该函数需要自行插入元素，且不能使用 Rspack 配置作用域中的变量。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    insert: (linkTag) => {
+      document.head.appendChild(linkTag);
     },
-    {
-      name: '类型',
-      key: 'type',
-    },
-    {
-      name: '默认值',
-      key: 'default',
-    },
-    {
-      name: '描述',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`filename`',
-      type: '`string`',
-      default: '"[name].css"',
-      description: 'CSS 产物的名称，请参考 `output.filename`',
-    },
-    {
-      name: '`chunkFilename`',
-      type: '`string`',
-      default: '"[name].css"',
-      description:
-        '异步加载的 CSS 产物的名称，如果不设置则会使用 `filename`，请参考 `output.chunkFilename`',
-    },
-    {
-      name: '`ignoreOrder`',
-      type: '`boolean`',
-      default: 'false',
-      description:
-        '若某些 CSS 在不同 chunk 中顺序有冲突，是否发出警告。例如 entryA 引入 a.css 和 b.css，entryB 引入 b.css 和 a.css，a.css 和 b.css 的顺序无法确定',
-    },
-    {
-      name: '`insert`',
-      type: '`string | ((linkTag: HTMLLinkElement) => void)`',
-      default: 'undefined',
-      description:
-        '决定 link 标签怎样插入到页面，如果传入 string 类型，则会视为 DOM 选择器，link 标签会插入到该选择器对应的元素后。如果传入 function 类型，则会将 function 转成字符串，在运行时进行调用，参数是 link 标签',
-    },
-    {
-      name: '`attributes`',
-      type: '`Record<string, string>`',
-      default: 'undefined',
-      description:
-        '设置 link 标签的自定义 attributes，仅对异步加载的 CSS 文件生效',
-    },
-    {
-      name: '`linkType`',
-      type: "`string | 'text/css' | false`",
-      default: '"text/css"',
-      description: '设置 link 标签的 type 属性值，仅对异步加载的 CSS 文件生效',
-    },
-    {
-      name: '`runtime`',
-      type: '`boolean`',
-      default: 'true',
-      description:
-        '是否注入 runtime 代码以加载 CSS。如果禁用，CSS 仍然会被提取，可用于自定义的加载方式',
-    },
-    {
-      name: '`pathinfo`',
-      type: '`boolean`',
-      default: 'false',
-      description: '是否在 CSS 产物中包含带有更详细的路径信息的注释',
-    },
-    {
-      name: '`enforceRelative`',
-      type: '`boolean`',
-      default: 'false',
-      description: '是否在生成的 CSS `url()` 是相对路径时，保留 "\.\/"',
-    },
-  ]}
-/>
+  });
+  ```
+
+当 [`runtime`](#runtime) 为 `false` 时，`insert` 不会生效。
+
+### attributes
+
+- **类型：** `Record<string, string>`
+- **默认值：** `undefined`
+
+为插件运行时创建的样式表 `<link>` 元素添加自定义属性。这些元素用于加载异步 CSS chunk，以及在 HMR 更新时替换样式；HTML 中已有的样式表链接不受影响。省略时，运行时不会添加自定义属性。
+
+```js
+new rspack.CssExtractRspackPlugin({
+  attributes: {
+    'data-source': 'rspack',
+  },
+});
+```
+
+请使用 [`linkType`](#linktype) 控制 `type` 属性。如果两个选项都设置了 `type`，字符串形式的 `linkType` 优先级更高。当 [`runtime`](#runtime) 为 `false` 时，`attributes` 不会生效。
+
+### linkType
+
+- **类型：** `string | false`
+- **默认值：** `'text/css'`
+
+设置插件运行时创建的样式表 `<link>` 元素的 `type` 属性。这些元素用于加载异步 CSS chunk，以及在 HMR 更新时替换样式；HTML 中已有的样式表链接不受影响。
+
+省略时，运行时会将该属性设为 `text/css`。
+
+- **字符串：** 将 `type` 属性设为指定值。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    linkType: 'text/css',
+  });
+  ```
+
+- **`false`：** 禁用插件默认的 `type` 赋值。除非 `attributes` 提供了自定义 `type`，否则运行时创建的样式表链接不会包含该属性。
+
+  ```js
+  new rspack.CssExtractRspackPlugin({
+    linkType: false,
+  });
+  ```
+
+当 [`runtime`](#runtime) 为 `false` 时，`linkType` 不会生效。
+
+### runtime
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+控制插件是否注入用于在运行时加载异步 CSS chunk 的代码。设为 `false` 后仍会输出提取的 CSS 产物，但应用需要自行加载按需加载的 CSS。
+
+省略时，插件会包含 CSS 加载运行时。
+
+禁用后，插件不会为异步 CSS 创建 `<link>` 元素，因此 [`insert`](#insert)、[`attributes`](#attributes) 和 [`linkType`](#linktype) 都不会影响异步 CSS 加载。
+
+```js
+new rspack.CssExtractRspackPlugin({
+  runtime: false,
+});
+```
+
+### pathinfo
+
+- **类型：** `boolean`
+- **默认值：** 启用 [`output.pathinfo`](/config/output#outputpathinfo) 时为 `true`，否则为 `false`
+
+控制是否在每个提取模块之前添加包含可读模块路径的注释。这些注释便于检查 CSS 产物，但也会增加文件体积，并可能暴露源码路径。
+
+显式设置的 `pathinfo` 优先级高于 `output.pathinfo`。省略该选项时，其值继承自 `output.pathinfo`。
+
+```js
+new rspack.CssExtractRspackPlugin({
+  pathinfo: true,
+});
+```
+
+### enforceRelative
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+当最终生效的 loader [`publicPath`](#publicpath) 为 `'auto'` 时，Rspack 会根据 CSS 产物的位置计算资源 URL 的相对路径。如果计算出的前缀为空，该选项控制 URL 是否以 `./` 开头。默认生成 `url(assets/icon.svg)`；设为 `true` 后生成 `url(./assets/icon.svg)`。
+
+如果显式设置了 `'auto'` 以外的 loader `publicPath`，该值的优先级更高，此时 `enforceRelative` 不会生效。
+
+```js
+new rspack.CssExtractRspackPlugin({
+  enforceRelative: true,
+});
+```
 
 ## Loader 选项
 
-`CssExtractRspackPlugin.loader` 的选项。
+以下选项设置在 [`module.rules`](/config/module#modulerules) 中的 `CssExtractRspackPlugin.loader` 上。
 
-- **Types:**
+### publicPath
 
-```ts
-interface LoaderOptions {
-  publicPath?: string | ((resourcePath: string, context: string) => string);
-  emit?: boolean;
-  esModule?: boolean;
-}
+- **类型：**
+
+  ```ts
+  type PublicPathFunction = (resourcePath: string, context: string) => string;
+
+  type PublicPath = string | PublicPathFunction;
+  ```
+
+- **默认值：** [`output.publicPath`](/config/output#outputpublicpath)
+
+设置 CSS 中引用的图片、字体等资源所使用的 public path。该值不会影响 CSS 产物本身的 URL。
+
+对于当前处理的 CSS 资源，显式设置的 loader `publicPath` 优先级高于 `output.publicPath`。
+
+省略时，loader 使用 `output.publicPath`。
+
+- **字符串：** 所有匹配的 CSS 资源使用同一个 public path。
+
+  ```js
+  const cssRule = {
+    test: /\.css$/i,
+    use: [
+      {
+        loader: rspack.CssExtractRspackPlugin.loader,
+        options: {
+          publicPath: '/assets/',
+        },
+      },
+      'css-loader',
+    ],
+  };
+  ```
+
+- **函数：** 构建时调用该函数，传入 CSS 的绝对 `resourcePath` 和编译器根 `context`，返回值作为该资源的 public path。
+
+  ```js
+  const cssRule = {
+    test: /\.css$/i,
+    use: [
+      {
+        loader: rspack.CssExtractRspackPlugin.loader,
+        options: {
+          publicPath: (resourcePath, context) =>
+            resourcePath.startsWith(context) ? '/assets/' : '/external-assets/',
+        },
+      },
+      'css-loader',
+    ],
+  };
+  ```
+
+### emit
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+控制当前 CSS 资源的内容是否写入提取出的 CSS 产物。设为 `false` 后仍会处理该资源，并在 JavaScript 中保留已有的 CSS Modules 导出，但不会把其中的 CSS 写入输出文件。
+
+省略时，该资源的 CSS 会写入 CSS 产物。
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        emit: false,
+      },
+    },
+    'css-loader',
+  ],
+};
 ```
 
-<Table
-  header={[
-    {
-      name: '名称',
-      key: 'name',
-    },
-    {
-      name: '类型',
-      key: 'type',
-    },
-    {
-      name: '默认值',
-      key: 'default',
-    },
-    {
-      name: '描述',
-      key: 'description',
-    },
-  ]}
-  body={[
-    {
-      name: '`publicPath`',
-      type: '`string | ((resourcePath: string, context: string) => string)`',
-      default: 'output.publicPath',
-      description:
-        '为 CSS 中的外部资源（如图片、文件等）指定自定义的 publicPath',
-    },
-    {
-      name: '`emit`',
-      type: '`boolean`',
-      default: 'true',
-      description:
-        '如果为 true，则输出 CSS 文件。如果为 false，则插件将提取 CSS，但不会输出文件',
-    },
-    {
-      name: '`esModule`',
-      type: '`boolean`',
-      default: 'true',
-      description:
-        '在生成的 JavaScript 模块中，是否使用 ES 模块语法进行 CSS Modules 类名导出',
-    },
-  ]}
-/>
+### esModule
 
-## 注意事项
+- **类型：** `boolean`
+- **默认值：** `true`
 
-当同时使用内置 CSS 和 `CssExtractRspackPlugin` 时，推荐显式手动给 `CssExtractRspackPlugin.loader` 的 `type` 设置成 `javascript/auto`。
+控制 `CssExtractRspackPlugin.loader` 生成的 JavaScript 模块使用 ES module 还是 CommonJS 语法。设为 `false` 时使用 CommonJS。为了保持输出格式一致，建议将 css-loader 的 `esModule` 设为相同的值。
 
-例如：
+省略时，`CssExtractRspackPlugin.loader` 使用 ES module 语法。
 
-```ts title="rspack.config.mjs"
-import { rspack } from '@rspack/core';
+如果 css-loader 生成 CSS Modules 具名导出，这些导出仍使用 ES module 语法。此时可以通过 [`defaultExport`](#defaultexport) 控制是否额外生成默认导出。
 
-export default {
-  plugins: [new rspack.CssExtractRspackPlugin({})],
-  module: {
-    rules: [
-      {
-        test: /src\/legacy-project\/.*\.css$/,
-        type: 'javascript/auto', // 覆盖默认的 CSS 模块类型，视为普通 JS 文件
-        use: [rspack.CssExtractRspackPlugin.loader, 'css-loader'],
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        esModule: false,
       },
-      {
-        test: /src\/new-project\/.*\.css$/,
-        type: 'css/auto', // 使用内置 CSS 处理
+    },
+    {
+      loader: 'css-loader',
+      options: {
+        esModule: false,
       },
-    ],
-  },
-  experiments: {
-    css: true,
-  },
+    },
+  ],
+};
+```
+
+### layer
+
+- **类型：** `string`
+- **默认值：** `undefined`
+
+将该 loader 处理的 CSS 资源分配到指定的 Rspack 模块 layer。这里指模块图中的 layer，并非 CSS 层叠规则 `@layer`。可以结合 [`splitChunks.cacheGroups.{cacheGroup}.layer`](/plugins/split-chunks-plugin#splitchunkscachegroupscachegrouplayer) 等选项，按 layer 选择提取出的 CSS。
+
+省略时，该 loader 不会显式分配模块 layer。
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        layer: 'theme',
+      },
+    },
+    'css-loader',
+  ],
+};
+```
+
+### defaultExport
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+当 css-loader 生成 CSS Modules 具名导出时，该选项控制 `CssExtractRspackPlugin.loader` 是否额外生成一个包含全部局部类名的默认导出对象。原有具名导出始终保留。
+
+如果 css-loader 没有生成具名导出，该选项不会生效。省略时，在具名导出模式下只生成具名导出。
+
+```js
+const cssRule = {
+  test: /\.css$/i,
+  use: [
+    {
+      loader: rspack.CssExtractRspackPlugin.loader,
+      options: {
+        defaultExport: true,
+      },
+    },
+    {
+      loader: 'css-loader',
+      options: {
+        modules: {
+          namedExport: true,
+        },
+      },
+    },
+  ],
 };
 ```


### PR DESCRIPTION
## Summary

This PR improves the English and Chinese `CssExtractRspackPlugin` documentation so plugin and loader options accurately reflect the public types and runtime behavior. It reorganizes the page around practical examples, documents each option with defaults and focused configurations, and clarifies CSS loading, HTML integration, and `splitChunks` usage.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).