### PR TITLE
docs: improve HTML plugin guidance

### DIFF
--- a/website/docs/en/guide/features/esm.mdx
+++ b/website/docs/en/guide/features/esm.mdx
@@ -89,4 +89,4 @@ Below are the main configuration options related to ESM and their descriptions, 
 4. [output.chunkLoading](/config/output#outputchunkloading): When building application ESM output, this is typically set to `'import'`; for `modern-module`, Rspack switches chunk loading to `import` automatically.
 5. [output.workerChunkLoading](/config/output#outputworkerchunkloading): When your application or library also needs ESM worker chunk loading, this is typically set to `'import'`.
 6. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): In some cases, Rspack wraps ESM output in an IIFE, which breaks ESM's modular characteristics.
-7. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): Set to `'module'` to use ESM `<script type="module">` for loading `.mjs` modules.
+7. [HtmlRspackPlugin.scriptLoading](/plugins/html-rspack-plugin#scriptloading): Set to `'module'` to use ESM `<script type="module">` for loading `.mjs` modules.

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -249,6 +249,32 @@ Check [Plugin compat](/guide/compatibility/plugin) for more information on Rspac
 
 Some webpack ecosystem packages, such as [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) and [`node-polyfill-webpack-plugin`](https://www.npmjs.com/package/node-polyfill-webpack-plugin), require newer versions for Rspack compatibility. Before reusing a community package, upgrade it to the latest version, as older versions may rely on incompatible webpack APIs.
 
+### html-webpack-plugin
+
+For most projects migrating from [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin), use [`html-rspack-plugin`](https://github.com/rstackjs/html-rspack-plugin). It is a JavaScript fork designed for Rspack and provides closer compatibility with existing options, templates, and integrations.
+
+<PackageManagerTabs command="add html-rspack-plugin -D" />
+
+Update the import and constructor name in the Rspack configuration:
+
+```diff title="rspack.config.mjs"
+-import HtmlWebpackPlugin from 'html-webpack-plugin';
++import HtmlRspackPlugin from 'html-rspack-plugin';
+
+ export default {
+   plugins: [
+-    new HtmlWebpackPlugin({
++    new HtmlRspackPlugin({
+       // ...
+     }),
+   ],
+ };
+```
+
+After completing the migration, remove `html-webpack-plugin` from the project dependencies.
+
+If build performance is the priority, you can also use the built-in Rust plugin [`rspack.HtmlRspackPlugin`](/plugins/html-rspack-plugin). See the [HTML guide](/guide/tech/html#choose-a-plugin) for details.
+
 ### unplugin
 
 Some [unplugin](/guide/features/plugin#unplugin) packages provide separate entry points for each bundler. When a `/rspack` entry is available, use it instead of `/webpack` so the plugin selects the Rspack adapter:

--- a/website/docs/en/guide/tech/html.mdx
+++ b/website/docs/en/guide/tech/html.mdx
@@ -1,24 +1,35 @@
 ---
-description: 'Use HTML with Rspack, covering setup, configuration, integration details, and framework-specific development patterns.'
+description: 'Generate HTML with Rspack using the built-in Rust plugin or a JavaScript plugin compatible with html-webpack-plugin.'
 ---
+
+import { PackageManagerTabs } from '@theme';
 
 # HTML
 
-Rspack can generate HTML files for your application and automatically inject the emitted JavaScript and CSS assets.
-This is useful for production builds where asset filenames often include content hashes, because the generated HTML will always reference the latest build outputs.
+Rspack can generate HTML through plugins and automatically inject emitted JavaScript and CSS assets. This guide covers two plugin options and how they differ in performance, features, and `html-webpack-plugin` compatibility.
 
-## Plugins
+## Choose a plugin
 
 Rspack provides two plugin options for generating HTML:
 
-- The built-in `HtmlRspackPlugin` is optimized for performance and common HTML generation needs.
-- The community-compatible `HtmlWebpackPlugin` is suitable when you need broader webpack ecosystem compatibility or features that are not yet implemented by `HtmlRspackPlugin`.
+- The built-in [`rspack.HtmlRspackPlugin`](/plugins/html-rspack-plugin) is implemented in Rust and focuses on performance and common HTML generation needs.
+- The standalone [`html-rspack-plugin`](https://github.com/rstackjs/html-rspack-plugin) is a JavaScript fork of `html-webpack-plugin` that prioritizes compatibility with its behavior.
 
-If you're not sure which plugin to choose, see the [comparison between HtmlRspackPlugin and HtmlWebpackPlugin](/plugins/html-rspack-plugin#comparison) to understand their differences in performance, features, and compatibility.
+### Performance
 
-### Built-in HtmlRspackPlugin
+The built-in Rust implementation provides better build performance, especially when generating many HTML files. The JavaScript plugin also includes Rspack-specific optimizations but prioritizes compatibility.
 
-[HtmlRspackPlugin](/plugins/html-rspack-plugin) is a high-performance HTML plugin implemented in Rust, offering significantly better build performance than the `HtmlWebpackPlugin`, especially when building a large number of HTML files.
+### Features
+
+`rspack.HtmlRspackPlugin` supports most `html-webpack-plugin` features, but cannot fully match all behaviors of the JavaScript implementation because its core logic runs in Rust. Use it when its features meet your needs and performance is the priority. Use `html-rspack-plugin` when migrating an existing `html-webpack-plugin` setup or when you need an unsupported option, capability, or behavior.
+
+:::tip
+`rspack.HtmlRspackPlugin` supports only a subset of EJS-style syntax and does not execute arbitrary JavaScript. For compatibility with `html-webpack-plugin` template processing behavior, use `html-rspack-plugin` and see its [template documentation](https://github.com/rstackjs/html-rspack-plugin#writing-your-own-templates).
+:::
+
+## Built-in HtmlRspackPlugin
+
+`rspack.HtmlRspackPlugin` is included in `@rspack/core`, so no additional package is required.
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
@@ -30,16 +41,20 @@ export default {
 
 For all configuration options, see the [plugin documentation](/plugins/html-rspack-plugin).
 
-### HtmlWebpackPlugin
+## html-rspack-plugin
 
-Rspack is fully compatible with [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin).
+Install `html-rspack-plugin` separately:
+
+<PackageManagerTabs command="add html-rspack-plugin -D" />
 
 ```js title="rspack.config.mjs"
-import HtmlWebpackPlugin from 'html-webpack-plugin';
+import HtmlRspackPlugin from 'html-rspack-plugin';
 
 export default {
-  plugins: [new HtmlWebpackPlugin()],
+  plugins: [new HtmlRspackPlugin()],
 };
 ```
 
-For all configuration options, see the [plugin documentation](https://github.com/jantimon/html-webpack-plugin#options).
+For configuration options, see [Options](https://github.com/rstackjs/html-rspack-plugin#options).
+
+If you are migrating from `html-webpack-plugin`, see the [webpack migration guide](/guide/migration/webpack#html-webpack-plugin).

--- a/website/docs/en/plugins/html-rspack-plugin.mdx
+++ b/website/docs/en/plugins/html-rspack-plugin.mdx
@@ -12,9 +12,10 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 - [Examples](#examples): Explore common use cases.
 - [Options](#options): Review types, defaults, and examples.
-- [Comparison](#comparison): Compare with `html-webpack-plugin`.
 - [Template syntax](#template-syntax): See supported interpolation and control statements.
 - [Hooks](#hooks): Modify asset URLs, tags, and HTML.
+
+For help choosing between the built-in plugin and the JavaScript `html-rspack-plugin`, see the [HTML guide](/guide/tech/html#choose-a-plugin).
 
 ## Examples
 
@@ -820,26 +821,6 @@ new rspack.HtmlRspackPlugin({
   hash: true,
 });
 ```
-
-## Comparison
-
-`rspack.HtmlRspackPlugin` differs from the community [`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin) in performance and supported features.
-
-### Performance
-
-Because `rspack.HtmlRspackPlugin` is implemented in Rust, it builds significantly faster than `html-webpack-plugin`, especially when generating many HTML files.
-
-### Features
-
-`rspack.HtmlRspackPlugin` supports a subset of the features provided by `html-webpack-plugin`. Some features are not implemented to keep the native implementation fast.
-
-Use the community [`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin) when you need an option or template feature that is not supported here.
-
-:::warning
-`rspack.HtmlRspackPlugin` supports only a subset of the full [EJS syntax](https://ejs.co/#docs). Use `html-webpack-plugin` if the template requires full EJS compatibility.
-
-To match the default template syntax of `html-webpack-plugin`, `<%-` escapes its result and `<%=` inserts its result without escaping.
-:::
 
 ## Template syntax
 

--- a/website/docs/zh/guide/features/esm.mdx
+++ b/website/docs/zh/guide/features/esm.mdx
@@ -87,4 +87,4 @@ export default {
 4. [output.chunkLoading](/config/output#outputchunkloading): 在构建应用的 ESM 产物时，通常设置为 `'import'`；对于 `modern-module`，Rspack 会自动切换到基于 `import` 的 chunk loading。
 5. [output.workerChunkLoading](/config/output#outputworkerchunkloading): 当你的应用或库还需要在 Worker 中以 ESM 方式加载 chunk 时，通常设置为 `'import'`。
 6. [optimization.avoidEntryIife](/config/optimization#optimizationavoidentryiife): 在某些情况下，Rspack 会将 ESM 产物的输出包裹在一个 IIFE 中，这会破坏 ESM 的模块化特性
-7. [HtmlWebpackPlugin.scriptLoading](/guide/tech/html#htmlwebpackplugin): 设置为 `'module'`，表示使用 ESM 的 `<script type="module">` 来加载 `.mjs` 模块。
+7. [HtmlRspackPlugin.scriptLoading](/plugins/html-rspack-plugin#scriptloading): 设置为 `'module'`，表示使用 ESM 的 `<script type="module">` 来加载 `.mjs` 模块。

--- a/website/docs/zh/guide/migration/webpack.mdx
+++ b/website/docs/zh/guide/migration/webpack.mdx
@@ -245,6 +245,32 @@ Rspack 支持大部分 webpack 社区插件，并为暂不支持的插件提供�
 
 部分 webpack 生态包需要升级到较新版本才能兼容 Rspack，例如 [`webpack-node-externals`](https://www.npmjs.com/package/webpack-node-externals) 和 [`node-polyfill-webpack-plugin`](https://www.npmjs.com/package/node-polyfill-webpack-plugin)。复用社区包前，建议升级到最新版本，因为旧版本可能依赖不兼容的 webpack API。
 
+### html-webpack-plugin
+
+大多数项目从 [`html-webpack-plugin`](https://github.com/jantimon/html-webpack-plugin) 迁移时，建议使用 [`html-rspack-plugin`](https://github.com/rstackjs/html-rspack-plugin)。它是面向 Rspack 的 JavaScript fork，能够更好地兼容已有的选项、模板和集成。
+
+<PackageManagerTabs command="add html-rspack-plugin -D" />
+
+在 Rspack 配置中更新导入和构造函数名称：
+
+```diff title="rspack.config.mjs"
+-import HtmlWebpackPlugin from 'html-webpack-plugin';
++import HtmlRspackPlugin from 'html-rspack-plugin';
+
+ export default {
+   plugins: [
+-    new HtmlWebpackPlugin({
++    new HtmlRspackPlugin({
+       // ...
+     }),
+   ],
+ };
+```
+
+完成迁移后，从项目依赖中移除 `html-webpack-plugin`。
+
+如果更关注构建性能，也可以选择内置的 Rust 插件 [`rspack.HtmlRspackPlugin`](/plugins/html-rspack-plugin)。详情请参阅 [HTML 指南](/guide/tech/html#选择插件)。
+
 ### unplugin
 
 部分 [unplugin](/guide/features/plugin#unplugin) 包会为不同构建工具提供独立入口。如果提供了 `/rspack` 入口，请使用它代替 `/webpack`，以选择 Rspack 适配层：

--- a/website/docs/zh/guide/tech/html.mdx
+++ b/website/docs/zh/guide/tech/html.mdx
@@ -1,23 +1,35 @@
 ---
-description: '在 Rspack 中使用HTML的指南，涵盖环境配置、集成方式、调试要点、开发模式与常见问题处理，帮助快速定位相关信息。'
+description: '使用 Rspack 内置的 Rust 插件或兼容 html-webpack-plugin 行为的 JavaScript 插件生成 HTML。'
 ---
+
+import { PackageManagerTabs } from '@theme';
 
 # HTML
 
-Rspack 可以为应用生成 HTML 文件，并自动注入构建产物中的 JavaScript 和 CSS 资源。这在生产构建中尤其有用，因为资源文件名通常会包含内容哈希，而生成的 HTML 会始终引用最新的构建产物。
+Rspack 支持通过插件生成 HTML，并自动注入构建产物中的 JavaScript 和 CSS 资源。本文介绍两种插件方案，以及它们在性能、功能和 `html-webpack-plugin` 兼容性方面的差异。
 
-## 插件
+## 选择插件
 
 Rspack 提供两种插件用于生成 HTML：
 
-- 内置的 `HtmlRspackPlugin` 针对性能和常见 HTML 生成场景做了优化；
-- 兼容社区的 `HtmlWebpackPlugin`，适合需要更完整的 webpack 生态兼容性，或需要 `HtmlRspackPlugin` 尚未实现的功能。
+- 内置的 [`rspack.HtmlRspackPlugin`](/plugins/html-rspack-plugin) 使用 Rust 实现，侧重性能和常见 HTML 生成场景。
+- 独立安装的 [`html-rspack-plugin`](https://github.com/rstackjs/html-rspack-plugin) 使用 JavaScript 实现，基于 `html-webpack-plugin` fork，侧重兼容其行为。
 
-如果你不确定应该选择哪个插件，可以先查看 [HtmlRspackPlugin 与 HtmlWebpackPlugin 的对比](/plugins/html-rspack-plugin#对比)，了解两者在性能、功能和兼容性上的差异。
+### 性能
 
-### 内置 HtmlRspackPlugin
+内置的 Rust 实现具有更好的构建性能，尤其适合生成大量 HTML 文件。JavaScript 插件也针对 Rspack 做了优化，但更侧重兼容性。
 
-[HtmlRspackPlugin](/plugins/html-rspack-plugin) 是以 Rust 实现的高性能 HTML 插件，它的构建性能显著优于 `HtmlWebpackPlugin` 插件，尤其是在构建大量 HTML 文件的场景下。
+### 功能
+
+`rspack.HtmlRspackPlugin` 支持 `html-webpack-plugin` 的大部分功能，但由于核心逻辑在 Rust 侧执行，无法完全对齐 JavaScript 插件的所有行为。当它能满足需求且更关注性能时，请使用内置插件；迁移已有的 `html-webpack-plugin` 配置，或需要尚未支持的选项、能力或行为时，请使用 `html-rspack-plugin`。
+
+:::tip
+`rspack.HtmlRspackPlugin` 只支持部分 EJS 风格语法，且不会执行任意 JavaScript。如需兼容 `html-webpack-plugin` 的模板处理行为，请使用 `html-rspack-plugin` 并参考其[模板文档](https://github.com/rstackjs/html-rspack-plugin#writing-your-own-templates)。
+:::
+
+## 内置 HtmlRspackPlugin
+
+`rspack.HtmlRspackPlugin` 已包含在 `@rspack/core` 中，无需安装额外的 npm 包。
 
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
@@ -29,16 +41,20 @@ export default {
 
 有关所有配置选项，请参阅[插件文档](/plugins/html-rspack-plugin)。
 
-### HtmlWebpackPlugin
+## html-rspack-plugin
 
-Rspack 完全兼容 [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin)。
+单独安装 `html-rspack-plugin`：
+
+<PackageManagerTabs command="add html-rspack-plugin -D" />
 
 ```js title="rspack.config.mjs"
-import HtmlWebpackPlugin from 'html-webpack-plugin';
+import HtmlRspackPlugin from 'html-rspack-plugin';
 
 export default {
-  plugins: [new HtmlWebpackPlugin()],
+  plugins: [new HtmlRspackPlugin()],
 };
 ```
 
-有关所有配置选项，请参阅[插件文档](https://github.com/jantimon/html-webpack-plugin#options)。
+配置选项请参阅 [Options](https://github.com/rstackjs/html-rspack-plugin#options)。
+
+从 `html-webpack-plugin` 迁移时，请参阅 [webpack 迁移指南](/guide/migration/webpack#html-webpack-plugin)。

--- a/website/docs/zh/plugins/html-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/html-rspack-plugin.mdx
@@ -12,9 +12,10 @@ import { ApiMeta } from '@components/ApiMeta.tsx';
 
 - [示例](#示例)：查看常见用法。
 - [选项](#选项)：查看类型、默认值和示例。
-- [对比](#对比)：了解与 `html-webpack-plugin` 的差异。
 - [模板语法](#模板语法)：查看支持的插值和控制语句。
 - [Hooks](#hooks)：修改产物 URL、标签和 HTML。
+
+关于内置插件与 JavaScript 版 `html-rspack-plugin` 的选择，请参考 [HTML 指南](/guide/tech/html#选择插件)。
 
 ## 示例
 
@@ -820,26 +821,6 @@ new rspack.HtmlRspackPlugin({
   hash: true,
 });
 ```
-
-## 对比
-
-与社区的 [`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin) 相比，`rspack.HtmlRspackPlugin` 在性能和功能支持上有所不同。
-
-### 性能
-
-`rspack.HtmlRspackPlugin` 基于 Rust 实现，构建性能显著高于 `html-webpack-plugin`，尤其是在需要生成大量 HTML 文件时。
-
-### 功能
-
-`rspack.HtmlRspackPlugin` 支持 `html-webpack-plugin` 的部分功能。为了保持原生实现的性能，还有一些功能尚未支持。
-
-如果需要插件尚未支持的选项或模板能力，可以使用社区的 [`html-webpack-plugin`](https://www.npmjs.com/package/html-webpack-plugin)。
-
-:::warning 警告
-`rspack.HtmlRspackPlugin` 只支持部分 [EJS 语法](https://ejs.co/#docs)。如果模板需要完整的 EJS 兼容性，请使用 `html-webpack-plugin`。
-
-为了兼容 `html-webpack-plugin` 的默认模板语法，`<%-` 会转义插值结果，`<%=` 则直接插入未经转义的结果。
-:::
 
 ## 模板语法
 


### PR DESCRIPTION
## Summary

This PR clarifies when to use the built-in Rust `HtmlRspackPlugin` or the standalone JavaScript `html-rspack-plugin`, and moves the comparison guidance into the HTML guide. It recommends `html-rspack-plugin` for most `html-webpack-plugin` migrations, updates related cross-links, and fixes the ESM `scriptLoading` reference.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).