### PR TITLE
docs: add Rstest testing guide

### DIFF
--- a/website/docs/en/guide/features/_meta.json
+++ b/website/docs/en/guide/features/_meta.json
@@ -11,5 +11,6 @@
   "builtin-swc-loader",
   "builtin-lightningcss-loader",
   "esm",
-  "layer"
+  "layer",
+  "rstest"
 ]

--- a/website/docs/en/guide/features/rstest.mdx
+++ b/website/docs/en/guide/features/rstest.mdx
@@ -1,0 +1,152 @@
+---
+description: 'Learn how to use Rstest for unit and end-to-end testing in Rspack projects'
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# Testing with Rstest
+
+[Rstest](https://rstest.rs/) is a JavaScript testing framework powered by Rspack. It runs tests through Rspack's bundling pipeline, and its official adapter can reuse module resolution, transforms, and plugins from an existing Rspack configuration.
+
+This guide covers unit testing with Rstest and end-to-end testing with [`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright).
+
+## Set up Rstest
+
+### Create a new project
+
+When creating a project with [create-rspack](https://www.npmjs.com/package/create-rspack), select **Rstest - testing** in the prompts. The generated project includes the Rstest dependencies, configuration, and test scripts.
+
+### Add Rstest to an existing project
+
+Install Rstest and the official Rspack adapter as development dependencies:
+
+<PackageManagerTabs command="add @rstest/core @rstest/adapter-rspack -D" />
+
+Then add scripts for running tests and watching for changes:
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest",
+    "test:watch": "rstest --watch"
+  }
+}
+```
+
+### Reuse the Rspack configuration
+
+Create an `rstest.config.ts` file in the project root and use `withRspackConfig` to reuse the existing Rspack configuration:
+
+```ts title="rstest.config.ts"
+import { withRspackConfig } from '@rstest/adapter-rspack';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  extends: withRspackConfig(),
+});
+```
+
+The adapter loads `rspack.config.ts`, maps compatible Rspack options to Rstest, and merges them with the rest of the Rstest configuration.
+
+:::note
+
+By default, the adapter looks for the Rspack configuration in `process.cwd()`. It also disables Rstest's built-in CSS plugins so that the Rspack CSS configuration takes effect. For monorepos, custom configuration paths, named configurations, and complete mapping details, see [Rstest - Rspack integration](https://rstest.rs/guide/integration/rspack).
+
+:::
+
+## Unit testing
+
+Unit tests verify individual modules and functions in isolation.
+
+### Write tests
+
+Create a source file and a corresponding test file:
+
+```ts title="src/utils.ts"
+export function add(a: number, b: number) {
+  return a + b;
+}
+```
+
+```ts title="src/utils.test.ts"
+import { expect, test } from '@rstest/core';
+import { add } from './utils';
+
+test('adds two numbers correctly', () => {
+  expect(add(1, 2)).toBe(3);
+  expect(add(-1, 1)).toBe(0);
+});
+```
+
+### Run tests
+
+```bash
+# Run all tests
+pnpm run test
+
+# Run tests in watch mode
+pnpm run test:watch
+
+# Run tests whose names match a pattern
+pnpm run test -- -t 'adds two numbers'
+```
+
+See the [Rstest documentation](https://rstest.rs/guide/) for test APIs, mocking, snapshots, coverage, and other features.
+
+## End-to-end testing
+
+[`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) is Rstest's Playwright integration. It provides Playwright-style assertions and fixtures for testing local, preview, or deployed applications while sharing Rstest's runner, configuration, and reporting workflow with unit tests.
+
+:::tip
+
+If you need the full Playwright Test runner and its `playwright.config.ts` configuration model, use [native Playwright](https://playwright.dev/docs/test-intro).
+
+:::
+
+### Install `@rstest/playwright`
+
+Install the Rstest integration and the Playwright browser automation runtime:
+
+<PackageManagerTabs command="add @rstest/playwright playwright -D" />
+
+Then install the Chromium browser binary:
+
+```bash
+pnpm exec playwright install chromium
+```
+
+### Test a running application
+
+Import `test` and `expect` from `@rstest/playwright` and navigate to the application served by Rspack:
+
+```ts title="tests/home.e2e.test.ts"
+import { expect, test } from '@rstest/playwright';
+
+test('home page', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page).toHaveTitle(/Rspack/);
+});
+```
+
+### Test local build output
+
+Use Rstest's `serve` fixture to start a static application from local files. The server is cleaned up automatically after the test:
+
+```ts title="tests/home.e2e.test.ts"
+import { expect, test } from '@rstest/playwright';
+
+test('home page', async ({ page, serve }) => {
+  const { url } = await serve('./dist/index.html');
+
+  await page.goto(url);
+  await expect(page.locator('h1')).toHaveText('Home');
+});
+```
+
+End-to-end tests use the Rstest runner, so they can live alongside unit tests and run with the same command:
+
+```bash
+pnpm run test
+```
+
+For more fixtures, browser options, tracing, and debugging, see [Rstest - Playwright](https://rstest.rs/guide/advanced/playwright).

--- a/website/docs/en/guide/features/rstest.mdx
+++ b/website/docs/en/guide/features/rstest.mdx
@@ -14,7 +14,7 @@ This guide covers unit testing with Rstest and end-to-end testing with [`@rstest
 
 ### Create a new project
 
-When creating a project with [create-rspack](https://www.npmjs.com/package/create-rspack), select **Rstest - testing** in the prompts. The generated project includes the Rstest dependencies, configuration, and test scripts.
+When creating a project, follow the [Quick start](/guide/start/quick-start) guide and select **Rstest - testing** in the prompts. The generated project includes the Rstest dependencies, configuration, and test scripts.
 
 ### Add Rstest to an existing project
 

--- a/website/docs/zh/guide/features/_meta.json
+++ b/website/docs/zh/guide/features/_meta.json
@@ -11,5 +11,6 @@
   "builtin-swc-loader",
   "builtin-lightningcss-loader",
   "esm",
-  "layer"
+  "layer",
+  "rstest"
 ]

--- a/website/docs/zh/guide/features/rstest.mdx
+++ b/website/docs/zh/guide/features/rstest.mdx
@@ -95,7 +95,7 @@ pnpm run test -- -t '正确计算两个数字的和'
 
 ## 端到端测试
 
-[`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) 是 Rstest 提供的 Playwright 集成包。它提供 Playwright 风格的断言和 fixtures，可测试本地、预览或已部署的应用，并与单元测试共用 Rstest 的运行器、配置和报告流程。
+[`@rstest/playwright`](https://rstest.rs/zh/guide/advanced/playwright) 是 Rstest 提供的 Playwright 集成包。它提供 Playwright 风格的断言和 fixtures，可测试本地、预览或已部署的应用，并与单元测试共用 Rstest 的运行器、配置和报告流程。
 
 :::tip
 

--- a/website/docs/zh/guide/features/rstest.mdx
+++ b/website/docs/zh/guide/features/rstest.mdx
@@ -91,7 +91,7 @@ pnpm run test:watch
 pnpm run test -- -t '正确计算两个数字的和'
 ```
 
-更多测试 API、Mock、Snapshot 和覆盖率等功能，请参阅 [Rstest 文档](https://rstest.rs/guide/)。
+更多测试 API、Mock、Snapshot 和覆盖率等功能，请参阅 [Rstest 文档](https://rstest.rs/zh/guide/)。
 
 ## 端到端测试
 

--- a/website/docs/zh/guide/features/rstest.mdx
+++ b/website/docs/zh/guide/features/rstest.mdx
@@ -1,0 +1,152 @@
+---
+description: '了解如何使用 Rstest 为 Rspack 项目添加单元测试和端到端测试'
+---
+
+import { PackageManagerTabs } from '@theme';
+
+# 使用 Rstest 测试
+
+[Rstest](https://rstest.rs/) 是一个基于 Rspack 的 JavaScript 测试框架。它通过 Rspack 的打包流程运行测试，并可借助官方适配器复用现有 Rspack 配置中的模块解析、代码转换和插件。
+
+本指南介绍如何使用 Rstest 编写单元测试，以及如何通过 [`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) 编写端到端测试。
+
+## 配置 Rstest
+
+### 创建新项目
+
+使用 [create-rspack](https://www.npmjs.com/package/create-rspack) 创建项目时，在交互式提示中选择 **Rstest - testing**。生成的项目会包含 Rstest 所需的依赖、配置和测试脚本。
+
+### 添加到现有项目
+
+将 Rstest 和官方的 Rspack 适配器安装为开发依赖：
+
+<PackageManagerTabs command="add @rstest/core @rstest/adapter-rspack -D" />
+
+然后在 `package.json` 中添加运行测试和监听文件变化的脚本：
+
+```json title="package.json"
+{
+  "scripts": {
+    "test": "rstest",
+    "test:watch": "rstest --watch"
+  }
+}
+```
+
+### 复用 Rspack 配置
+
+在项目根目录创建 `rstest.config.ts`，通过 `withRspackConfig` 复用现有的 Rspack 配置：
+
+```ts title="rstest.config.ts"
+import { withRspackConfig } from '@rstest/adapter-rspack';
+import { defineConfig } from '@rstest/core';
+
+export default defineConfig({
+  extends: withRspackConfig(),
+});
+```
+
+适配器会加载 `rspack.config.ts`，将兼容的 Rspack 配置转换为 Rstest 配置，并与其他 Rstest 配置合并。
+
+:::note
+
+适配器默认从 `process.cwd()` 查找 Rspack 配置。它还会关闭 Rstest 内置的 CSS 插件，让 Rspack 的 CSS 配置生效。关于 monorepo、自定义配置路径、具名配置和完整的配置映射，请参阅 [Rstest：Rspack 集成](https://rstest.rs/guide/integration/rspack)。
+
+:::
+
+## 单元测试
+
+单元测试用于隔离验证模块和函数。
+
+### 编写测试
+
+创建源文件和对应的测试文件：
+
+```ts title="src/utils.ts"
+export function add(a: number, b: number) {
+  return a + b;
+}
+```
+
+```ts title="src/utils.test.ts"
+import { expect, test } from '@rstest/core';
+import { add } from './utils';
+
+test('正确计算两个数字的和', () => {
+  expect(add(1, 2)).toBe(3);
+  expect(add(-1, 1)).toBe(0);
+});
+```
+
+### 运行测试
+
+```bash
+# 运行全部测试
+pnpm run test
+
+# 以 watch 模式运行测试
+pnpm run test:watch
+
+# 运行测试名称匹配指定模式的测试
+pnpm run test -- -t '正确计算两个数字的和'
+```
+
+更多测试 API、Mock、Snapshot 和覆盖率等功能，请参阅 [Rstest 文档](https://rstest.rs/guide/)。
+
+## 端到端测试
+
+[`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) 是 Rstest 提供的 Playwright 集成包。它提供 Playwright 风格的断言和 fixtures，可测试本地、预览或已部署的应用，并与单元测试共用 Rstest 的运行器、配置和报告流程。
+
+:::tip
+
+如果需要完整的 Playwright Test runner 和 `playwright.config.ts` 配置模型，请使用 [原生 Playwright](https://playwright.dev/docs/test-intro)。
+
+:::
+
+### 安装 `@rstest/playwright`
+
+安装 Rstest 集成包和 Playwright 浏览器自动化运行时：
+
+<PackageManagerTabs command="add @rstest/playwright playwright -D" />
+
+然后安装 Chromium 浏览器：
+
+```bash
+pnpm exec playwright install chromium
+```
+
+### 测试运行中的应用
+
+从 `@rstest/playwright` 导入 `test` 和 `expect`，访问由 Rspack 提供服务的应用：
+
+```ts title="tests/home.e2e.test.ts"
+import { expect, test } from '@rstest/playwright';
+
+test('首页', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await expect(page).toHaveTitle(/Rspack/);
+});
+```
+
+### 测试本地构建产物
+
+使用 Rstest 提供的 `serve` fixture，可以从本地文件启动静态应用。测试结束后，服务器会自动清理：
+
+```ts title="tests/home.e2e.test.ts"
+import { expect, test } from '@rstest/playwright';
+
+test('首页', async ({ page, serve }) => {
+  const { url } = await serve('./dist/index.html');
+
+  await page.goto(url);
+  await expect(page.locator('h1')).toHaveText('Home');
+});
+```
+
+端到端测试使用 Rstest runner，可以和单元测试放在一起，并通过同一条命令运行：
+
+```bash
+pnpm run test
+```
+
+更多 fixtures、浏览器配置、Trace 和调试方式，请参阅 [Rstest：Playwright](https://rstest.rs/guide/advanced/playwright)。

--- a/website/docs/zh/guide/features/rstest.mdx
+++ b/website/docs/zh/guide/features/rstest.mdx
@@ -8,13 +8,13 @@ import { PackageManagerTabs } from '@theme';
 
 [Rstest](https://rstest.rs/) 是一个基于 Rspack 的 JavaScript 测试框架。它通过 Rspack 的打包流程运行测试，并可借助官方适配器复用现有 Rspack 配置中的模块解析、代码转换和插件。
 
-本指南介绍如何使用 Rstest 编写单元测试，以及如何通过 [`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) 编写端到端测试。
+本指南介绍如何使用 Rstest 编写单元测试，以及如何通过 [`@rstest/playwright`](https://rstest.rs/zh/guide/advanced/playwright) 编写端到端测试。
 
 ## 配置 Rstest
 
 ### 创建新项目
 
-使用 [create-rspack](https://www.npmjs.com/package/create-rspack) 创建项目时，在交互式提示中选择 **Rstest - testing**。生成的项目会包含 Rstest 所需的依赖、配置和测试脚本。
+创建项目时，请参阅[快速上手](/guide/start/quick-start)，并在交互式提示中选择 **Rstest - testing**。生成的项目会包含 Rstest 所需的依赖、配置和测试脚本。
 
 ### 添加到现有项目
 
@@ -72,7 +72,7 @@ export function add(a: number, b: number) {
 import { expect, test } from '@rstest/core';
 import { add } from './utils';
 
-test('正确计算两个数字的和', () => {
+test('adds two numbers correctly', () => {
   expect(add(1, 2)).toBe(3);
   expect(add(-1, 1)).toBe(0);
 });
@@ -88,14 +88,14 @@ pnpm run test
 pnpm run test:watch
 
 # 运行测试名称匹配指定模式的测试
-pnpm run test -- -t '正确计算两个数字的和'
+pnpm run test -- -t 'adds two numbers'
 ```
 
-更多测试 API、Mock、Snapshot 和覆盖率等功能，请参阅 [Rstest 文档](https://rstest.rs/guide/)。
+更多测试 API、Mock、Snapshot 和覆盖率等功能，请参阅 [Rstest 文档](https://rstest.rs/zh/guide/)。
 
 ## 端到端测试
 
-[`@rstest/playwright`](https://rstest.rs/guide/advanced/playwright) 是 Rstest 提供的 Playwright 集成包。它提供 Playwright 风格的断言和 fixtures，可测试本地、预览或已部署的应用，并与单元测试共用 Rstest 的运行器、配置和报告流程。
+[`@rstest/playwright`](https://rstest.rs/zh/guide/advanced/playwright) 是 Rstest 提供的 Playwright 集成包。它提供 Playwright 风格的断言和 fixtures，可测试本地、预览或已部署的应用，并与单元测试共用 Rstest 的运行器、配置和报告流程。
 
 :::tip
 
@@ -122,7 +122,7 @@ pnpm exec playwright install chromium
 ```ts title="tests/home.e2e.test.ts"
 import { expect, test } from '@rstest/playwright';
 
-test('首页', async ({ page }) => {
+test('home page', async ({ page }) => {
   await page.goto('http://localhost:3000');
   await expect(page).toHaveTitle(/Rspack/);
 });
@@ -135,7 +135,7 @@ test('首页', async ({ page }) => {
 ```ts title="tests/home.e2e.test.ts"
 import { expect, test } from '@rstest/playwright';
 
-test('首页', async ({ page, serve }) => {
+test('home page', async ({ page, serve }) => {
   const { url } = await serve('./dist/index.html');
 
   await page.goto(url);
@@ -149,4 +149,4 @@ test('首页', async ({ page, serve }) => {
 pnpm run test
 ```
 
-更多 fixtures、浏览器配置、Trace 和调试方式，请参阅 [Rstest：Playwright](https://rstest.rs/guide/advanced/playwright)。
+更多 fixtures、浏览器配置、Trace 和调试方式，请参阅 [Rstest：Playwright](https://rstest.rs/zh/guide/advanced/playwright)。


### PR DESCRIPTION
## Summary

- Add English and Chinese Rspack testing guides under the Features section.
- Document Rstest setup, Rspack configuration reuse, unit testing, and `@rstest/playwright` end-to-end testing.
- Use the `rstest` route to keep the page scope aligned with the guide content.

## Related links

- https://rstest.rs/guide/integration/rspack
- https://rstest.rs/guide/advanced/playwright
- https://rsbuild.rs/guide/advanced/testing

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).