### PR TITLE
chore: release version 2.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "css-module-lexer"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "bitflags 2.13.1",
  "indoc",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "rspack"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "bitflags 2.13.1",
  "derive_more",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_allocator"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "mimalloc",
  "sftrace-setup",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_benchmark"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_api"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4090,21 +4090,21 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_build"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "napi-build",
 ]
 
 [[package]]
 name = "rspack_binding_builder"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_binding_api",
 ]
 
 [[package]]
 name = "rspack_binding_builder_macros"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_builder_testing"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "napi",
  "napi-derive",
@@ -4128,7 +4128,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_browserslist"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
@@ -4137,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "camino",
  "dashmap",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_macros"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_test"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "camino",
  "dashmap",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_collections"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "dashmap",
  "hashlink",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_core"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anymap3",
  "async-recursion",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_dojang"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "html-escape",
  "serde_json",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_error"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "miette",
@@ -4307,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_fs"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4324,7 +4324,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hash"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "base64-simd 0.8.0",
  "itoa",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hook"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_error",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_ids"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "derive_more",
  "futures",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_intern"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -4385,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4406,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_lightningcss"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_preact_refresh"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_react_refresh"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_runner"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_swc"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "either",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_testing"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_location"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "itoa",
  "memchr",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4543,7 +4543,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros_test"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "napi",
  "oneshot",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi_macros"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_node"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "napi-derive",
  "rspack_binding_api",
@@ -4591,7 +4591,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_parallel"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rayon",
  "rspack_tasks",
@@ -4600,7 +4600,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_paths"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "camino",
  "dashmap",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_asset"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "mime_guess",
@@ -4630,7 +4630,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_banner"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "futures",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_case_sensitive"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "itertools 0.14.0",
@@ -4658,7 +4658,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_circular_dependencies"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_copy"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4728,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css_chunking"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "indexmap",
  "rspack_collections",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_devtool"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dll"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dynamic_entry"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "atomic_refcell",
  "derive_more",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ensure_chunk_conditions"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_entry"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_esm_library"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4859,7 +4859,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_externals"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "regex",
  "rspack_core",
@@ -4872,7 +4872,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_extract_css"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_hmr"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_html"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "atomic_refcell",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ignore"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "derive_more",
  "futures",
@@ -4961,7 +4961,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_javascript"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -5011,7 +5011,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_json"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5025,7 +5025,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lazy_compilation"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_library"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "futures",
  "regex",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lightning_css_minimizer"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "lightningcss",
  "parcel_sourcemap",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_limit_chunk_count"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5094,7 +5094,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_merge_duplicate_chunks"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rayon",
  "rspack_core",
@@ -5106,7 +5106,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_mf"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "camino",
@@ -5133,7 +5133,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_info_header"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_cacheable",
  "rspack_core",
@@ -5148,7 +5148,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_replacement"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "derive_more",
  "futures",
@@ -5163,7 +5163,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_no_emit_on_errors"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_progress"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "futures",
  "indicatif",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_real_content_hash"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "aho-corasick",
  "atomic_refcell",
@@ -5207,7 +5207,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_duplicate_modules"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rayon",
  "rspack_collections",
@@ -5220,7 +5220,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_empty_chunks"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsc"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsdoctor"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "atomic_refcell",
  "json",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rslib"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rstest"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "camino",
  "cow-utils",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5358,7 +5358,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime_chunk"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "futures",
  "rspack_core",
@@ -5369,7 +5369,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_schemes"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_size_limits"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "derive_more",
  "futures",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_split_chunks"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "derive_more",
  "futures",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_sri"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_swc_js_minimizer"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "once_cell",
@@ -5486,7 +5486,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_wasm"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_worker"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5515,7 +5515,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_regex"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "napi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "memchr",
  "regex",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_storage"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_import"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "heck",
@@ -5600,7 +5600,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_ts_collector"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "glob",
  "insta",
@@ -5611,14 +5611,14 @@ dependencies = [
 
 [[package]]
 name = "rspack_tasks"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rspack_tools"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "clap",
  "itertools 0.14.0",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "chrono",
  "rspack_tracing_perfetto",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing_perfetto"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "bytes",
  "micromegas-perfetto",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_util"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "anyhow",
  "base64-simd 0.8.0",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_watcher"
-version = "0.102.1"
+version = "0.102.2"
 dependencies = [
  "cow-utils",
  "dashmap",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_workspace"
-version = "0.102.1"
+version = "0.102.2"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition       = "2024"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
-version       = "0.102.1"
+version       = "0.102.2"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "linting/*" }]
@@ -169,96 +169,96 @@ wasmtime     = { version = "36.0.13", default-features = false }
 
 
 # all rspack workspace dependencies
-css-module-lexer                       = { version = "=0.102.1", path = "crates/css-module-lexer", default-features = false }
-rspack                                 = { version = "=0.102.1", path = "crates/rspack", default-features = false }
-rspack_allocator                       = { version = "=0.102.1", path = "crates/rspack_allocator", default-features = false }
-rspack_binding_api                     = { version = "=0.102.1", path = "crates/rspack_binding_api", default-features = false }
-rspack_binding_build                   = { version = "=0.102.1", path = "crates/rspack_binding_build", default-features = false }
-rspack_binding_builder                 = { version = "=0.102.1", path = "crates/rspack_binding_builder", default-features = false }
-rspack_binding_builder_macros          = { version = "=0.102.1", path = "crates/rspack_binding_builder_macros", default-features = false }
-rspack_browserslist                    = { version = "=0.102.1", path = "crates/rspack_browserslist", default-features = false }
-rspack_cacheable                       = { version = "=0.102.1", path = "crates/rspack_cacheable", default-features = false }
-rspack_cacheable_macros                = { version = "=0.102.1", path = "crates/rspack_cacheable_macros", default-features = false }
-rspack_collections                     = { version = "=0.102.1", path = "crates/rspack_collections", default-features = false }
-rspack_core                            = { version = "=0.102.1", path = "crates/rspack_core", default-features = false }
-rspack_dojang                          = { version = "=0.102.1", path = "crates/rspack_dojang", default-features = false }
-rspack_error                           = { version = "=0.102.1", path = "crates/rspack_error", default-features = false }
-rspack_fs                              = { version = "=0.102.1", path = "crates/rspack_fs", default-features = false }
-rspack_hash                            = { version = "=0.102.1", path = "crates/rspack_hash", default-features = false }
-rspack_hook                            = { version = "=0.102.1", path = "crates/rspack_hook", default-features = false }
-rspack_ids                             = { version = "=0.102.1", path = "crates/rspack_ids", default-features = false }
-rspack_intern                          = { version = "=0.102.1", path = "crates/rspack_intern", default-features = false }
-rspack_javascript_compiler             = { version = "=0.102.1", path = "crates/rspack_javascript_compiler", default-features = false }
-rspack_loader_lightningcss             = { version = "=0.102.1", path = "crates/rspack_loader_lightningcss", default-features = false }
-rspack_loader_preact_refresh           = { version = "=0.102.1", path = "crates/rspack_loader_preact_refresh", default-features = false }
-rspack_loader_react_refresh            = { version = "=0.102.1", path = "crates/rspack_loader_react_refresh", default-features = false }
-rspack_loader_runner                   = { version = "=0.102.1", path = "crates/rspack_loader_runner", default-features = false }
-rspack_loader_swc                      = { version = "=0.102.1", path = "crates/rspack_loader_swc", default-features = false }
-rspack_loader_testing                  = { version = "=0.102.1", path = "crates/rspack_loader_testing", default-features = false }
-rspack_location                        = { version = "=0.102.1", path = "crates/rspack_location", default-features = false }
-rspack_macros                          = { version = "=0.102.1", path = "crates/rspack_macros", default-features = false }
-rspack_napi                            = { version = "=0.102.1", path = "crates/rspack_napi", default-features = false }
-rspack_napi_macros                     = { version = "=0.102.1", path = "crates/rspack_napi_macros", default-features = false }
-rspack_parallel                        = { version = "=0.102.1", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.102.1", path = "crates/rspack_paths", default-features = false }
-rspack_plugin_asset                    = { version = "=0.102.1", path = "crates/rspack_plugin_asset", default-features = false }
-rspack_plugin_banner                   = { version = "=0.102.1", path = "crates/rspack_plugin_banner", default-features = false }
-rspack_plugin_case_sensitive           = { version = "=0.102.1", path = "crates/rspack_plugin_case_sensitive", default-features = false }
-rspack_plugin_circular_dependencies    = { version = "=0.102.1", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
-rspack_plugin_copy                     = { version = "=0.102.1", path = "crates/rspack_plugin_copy", default-features = false }
-rspack_plugin_css                      = { version = "=0.102.1", path = "crates/rspack_plugin_css", default-features = false }
-rspack_plugin_css_chunking             = { version = "=0.102.1", path = "crates/rspack_plugin_css_chunking", default-features = false }
-rspack_plugin_devtool                  = { version = "=0.102.1", path = "crates/rspack_plugin_devtool", default-features = false }
-rspack_plugin_dll                      = { version = "=0.102.1", path = "crates/rspack_plugin_dll", default-features = false }
-rspack_plugin_dynamic_entry            = { version = "=0.102.1", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
-rspack_plugin_ensure_chunk_conditions  = { version = "=0.102.1", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
-rspack_plugin_entry                    = { version = "=0.102.1", path = "crates/rspack_plugin_entry", default-features = false }
-rspack_plugin_esm_library              = { version = "=0.102.1", path = "crates/rspack_plugin_esm_library", default-features = false }
-rspack_plugin_externals                = { version = "=0.102.1", path = "crates/rspack_plugin_externals", default-features = false }
-rspack_plugin_extract_css              = { version = "=0.102.1", path = "crates/rspack_plugin_extract_css", default-features = false }
-rspack_plugin_hmr                      = { version = "=0.102.1", path = "crates/rspack_plugin_hmr", default-features = false }
-rspack_plugin_html                     = { version = "=0.102.1", path = "crates/rspack_plugin_html", default-features = false }
-rspack_plugin_ignore                   = { version = "=0.102.1", path = "crates/rspack_plugin_ignore", default-features = false }
-rspack_plugin_javascript               = { version = "=0.102.1", path = "crates/rspack_plugin_javascript", default-features = false }
-rspack_plugin_json                     = { version = "=0.102.1", path = "crates/rspack_plugin_json", default-features = false }
-rspack_plugin_lazy_compilation         = { version = "=0.102.1", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
-rspack_plugin_library                  = { version = "=0.102.1", path = "crates/rspack_plugin_library", default-features = false }
-rspack_plugin_lightning_css_minimizer  = { version = "=0.102.1", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
-rspack_plugin_limit_chunk_count        = { version = "=0.102.1", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
-rspack_plugin_merge_duplicate_chunks   = { version = "=0.102.1", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
-rspack_plugin_mf                       = { version = "=0.102.1", path = "crates/rspack_plugin_mf", default-features = false }
-rspack_plugin_module_info_header       = { version = "=0.102.1", path = "crates/rspack_plugin_module_info_header", default-features = false }
-rspack_plugin_module_replacement       = { version = "=0.102.1", path = "crates/rspack_plugin_module_replacement", default-features = false }
-rspack_plugin_no_emit_on_errors        = { version = "=0.102.1", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
-rspack_plugin_progress                 = { version = "=0.102.1", path = "crates/rspack_plugin_progress", default-features = false }
-rspack_plugin_real_content_hash        = { version = "=0.102.1", path = "crates/rspack_plugin_real_content_hash", default-features = false }
-rspack_plugin_remove_duplicate_modules = { version = "=0.102.1", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
-rspack_plugin_remove_empty_chunks      = { version = "=0.102.1", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
-rspack_plugin_rsc                      = { version = "=0.102.1", path = "crates/rspack_plugin_rsc", default-features = false }
-rspack_plugin_rsdoctor                 = { version = "=0.102.1", path = "crates/rspack_plugin_rsdoctor", default-features = false }
-rspack_plugin_rslib                    = { version = "=0.102.1", path = "crates/rspack_plugin_rslib", default-features = false }
-rspack_plugin_rstest                   = { version = "=0.102.1", path = "crates/rspack_plugin_rstest", default-features = false }
-rspack_plugin_runtime                  = { version = "=0.102.1", path = "crates/rspack_plugin_runtime", default-features = false }
-rspack_plugin_runtime_chunk            = { version = "=0.102.1", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
-rspack_plugin_schemes                  = { version = "=0.102.1", path = "crates/rspack_plugin_schemes", default-features = false }
-rspack_plugin_size_limits              = { version = "=0.102.1", path = "crates/rspack_plugin_size_limits", default-features = false }
-rspack_plugin_split_chunks             = { version = "=0.102.1", path = "crates/rspack_plugin_split_chunks", default-features = false }
-rspack_plugin_sri                      = { version = "=0.102.1", path = "crates/rspack_plugin_sri", default-features = false }
-rspack_plugin_swc_js_minimizer         = { version = "=0.102.1", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
-rspack_plugin_wasm                     = { version = "=0.102.1", path = "crates/rspack_plugin_wasm", default-features = false }
-rspack_plugin_worker                   = { version = "=0.102.1", path = "crates/rspack_plugin_worker", default-features = false }
-rspack_regex                           = { version = "=0.102.1", path = "crates/rspack_regex", default-features = false }
-rspack_resolver                        = { version = "=0.102.1", path = "crates/rspack_resolver", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
-rspack_sources                         = { version = "=0.102.1", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
-rspack_storage                         = { version = "=0.102.1", path = "crates/rspack_storage", default-features = false }
-rspack_swc_plugin_import               = { version = "=0.102.1", path = "crates/swc_plugin_import", default-features = false }
-rspack_swc_plugin_ts_collector         = { version = "=0.102.1", path = "crates/swc_plugin_ts_collector", default-features = false }
-rspack_tasks                           = { version = "=0.102.1", path = "crates/rspack_tasks", default-features = false }
-rspack_tracing                         = { version = "=0.102.1", path = "crates/rspack_tracing", default-features = false }
-rspack_tracing_perfetto                = { version = "=0.102.1", path = "crates/rspack_tracing_perfetto", default-features = false }
-rspack_util                            = { version = "=0.102.1", path = "crates/rspack_util", default-features = false }
-rspack_watcher                         = { version = "=0.102.1", path = "crates/rspack_watcher", default-features = false }
-rspack_workspace                       = { version = "=0.102.1", path = "crates/rspack_workspace", default-features = false }
+css-module-lexer                       = { version = "=0.102.2", path = "crates/css-module-lexer", default-features = false }
+rspack                                 = { version = "=0.102.2", path = "crates/rspack", default-features = false }
+rspack_allocator                       = { version = "=0.102.2", path = "crates/rspack_allocator", default-features = false }
+rspack_binding_api                     = { version = "=0.102.2", path = "crates/rspack_binding_api", default-features = false }
+rspack_binding_build                   = { version = "=0.102.2", path = "crates/rspack_binding_build", default-features = false }
+rspack_binding_builder                 = { version = "=0.102.2", path = "crates/rspack_binding_builder", default-features = false }
+rspack_binding_builder_macros          = { version = "=0.102.2", path = "crates/rspack_binding_builder_macros", default-features = false }
+rspack_browserslist                    = { version = "=0.102.2", path = "crates/rspack_browserslist", default-features = false }
+rspack_cacheable                       = { version = "=0.102.2", path = "crates/rspack_cacheable", default-features = false }
+rspack_cacheable_macros                = { version = "=0.102.2", path = "crates/rspack_cacheable_macros", default-features = false }
+rspack_collections                     = { version = "=0.102.2", path = "crates/rspack_collections", default-features = false }
+rspack_core                            = { version = "=0.102.2", path = "crates/rspack_core", default-features = false }
+rspack_dojang                          = { version = "=0.102.2", path = "crates/rspack_dojang", default-features = false }
+rspack_error                           = { version = "=0.102.2", path = "crates/rspack_error", default-features = false }
+rspack_fs                              = { version = "=0.102.2", path = "crates/rspack_fs", default-features = false }
+rspack_hash                            = { version = "=0.102.2", path = "crates/rspack_hash", default-features = false }
+rspack_hook                            = { version = "=0.102.2", path = "crates/rspack_hook", default-features = false }
+rspack_ids                             = { version = "=0.102.2", path = "crates/rspack_ids", default-features = false }
+rspack_intern                          = { version = "=0.102.2", path = "crates/rspack_intern", default-features = false }
+rspack_javascript_compiler             = { version = "=0.102.2", path = "crates/rspack_javascript_compiler", default-features = false }
+rspack_loader_lightningcss             = { version = "=0.102.2", path = "crates/rspack_loader_lightningcss", default-features = false }
+rspack_loader_preact_refresh           = { version = "=0.102.2", path = "crates/rspack_loader_preact_refresh", default-features = false }
+rspack_loader_react_refresh            = { version = "=0.102.2", path = "crates/rspack_loader_react_refresh", default-features = false }
+rspack_loader_runner                   = { version = "=0.102.2", path = "crates/rspack_loader_runner", default-features = false }
+rspack_loader_swc                      = { version = "=0.102.2", path = "crates/rspack_loader_swc", default-features = false }
+rspack_loader_testing                  = { version = "=0.102.2", path = "crates/rspack_loader_testing", default-features = false }
+rspack_location                        = { version = "=0.102.2", path = "crates/rspack_location", default-features = false }
+rspack_macros                          = { version = "=0.102.2", path = "crates/rspack_macros", default-features = false }
+rspack_napi                            = { version = "=0.102.2", path = "crates/rspack_napi", default-features = false }
+rspack_napi_macros                     = { version = "=0.102.2", path = "crates/rspack_napi_macros", default-features = false }
+rspack_parallel                        = { version = "=0.102.2", path = "crates/rspack_parallel", default-features = false }
+rspack_paths                           = { version = "=0.102.2", path = "crates/rspack_paths", default-features = false }
+rspack_plugin_asset                    = { version = "=0.102.2", path = "crates/rspack_plugin_asset", default-features = false }
+rspack_plugin_banner                   = { version = "=0.102.2", path = "crates/rspack_plugin_banner", default-features = false }
+rspack_plugin_case_sensitive           = { version = "=0.102.2", path = "crates/rspack_plugin_case_sensitive", default-features = false }
+rspack_plugin_circular_dependencies    = { version = "=0.102.2", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
+rspack_plugin_copy                     = { version = "=0.102.2", path = "crates/rspack_plugin_copy", default-features = false }
+rspack_plugin_css                      = { version = "=0.102.2", path = "crates/rspack_plugin_css", default-features = false }
+rspack_plugin_css_chunking             = { version = "=0.102.2", path = "crates/rspack_plugin_css_chunking", default-features = false }
+rspack_plugin_devtool                  = { version = "=0.102.2", path = "crates/rspack_plugin_devtool", default-features = false }
+rspack_plugin_dll                      = { version = "=0.102.2", path = "crates/rspack_plugin_dll", default-features = false }
+rspack_plugin_dynamic_entry            = { version = "=0.102.2", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
+rspack_plugin_ensure_chunk_conditions  = { version = "=0.102.2", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
+rspack_plugin_entry                    = { version = "=0.102.2", path = "crates/rspack_plugin_entry", default-features = false }
+rspack_plugin_esm_library              = { version = "=0.102.2", path = "crates/rspack_plugin_esm_library", default-features = false }
+rspack_plugin_externals                = { version = "=0.102.2", path = "crates/rspack_plugin_externals", default-features = false }
+rspack_plugin_extract_css              = { version = "=0.102.2", path = "crates/rspack_plugin_extract_css", default-features = false }
+rspack_plugin_hmr                      = { version = "=0.102.2", path = "crates/rspack_plugin_hmr", default-features = false }
+rspack_plugin_html                     = { version = "=0.102.2", path = "crates/rspack_plugin_html", default-features = false }
+rspack_plugin_ignore                   = { version = "=0.102.2", path = "crates/rspack_plugin_ignore", default-features = false }
+rspack_plugin_javascript               = { version = "=0.102.2", path = "crates/rspack_plugin_javascript", default-features = false }
+rspack_plugin_json                     = { version = "=0.102.2", path = "crates/rspack_plugin_json", default-features = false }
+rspack_plugin_lazy_compilation         = { version = "=0.102.2", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
+rspack_plugin_library                  = { version = "=0.102.2", path = "crates/rspack_plugin_library", default-features = false }
+rspack_plugin_lightning_css_minimizer  = { version = "=0.102.2", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
+rspack_plugin_limit_chunk_count        = { version = "=0.102.2", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
+rspack_plugin_merge_duplicate_chunks   = { version = "=0.102.2", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
+rspack_plugin_mf                       = { version = "=0.102.2", path = "crates/rspack_plugin_mf", default-features = false }
+rspack_plugin_module_info_header       = { version = "=0.102.2", path = "crates/rspack_plugin_module_info_header", default-features = false }
+rspack_plugin_module_replacement       = { version = "=0.102.2", path = "crates/rspack_plugin_module_replacement", default-features = false }
+rspack_plugin_no_emit_on_errors        = { version = "=0.102.2", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
+rspack_plugin_progress                 = { version = "=0.102.2", path = "crates/rspack_plugin_progress", default-features = false }
+rspack_plugin_real_content_hash        = { version = "=0.102.2", path = "crates/rspack_plugin_real_content_hash", default-features = false }
+rspack_plugin_remove_duplicate_modules = { version = "=0.102.2", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
+rspack_plugin_remove_empty_chunks      = { version = "=0.102.2", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
+rspack_plugin_rsc                      = { version = "=0.102.2", path = "crates/rspack_plugin_rsc", default-features = false }
+rspack_plugin_rsdoctor                 = { version = "=0.102.2", path = "crates/rspack_plugin_rsdoctor", default-features = false }
+rspack_plugin_rslib                    = { version = "=0.102.2", path = "crates/rspack_plugin_rslib", default-features = false }
+rspack_plugin_rstest                   = { version = "=0.102.2", path = "crates/rspack_plugin_rstest", default-features = false }
+rspack_plugin_runtime                  = { version = "=0.102.2", path = "crates/rspack_plugin_runtime", default-features = false }
+rspack_plugin_runtime_chunk            = { version = "=0.102.2", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
+rspack_plugin_schemes                  = { version = "=0.102.2", path = "crates/rspack_plugin_schemes", default-features = false }
+rspack_plugin_size_limits              = { version = "=0.102.2", path = "crates/rspack_plugin_size_limits", default-features = false }
+rspack_plugin_split_chunks             = { version = "=0.102.2", path = "crates/rspack_plugin_split_chunks", default-features = false }
+rspack_plugin_sri                      = { version = "=0.102.2", path = "crates/rspack_plugin_sri", default-features = false }
+rspack_plugin_swc_js_minimizer         = { version = "=0.102.2", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
+rspack_plugin_wasm                     = { version = "=0.102.2", path = "crates/rspack_plugin_wasm", default-features = false }
+rspack_plugin_worker                   = { version = "=0.102.2", path = "crates/rspack_plugin_worker", default-features = false }
+rspack_regex                           = { version = "=0.102.2", path = "crates/rspack_regex", default-features = false }
+rspack_resolver                        = { version = "=0.102.2", path = "crates/rspack_resolver", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
+rspack_sources                         = { version = "=0.102.2", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_storage                         = { version = "=0.102.2", path = "crates/rspack_storage", default-features = false }
+rspack_swc_plugin_import               = { version = "=0.102.2", path = "crates/swc_plugin_import", default-features = false }
+rspack_swc_plugin_ts_collector         = { version = "=0.102.2", path = "crates/swc_plugin_ts_collector", default-features = false }
+rspack_tasks                           = { version = "=0.102.2", path = "crates/rspack_tasks", default-features = false }
+rspack_tracing                         = { version = "=0.102.2", path = "crates/rspack_tracing", default-features = false }
+rspack_tracing_perfetto                = { version = "=0.102.2", path = "crates/rspack_tracing_perfetto", default-features = false }
+rspack_util                            = { version = "=0.102.2", path = "crates/rspack_util", default-features = false }
+rspack_watcher                         = { version = "=0.102.2", path = "crates/rspack_watcher", default-features = false }
+rspack_workspace                       = { version = "=0.102.2", path = "crates/rspack_workspace", default-features = false }
 
 
 [workspace.metadata.release]

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -6,5 +6,5 @@ pub const fn rspack_swc_core_version() -> &'static str {
 
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {
-  "2.2.1"
+  "2.2.2"
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-gnu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-gnu.node",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-musl",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-musl.node",

--- a/npm/linux-ppc64-gnu/package.json
+++ b/npm/linux-ppc64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-ppc64-gnu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-ppc64-gnu.node",

--- a/npm/linux-riscv64-gnu/package.json
+++ b/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-gnu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-gnu.node",

--- a/npm/linux-riscv64-musl/package.json
+++ b/npm/linux-riscv64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-musl",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-musl.node",

--- a/npm/linux-s390x-gnu/package.json
+++ b/npm/linux-s390x-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-s390x-gnu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-s390x-gnu.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-musl",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-musl.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-arm64-msvc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-arm64-msvc.node",

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-ia32-msvc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-ia32-msvc.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/browser",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Rspack for running in the browser. This is still in early stage and may not follow the semver.",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Test tools for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",


### PR DESCRIPTION
## Release Information

- Released By: intellild
- Release Date: 2026-09-01
- JavaScript Packages Version: 2.2.2
- Rust Crates Version: 0.102.2

---
_by OpenAI Codex_