### PR TITLE
refactor: share concatenation backend logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4849,10 +4849,6 @@ dependencies = [
  "serde_json",
  "sugar_path",
  "swc_core",
- "swc_experimental_allocator",
- "swc_experimental_ecma_ast",
- "swc_experimental_ecma_parser",
- "swc_experimental_ecma_semantic",
  "tokio",
  "tracing",
 ]

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1060,7 +1060,14 @@ impl Module for ConcatenatedModule {
                 } else {
                   let ns_import_key = ns_import.clone();
                   let new_name = if name_allocator.contains(&ns_import) {
-                    name_allocator.find_new_binding_name(&ns_import, &[], &concatenation_context)
+                    name_allocator.find_new_name(
+                      concatenation_context
+                        .escaped_names
+                        .get(&ns_import)
+                        .expect("should have escaped name")
+                        .as_ref(),
+                      &[],
+                    )
                   } else {
                     name_allocator.insert(ns_import);
                     ns_import_key.clone()
@@ -1111,10 +1118,9 @@ impl Module for ConcatenatedModule {
             if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
               info.internal_names.get(namespace_export_symbol).cloned()
             } else {
-              Some(name_allocator.find_new_module_name(
+              Some(name_allocator.find_new_name(
                 "namespaceObject",
-                &info.module,
-                &concatenation_context,
+                concatenation_context.module_identifier(&info.module),
               ))
             };
           if let Some(namespace_object_name) = namespace_object_name {
@@ -1136,22 +1142,18 @@ impl Module for ConcatenatedModule {
 
         // Handle external type
         ModuleInfo::External(info) => {
-          let external_name: Atom =
-            name_allocator.find_new_module_name("", &info.module, &concatenation_context);
+          let module_identifier = concatenation_context.module_identifier(&info.module);
+          let external_name: Atom = name_allocator.find_new_name("", module_identifier);
           info.name = Some(external_name.clone());
           top_level_declarations.insert(external_name.clone());
 
           if info.deferred {
-            let external_name =
-              name_allocator.find_new_module_name("deferred", &info.module, &concatenation_context);
+            let external_name = name_allocator.find_new_name("deferred", module_identifier);
             info.deferred_name = Some(external_name.clone());
             top_level_declarations.insert(external_name.clone());
 
-            let external_name_interop = name_allocator.find_new_module_name(
-              "deferredNamespaceObject",
-              &info.module,
-              &concatenation_context,
-            );
+            let external_name_interop =
+              name_allocator.find_new_name("deferredNamespaceObject", module_identifier);
             info.deferred_namespace_object_name = Some(external_name_interop.clone());
             top_level_declarations.insert(external_name_interop.clone());
           }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1164,13 +1164,16 @@ impl Module for ConcatenatedModule {
     // Move it off the critical path once naming is complete.
     drop(name_allocator);
 
-    // `escaped_names` / `escaped_identifiers` can retain a large amount of
-    // temporary escaped naming state. Move them off the critical path once
-    // naming is complete.
+    // The escaped naming maps can retain a large amount of temporary state.
+    // Move them off the critical path once naming is complete.
     fast_set(&mut concatenation_context.escaped_names, HashMap::default());
     fast_set(
       &mut concatenation_context.escaped_identifiers,
       HashMap::default(),
+    );
+    fast_set(
+      &mut concatenation_context.module_identifiers,
+      IdentifierMap::default(),
     );
 
     let binding_resolver = ConcatenationBindingResolver {

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -1176,7 +1176,7 @@ impl Module for ConcatenatedModule {
     let binding_resolver = ConcatenationBindingResolver {
       context: &concatenation_context,
       module_to_info_map: &mut module_to_info_map,
-      normalize_export_name: |_, _, _| {},
+      normalize_export_name: None,
     };
 
     // Find and replace references to modules
@@ -2505,7 +2505,7 @@ impl ConcatenatedModule {
               }
             }
           };
-        return FinalBindingResult {
+        FinalBindingResult {
           binding: Binding::Raw(RawBinding {
             info_id,
             raw_name: raw_name.cloned().expect("should have raw name"),
@@ -2518,7 +2518,7 @@ impl ConcatenatedModule {
           interop_default_access_used: None,
           deferred_namespace_object_used: is_deferred.then_some(true),
           needed_namespace_object,
-        };
+        }
       }
       ConcatenationBindingTarget::InteropDefault => {
         let info = module_to_info_map
@@ -2562,7 +2562,7 @@ impl ConcatenatedModule {
           format!("{default_access_name}.a")
         };
 
-        return FinalBindingResult {
+        FinalBindingResult {
           binding: Binding::Raw(RawBinding {
             raw_name: default_export.into(),
             ids: export_name.clone(),
@@ -2575,50 +2575,48 @@ impl ConcatenatedModule {
           interop_namespace_object2_used: None,
           deferred_namespace_object_used: None,
           needed_namespace_object: None,
-        };
+        }
       }
       ConcatenationBindingTarget::EsModule(ids) => {
-        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+        FinalBindingResult::from_binding(Binding::Raw(RawBinding {
           info_id,
           raw_name: "/* __esModule */true".into(),
           ids,
           export_name,
           comment: None,
-        }));
+        }))
       }
       ConcatenationBindingTarget::UnsupportedDefaultImport => {
-        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+        FinalBindingResult::from_binding(Binding::Raw(RawBinding {
           raw_name: "/* non-default import from default-exporting module */undefined".into(),
           ids: export_name.clone(),
           export_name,
           info_id,
           comment: None,
-        }));
+        }))
       }
       ConcatenationBindingTarget::Namespace => {
         match module_to_info_map
           .get(&info_id)
           .expect("should have module info")
         {
-          ModuleInfo::Concatenated(info) => {
-            return FinalBindingResult {
-              binding: Binding::Raw(RawBinding {
-                raw_name: info
-                  .namespace_object_name
-                  .clone()
-                  .expect("should have namespace_object_name"),
-                ids: export_name.clone(),
-                export_name,
-                info_id: info.module,
-                comment: None,
-              }),
-              needed_namespace_object: Some(info.module),
-              interop_namespace_object_used: None,
-              interop_namespace_object2_used: None,
-              interop_default_access_used: None,
-              deferred_namespace_object_used: None,
-            };
-          }
+          ModuleInfo::Concatenated(info) => FinalBindingResult {
+            binding: Binding::Raw(RawBinding {
+              raw_name: info
+                .namespace_object_name
+                .clone()
+                .expect("should have namespace_object_name"),
+              ids: export_name.clone(),
+              export_name,
+              info_id: info.module,
+              comment: None,
+            }),
+            needed_namespace_object: Some(info.module),
+            interop_namespace_object_used: None,
+            interop_namespace_object2_used: None,
+            interop_default_access_used: None,
+            deferred_namespace_object_used: None,
+          },
           ModuleInfo::External(info) => {
             if is_deferred {
               return FinalBindingResult {
@@ -2639,27 +2637,27 @@ impl ConcatenatedModule {
                 needed_namespace_object: None,
               };
             }
-            return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+            FinalBindingResult::from_binding(Binding::Raw(RawBinding {
               raw_name: info.name.clone().expect("should have raw name"),
               ids: export_name.clone(),
               export_name,
               info_id: info.module,
               comment: None,
-            }));
+            }))
           }
         }
       }
       ConcatenationBindingTarget::Circular => {
-        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+        FinalBindingResult::from_binding(Binding::Raw(RawBinding {
           raw_name: "/* circular reexport */ Object(function x() { x() }())".into(),
           ids: Vec::new(),
           export_name,
           info_id,
           comment: None,
-        }));
+        }))
       }
       ConcatenationBindingTarget::Direct { symbol, used_name } => {
-        return FinalBindingResult::from_binding(match used_name {
+        FinalBindingResult::from_binding(match used_name {
           Some(UsedName::Normal(used_name)) => Binding::Symbol(SymbolBinding {
             info_id,
             name: symbol,
@@ -2687,22 +2685,22 @@ impl ConcatenatedModule {
             info_id,
             comment: None,
           }),
-        });
+        })
       }
       ConcatenationBindingTarget::Raw(symbol) => {
-        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+        FinalBindingResult::from_binding(Binding::Raw(RawBinding {
           info_id,
           raw_name: symbol,
           ids: export_name[1..].to_vec(),
           export_name,
           comment: None,
-        }));
+        }))
       }
       ConcatenationBindingTarget::Inlined(used_name) => {
         let UsedName::Inlined(inlined) = used_name else {
           unreachable!("inlined binding plan should contain an inlined used name")
         };
-        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+        FinalBindingResult::from_binding(Binding::Raw(RawBinding {
           raw_name: inlined
             .inlined_value()
             .render(&to_normal_comment(&format!(
@@ -2714,14 +2712,14 @@ impl ConcatenatedModule {
           export_name,
           info_id,
           comment: None,
-        }));
+        }))
       }
       ConcatenationBindingTarget::NamespaceExport(used_name) => {
         let info = module_to_info_map
           .get(&info_id)
           .expect("should have module info")
           .as_concatenated();
-        return FinalBindingResult::from_binding(match used_name {
+        FinalBindingResult::from_binding(match used_name {
           UsedName::Normal(used_name) => Binding::Raw(RawBinding {
             info_id,
             raw_name: info
@@ -2747,7 +2745,7 @@ impl ConcatenatedModule {
             export_name,
             comment: None,
           }),
-        });
+        })
       }
       ConcatenationBindingTarget::Missing(_) => {
         let module = module_graph

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -58,7 +58,7 @@ use crate::{
   merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
-  subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
+  subtract_runtime_condition, to_normal_comment,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -1011,14 +1011,14 @@ impl Module for ConcatenatedModule {
     let mut concatenation_context =
       ConcatenationContext::prepare(&module_to_info_map, compilation, runtime);
 
-    let mut name_allocator = ConcatenationNameAllocator(all_used_names, &concatenation_context);
+    let mut name_allocator = ConcatenationNameAllocator::new(all_used_names);
 
     for info in module_to_info_map.values_mut() {
       // Get used names in the scope
       match info {
         // Handle concatenated type
         ModuleInfo::Concatenated(info) => {
-          name_allocator.assign_module_binding_names(info);
+          name_allocator.assign_module_binding_names(info, &concatenation_context);
 
           for ((name, ctxt), refs) in &info.binding_to_ref {
             if ctxt != &info.module_ctxt {
@@ -1060,7 +1060,7 @@ impl Module for ConcatenatedModule {
                 } else {
                   let ns_import_key = ns_import.clone();
                   let new_name = if name_allocator.contains(&ns_import) {
-                    name_allocator.find_new_binding_name(&ns_import, &[])
+                    name_allocator.find_new_binding_name(&ns_import, &[], &concatenation_context)
                   } else {
                     name_allocator.insert(ns_import);
                     ns_import_key.clone()
@@ -1078,6 +1078,7 @@ impl Module for ConcatenatedModule {
                   existing_name.as_ref(),
                   &source,
                   info,
+                  &concatenation_context,
                 );
 
                 if existing_name.is_none() {
@@ -1110,7 +1111,11 @@ impl Module for ConcatenatedModule {
             if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
               info.internal_names.get(namespace_export_symbol).cloned()
             } else {
-              Some(name_allocator.find_new_module_name("namespaceObject", &info.module))
+              Some(name_allocator.find_new_module_name(
+                "namespaceObject",
+                &info.module,
+                &concatenation_context,
+              ))
             };
           if let Some(namespace_object_name) = namespace_object_name {
             info.namespace_object_name = Some(namespace_object_name.clone());
@@ -1131,23 +1136,28 @@ impl Module for ConcatenatedModule {
 
         // Handle external type
         ModuleInfo::External(info) => {
-          let external_name: Atom = name_allocator.find_new_module_name("", &info.module);
+          let external_name: Atom =
+            name_allocator.find_new_module_name("", &info.module, &concatenation_context);
           info.name = Some(external_name.clone());
           top_level_declarations.insert(external_name.clone());
 
           if info.deferred {
-            let external_name = name_allocator.find_new_module_name("deferred", &info.module);
+            let external_name =
+              name_allocator.find_new_module_name("deferred", &info.module, &concatenation_context);
             info.deferred_name = Some(external_name.clone());
             top_level_declarations.insert(external_name.clone());
 
-            let external_name_interop =
-              name_allocator.find_new_module_name("deferredNamespaceObject", &info.module);
+            let external_name_interop = name_allocator.find_new_module_name(
+              "deferredNamespaceObject",
+              &info.module,
+              &concatenation_context,
+            );
             info.deferred_namespace_object_name = Some(external_name_interop.clone());
             top_level_declarations.insert(external_name_interop.clone());
           }
         }
       }
-      name_allocator.assign_interop_names(info);
+      name_allocator.assign_interop_names(info, &concatenation_context);
       for name in [
         info.get_interop_namespace_object_name(),
         info.get_interop_namespace_object2_name(),
@@ -1160,7 +1170,7 @@ impl Module for ConcatenatedModule {
       }
     }
 
-    // `NameAllocator` can retain a large amount of temporary name state.
+    // `ConcatenationNameAllocator` can retain a large amount of temporary name state.
     // Move it off the critical path once naming is complete.
     drop(name_allocator);
 
@@ -2833,57 +2843,6 @@ pub fn is_esm_dep_like(dep: &dyn Dependency) -> bool {
       | DependencyType::EsmExportImport
       | DependencyType::CssImport
   )
-}
-
-pub fn find_new_name(old_name: &str, used_names: &HashSet<Atom>, extra_info: &[Atom]) -> Atom {
-  let mut name = old_name.to_string();
-
-  for info_part in extra_info {
-    let info_str = info_part.as_ref();
-    let mut new_name = String::with_capacity(info_str.len() + 1 + name.len());
-    new_name.push_str(info_str);
-    if !name.is_empty() {
-      if name.starts_with('_') || info_str.ends_with('_') {
-        new_name.push_str(&name);
-      } else {
-        new_name.push('_');
-        new_name.push_str(&name);
-      }
-    }
-    name = new_name;
-
-    let candidate: Atom = to_identifier_with_escaped(name.clone()).into();
-    if !used_names.contains(&candidate) {
-      return candidate;
-    }
-  }
-
-  let base: Atom = to_identifier_with_escaped(name).into();
-  if !base.is_empty() && !used_names.contains(&base) {
-    return base;
-  }
-
-  let mut i = 0;
-  let mut i_buffer = itoa::Buffer::new();
-
-  let mut base_with_underscore = String::with_capacity(base.len() + 1);
-  base_with_underscore.push_str(base.as_ref());
-  base_with_underscore.push('_');
-
-  let mut numbered = String::with_capacity(base_with_underscore.len() + 8);
-  loop {
-    numbered.clear();
-    numbered.push_str(&base_with_underscore);
-    numbered.push_str(i_buffer.format(i));
-
-    // Same as above: `base` is already escaped, appending '_' and a number still yields a valid identifier.
-    let candidate: Atom = Atom::from(numbered.as_str());
-    if !used_names.contains(&candidate) {
-      return candidate;
-    }
-
-    i += 1;
-  }
 }
 
 #[derive(Debug)]

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -15,7 +15,7 @@ use rspack_cacheable::{
 use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet,
 };
-use rspack_error::{Diagnosable, Diagnostic, Error, Result, ToStringResultToRspackResultExt};
+use rspack_error::{Diagnosable, Diagnostic, Result, ToStringResultToRspackResultExt};
 use rspack_hash::{HashDigest, HashFunction, RspackHash, RspackHashDigest, RspackHasher};
 use rspack_hook::define_hook;
 use rspack_sources::{
@@ -35,29 +35,27 @@ use swc_core::{
   ecma::visit::swc_ecma_ast,
 };
 use swc_experimental_allocator::{Allocator, CloneIn};
-use swc_experimental_ecma_ast::{
-  ClassExpr, EsVersion, Ident, ObjectPatProp, Program, Prop, Visit, VisitWith,
-};
-use swc_experimental_ecma_parser::{EsSyntax, Parser, StringSource, Syntax};
-use swc_experimental_ecma_semantic::resolver::{Semantic, resolver};
+use swc_experimental_ecma_ast::{ClassExpr, Ident, ObjectPatProp, Program, Prop, Visit, VisitWith};
+use swc_experimental_ecma_semantic::resolver::Semantic;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildMetaDefaultObject, BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments,
-  CodeGenerationDataChunkInitFragments, CodeGenerationDataTopLevelDeclarations,
-  CodeGenerationPublicPathAutoReplace, CodeGenerationResultBuilder,
-  CodeGenerationRuntimeRequirementsWrite, Compilation, ConcatenatedModuleIdent, ConcatenationScope,
-  ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT, DEFAULT_EXPORT_ATOM,
-  DependenciesBlock, Dependency, DependencyCodeGenerationRef, DependencyId, DependencyType,
-  ExportInfo, ExportProvided, ExportsArgument, ExportsInfoArtifact, ExportsType, FactoryMeta,
-  ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage, LibIdentOptions, Module,
-  ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType,
-  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
-  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
-  escape_identifier, fast_set, filter_runtime, find_target, get_runtime_key,
-  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
-  module_update_hash, property_access, property_name,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  ChunkGraph, ChunkInitFragments, CodeGenerationDataChunkInitFragments,
+  CodeGenerationDataTopLevelDeclarations, CodeGenerationPublicPathAutoReplace,
+  CodeGenerationResultBuilder, CodeGenerationRuntimeRequirementsWrite, Compilation,
+  ConcatenatedModuleIdent, ConcatenationBindingPlan, ConcatenationBindingResolver,
+  ConcatenationBindingTarget, ConcatenationContext, ConcatenationInterop,
+  ConcatenationNameAllocator, ConcatenationScope, ConditionalInitFragment, ConnectionState,
+  Context, DEFAULT_EXPORT, DEFAULT_EXPORT_ATOM, DependenciesBlock, Dependency,
+  DependencyCodeGenerationRef, DependencyId, DependencyType, ExportProvided, ExportsArgument,
+  ExportsInfoArtifact, FactoryMeta, ImportedByDeferModulesArtifact, InitFragment,
+  InitFragmentStage, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
+  ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition,
+  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState,
+  UsedName, UsedNameItem, analyze_module_scope, escape_identifier, fast_set, filter_runtime,
+  get_runtime_key, impl_source_map_config, merge_runtime_condition,
+  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_identifier_with_escaped, to_normal_comment,
@@ -149,101 +147,6 @@ static REGEX: LazyLock<Regex> = LazyLock::new(|| {
   let pattern = r"\.+\/|(\/index)?\.([a-zA-Z0-9]{1,4})($|\s|\?)|\s*\+\s*\d+\s*modules";
   Regex::new(pattern).expect("should construct the regex")
 });
-
-#[derive(Default)]
-struct NameAllocator {
-  used_names: HashSet<Atom>,
-  used_strings: HashSet<String>,
-  suffix_counters: HashMap<Atom, u32>,
-}
-
-impl NameAllocator {
-  fn new(used_names: HashSet<Atom>) -> Self {
-    let mut used_strings: HashSet<String> = HashSet::default();
-    used_strings.reserve(used_names.len());
-    for name in &used_names {
-      used_strings.insert(name.as_ref().to_string());
-    }
-
-    Self {
-      used_names,
-      used_strings,
-      suffix_counters: HashMap::default(),
-    }
-  }
-
-  fn contains(&self, name: &Atom) -> bool {
-    self.used_names.contains(name)
-  }
-
-  fn insert(&mut self, name: Atom) {
-    self.used_strings.insert(name.as_ref().to_string());
-    self.used_names.insert(name);
-  }
-
-  fn find_new_name(&mut self, old_name: &str, extra_info: &[Atom]) -> Atom {
-    let mut name = old_name.to_string();
-
-    // try to prepend extra_info segments one by one (from most specific to least),
-    // checking for an available escaped identifier at each step
-    for info_part in extra_info {
-      let info_str = info_part.as_ref();
-      let mut new_name = String::with_capacity(info_str.len() + 1 + name.len());
-      new_name.push_str(info_str);
-      if !name.is_empty() {
-        if name.starts_with('_') || info_str.ends_with('_') {
-          new_name.push_str(&name);
-        } else {
-          new_name.push('_');
-          new_name.push_str(&name);
-        }
-      }
-      name = new_name;
-
-      let escaped = to_identifier_with_escaped(name.clone());
-      if !self.used_strings.contains(&escaped) {
-        self.used_strings.insert(escaped.clone());
-        let candidate: Atom = escaped.into();
-        self.used_names.insert(candidate.clone());
-        return candidate;
-      }
-    }
-
-    let base_str = to_identifier_with_escaped(name);
-    if !base_str.is_empty() && !self.used_strings.contains(&base_str) {
-      self.used_strings.insert(base_str.clone());
-      let base: Atom = base_str.into();
-      self.used_names.insert(base.clone());
-      return base;
-    }
-
-    let base: Atom = base_str.into();
-    let counter = self.suffix_counters.entry(base.clone()).or_insert(0);
-    let mut i = *counter;
-    let mut i_buffer = itoa::Buffer::new();
-
-    let mut base_with_underscore = String::with_capacity(base.len() + 1);
-    base_with_underscore.push_str(base.as_ref());
-    base_with_underscore.push('_');
-
-    let mut numbered = String::with_capacity(base_with_underscore.len() + 8);
-    loop {
-      numbered.clear();
-      numbered.push_str(&base_with_underscore);
-      numbered.push_str(i_buffer.format(i));
-
-      if !self.used_strings.contains(&numbered) {
-        self.used_strings.insert(numbered.clone());
-        let candidate: Atom = Atom::from(numbered.as_str());
-        self.used_names.insert(candidate.clone());
-        *counter = i + 1;
-        return candidate;
-      }
-
-      i += 1;
-    }
-  }
-}
 
 #[derive(Debug, Clone)]
 pub enum ConcatenationEntry {
@@ -1011,9 +914,10 @@ impl Module for ConcatenatedModule {
     };
     let runtime = runtime.as_deref();
     let context = compilation.options.context.clone();
+    let module_graph = compilation.get_module_graph();
 
     let (references_info, module_to_info_map) = self.get_modules_with_info(
-      compilation.get_module_graph(),
+      module_graph,
       &compilation.module_graph_cache_artifact,
       runtime,
       &compilation
@@ -1102,166 +1006,51 @@ impl Module for ConcatenatedModule {
       }
     }
 
-    let module_graph = compilation.get_module_graph();
     let mut import_stmts = FxIndexMap::<(String, Option<String>), ImportSpec>::default();
 
-    let (escaped_name_entries, escaped_identifier_entries) = module_to_info_map
-      .par_values()
-      .map(|info| {
-        let (name_capacity, identifier_capacity) = match info {
-          ModuleInfo::Concatenated(info) => {
-            let import_map = info.import_map.as_ref();
-            let import_sources = import_map.map_or(0, |map| map.len());
-            let imported_names = import_map.map_or(0, |map| {
-              map
-                .values()
-                .map(|imported| {
-                  imported.specifiers.len() + usize::from(imported.namespace.is_some())
-                })
-                .sum::<usize>()
-            });
-            (
-              info.binding_to_ref.len() + imported_names,
-              1 + import_sources,
-            )
-          }
-          ModuleInfo::External(_) => (0, 1),
-        };
-        let mut escaped_names =
-          HashMap::with_capacity_and_hasher(name_capacity, Default::default());
-        let mut escaped_identifiers = Vec::with_capacity(identifier_capacity);
-        let readable_identifier = get_cached_readable_identifier(
-          &info.id(),
-          module_graph,
-          &compilation.module_static_cache,
-          &context,
-        );
-        let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-        escaped_identifiers.push((readable_identifier, splitted_readable_identifier));
+    let mut concatenation_context =
+      ConcatenationContext::prepare(&module_to_info_map, compilation, runtime);
 
-        match info {
-          ModuleInfo::Concatenated(info) => {
-            for (id, _) in info.binding_to_ref.iter() {
-              escaped_names
-                .entry(id.0.clone())
-                .or_insert_with(|| escape_name_atom_ref(&id.0));
-            }
-
-            if let Some(import_map) = &info.import_map {
-              for ((source, _), imported) in import_map.iter() {
-                let specifiers = &imported.specifiers;
-                escaped_identifiers
-                  .push((source.clone(), split_readable_identifier(source.as_str())));
-                for atom in specifiers {
-                  escaped_names
-                    .entry(atom.clone())
-                    .or_insert_with(|| escape_name_atom_ref(atom));
-                }
-
-                if let Some(ns_symbol) = &imported.namespace {
-                  escaped_names
-                    .entry(ns_symbol.clone())
-                    .or_insert_with(|| escape_name_atom_ref(ns_symbol));
-                }
-              }
-            }
-          }
-          ModuleInfo::External(_) => (),
-        }
-        (
-          escaped_names.into_iter().collect::<Vec<_>>(),
-          escaped_identifiers,
-        )
-      })
-      .reduce(
-        || (Vec::new(), Vec::new()),
-        |mut a, mut b| {
-          a.0.append(&mut b.0);
-          a.1.append(&mut b.1);
-          a
-        },
-      );
-    let mut escaped_names =
-      HashMap::with_capacity_and_hasher(escaped_name_entries.len(), Default::default());
-    for (name, escaped_name) in escaped_name_entries {
-      escaped_names.insert(name, escaped_name);
-    }
-    let mut escaped_identifiers =
-      HashMap::with_capacity_and_hasher(escaped_identifier_entries.len(), Default::default());
-    for (identifier, parts) in escaped_identifier_entries {
-      escaped_identifiers.insert(identifier, parts);
-    }
-
-    let mut name_allocator = NameAllocator::new(all_used_names);
+    let mut name_allocator = ConcatenationNameAllocator(all_used_names, &concatenation_context);
 
     for info in module_to_info_map.values_mut() {
       // Get used names in the scope
-
-      let module = module_graph
-        .module_by_identifier(&info.id())
-        .expect("should have module identifier");
-      let readable_identifier = get_cached_readable_identifier(
-        &info.id(),
-        module_graph,
-        &compilation.module_static_cache,
-        &context,
-      );
-      let exports_type: BuildMetaExportsType = module.build_meta().exports_type();
-      let default_object: BuildMetaDefaultObject = module.build_meta().default_object();
       match info {
         // Handle concatenated type
         ModuleInfo::Concatenated(info) => {
-          // Iterate over variables in moduleScope
-          for (id, refs) in info.binding_to_ref.iter() {
-            let name = &id.0;
-            let ctxt = id.1;
-            if ctxt != info.module_ctxt {
+          name_allocator.assign_module_binding_names(info);
+
+          for ((name, ctxt), refs) in &info.binding_to_ref {
+            if ctxt != &info.module_ctxt {
               continue;
             }
-            // Check if the name is already used
-            if name_allocator.contains(name) {
-              // Find a new name and update references
-              let new_name = name_allocator.find_new_name(
-                escaped_names
-                  .get(name)
-                  .expect("should have escaped name")
-                  .as_ref(),
-                escaped_identifiers
-                  .get(&readable_identifier)
-                  .expect("should have escaped identifier"),
-              );
-              info.internal_names.insert(name.clone(), new_name.clone());
-              top_level_declarations.insert(new_name.clone());
+            let new_name = info
+              .internal_names
+              .get(name)
+              .expect("should have internal name");
+            top_level_declarations.insert(new_name.clone());
+            if new_name == name {
+              continue;
+            }
 
-              // Update source
-              let source = info.source.as_mut().expect("should have source");
-
-              for identifier in refs {
-                let span = identifier.id.span();
-                let low = span.real_lo();
-                let high = span.real_hi();
-                if identifier.shorthand {
-                  source.insert(high, format!(": {new_name}"), None);
-                  continue;
-                }
-
-                source.replace(low, high, new_name.to_string(), None);
+            let source = info.source.as_mut().expect("should have source");
+            for identifier in refs {
+              let span = identifier.id.span();
+              let low = span.real_lo();
+              let high = span.real_hi();
+              if identifier.shorthand {
+                source.insert(high, format!(": {new_name}"), None);
+                continue;
               }
-            } else {
-              // Handle the case when the name is not already used
-              name_allocator.insert(name.clone());
-              info.internal_names.insert(name.clone(), name.clone());
-              top_level_declarations.insert(name.clone());
+
+              source.replace(low, high, new_name.to_string(), None);
             }
           }
 
           // Iterate over imported symbols
           if let Some(import_map) = info.import_map.take() {
             for ((source, attr), imported) in import_map {
-              let source_parts = escaped_identifiers
-                .get(&source)
-                .expect("should have escaped identifier");
-              let total_imported_atoms = import_stmts.entry((source, attr)).or_default();
+              let total_imported_atoms = import_stmts.entry((source.clone(), attr)).or_default();
 
               if let Some(ns_import) = imported.namespace {
                 if let Some(internal_ns_import) = total_imported_atoms.ns_import.as_ref() {
@@ -1271,13 +1060,7 @@ impl Module for ConcatenatedModule {
                 } else {
                   let ns_import_key = ns_import.clone();
                   let new_name = if name_allocator.contains(&ns_import) {
-                    name_allocator.find_new_name(
-                      escaped_names
-                        .get(&ns_import)
-                        .expect("should have escaped name")
-                        .as_ref(),
-                      &[],
-                    )
+                    name_allocator.find_new_binding_name(&ns_import, &[])
                   } else {
                     name_allocator.insert(ns_import);
                     ns_import_key.clone()
@@ -1289,53 +1072,21 @@ impl Module for ConcatenatedModule {
               }
 
               for atom in imported.specifiers {
-                // already import this symbol
-                if let Some(internal_atom) = total_imported_atoms.atoms.get(&atom) {
-                  // if the imported symbol is exported, we rename the export as well
-                  if let Some(raw_export_map) = info.raw_export_map.as_mut()
-                    && raw_export_map.contains_key(&atom)
-                  {
-                    raw_export_map.insert(atom.clone(), internal_atom.to_string());
-                  }
-                  info.internal_names.insert(atom, internal_atom.clone());
-                  continue;
-                }
+                let existing_name = total_imported_atoms.atoms.get(&atom).cloned();
+                let new_name = name_allocator.assign_import_binding_name(
+                  &atom,
+                  existing_name.as_ref(),
+                  &source,
+                  info,
+                );
 
-                let new_name = if name_allocator.contains(&atom) {
-                  let new_name = if atom == "default" {
-                    name_allocator.find_new_name("", source_parts)
+                if existing_name.is_none() {
+                  if atom == "default" {
+                    total_imported_atoms.default_import = Some(new_name);
                   } else {
-                    name_allocator.find_new_name(
-                      escaped_names
-                        .get(&atom)
-                        .expect("should have escaped name")
-                        .as_ref(),
-                      escaped_identifiers
-                        .get(&readable_identifier)
-                        .expect("should have escaped identifier"),
-                    )
-                  };
-                  // if the imported symbol is exported, we rename the export as well
-                  if let Some(raw_export_map) = info.raw_export_map.as_mut()
-                    && raw_export_map.contains_key(&atom)
-                  {
-                    raw_export_map.insert(atom.clone(), new_name.to_string());
+                    total_imported_atoms.atoms.insert(atom, new_name);
                   }
-                  new_name
-                } else {
-                  name_allocator.insert(atom.clone());
-                  atom.clone()
-                };
-
-                if atom == "default" {
-                  total_imported_atoms.default_import = Some(new_name.clone());
-                } else {
-                  total_imported_atoms
-                    .atoms
-                    .insert(atom.clone(), new_name.clone());
                 }
-
-                info.internal_names.insert(atom, new_name);
               }
             }
           }
@@ -1359,14 +1110,7 @@ impl Module for ConcatenatedModule {
             if let Some(ref namespace_export_symbol) = info.namespace_export_symbol {
               info.internal_names.get(namespace_export_symbol).cloned()
             } else {
-              Some(
-                name_allocator.find_new_name(
-                  "namespaceObject",
-                  escaped_identifiers
-                    .get(&readable_identifier)
-                    .expect("should have escaped identifier"),
-                ),
-              )
+              Some(name_allocator.find_new_module_name("namespaceObject", &info.module))
             };
           if let Some(namespace_object_name) = namespace_object_name {
             info.namespace_object_name = Some(namespace_object_name.clone());
@@ -1387,89 +1131,58 @@ impl Module for ConcatenatedModule {
 
         // Handle external type
         ModuleInfo::External(info) => {
-          let external_name: Atom = name_allocator.find_new_name(
-            "",
-            escaped_identifiers
-              .get(&readable_identifier)
-              .expect("should have escaped identifier"),
-          );
+          let external_name: Atom = name_allocator.find_new_module_name("", &info.module);
           info.name = Some(external_name.clone());
           top_level_declarations.insert(external_name.clone());
 
           if info.deferred {
-            let external_name = name_allocator.find_new_name(
-              "deferred",
-              escaped_identifiers
-                .get(&readable_identifier)
-                .expect("should have escaped identifier"),
-            );
+            let external_name = name_allocator.find_new_module_name("deferred", &info.module);
             info.deferred_name = Some(external_name.clone());
             top_level_declarations.insert(external_name.clone());
 
-            let external_name_interop = name_allocator.find_new_name(
-              "deferredNamespaceObject",
-              escaped_identifiers
-                .get(&readable_identifier)
-                .expect("should have escaped identifier"),
-            );
+            let external_name_interop =
+              name_allocator.find_new_module_name("deferredNamespaceObject", &info.module);
             info.deferred_namespace_object_name = Some(external_name_interop.clone());
             top_level_declarations.insert(external_name_interop.clone());
           }
         }
       }
-      // Handle additional logic based on module build meta
-      if exports_type != BuildMetaExportsType::Namespace {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "namespaceObject",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
-        info.set_interop_namespace_object_name(Some(external_name_interop.clone()));
-        top_level_declarations.insert(external_name_interop.clone());
-      }
-
-      if exports_type == BuildMetaExportsType::Default
-        && !matches!(default_object, BuildMetaDefaultObject::Redirect)
+      name_allocator.assign_interop_names(info);
+      for name in [
+        info.get_interop_namespace_object_name(),
+        info.get_interop_namespace_object2_name(),
+        info.get_interop_default_access_name(),
+      ]
+      .into_iter()
+      .flatten()
       {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "namespaceObject2",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
-        info.set_interop_namespace_object2_name(Some(external_name_interop.clone()));
-        top_level_declarations.insert(external_name_interop.clone());
-      }
-
-      if matches!(
-        exports_type,
-        BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
-      ) {
-        let external_name_interop: Atom = name_allocator.find_new_name(
-          "default",
-          escaped_identifiers
-            .get(&readable_identifier)
-            .expect("should have escaped identifier"),
-        );
-        info.set_interop_default_access_name(Some(external_name_interop.clone()));
-        top_level_declarations.insert(external_name_interop.clone());
+        top_level_declarations.insert(name.clone());
       }
     }
+
+    // `NameAllocator` can retain a large amount of temporary name state.
+    // Move it off the critical path once naming is complete.
+    drop(name_allocator);
 
     // `escaped_names` / `escaped_identifiers` can retain a large amount of
     // temporary escaped naming state. Move them off the critical path once
     // naming is complete.
-    fast_set(&mut escaped_names, HashMap::default());
-    fast_set(&mut escaped_identifiers, HashMap::default());
+    fast_set(&mut concatenation_context.escaped_names, HashMap::default());
+    fast_set(
+      &mut concatenation_context.escaped_identifiers,
+      HashMap::default(),
+    );
 
-    // `NameAllocator` can retain a large amount of temporary name state.
-    // Move it off the critical path once naming is complete.
-    fast_set(&mut name_allocator, NameAllocator::default());
+    let binding_resolver = ConcatenationBindingResolver {
+      context: &concatenation_context,
+      module_to_info_map: &mut module_to_info_map,
+      normalize_export_name: |_, _, _| {},
+    };
 
     // Find and replace references to modules
     // Splitting read and write to avoid violating rustc borrow rules
-    let mut changes = module_to_info_map
+    let mut changes = binding_resolver
+      .module_to_info_map
       .par_values()
       .filter_map(|info| {
         let ModuleInfo::Concatenated(info) = info else {
@@ -1514,21 +1227,15 @@ impl Module for ConcatenatedModule {
           asi_safe,
         ) in refs
         {
-          let final_name = Self::get_final_name(
-            compilation.get_module_graph(),
-            &compilation.module_graph_cache_artifact,
-            &compilation.exports_info_artifact,
-            &compilation.module_static_cache,
+          let final_name = self.get_final_name(
+            &binding_resolver,
             referenced_info_id,
             export_name,
-            &module_to_info_map,
-            runtime,
             deferred_import,
             call,
             call_context,
             strict_esm_module,
             asi_safe,
-            &context,
           );
 
           // We assume this should be concatenated module info because previous loop
@@ -1547,11 +1254,12 @@ impl Module for ConcatenatedModule {
     for (module_info_id, module_changes) in changes.iter_mut() {
       for (name_result, (low, high)) in mem::take(module_changes) {
         name_result.apply_to_info(
-          &mut module_to_info_map,
+          &mut *binding_resolver.module_to_info_map,
           &mut needed_namespace_objects,
           &mut needed_namespace_objects_queue,
         );
-        let info = module_to_info_map
+        let info = binding_resolver
+          .module_to_info_map
           .get_mut(module_info_id)
           .and_then(|info| info.try_as_concatenated_mut())
           .expect("should have concatenate module info");
@@ -1568,7 +1276,8 @@ impl Module for ConcatenatedModule {
     let mut unused_exports: FxIndexSet<Atom> = FxIndexSet::default();
     let mut inlined_exports: FxIndexSet<Atom> = FxIndexSet::default();
 
-    let root_info = module_to_info_map
+    let root_info = binding_resolver
+      .module_to_info_map
       .get(&self.root_module_ctxt.id)
       .expect("should have root module");
     let root_module_id = root_info.id();
@@ -1600,24 +1309,18 @@ impl Module for ConcatenatedModule {
         continue;
       };
       exports_map.insert(used_name.clone(), {
-        let final_name = Self::get_final_name(
-          compilation.get_module_graph(),
-          &compilation.module_graph_cache_artifact,
-          &compilation.exports_info_artifact,
-          &compilation.module_static_cache,
+        let final_name = self.get_final_name(
+          &binding_resolver,
           &root_module_id,
           [name.clone()].to_vec(),
-          &module_to_info_map,
-          runtime,
           false,
           false,
           false,
           strict_esm_module,
           Some(true),
-          &compilation.options.context,
         );
         final_name.apply_to_info(
-          &mut module_to_info_map,
+          &mut *binding_resolver.module_to_info_map,
           &mut needed_namespace_objects,
           &mut needed_namespace_objects_queue,
         );
@@ -1730,7 +1433,8 @@ impl Module for ConcatenatedModule {
     let mut namespace_object_sources: IdentifierMap<String> = IdentifierMap::default();
 
     while let Some(module_info_id) = needed_namespace_objects_queue.pop_front() {
-      let module_info = module_to_info_map
+      let module_info = binding_resolver
+        .module_to_info_map
         .get(&module_info_id)
         .map(|m| m.as_concatenated())
         .expect("should have module info");
@@ -1762,24 +1466,18 @@ impl Module for ConcatenatedModule {
         }
 
         if let Some(UsedNameItem::Str(used_name)) = export_info.get_used_name(None, runtime) {
-          let final_name = Self::get_final_name(
-            compilation.get_module_graph(),
-            &compilation.module_graph_cache_artifact,
-            &compilation.exports_info_artifact,
-            &compilation.module_static_cache,
+          let final_name = self.get_final_name(
+            &binding_resolver,
             &module_info_id,
             vec![export_info.name().cloned().unwrap_or_else(|| "".into())],
-            &module_to_info_map,
-            runtime,
             false,
             false,
             false,
             strict_esm_module,
             Some(true),
-            &context,
           );
           final_name.apply_to_info(
-            &mut module_to_info_map,
+            &mut *binding_resolver.module_to_info_map,
             &mut needed_namespace_objects,
             &mut needed_namespace_objects_queue,
           );
@@ -1818,7 +1516,7 @@ impl Module for ConcatenatedModule {
     }
 
     // Define required code that needed in evaluation modules
-    for info in module_to_info_map.values() {
+    for info in binding_resolver.module_to_info_map.values() {
       // Define required namespace objects
       if let Some(info) = info.try_as_concatenated()
         && let Some(source) = namespace_object_sources.get(&info.module)
@@ -1894,7 +1592,8 @@ impl Module for ConcatenatedModule {
     for (module_info_id, reference_info) in references_info {
       let mut name = None;
       let mut is_conditional = false;
-      let info = module_to_info_map
+      let info = binding_resolver
+        .module_to_info_map
         .get_mut(&module_info_id)
         .expect("should have module info");
       let module_readable_identifier = get_cached_readable_identifier(
@@ -2010,7 +1709,10 @@ impl Module for ConcatenatedModule {
     }
 
     // `module_to_info_map` can be large and expensive to tear down on the critical path.
-    fast_set(&mut module_to_info_map, IdentifierIndexMap::default());
+    fast_set(
+      &mut *binding_resolver.module_to_info_map,
+      IdentifierIndexMap::default(),
+    );
 
     let mut code_generation_result = CodeGenerationResultBuilder::default();
     code_generation_result.add(SourceType::JavaScript, CachedSource::new(result).boxed());
@@ -2620,81 +2322,8 @@ impl ConcatenatedModule {
         })
         .unwrap_or(false);
 
-      let allocator = Allocator::new();
-      let lexer = swc_experimental_ecma_parser::Lexer::new(
-        &allocator,
-        Syntax::Es(EsSyntax {
-          jsx,
-          ..Default::default()
-        }),
-        EsVersion::EsNext,
-        StringSource::new(source_code.as_ref()),
-        None,
-      );
-      let mut p = Parser::new_from(&allocator, lexer);
-      let ret = p.parse_module();
-
-      let module = match ret {
-        Ok(module) => module,
-        Err(err) => {
-          // return empty error as we already push error to compilation.diagnostics
-          return Err(Error::from_string(
-            Some(source_code.into_owned()),
-            err.span().start.saturating_sub(1) as usize,
-            err.span().end.saturating_sub(1) as usize,
-            "JavaScript parse error:\n".to_string(),
-            err.kind().msg().to_string(),
-          ));
-        }
-      };
-      let program = Program::Module(allocator.boxed(module));
-      let semantic = resolver(&program);
-      let ids = collect_ident(&allocator, &program);
-
-      module_info.module_ctxt = SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
-      module_info.global_ctxt = SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
-
-      let top_level_scope_id = semantic.top_level_scope_id();
-      let mut all_used_names = HashSet::default();
-      all_used_names.reserve(ids.len());
-      module_info.idents.reserve(ids.len());
-      module_info.global_scope_ident.reserve(ids.len());
-      let mut binding_to_ref: FxIndexMap<(Atom, SyntaxContext), Vec<ConcatenatedModuleIdent>> =
-        FxIndexMap::default();
-      binding_to_ref.reserve(ids.len());
-
-      for ident in ids {
-        let scope = semantic.node_scope(&ident.id);
-        let is_global = SyntaxContext::from_u32(scope.raw()) == module_info.global_ctxt;
-        let legacy = if is_global {
-          let leg = ident.to_legacy(&semantic);
-          module_info.global_scope_ident.push(leg.clone());
-          all_used_names.insert(leg.id.sym.clone());
-          Some(leg)
-        } else {
-          None
-        };
-        if ident.is_class_expr_with_ident {
-          all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-          continue;
-        }
-        // deconflict naming from inner scope, the module level deconflict will be finished
-        // you could see tests/webpack-test/cases/scope-hoisting/renaming-4967 as a example
-        // during module eval phase.
-        if scope != top_level_scope_id {
-          all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-        }
-        let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
-        module_info.idents.push(legacy.clone());
-        binding_to_ref
-          .entry((legacy.id.sym.clone(), legacy.id.ctxt))
-          .or_default()
-          .push(legacy);
-      }
-      module_info.all_used_names = all_used_names;
-      module_info.binding_to_ref = binding_to_ref;
+      analyze_module_scope(source_code.as_ref(), jsx, &mut module_info)?;
       let result_source = ReplaceSource::new(source.clone());
-      module_info.has_ast = true;
       module_info.runtime_requirements = runtime_requirements;
       if let Some(runtime_requirements_write) = codegen_res
         .data()
@@ -2723,34 +2352,24 @@ impl ConcatenatedModule {
   #[allow(clippy::too_many_arguments)]
   #[allow(clippy::fn_params_excessive_bools)]
   fn get_final_name(
-    module_graph: &ModuleGraph,
-    module_graph_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
-    module_static_cache: &ModuleStaticCache,
+    &self,
+    binding_resolver: &ConcatenationBindingResolver,
     info: &ModuleIdentifier,
     export_name: Vec<Atom>,
-    module_to_info_map: &IdentifierIndexMap<ModuleInfo>,
-    runtime: Option<&RuntimeSpec>,
     dep_deferred: bool,
     as_call: bool,
     call_context: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    context: &Context,
   ) -> FinalNameResult {
-    let final_binding_result = Self::get_final_binding(
-      module_graph,
-      module_graph_cache,
-      exports_info_artifact,
+    let final_binding_result = self.get_final_binding(
+      binding_resolver,
       info,
       export_name,
-      module_to_info_map,
-      runtime,
       as_call,
       dep_deferred,
       strict_esm_module,
       asi_safe,
-      &mut HashSet::default(),
     );
     let binding_info_id = final_binding_result.get_info_id();
     let FinalBindingResult {
@@ -2780,7 +2399,8 @@ impl ConcatenatedModule {
       }
       Binding::Symbol(ref binding) => {
         let export_id = &binding.name;
-        let info = module_to_info_map
+        let info = binding_resolver
+          .module_to_info_map
           .get(&binding.info_id)
           .and_then(|info| info.try_as_concatenated())
           .expect("should have concatenate module info");
@@ -2788,12 +2408,7 @@ impl ConcatenatedModule {
           panic!(
             "The export \"{}\" in \"{}\" has no internal name (existing names: {})",
             export_id,
-            get_cached_readable_identifier(
-              &info.module,
-              module_graph,
-              module_static_cache,
-              context
-            ),
+            binding_resolver.context.readable_identifier(&info.module),
             info
               .internal_names
               .iter()
@@ -2843,433 +2458,344 @@ impl ConcatenatedModule {
 
   #[allow(clippy::too_many_arguments)]
   fn get_final_binding(
-    mg: &ModuleGraph,
-    mg_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
+    &self,
+    binding_resolver: &ConcatenationBindingResolver,
     info_id: &ModuleIdentifier,
-    mut export_name: Vec<Atom>,
-    module_to_info_map: &IdentifierIndexMap<ModuleInfo>,
-    runtime: Option<&RuntimeSpec>,
+    export_name: Vec<Atom>,
     as_call: bool,
     dep_deferred: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut HashSet<ExportInfo>,
   ) -> FinalBindingResult {
-    let info = module_to_info_map
-      .get(info_id)
-      .expect("should have module info");
+    let ConcatenationBindingPlan {
+      info_id,
+      export_name,
+      reexport_deferred,
+      target,
+    } = binding_resolver.resolve(info_id, export_name, strict_esm_module);
 
-    let module = mg
+    let module_graph = binding_resolver.context.module_graph;
+    let module_to_info_map = &*binding_resolver.module_to_info_map;
+    let info = module_to_info_map
+      .get(&info_id)
+      .expect("should have module info");
+    let module = module_graph
       .module_by_identifier(&info.id())
       .expect("should have module");
-    let exports_type =
-      module.get_exports_type(mg, mg_cache, exports_info_artifact, strict_esm_module);
     let is_module_deferred = matches!(info, ModuleInfo::External(info) if info.deferred)
       && !module.build_meta().has_top_level_await();
-    let is_deferred = dep_deferred && is_module_deferred;
+    let is_deferred = reexport_deferred.unwrap_or(dep_deferred) && is_module_deferred;
 
-    if export_name.is_empty() {
-      match exports_type {
-        ExportsType::DefaultOnly => {
-          let needed_namespace_object = info.try_as_concatenated().map(|info| info.module);
-          // shadowing the previous immutable ref to avoid violating rustc borrow rules
-          let (raw_name, interop_namespace_object2_used, deferred_namespace_object_used) =
-            if is_deferred {
-              (info.get_deferred_namespace_object_name(), None, Some(true))
-            } else {
-              (info.get_interop_namespace_object2_name(), Some(true), None)
-            };
-          return FinalBindingResult {
-            binding: Binding::Raw(RawBinding {
-              info_id: *info_id,
-              raw_name: raw_name.cloned().expect("should have raw name"),
-              ids: export_name.clone(),
-              export_name,
-              comment: None,
-            }),
-            interop_namespace_object2_used,
-            interop_namespace_object_used: None,
-            interop_default_access_used: None,
-            deferred_namespace_object_used,
-            needed_namespace_object,
-          };
-        }
-        ExportsType::DefaultWithNamed => {
-          let needed_namespace_object = info.try_as_concatenated().map(|info| info.module);
-          // shadowing the previous immutable ref to avoid violating rustc borrow rules
-          let (raw_name, interop_namespace_object_used, deferred_namespace_object_used) =
-            if is_deferred {
-              (info.get_deferred_namespace_object_name(), None, Some(true))
-            } else {
-              (info.get_interop_namespace_object_name(), Some(true), None)
-            };
-          return FinalBindingResult {
-            binding: Binding::Raw(RawBinding {
-              info_id: *info_id,
-              raw_name: raw_name.cloned().expect("should have raw name"),
-              ids: export_name.clone(),
-              export_name,
-              comment: None,
-            }),
-            interop_namespace_object_used,
-            interop_namespace_object2_used: None,
-            interop_default_access_used: None,
-            deferred_namespace_object_used,
-            needed_namespace_object,
-          };
-        }
-        _ => {}
-      }
-    } else {
-      match exports_type {
-        ExportsType::Namespace => {}
-        ExportsType::DefaultWithNamed => match export_name.first().map(|atom| atom.as_str()) {
-          Some("default") => {
-            export_name = export_name[1..].to_vec();
-          }
-          Some("__esModule") => {
-            return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-              info_id: *info_id,
-              raw_name: "/* __esModule */true".into(),
-              ids: export_name[1..].to_vec(),
-              export_name,
-              comment: None,
-            }));
-          }
-          _ => {}
-        },
-        ExportsType::DefaultOnly => {
-          if export_name.first().map(|item| item.as_str()) == Some("__esModule") {
-            return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-              info_id: info.id(),
-              raw_name: "/* __esModule */true".into(),
-              ids: export_name[1..].to_vec(),
-              export_name,
-              comment: None,
-            }));
-          }
-
-          let first_export_id = export_name.remove(0);
-          if first_export_id != "default" {
-            return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-              raw_name: "/* non-default import from default-exporting module */undefined".into(),
-              ids: export_name.clone(),
-              export_name,
-              info_id: *info_id,
-              comment: None,
-            }));
-          }
-        }
-        ExportsType::Dynamic => match export_name.first().map(|atom| atom.as_str()) {
-          Some("default") => {
-            // shadowing the previous immutable ref to avoid violating rustc borrow rules
-            export_name = export_name[1..].to_vec();
-            if is_deferred {
-              let deferred_name = info
-                .as_external()
-                .deferred_name
-                .as_ref()
-                .expect("should have deferred_name");
-              return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-                raw_name: format!("{deferred_name}.a").into(),
-                ids: export_name.clone(),
-                export_name,
-                info_id: *info_id,
-                comment: None,
-              }));
-            }
-            if is_module_deferred {
-              let name = info.as_external().name.as_ref().expect("should have name");
-              return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-                raw_name: name.clone(),
-                ids: export_name.clone(),
-                export_name,
-                info_id: *info_id,
-                comment: None,
-              }));
-            }
-            // https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L335-L341
-            let default_access_name = info
-              .get_interop_default_access_name()
-              .cloned()
-              .expect("should have default access name");
-            let default_export = if as_call {
-              format!("{default_access_name}()")
-            } else if let Some(true) = asi_safe {
-              format!("({default_access_name}())")
-            } else if let Some(false) = asi_safe {
-              format!(";({default_access_name}())")
-            } else {
-              format!("{default_access_name}.a")
-            };
-
-            return FinalBindingResult {
-              binding: Binding::Raw(RawBinding {
-                raw_name: default_export.into(),
-                ids: export_name.clone(),
-                export_name,
-                info_id: *info_id,
-                comment: None,
-              }),
-              interop_default_access_used: Some(true),
-              interop_namespace_object_used: None,
-              interop_namespace_object2_used: None,
-              deferred_namespace_object_used: None,
-              needed_namespace_object: None,
-            };
-          }
-          Some("__esModule") => {
-            return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-              raw_name: "/* __esModule */true".into(),
-              ids: export_name[1..].to_vec(),
-              export_name,
-              info_id: *info_id,
-              comment: None,
-            }));
-          }
-          _ => {}
-        },
-      }
-    }
-
-    if export_name.is_empty() {
-      match info {
-        ModuleInfo::Concatenated(info) => {
-          return FinalBindingResult {
-            binding: Binding::Raw(RawBinding {
-              raw_name: info
-                .namespace_object_name
-                .clone()
-                .expect("should have namespace_object_name"),
-              ids: export_name.clone(),
-              export_name,
-              info_id: info.module,
-              comment: None,
-            }),
-            needed_namespace_object: Some(info.module),
-            interop_namespace_object_used: None,
-            interop_namespace_object2_used: None,
-            interop_default_access_used: None,
-            deferred_namespace_object_used: None,
-          };
-        }
-        ModuleInfo::External(info) => {
+    match target {
+      ConcatenationBindingTarget::InteropNamespace(kind) => {
+        let info = module_to_info_map
+          .get(&info_id)
+          .expect("should have module info");
+        let needed_namespace_object = info.try_as_concatenated().map(|info| info.module);
+        let (raw_name, interop_namespace_object_used, interop_namespace_object2_used) =
           if is_deferred {
+            (info.get_deferred_namespace_object_name(), None, None)
+          } else {
+            match kind {
+              ConcatenationInterop::Namespace => {
+                (info.get_interop_namespace_object_name(), Some(true), None)
+              }
+              ConcatenationInterop::Namespace2 => {
+                (info.get_interop_namespace_object2_name(), None, Some(true))
+              }
+            }
+          };
+        return FinalBindingResult {
+          binding: Binding::Raw(RawBinding {
+            info_id,
+            raw_name: raw_name.cloned().expect("should have raw name"),
+            ids: export_name.clone(),
+            export_name,
+            comment: None,
+          }),
+          interop_namespace_object_used,
+          interop_namespace_object2_used,
+          interop_default_access_used: None,
+          deferred_namespace_object_used: is_deferred.then_some(true),
+          needed_namespace_object,
+        };
+      }
+      ConcatenationBindingTarget::InteropDefault => {
+        let info = module_to_info_map
+          .get(&info_id)
+          .expect("should have module info");
+        if is_deferred {
+          let deferred_name = info
+            .as_external()
+            .deferred_name
+            .as_ref()
+            .expect("should have deferred_name");
+          return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+            raw_name: format!("{deferred_name}.a").into(),
+            ids: export_name.clone(),
+            export_name,
+            info_id,
+            comment: None,
+          }));
+        }
+        if is_module_deferred {
+          let name = info.as_external().name.as_ref().expect("should have name");
+          return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+            raw_name: name.clone(),
+            ids: export_name.clone(),
+            export_name,
+            info_id,
+            comment: None,
+          }));
+        }
+        let default_access_name = info
+          .get_interop_default_access_name()
+          .cloned()
+          .expect("should have default access name");
+        let default_export = if as_call {
+          format!("{default_access_name}()")
+        } else if let Some(true) = asi_safe {
+          format!("({default_access_name}())")
+        } else if let Some(false) = asi_safe {
+          format!(";({default_access_name}())")
+        } else {
+          format!("{default_access_name}.a")
+        };
+
+        return FinalBindingResult {
+          binding: Binding::Raw(RawBinding {
+            raw_name: default_export.into(),
+            ids: export_name.clone(),
+            export_name,
+            info_id,
+            comment: None,
+          }),
+          interop_default_access_used: Some(true),
+          interop_namespace_object_used: None,
+          interop_namespace_object2_used: None,
+          deferred_namespace_object_used: None,
+          needed_namespace_object: None,
+        };
+      }
+      ConcatenationBindingTarget::EsModule(ids) => {
+        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+          info_id,
+          raw_name: "/* __esModule */true".into(),
+          ids,
+          export_name,
+          comment: None,
+        }));
+      }
+      ConcatenationBindingTarget::UnsupportedDefaultImport => {
+        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+          raw_name: "/* non-default import from default-exporting module */undefined".into(),
+          ids: export_name.clone(),
+          export_name,
+          info_id,
+          comment: None,
+        }));
+      }
+      ConcatenationBindingTarget::Namespace => {
+        match module_to_info_map
+          .get(&info_id)
+          .expect("should have module info")
+        {
+          ModuleInfo::Concatenated(info) => {
             return FinalBindingResult {
               binding: Binding::Raw(RawBinding {
                 raw_name: info
-                  .deferred_namespace_object_name
+                  .namespace_object_name
                   .clone()
-                  .expect("should have deferred_namespace_object_name"),
+                  .expect("should have namespace_object_name"),
                 ids: export_name.clone(),
                 export_name,
                 info_id: info.module,
                 comment: None,
               }),
+              needed_namespace_object: Some(info.module),
               interop_namespace_object_used: None,
               interop_namespace_object2_used: None,
               interop_default_access_used: None,
-              deferred_namespace_object_used: Some(true),
-              needed_namespace_object: None,
+              deferred_namespace_object_used: None,
             };
           }
-          return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-            raw_name: info.name.clone().expect("should have raw name"),
-            ids: export_name.clone(),
-            export_name,
-            info_id: info.module,
-            comment: None,
-          }));
-        }
-      }
-    }
-
-    let exports_info = exports_info_artifact.get_exports_info_data(&info.id());
-    // webpack use `get_exports_info` here, https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/ConcatenatedModule.js#L377-L377
-    // But in our arch, there is no way to modify module graph during code_generation phase, so we use `get_export_info_without_mut_module_graph` instead.`
-    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
-    let export_info_id = export_info.id();
-
-    if already_visited.contains(&export_info_id) {
-      return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-        raw_name: "/* circular reexport */ Object(function x() { x() }())".into(),
-        ids: Vec::new(),
-        export_name,
-        info_id: info.id(),
-        comment: None,
-      }));
-    }
-
-    already_visited.insert(export_info_id);
-
-    match info {
-      ModuleInfo::Concatenated(info) => {
-        let export_id = export_name.first().cloned();
-        if matches!(
-          export_info.provided(),
-          Some(crate::ExportProvided::NotProvided)
-        ) {
-          return FinalBindingResult {
-            binding: Binding::Raw(RawBinding {
-              raw_name: info
-                .namespace_object_name
-                .clone()
-                .expect("should have namespace_object_name"),
-              ids: export_name.clone(),
-              export_name,
-              info_id: info.module,
-              comment: None,
-            }),
-            needed_namespace_object: Some(info.module),
-            interop_namespace_object_used: None,
-            interop_namespace_object2_used: None,
-            interop_default_access_used: None,
-            deferred_namespace_object_used: None,
-          };
-        }
-
-        if let Some(ref export_id) = export_id
-          && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
-        {
-          if let Some(used_name) =
-            exports_info.get_used_name(exports_info_artifact, runtime, &export_name)
-          {
-            match used_name {
-              UsedName::Normal(used_name) => {
-                // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L402-L404
-                return FinalBindingResult::from_binding(Binding::Symbol(SymbolBinding {
-                  info_id: info.module,
-                  name: direct_export.as_str().into(),
-                  ids: used_name[1..].to_vec(),
-                  export_name,
-                  comment: None,
-                }));
-              }
-              UsedName::Inlined(inlined) => {
-                return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-                  raw_name: inlined
-                    .inlined_value()
-                    .render(&to_normal_comment(&format!(
-                      "inlined export {}",
-                      property_access(&export_name, 0)
-                    )))
-                    .into(),
-                  ids: inlined.suffix_ids().to_vec(),
+          ModuleInfo::External(info) => {
+            if is_deferred {
+              return FinalBindingResult {
+                binding: Binding::Raw(RawBinding {
+                  raw_name: info
+                    .deferred_namespace_object_name
+                    .clone()
+                    .expect("should have deferred_namespace_object_name"),
+                  ids: export_name.clone(),
                   export_name,
                   info_id: info.module,
                   comment: None,
-                }));
-              }
+                }),
+                interop_namespace_object_used: None,
+                interop_namespace_object2_used: None,
+                interop_default_access_used: None,
+                deferred_namespace_object_used: Some(true),
+                needed_namespace_object: None,
+              };
             }
-          } else {
             return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-              raw_name: "/* unused export */ undefined".into(),
-              ids: export_name[1..].to_vec(),
+              raw_name: info.name.clone().expect("should have raw name"),
+              ids: export_name.clone(),
               export_name,
               info_id: info.module,
               comment: None,
             }));
           }
         }
-
-        if let Some(ref export_id) = export_id
-          && let Some(raw_export) = info
-            .raw_export_map
-            .as_ref()
-            .and_then(|map| map.get(export_id))
-        {
-          return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-            info_id: info.module,
-            raw_name: raw_export.as_str().into(),
-            ids: export_name[1..].to_vec(),
+      }
+      ConcatenationBindingTarget::Circular => {
+        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+          raw_name: "/* circular reexport */ Object(function x() { x() }())".into(),
+          ids: Vec::new(),
+          export_name,
+          info_id,
+          comment: None,
+        }));
+      }
+      ConcatenationBindingTarget::Direct { symbol, used_name } => {
+        return FinalBindingResult::from_binding(match used_name {
+          Some(UsedName::Normal(used_name)) => Binding::Symbol(SymbolBinding {
+            info_id,
+            name: symbol,
+            ids: used_name[1..].to_vec(),
             export_name,
             comment: None,
-          }));
-        }
-
-        let reexport = find_target(
-          &export_info,
-          mg,
-          exports_info_artifact,
-          Arc::new(|module: &ModuleIdentifier| module_to_info_map.contains_key(module)),
-          &mut Default::default(),
+          }),
+          Some(UsedName::Inlined(inlined)) => Binding::Raw(RawBinding {
+            raw_name: inlined
+              .inlined_value()
+              .render(&to_normal_comment(&format!(
+                "inlined export {}",
+                property_access(&export_name, 0)
+              )))
+              .into(),
+            ids: inlined.suffix_ids().to_vec(),
+            export_name,
+            info_id,
+            comment: None,
+          }),
+          None => Binding::Raw(RawBinding {
+            raw_name: "/* unused export */ undefined".into(),
+            ids: export_name[1..].to_vec(),
+            export_name,
+            info_id,
+            comment: None,
+          }),
+        });
+      }
+      ConcatenationBindingTarget::Raw(symbol) => {
+        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+          info_id,
+          raw_name: symbol,
+          ids: export_name[1..].to_vec(),
+          export_name,
+          comment: None,
+        }));
+      }
+      ConcatenationBindingTarget::Inlined(used_name) => {
+        let UsedName::Inlined(inlined) = used_name else {
+          unreachable!("inlined binding plan should contain an inlined used name")
+        };
+        return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
+          raw_name: inlined
+            .inlined_value()
+            .render(&to_normal_comment(&format!(
+              "inlined export {}",
+              property_access(&export_name, 0)
+            )))
+            .into(),
+          ids: inlined.suffix_ids().to_vec(),
+          export_name,
+          info_id,
+          comment: None,
+        }));
+      }
+      ConcatenationBindingTarget::NamespaceExport(used_name) => {
+        let info = module_to_info_map
+          .get(&info_id)
+          .expect("should have module info")
+          .as_concatenated();
+        return FinalBindingResult::from_binding(match used_name {
+          UsedName::Normal(used_name) => Binding::Raw(RawBinding {
+            info_id,
+            raw_name: info
+              .namespace_object_name
+              .as_ref()
+              .expect("should have raw name")
+              .as_str()
+              .into(),
+            ids: used_name,
+            export_name,
+            comment: None,
+          }),
+          UsedName::Inlined(inlined) => Binding::Raw(RawBinding {
+            info_id,
+            raw_name: inlined
+              .inlined_value()
+              .render(&to_normal_comment(&format!(
+                "inlined export {}",
+                property_access(&export_name, 0)
+              )))
+              .into(),
+            ids: inlined.suffix_ids().to_vec(),
+            export_name,
+            comment: None,
+          }),
+        });
+      }
+      ConcatenationBindingTarget::Missing(_) => {
+        let module = module_graph
+          .module_by_identifier(&info_id)
+          .expect("should have module");
+        panic!(
+          "Cannot get final name for export '{}' of module '{}'",
+          join_atom(export_name.iter(), "."),
+          module.identifier()
         );
-        match reexport {
-          crate::FindTargetResult::NoTarget => {}
-          crate::FindTargetResult::InvalidTarget(target) => {
-            if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
-              if let Some(UsedName::Inlined(inlined)) =
-                exports_info.get_used_name(exports_info_artifact, runtime, &export)
-              {
-                return FinalBindingResult::from_binding(Binding::Raw(RawBinding {
-                  raw_name: inlined
-                    .inlined_value()
-                    .render(&to_normal_comment(&format!(
-                      "inlined export {}",
-                      property_access(&export_name, 0)
-                    )))
-                    .into(),
-                  ids: inlined.suffix_ids().to_vec(),
-                  export_name,
-                  info_id: info.module,
-                  comment: None,
-                }));
-              }
-            }
-            panic!(
-              "Target module of reexport is not part of the concatenation (export '{:?}')",
-              &export_id
-            );
-          }
-          crate::FindTargetResult::ValidTarget(reexport) => {
-            if let Some(ref_info) = module_to_info_map.get(&reexport.module) {
-              // https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L457
-
-              return Self::get_final_binding(
-                mg,
-                mg_cache,
-                exports_info_artifact,
-                &ref_info.id(),
-                if let Some(reexport_export) = reexport.export {
-                  [reexport_export, export_name[1..].to_vec()].concat()
+      }
+      ConcatenationBindingTarget::External(used_name) => {
+        let info = module_to_info_map
+          .get(&info_id)
+          .expect("should have module info")
+          .as_external();
+        let binding = match used_name {
+          Some(UsedName::Normal(used_name)) => {
+            let comment = if used_name == export_name {
+              String::new()
+            } else {
+              to_normal_comment(&property_access(&export_name, 0))
+            };
+            Binding::Raw(RawBinding {
+              raw_name: format!(
+                "{}{}{}",
+                if is_deferred {
+                  info.deferred_name.as_ref()
                 } else {
-                  export_name[1..].to_vec()
-                },
-                module_to_info_map,
-                runtime,
-                as_call,
-                reexport.defer,
-                module.build_meta().strict_esm_module(),
-                asi_safe,
-                already_visited,
-              );
-            }
-          }
-        }
-
-        if info.namespace_export_symbol.is_some() {
-          // That's how webpack write https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L463-L471
-          let used_name = exports_info
-            .get_used_name(exports_info_artifact, runtime, &export_name)
-            .expect("should have export name");
-          return FinalBindingResult::from_binding(match used_name {
-            UsedName::Normal(used_name) => Binding::Raw(RawBinding {
-              info_id: info.module,
-              raw_name: info
-                .namespace_object_name
-                .as_ref()
-                .expect("should have raw name")
-                .as_str()
-                .into(),
+                  info.name.as_ref()
+                }
+                .expect("should have name"),
+                if is_deferred { ".a" } else { "" },
+                comment
+              )
+              .into(),
               ids: used_name,
               export_name,
+              info_id,
               comment: None,
-            }),
-            // Inlined namespace export symbol is not possible for now but we compat it here
-            UsedName::Inlined(inlined) => Binding::Raw(RawBinding {
-              info_id: info.module,
+            })
+          }
+          Some(UsedName::Inlined(inlined)) => {
+            assert!(
+              !is_deferred,
+              "inlined export is not possible for deferred external module"
+            );
+            Binding::Raw(RawBinding {
               raw_name: inlined
                 .inlined_value()
                 .render(&to_normal_comment(&format!(
@@ -3279,75 +2805,17 @@ impl ConcatenatedModule {
                 .into(),
               ids: inlined.suffix_ids().to_vec(),
               export_name,
+              info_id,
               comment: None,
-            }),
-          });
-        }
-
-        panic!(
-          "Cannot get final name for export '{}' of module '{}'",
-          join_atom(export_name.iter(), "."),
-          module.identifier()
-        );
-      }
-      ModuleInfo::External(info) => {
-        let binding = if let Some(used_name) =
-          exports_info.get_used_name(exports_info_artifact, runtime, &export_name)
-        {
-          match used_name {
-            UsedName::Normal(used_name) => {
-              let comment = if used_name == export_name {
-                String::new()
-              } else {
-                to_normal_comment(&property_access(&export_name, 0))
-              };
-              Binding::Raw(RawBinding {
-                raw_name: format!(
-                  "{}{}{}",
-                  if is_deferred {
-                    info.deferred_name.as_ref()
-                  } else {
-                    info.name.as_ref()
-                  }
-                  .expect("should have name"),
-                  if is_deferred { ".a" } else { "" },
-                  comment
-                )
-                .into(),
-                ids: used_name,
-                export_name,
-                info_id: info.module,
-                comment: None,
-              })
-            }
-            UsedName::Inlined(inlined) => {
-              assert!(
-                !is_deferred,
-                "inlined export is not possible for deferred external module"
-              );
-              Binding::Raw(RawBinding {
-                raw_name: inlined
-                  .inlined_value()
-                  .render(&to_normal_comment(&format!(
-                    "inlined export {}",
-                    property_access(&export_name, 0)
-                  )))
-                  .into(),
-                ids: inlined.suffix_ids().to_vec(),
-                export_name,
-                info_id: info.module,
-                comment: None,
-              })
-            }
+            })
           }
-        } else {
-          Binding::Raw(RawBinding {
+          None => Binding::Raw(RawBinding {
             raw_name: "/* unused export */ undefined".into(),
             ids: export_name[1..].to_vec(),
             export_name,
-            info_id: info.module,
+            info_id,
             comment: None,
-          })
+          }),
         };
         FinalBindingResult::from_binding(binding)
       }

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -147,31 +147,6 @@ impl ConcatenationNameAllocator {
       i += 1;
     }
   }
-
-  pub fn find_new_module_name(
-    &mut self,
-    old_name: &str,
-    module: &ModuleIdentifier,
-    context: &ConcatenationContext,
-  ) -> Atom {
-    self.find_new_name(old_name, context.module_identifier(module))
-  }
-
-  pub fn find_new_binding_name(
-    &mut self,
-    name: &Atom,
-    extra_info: &[Atom],
-    context: &ConcatenationContext,
-  ) -> Atom {
-    self.find_new_name(
-      context
-        .escaped_names
-        .get(name)
-        .expect("should have escaped name")
-        .as_ref(),
-      extra_info,
-    )
-  }
 }
 
 pub enum ConcatenationInterop {
@@ -562,31 +537,27 @@ impl ConcatenationNameAllocator {
       .build_meta();
     let exports_type: BuildMetaExportsType = build_meta.exports_type();
     let default_object: BuildMetaDefaultObject = build_meta.default_object();
+    let module_identifier = context.module_identifier(&module);
     if exports_type != BuildMetaExportsType::Namespace {
-      module_info.set_interop_namespace_object_name(Some(self.find_new_module_name(
-        "namespaceObject",
-        &module,
-        context,
-      )));
+      module_info.set_interop_namespace_object_name(Some(
+        self.find_new_name("namespaceObject", module_identifier),
+      ));
     }
 
     if exports_type == BuildMetaExportsType::Default
       && !matches!(default_object, BuildMetaDefaultObject::Redirect)
     {
-      module_info.set_interop_namespace_object2_name(Some(self.find_new_module_name(
-        "namespaceObject2",
-        &module,
-        context,
-      )));
+      module_info.set_interop_namespace_object2_name(Some(
+        self.find_new_name("namespaceObject2", module_identifier),
+      ));
     }
 
     if matches!(
       exports_type,
       BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
     ) {
-      module_info.set_interop_default_access_name(Some(
-        self.find_new_module_name("default", &module, context),
-      ));
+      module_info
+        .set_interop_default_access_name(Some(self.find_new_name("default", module_identifier)));
     }
   }
 }

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -7,6 +7,7 @@ use rspack_util::{
   SpanExt,
   atom::Atom,
   fx_hash::{FxHashMap, FxHashSet},
+  itoa,
 };
 use swc_core::common::SyntaxContext;
 use swc_experimental_allocator::Allocator;
@@ -18,8 +19,8 @@ use crate::{
   BuildMetaDefaultObject, BuildMetaExportsType, Compilation, ConcatenatedModuleInfo, Context,
   ExportInfo, ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, ModuleStaticCache, RuntimeSpec, UsedName,
-  collect_ident, escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
-  split_readable_identifier,
+  collect_ident, escape_name_atom_ref, find_target, get_cached_readable_identifier,
+  split_readable_identifier, to_identifier_with_escaped,
 };
 
 /// Reusable read-only context shared by concatenation implementations.
@@ -35,43 +36,141 @@ pub struct ConcatenationContext<'a> {
   pub module_identifiers: IdentifierMap<Vec<Atom>>,
 }
 
-pub struct ConcatenationNameAllocator<'a>(pub FxHashSet<Atom>, pub &'a ConcatenationContext<'a>);
+/// Allocates unique JavaScript identifiers while retaining per-base suffix cursors.
+#[derive(Debug, Clone, Default)]
+pub struct ConcatenationNameAllocator {
+  used_names: FxHashSet<Atom>,
+  used_strings: FxHashSet<String>,
+  suffix_counters: FxHashMap<Atom, u32>,
+}
 
-impl ConcatenationNameAllocator<'_> {
+impl ConcatenationNameAllocator {
+  pub fn new(used_names: FxHashSet<Atom>) -> Self {
+    let mut used_strings = FxHashSet::default();
+    used_strings.reserve(used_names.len());
+    for name in &used_names {
+      used_strings.insert(name.as_ref().to_string());
+    }
+
+    Self {
+      used_names,
+      used_strings,
+      suffix_counters: FxHashMap::default(),
+    }
+  }
+
   pub fn contains(&self, name: &Atom) -> bool {
-    self.0.contains(name)
+    self.used_names.contains(name)
   }
 
   pub fn insert(&mut self, name: Atom) {
-    self.0.insert(name);
+    self.used_strings.insert(name.as_ref().to_string());
+    self.used_names.insert(name);
   }
 
+  pub fn extend(&mut self, names: impl IntoIterator<Item = Atom>) {
+    for name in names {
+      self.insert(name);
+    }
+  }
+
+  pub fn merge(&mut self, other: Self) {
+    self.used_names.extend(other.used_names);
+    self.used_strings.extend(other.used_strings);
+    for (base, next_suffix) in other.suffix_counters {
+      self
+        .suffix_counters
+        .entry(base)
+        .and_modify(|current| *current = (*current).max(next_suffix))
+        .or_insert(next_suffix);
+    }
+  }
+
+  /// Returns a unique name and reserves it in this allocator.
   pub fn find_new_name(&mut self, old_name: &str, extra_info: &[Atom]) -> Atom {
-    let name = find_new_name(old_name, &self.0, extra_info);
-    self.0.insert(name.clone());
-    name
+    let mut name = old_name.to_string();
+
+    for info_part in extra_info {
+      let info_str = info_part.as_ref();
+      let mut new_name = String::with_capacity(info_str.len() + 1 + name.len());
+      new_name.push_str(info_str);
+      if !name.is_empty() {
+        if name.starts_with('_') || info_str.ends_with('_') {
+          new_name.push_str(&name);
+        } else {
+          new_name.push('_');
+          new_name.push_str(&name);
+        }
+      }
+      name = new_name;
+
+      let escaped = to_identifier_with_escaped(name.clone());
+      if !self.used_strings.contains(&escaped) {
+        self.used_strings.insert(escaped.clone());
+        let candidate: Atom = escaped.into();
+        self.used_names.insert(candidate.clone());
+        return candidate;
+      }
+    }
+
+    let base_str = to_identifier_with_escaped(name);
+    if !base_str.is_empty() && !self.used_strings.contains(&base_str) {
+      self.used_strings.insert(base_str.clone());
+      let base: Atom = base_str.into();
+      self.used_names.insert(base.clone());
+      return base;
+    }
+
+    let base: Atom = base_str.into();
+    let counter = self.suffix_counters.entry(base.clone()).or_insert(0);
+    let mut i = *counter;
+    let mut i_buffer = itoa::Buffer::new();
+
+    let mut base_with_underscore = String::with_capacity(base.len() + 1);
+    base_with_underscore.push_str(base.as_ref());
+    base_with_underscore.push('_');
+
+    let mut numbered = String::with_capacity(base_with_underscore.len() + 8);
+    loop {
+      numbered.clear();
+      numbered.push_str(&base_with_underscore);
+      numbered.push_str(i_buffer.format(i));
+
+      if !self.used_strings.contains(&numbered) {
+        self.used_strings.insert(numbered.clone());
+        let candidate: Atom = Atom::from(numbered.as_str());
+        self.used_names.insert(candidate.clone());
+        *counter = i + 1;
+        return candidate;
+      }
+
+      i += 1;
+    }
   }
 
-  pub fn find_new_module_name(&mut self, old_name: &str, module: &ModuleIdentifier) -> Atom {
-    let Self(used_names, context) = self;
-    let name = find_new_name(old_name, used_names, context.module_identifier(module));
-    used_names.insert(name.clone());
-    name
+  pub fn find_new_module_name(
+    &mut self,
+    old_name: &str,
+    module: &ModuleIdentifier,
+    context: &ConcatenationContext,
+  ) -> Atom {
+    self.find_new_name(old_name, context.module_identifier(module))
   }
 
-  pub fn find_new_binding_name(&mut self, name: &Atom, extra_info: &[Atom]) -> Atom {
-    let Self(used_names, context) = self;
-    let name = find_new_name(
+  pub fn find_new_binding_name(
+    &mut self,
+    name: &Atom,
+    extra_info: &[Atom],
+    context: &ConcatenationContext,
+  ) -> Atom {
+    self.find_new_name(
       context
         .escaped_names
         .get(name)
         .expect("should have escaped name")
         .as_ref(),
-      used_names,
       extra_info,
-    );
-    used_names.insert(name.clone());
-    name
+    )
   }
 }
 
@@ -378,29 +477,29 @@ impl<'a> ConcatenationBindingResolver<'a> {
   }
 }
 
-impl ConcatenationNameAllocator<'_> {
-  pub fn assign_module_binding_names(&mut self, module_info: &mut ConcatenatedModuleInfo) {
-    let Self(used_names, context) = self;
+impl ConcatenationNameAllocator {
+  pub fn assign_module_binding_names(
+    &mut self,
+    module_info: &mut ConcatenatedModuleInfo,
+    context: &ConcatenationContext,
+  ) {
     let escaped_identifier = context.module_identifier(&module_info.module);
     for (name, ctxt) in module_info.binding_to_ref.keys() {
       if ctxt != &module_info.module_ctxt {
         continue;
       }
 
-      let internal_name = if used_names.contains(name) {
-        let internal_name = find_new_name(
+      let internal_name = if self.contains(name) {
+        self.find_new_name(
           context
             .escaped_names
             .get(name)
             .expect("should have escaped name")
             .as_ref(),
-          used_names,
           escaped_identifier,
-        );
-        used_names.insert(internal_name.clone());
-        internal_name
+        )
       } else {
-        used_names.insert(name.clone());
+        self.insert(name.clone());
         name.clone()
       };
       module_info
@@ -415,30 +514,27 @@ impl ConcatenationNameAllocator<'_> {
     existing_name: Option<&Atom>,
     source: &str,
     module_info: &mut ConcatenatedModuleInfo,
+    context: &ConcatenationContext,
   ) -> Atom {
-    let Self(used_names, context) = self;
-    let should_update_raw_export = existing_name.is_some() || used_names.contains(imported_name);
+    let should_update_raw_export = existing_name.is_some() || self.contains(imported_name);
     let internal_name = existing_name.cloned().unwrap_or_else(|| {
-      if !used_names.contains(imported_name) {
-        used_names.insert(imported_name.clone());
+      if !self.contains(imported_name) {
+        self.insert(imported_name.clone());
         return imported_name.clone();
       }
 
-      let internal_name = if imported_name == "default" {
-        find_new_name("", used_names, context.source_identifier(source))
+      if imported_name == "default" {
+        self.find_new_name("", context.source_identifier(source))
       } else {
-        find_new_name(
+        self.find_new_name(
           context
             .escaped_names
             .get(imported_name)
             .expect("should have escaped name")
             .as_ref(),
-          used_names,
           context.module_identifier(&module_info.module),
         )
-      };
-      used_names.insert(internal_name.clone());
-      internal_name
+      }
     });
 
     if should_update_raw_export
@@ -453,10 +549,13 @@ impl ConcatenationNameAllocator<'_> {
     internal_name
   }
 
-  pub fn assign_interop_names(&mut self, module_info: &mut ModuleInfo) {
+  pub fn assign_interop_names(
+    &mut self,
+    module_info: &mut ModuleInfo,
+    context: &ConcatenationContext,
+  ) {
     let module = module_info.id();
-    let build_meta = self
-      .1
+    let build_meta = context
       .module_graph
       .module_by_identifier(&module)
       .expect("should have module")
@@ -464,25 +563,30 @@ impl ConcatenationNameAllocator<'_> {
     let exports_type: BuildMetaExportsType = build_meta.exports_type();
     let default_object: BuildMetaDefaultObject = build_meta.default_object();
     if exports_type != BuildMetaExportsType::Namespace {
-      module_info.set_interop_namespace_object_name(Some(
-        self.find_new_module_name("namespaceObject", &module),
-      ));
+      module_info.set_interop_namespace_object_name(Some(self.find_new_module_name(
+        "namespaceObject",
+        &module,
+        context,
+      )));
     }
 
     if exports_type == BuildMetaExportsType::Default
       && !matches!(default_object, BuildMetaDefaultObject::Redirect)
     {
-      module_info.set_interop_namespace_object2_name(Some(
-        self.find_new_module_name("namespaceObject2", &module),
-      ));
+      module_info.set_interop_namespace_object2_name(Some(self.find_new_module_name(
+        "namespaceObject2",
+        &module,
+        context,
+      )));
     }
 
     if matches!(
       exports_type,
       BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
     ) {
-      module_info
-        .set_interop_default_access_name(Some(self.find_new_module_name("default", &module)));
+      module_info.set_interop_default_access_name(Some(
+        self.find_new_module_name("default", &module, context),
+      ));
     }
   }
 }

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rayon::prelude::*;
-use rspack_collections::IdentifierIndexMap;
+use rspack_collections::{IdentifierIndexMap, IdentifierMap};
 use rspack_error::{Error, Result};
 use rspack_util::{
   SpanExt,
@@ -32,6 +32,7 @@ pub struct ConcatenationContext<'a> {
   pub compiler_context: &'a Context,
   pub escaped_names: FxHashMap<Atom, Atom>,
   pub escaped_identifiers: FxHashMap<String, Vec<Atom>>,
+  pub module_identifiers: IdentifierMap<Vec<Atom>>,
 }
 
 pub struct ConcatenationNameAllocator<'a>(pub FxHashSet<Atom>, pub &'a ConcatenationContext<'a>);
@@ -607,10 +608,8 @@ impl<'a> ConcatenationContext<'a> {
           module_static_cache,
           compiler_context,
         );
-        escaped_identifiers.push((
-          readable_identifier.clone(),
-          split_readable_identifier(&readable_identifier),
-        ));
+        let module_identifier = split_readable_identifier(&readable_identifier);
+        escaped_identifiers.push((Some(info.id()), readable_identifier, module_identifier));
 
         if let ModuleInfo::Concatenated(info) = info {
           for (identifier, _) in &info.binding_to_ref {
@@ -621,8 +620,11 @@ impl<'a> ConcatenationContext<'a> {
 
           if let Some(import_map) = &info.import_map {
             for ((source, _), imported) in import_map {
-              escaped_identifiers
-                .push((source.clone(), split_readable_identifier(source.as_str())));
+              escaped_identifiers.push((
+                None,
+                source.clone(),
+                split_readable_identifier(source.as_str()),
+              ));
               for atom in &imported.specifiers {
                 escaped_names
                   .entry(atom.clone())
@@ -656,7 +658,14 @@ impl<'a> ConcatenationContext<'a> {
     escaped_names.extend(escaped_name_entries);
     let mut escaped_identifiers =
       FxHashMap::with_capacity_and_hasher(escaped_identifier_entries.len(), Default::default());
-    escaped_identifiers.extend(escaped_identifier_entries);
+    let mut module_identifiers = IdentifierMap::default();
+    module_identifiers.reserve(module_to_info_map.len());
+    for (module, identifier, escaped_identifier) in escaped_identifier_entries {
+      if let Some(module) = module {
+        module_identifiers.insert(module, escaped_identifier.clone());
+      }
+      escaped_identifiers.insert(identifier, escaped_identifier);
+    }
 
     Self {
       module_graph,
@@ -667,6 +676,7 @@ impl<'a> ConcatenationContext<'a> {
       compiler_context,
       escaped_names,
       escaped_identifiers,
+      module_identifiers,
     }
   }
 
@@ -680,10 +690,9 @@ impl<'a> ConcatenationContext<'a> {
   }
 
   pub fn module_identifier(&self, module: &ModuleIdentifier) -> &[Atom] {
-    let readable_identifier = self.readable_identifier(module);
     self
-      .escaped_identifiers
-      .get(&readable_identifier)
+      .module_identifiers
+      .get(module)
       .expect("should have escaped identifier")
   }
 

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -1,0 +1,694 @@
+use std::sync::Arc;
+
+use rayon::prelude::*;
+use rspack_collections::IdentifierIndexMap;
+use rspack_error::{Error, Result};
+use rspack_util::{
+  SpanExt,
+  atom::Atom,
+  fx_hash::{FxHashMap, FxHashSet},
+};
+use swc_core::common::SyntaxContext;
+use swc_experimental_allocator::Allocator;
+use swc_experimental_ecma_ast::{EsVersion, Program};
+use swc_experimental_ecma_parser::{EsSyntax, Parser, StringSource, Syntax};
+use swc_experimental_ecma_semantic::resolver::resolver;
+
+use crate::{
+  BuildMetaDefaultObject, BuildMetaExportsType, Compilation, ConcatenatedModuleInfo, Context,
+  ExportInfo, ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, ModuleStaticCache, RuntimeSpec, UsedName,
+  collect_ident, escape_name_atom_ref, find_new_name, find_target, get_cached_readable_identifier,
+  split_readable_identifier,
+};
+
+/// Reusable read-only context shared by concatenation implementations.
+pub struct ConcatenationContext<'a> {
+  pub module_graph: &'a ModuleGraph,
+  pub module_graph_cache: &'a ModuleGraphCacheArtifact,
+  pub module_static_cache: &'a ModuleStaticCache,
+  pub exports_info_artifact: &'a ExportsInfoArtifact,
+  pub runtime: Option<&'a RuntimeSpec>,
+  pub compiler_context: &'a Context,
+  pub escaped_names: FxHashMap<Atom, Atom>,
+  pub escaped_identifiers: FxHashMap<String, Vec<Atom>>,
+}
+
+pub struct ConcatenationNameAllocator<'a>(pub FxHashSet<Atom>, pub &'a ConcatenationContext<'a>);
+
+impl ConcatenationNameAllocator<'_> {
+  pub fn contains(&self, name: &Atom) -> bool {
+    self.0.contains(name)
+  }
+
+  pub fn insert(&mut self, name: Atom) {
+    self.0.insert(name);
+  }
+
+  pub fn find_new_name(&mut self, old_name: &str, extra_info: &[Atom]) -> Atom {
+    let name = find_new_name(old_name, &self.0, extra_info);
+    self.0.insert(name.clone());
+    name
+  }
+
+  pub fn find_new_module_name(&mut self, old_name: &str, module: &ModuleIdentifier) -> Atom {
+    let Self(used_names, context) = self;
+    let name = find_new_name(old_name, used_names, context.module_identifier(module));
+    used_names.insert(name.clone());
+    name
+  }
+
+  pub fn find_new_binding_name(&mut self, name: &Atom, extra_info: &[Atom]) -> Atom {
+    let Self(used_names, context) = self;
+    let name = find_new_name(
+      context
+        .escaped_names
+        .get(name)
+        .expect("should have escaped name")
+        .as_ref(),
+      used_names,
+      extra_info,
+    );
+    used_names.insert(name.clone());
+    name
+  }
+}
+
+pub enum ConcatenationInterop {
+  Namespace,
+  Namespace2,
+}
+
+pub struct ConcatenationBindingPlan {
+  pub info_id: ModuleIdentifier,
+  pub export_name: Vec<Atom>,
+  /// The defer flag on the re-export edge closest to the resolved target.
+  pub reexport_deferred: Option<bool>,
+  pub target: ConcatenationBindingTarget,
+}
+
+pub enum ConcatenationBindingTarget {
+  InteropNamespace(ConcatenationInterop),
+  InteropDefault,
+  EsModule(Vec<Atom>),
+  UnsupportedDefaultImport,
+  Namespace,
+  Circular,
+  Direct {
+    symbol: Atom,
+    used_name: Option<UsedName>,
+  },
+  Raw(Atom),
+  Inlined(UsedName),
+  NamespaceExport(UsedName),
+  Missing(Option<UsedName>),
+  External(Option<UsedName>),
+}
+
+/// Stateful backend-independent binding resolver.
+///
+/// Shared read-only dependencies live in `context`, module binding state lives
+/// in `module_to_info_map`, and only recursion-local cycle detection is created
+/// per `resolve` call.
+pub struct ConcatenationBindingResolver<'a> {
+  pub context: &'a ConcatenationContext<'a>,
+  pub module_to_info_map: &'a mut IdentifierIndexMap<ModuleInfo>,
+  pub normalize_export_name: fn(&ModuleGraph, &ModuleIdentifier, &mut Vec<Atom>),
+}
+
+impl<'a> ConcatenationBindingResolver<'a> {
+  pub fn resolve(
+    &self,
+    info_id: &ModuleIdentifier,
+    export_name: Vec<Atom>,
+    strict_esm_module: bool,
+  ) -> ConcatenationBindingPlan {
+    self.resolve_inner(
+      info_id,
+      export_name,
+      strict_esm_module,
+      &mut Default::default(),
+    )
+  }
+
+  fn resolve_inner(
+    &self,
+    info_id: &ModuleIdentifier,
+    mut export_name: Vec<Atom>,
+    strict_esm_module: bool,
+    visited_exports: &mut FxHashSet<ExportInfo>,
+  ) -> ConcatenationBindingPlan {
+    let module_graph = self.context.module_graph;
+    let module_graph_cache = self.context.module_graph_cache;
+    let exports_info_artifact = self.context.exports_info_artifact;
+    let module_to_info_map = &*self.module_to_info_map;
+    let runtime = self.context.runtime;
+    let info = module_to_info_map
+      .get(info_id)
+      .expect("should have module info");
+    let module = module_graph
+      .module_by_identifier(&info.id())
+      .expect("should have module");
+    let exports_type = module.get_exports_type(
+      module_graph,
+      module_graph_cache,
+      exports_info_artifact,
+      strict_esm_module,
+    );
+
+    (self.normalize_export_name)(module_graph, info_id, &mut export_name);
+
+    if export_name.is_empty() {
+      match exports_type {
+        ExportsType::DefaultOnly => {
+          return ConcatenationBindingPlan {
+            info_id: *info_id,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::InteropNamespace(ConcatenationInterop::Namespace2),
+          };
+        }
+        ExportsType::DefaultWithNamed => {
+          return ConcatenationBindingPlan {
+            info_id: *info_id,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::InteropNamespace(ConcatenationInterop::Namespace),
+          };
+        }
+        _ => {}
+      }
+    } else {
+      match exports_type {
+        ExportsType::Namespace => {}
+        ExportsType::DefaultWithNamed => match export_name.first().map(Atom::as_str) {
+          Some("default") => export_name = export_name[1..].to_vec(),
+          Some("__esModule") => {
+            return ConcatenationBindingPlan {
+              info_id: *info_id,
+              export_name: export_name.clone(),
+              reexport_deferred: None,
+              target: ConcatenationBindingTarget::EsModule(export_name[1..].to_vec()),
+            };
+          }
+          _ => {}
+        },
+        ExportsType::DefaultOnly => {
+          if export_name.first().map(Atom::as_str) == Some("__esModule") {
+            return ConcatenationBindingPlan {
+              info_id: *info_id,
+              export_name: export_name.clone(),
+              reexport_deferred: None,
+              target: ConcatenationBindingTarget::EsModule(export_name[1..].to_vec()),
+            };
+          }
+
+          let first_export = export_name.remove(0);
+          if first_export != "default" {
+            return ConcatenationBindingPlan {
+              info_id: *info_id,
+              export_name,
+              reexport_deferred: None,
+              target: ConcatenationBindingTarget::UnsupportedDefaultImport,
+            };
+          }
+        }
+        ExportsType::Dynamic => match export_name.first().map(Atom::as_str) {
+          Some("default") => {
+            return ConcatenationBindingPlan {
+              info_id: *info_id,
+              export_name: export_name[1..].to_vec(),
+              reexport_deferred: None,
+              target: ConcatenationBindingTarget::InteropDefault,
+            };
+          }
+          Some("__esModule") => {
+            return ConcatenationBindingPlan {
+              info_id: *info_id,
+              export_name: export_name.clone(),
+              reexport_deferred: None,
+              target: ConcatenationBindingTarget::EsModule(export_name[1..].to_vec()),
+            };
+          }
+          _ => {}
+        },
+      }
+    }
+
+    if export_name.is_empty() {
+      return ConcatenationBindingPlan {
+        info_id: info.id(),
+        export_name,
+        reexport_deferred: None,
+        target: ConcatenationBindingTarget::Namespace,
+      };
+    }
+
+    let exports_info = exports_info_artifact.get_exports_info_data(&info.id());
+    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
+    let export_info_id = export_info.id();
+
+    if !visited_exports.insert(export_info_id) {
+      return ConcatenationBindingPlan {
+        info_id: info.id(),
+        export_name,
+        reexport_deferred: None,
+        target: ConcatenationBindingTarget::Circular,
+      };
+    }
+
+    match info {
+      ModuleInfo::Concatenated(info) => {
+        if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
+          return ConcatenationBindingPlan {
+            info_id: info.module,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::Namespace,
+          };
+        }
+
+        let export_id = export_name.first().cloned();
+        let used_name = exports_info.get_used_name(exports_info_artifact, runtime, &export_name);
+
+        if let Some(export_id) = &export_id
+          && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
+        {
+          return ConcatenationBindingPlan {
+            info_id: info.module,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::Direct {
+              symbol: direct_export.as_str().into(),
+              used_name,
+            },
+          };
+        }
+
+        if let Some(export_id) = &export_id
+          && let Some(raw_export) = info
+            .raw_export_map
+            .as_ref()
+            .and_then(|map| map.get(export_id))
+        {
+          return ConcatenationBindingPlan {
+            info_id: info.module,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::Raw(raw_export.as_str().into()),
+          };
+        }
+
+        match find_target(
+          &export_info,
+          module_graph,
+          exports_info_artifact,
+          Arc::new(|module: &ModuleIdentifier| module_to_info_map.contains_key(module)),
+          &mut Default::default(),
+        ) {
+          FindTargetResult::NoTarget => {}
+          FindTargetResult::InvalidTarget(target) => {
+            if let Some(export) = target.export {
+              let target_exports_info = exports_info_artifact.get_exports_info_data(&target.module);
+              if let Some(used_name @ UsedName::Inlined(_)) =
+                target_exports_info.get_used_name(exports_info_artifact, runtime, &export)
+              {
+                return ConcatenationBindingPlan {
+                  info_id: info.module,
+                  export_name,
+                  reexport_deferred: None,
+                  target: ConcatenationBindingTarget::Inlined(used_name),
+                };
+              }
+            }
+            panic!(
+              "Target module of reexport is not part of the concatenation (export '{export_id:?}')"
+            );
+          }
+          FindTargetResult::ValidTarget(reexport) => {
+            if let Some(ref_info) = module_to_info_map.get(&reexport.module) {
+              let target_export_name = if let Some(reexport_export) = reexport.export {
+                [reexport_export, export_name[1..].to_vec()].concat()
+              } else {
+                export_name[1..].to_vec()
+              };
+              let mut plan = self.resolve_inner(
+                &ref_info.id(),
+                target_export_name,
+                module.build_meta().strict_esm_module(),
+                visited_exports,
+              );
+              plan.reexport_deferred.get_or_insert(reexport.defer);
+              return plan;
+            }
+          }
+        }
+
+        if info.namespace_export_symbol.is_some() {
+          return ConcatenationBindingPlan {
+            info_id: info.module,
+            export_name,
+            reexport_deferred: None,
+            target: ConcatenationBindingTarget::NamespaceExport(
+              used_name.expect("should have export name"),
+            ),
+          };
+        }
+
+        ConcatenationBindingPlan {
+          info_id: info.module,
+          export_name,
+          reexport_deferred: None,
+          target: ConcatenationBindingTarget::Missing(used_name),
+        }
+      }
+      ModuleInfo::External(info) => {
+        let used_name = exports_info.get_used_name(exports_info_artifact, runtime, &export_name);
+        ConcatenationBindingPlan {
+          info_id: info.module,
+          export_name,
+          reexport_deferred: None,
+          target: ConcatenationBindingTarget::External(used_name),
+        }
+      }
+    }
+  }
+}
+
+impl ConcatenationNameAllocator<'_> {
+  pub fn assign_module_binding_names(&mut self, module_info: &mut ConcatenatedModuleInfo) {
+    let Self(used_names, context) = self;
+    let escaped_identifier = context.module_identifier(&module_info.module);
+    for (name, ctxt) in module_info.binding_to_ref.keys() {
+      if ctxt != &module_info.module_ctxt {
+        continue;
+      }
+
+      let internal_name = if used_names.contains(name) {
+        let internal_name = find_new_name(
+          context
+            .escaped_names
+            .get(name)
+            .expect("should have escaped name")
+            .as_ref(),
+          used_names,
+          escaped_identifier,
+        );
+        used_names.insert(internal_name.clone());
+        internal_name
+      } else {
+        used_names.insert(name.clone());
+        name.clone()
+      };
+      module_info
+        .internal_names
+        .insert(name.clone(), internal_name);
+    }
+  }
+
+  pub fn assign_import_binding_name(
+    &mut self,
+    imported_name: &Atom,
+    existing_name: Option<&Atom>,
+    source: &str,
+    module_info: &mut ConcatenatedModuleInfo,
+  ) -> Atom {
+    let Self(used_names, context) = self;
+    let should_update_raw_export = existing_name.is_some() || used_names.contains(imported_name);
+    let internal_name = existing_name.cloned().unwrap_or_else(|| {
+      if !used_names.contains(imported_name) {
+        used_names.insert(imported_name.clone());
+        return imported_name.clone();
+      }
+
+      let internal_name = if imported_name == "default" {
+        find_new_name("", used_names, context.source_identifier(source))
+      } else {
+        find_new_name(
+          context
+            .escaped_names
+            .get(imported_name)
+            .expect("should have escaped name")
+            .as_ref(),
+          used_names,
+          context.module_identifier(&module_info.module),
+        )
+      };
+      used_names.insert(internal_name.clone());
+      internal_name
+    });
+
+    if should_update_raw_export
+      && let Some(raw_export_map) = module_info.raw_export_map.as_mut()
+      && raw_export_map.contains_key(imported_name)
+    {
+      raw_export_map.insert(imported_name.clone(), internal_name.to_string());
+    }
+    module_info
+      .internal_names
+      .insert(imported_name.clone(), internal_name.clone());
+    internal_name
+  }
+
+  pub fn assign_interop_names(&mut self, module_info: &mut ModuleInfo) {
+    let module = module_info.id();
+    let build_meta = self
+      .1
+      .module_graph
+      .module_by_identifier(&module)
+      .expect("should have module")
+      .build_meta();
+    let exports_type: BuildMetaExportsType = build_meta.exports_type();
+    let default_object: BuildMetaDefaultObject = build_meta.default_object();
+    if exports_type != BuildMetaExportsType::Namespace {
+      module_info.set_interop_namespace_object_name(Some(
+        self.find_new_module_name("namespaceObject", &module),
+      ));
+    }
+
+    if exports_type == BuildMetaExportsType::Default
+      && !matches!(default_object, BuildMetaDefaultObject::Redirect)
+    {
+      module_info.set_interop_namespace_object2_name(Some(
+        self.find_new_module_name("namespaceObject2", &module),
+      ));
+    }
+
+    if matches!(
+      exports_type,
+      BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
+    ) {
+      module_info
+        .set_interop_default_access_name(Some(self.find_new_module_name("default", &module)));
+    }
+  }
+}
+
+pub fn analyze_module_scope(
+  source: &str,
+  jsx: bool,
+  module_info: &mut ConcatenatedModuleInfo,
+) -> Result<()> {
+  let allocator = Allocator::new();
+  let lexer = swc_experimental_ecma_parser::Lexer::new(
+    &allocator,
+    Syntax::Es(EsSyntax {
+      jsx,
+      ..Default::default()
+    }),
+    EsVersion::EsNext,
+    StringSource::new(source),
+    None,
+  );
+  let mut parser = Parser::new_from(&allocator, lexer);
+  let parsed_module = parser.parse_module().map_err(|error| {
+    Error::from_string(
+      Some(source.to_owned()),
+      error.span().real_lo() as usize,
+      error.span().real_hi() as usize,
+      "JavaScript parse error:\n".to_string(),
+      error.kind().msg().to_string(),
+    )
+  })?;
+  let program = Program::Module(allocator.boxed(parsed_module));
+  let semantic = resolver(&program);
+  let identifiers = collect_ident(&allocator, &program);
+
+  module_info.module_ctxt = SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
+  module_info.global_ctxt = SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
+
+  let top_level_scope_id = semantic.top_level_scope_id();
+  module_info.all_used_names.clear();
+  module_info.binding_to_ref.clear();
+  module_info.all_used_names.reserve(identifiers.len());
+  module_info.idents.reserve(identifiers.len());
+  module_info.global_scope_ident.reserve(identifiers.len());
+  module_info.binding_to_ref.reserve(identifiers.len());
+
+  for identifier in identifiers {
+    let scope = semantic.node_scope(&identifier.id);
+    let is_global = SyntaxContext::from_u32(scope.raw()) == module_info.global_ctxt;
+    let legacy = if is_global {
+      let legacy = identifier.to_legacy(&semantic);
+      module_info.global_scope_ident.push(legacy.clone());
+      module_info.all_used_names.insert(legacy.id.sym.clone());
+      Some(legacy)
+    } else {
+      None
+    };
+
+    if identifier.is_class_expr_with_ident {
+      module_info
+        .all_used_names
+        .insert(Atom::from(identifier.id.sym.as_str()));
+      continue;
+    }
+
+    if scope != top_level_scope_id {
+      module_info
+        .all_used_names
+        .insert(Atom::from(identifier.id.sym.as_str()));
+    }
+
+    let legacy = legacy.unwrap_or_else(|| identifier.to_legacy(&semantic));
+    module_info.idents.push(legacy.clone());
+    module_info
+      .binding_to_ref
+      .entry((legacy.id.sym.clone(), legacy.id.ctxt))
+      .or_default()
+      .push(legacy);
+  }
+
+  module_info.has_ast = true;
+  Ok(())
+}
+
+impl<'a> ConcatenationContext<'a> {
+  pub fn prepare(
+    module_to_info_map: &IdentifierIndexMap<ModuleInfo>,
+    compilation: &'a Compilation,
+    runtime: Option<&'a RuntimeSpec>,
+  ) -> ConcatenationContext<'a> {
+    let module_graph = compilation.get_module_graph();
+    let module_graph_cache = &compilation.module_graph_cache_artifact;
+    let module_static_cache = &compilation.module_static_cache;
+    let exports_info_artifact = &compilation.exports_info_artifact;
+    let compiler_context = &compilation.options.context;
+    let (escaped_name_entries, escaped_identifier_entries) = module_to_info_map
+      .par_values()
+      .map(|info| {
+        let (name_capacity, identifier_capacity) = match info {
+          ModuleInfo::Concatenated(info) => {
+            let import_map = info.import_map.as_ref();
+            let import_sources = import_map.map_or(0, |map| map.len());
+            let imported_names = import_map.map_or(0, |map| {
+              map
+                .values()
+                .map(|imported| {
+                  imported.specifiers.len() + usize::from(imported.namespace.is_some())
+                })
+                .sum::<usize>()
+            });
+            (
+              info.binding_to_ref.len() + imported_names,
+              1 + import_sources,
+            )
+          }
+          ModuleInfo::External(_) => (0, 1),
+        };
+        let mut escaped_names =
+          FxHashMap::with_capacity_and_hasher(name_capacity, Default::default());
+        let mut escaped_identifiers = Vec::with_capacity(identifier_capacity);
+        let readable_identifier = get_cached_readable_identifier(
+          &info.id(),
+          module_graph,
+          module_static_cache,
+          compiler_context,
+        );
+        escaped_identifiers.push((
+          readable_identifier.clone(),
+          split_readable_identifier(&readable_identifier),
+        ));
+
+        if let ModuleInfo::Concatenated(info) = info {
+          for (identifier, _) in &info.binding_to_ref {
+            escaped_names
+              .entry(identifier.0.clone())
+              .or_insert_with(|| escape_name_atom_ref(&identifier.0));
+          }
+
+          if let Some(import_map) = &info.import_map {
+            for ((source, _), imported) in import_map {
+              escaped_identifiers
+                .push((source.clone(), split_readable_identifier(source.as_str())));
+              for atom in &imported.specifiers {
+                escaped_names
+                  .entry(atom.clone())
+                  .or_insert_with(|| escape_name_atom_ref(atom));
+              }
+              if let Some(namespace) = &imported.namespace {
+                escaped_names
+                  .entry(namespace.clone())
+                  .or_insert_with(|| escape_name_atom_ref(namespace));
+              }
+            }
+          }
+        }
+
+        (
+          escaped_names.into_iter().collect::<Vec<_>>(),
+          escaped_identifiers,
+        )
+      })
+      .reduce(
+        || (Vec::new(), Vec::new()),
+        |mut left, mut right| {
+          left.0.append(&mut right.0);
+          left.1.append(&mut right.1);
+          left
+        },
+      );
+
+    let mut escaped_names =
+      FxHashMap::with_capacity_and_hasher(escaped_name_entries.len(), Default::default());
+    escaped_names.extend(escaped_name_entries);
+    let mut escaped_identifiers =
+      FxHashMap::with_capacity_and_hasher(escaped_identifier_entries.len(), Default::default());
+    escaped_identifiers.extend(escaped_identifier_entries);
+
+    Self {
+      module_graph,
+      module_graph_cache,
+      module_static_cache,
+      exports_info_artifact,
+      runtime,
+      compiler_context,
+      escaped_names,
+      escaped_identifiers,
+    }
+  }
+
+  pub fn readable_identifier(&self, module: &ModuleIdentifier) -> String {
+    get_cached_readable_identifier(
+      module,
+      self.module_graph,
+      self.module_static_cache,
+      self.compiler_context,
+    )
+  }
+
+  pub fn module_identifier(&self, module: &ModuleIdentifier) -> &[Atom] {
+    let readable_identifier = self.readable_identifier(module);
+    self
+      .escaped_identifiers
+      .get(&readable_identifier)
+      .expect("should have escaped identifier")
+  }
+
+  pub fn source_identifier(&self, source: &str) -> &[Atom] {
+    self
+      .escaped_identifiers
+      .get(source)
+      .expect("should have escaped identifier")
+  }
+}

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -113,7 +113,7 @@ pub enum ConcatenationBindingTarget {
 pub struct ConcatenationBindingResolver<'a> {
   pub context: &'a ConcatenationContext<'a>,
   pub module_to_info_map: &'a mut IdentifierIndexMap<ModuleInfo>,
-  pub normalize_export_name: fn(&ModuleGraph, &ModuleIdentifier, &mut Vec<Atom>),
+  pub normalize_export_name: Option<fn(&ModuleGraph, &ModuleIdentifier, &mut Vec<Atom>)>,
 }
 
 impl<'a> ConcatenationBindingResolver<'a> {
@@ -156,7 +156,9 @@ impl<'a> ConcatenationBindingResolver<'a> {
       strict_esm_module,
     );
 
-    (self.normalize_export_name)(module_graph, info_id, &mut export_name);
+    if let Some(normalize_export_name) = self.normalize_export_name {
+      normalize_export_name(module_graph, info_id, &mut export_name);
+    }
 
     if export_name.is_empty() {
       match exports_type {

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -21,7 +21,9 @@ pub use new_cache::{
 };
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;
+mod concatenation_backend;
 mod dependencies_block;
+pub use concatenation_backend::*;
 pub mod diagnostics;
 pub mod incremental;
 pub use dependencies_block::{

--- a/crates/rspack_plugin_esm_library/Cargo.toml
+++ b/crates/rspack_plugin_esm_library/Cargo.toml
@@ -24,17 +24,17 @@ rspack_plugin_runtime      = { workspace = true }
 rspack_plugin_split_chunks = { workspace = true }
 rspack_util                = { workspace = true }
 
-async-trait                    = { workspace = true }
-atomic_refcell                 = { workspace = true }
-cow-utils                      = { workspace = true }
-rayon                          = { workspace = true }
-regex                          = { workspace = true }
-serde                          = { workspace = true }
-serde_json                     = { workspace = true }
-sugar_path                     = { workspace = true }
-swc_core                       = { workspace = true, features = ["swc_ecma_transforms_base"] }
-tokio                          = { workspace = true }
-tracing                        = { workspace = true }
+async-trait    = { workspace = true }
+atomic_refcell = { workspace = true }
+cow-utils      = { workspace = true }
+rayon          = { workspace = true }
+regex          = { workspace = true }
+serde          = { workspace = true }
+serde_json     = { workspace = true }
+sugar_path     = { workspace = true }
+swc_core       = { workspace = true, features = ["swc_ecma_transforms_base"] }
+tokio          = { workspace = true }
+tracing        = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rspack_plugin_esm_library/Cargo.toml
+++ b/crates/rspack_plugin_esm_library/Cargo.toml
@@ -33,10 +33,6 @@ serde                          = { workspace = true }
 serde_json                     = { workspace = true }
 sugar_path                     = { workspace = true }
 swc_core                       = { workspace = true, features = ["swc_ecma_transforms_base"] }
-swc_experimental_allocator     = { workspace = true }
-swc_experimental_ecma_ast      = { workspace = true }
-swc_experimental_ecma_parser   = { workspace = true }
-swc_experimental_ecma_semantic = { workspace = true }
 tokio                          = { workspace = true }
 tracing                        = { workspace = true }
 

--- a/crates/rspack_plugin_esm_library/src/chunk_link.rs
+++ b/crates/rspack_plugin_esm_library/src/chunk_link.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, sync::Arc};
 
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap, IdentifierSet};
 use rspack_core::{
-  BoxChunkInitFragment, ChunkGraph, ChunkUkey, Compilation, ImportSpec, ModuleGraph,
-  ModuleIdentifier, RuntimeCodeTemplate, RuntimeGlobals, find_new_name,
+  BoxChunkInitFragment, ChunkGraph, ChunkUkey, Compilation, ConcatenationNameAllocator, ImportSpec,
+  ModuleGraph, ModuleIdentifier, RuntimeCodeTemplate, RuntimeGlobals,
   rspack_sources::{ConcatSource, RawStringSource},
 };
 use rspack_util::fx_hash::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet};
@@ -79,11 +79,10 @@ fn get_or_create_interop_name(
   required_symbol: &mut Option<Atom>,
   field: &mut Option<Atom>,
   suffix: &str,
-  used_names: &mut FxHashSet<Atom>,
+  name_allocator: &mut ConcatenationNameAllocator,
 ) -> Atom {
   if required_symbol.is_none() {
-    let new_name = find_new_name("", used_names, &[]);
-    used_names.insert(new_name.clone());
+    let new_name = name_allocator.find_new_name("", &[]);
     *required_symbol = Some(new_name);
   }
   if let Some(existing) = field {
@@ -94,46 +93,46 @@ fn get_or_create_interop_name(
     required_symbol.as_ref().expect("already set"),
     suffix
   ));
-  if used_names.contains(&new_name) {
-    new_name = find_new_name(new_name.as_str(), used_names, &[]);
+  if name_allocator.contains(&new_name) {
+    new_name = name_allocator.find_new_name(new_name.as_str(), &[]);
+  } else {
+    name_allocator.insert(new_name.clone());
   }
   *field = Some(new_name.clone());
-  used_names.insert(new_name.clone());
   new_name
 }
 
 impl ExternalInterop {
-  pub fn namespace(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn namespace(&mut self, name_allocator: &mut ConcatenationNameAllocator) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.namespace_object,
       "_namespace",
-      used_names,
+      name_allocator,
     )
   }
 
-  pub fn namespace2(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn namespace2(&mut self, name_allocator: &mut ConcatenationNameAllocator) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.namespace_object2,
       "_namespace2",
-      used_names,
+      name_allocator,
     )
   }
 
-  pub fn default_access(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn default_access(&mut self, name_allocator: &mut ConcatenationNameAllocator) -> Atom {
     get_or_create_interop_name(
       &mut self.required_symbol,
       &mut self.default_access,
       "_default",
-      used_names,
+      name_allocator,
     )
   }
 
-  pub fn default_exported(&mut self, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn default_exported(&mut self, name_allocator: &mut ConcatenationNameAllocator) -> Atom {
     if self.required_symbol.is_none() {
-      let new_name = find_new_name("", used_names, &[]);
-      used_names.insert(new_name.clone());
+      let new_name = name_allocator.find_new_name("", &[]);
       self.required_symbol = Some(new_name);
     }
 
@@ -141,17 +140,19 @@ impl ExternalInterop {
       return default_exported.clone();
     }
 
-    let default_access_symbol = self.default_access(used_names);
-    let default_exported_symbol = find_new_name(&default_access_symbol, used_names, &[]);
-    used_names.insert(default_exported_symbol.clone());
+    let default_access_symbol = self.default_access(name_allocator);
+    let default_exported_symbol = name_allocator.find_new_name(&default_access_symbol, &[]);
     self.default_exported = Some(default_exported_symbol.clone());
     default_exported_symbol
   }
 
-  pub fn property_access(&mut self, atom: &Atom, used_names: &mut FxHashSet<Atom>) -> Atom {
+  pub fn property_access(
+    &mut self,
+    atom: &Atom,
+    name_allocator: &mut ConcatenationNameAllocator,
+  ) -> Atom {
     self.property_access.get(atom).cloned().unwrap_or_else(|| {
-      let local_name = find_new_name(atom, used_names, &[]);
-      used_names.insert(local_name.clone());
+      let local_name = name_allocator.find_new_name(atom, &[]);
       self.property_access.insert(atom.clone(), local_name);
       self
         .property_access
@@ -329,9 +330,9 @@ pub struct ChunkLinkContext {
   pub refs: FxHashMap<String, Ref>,
 
   /**
-  all used symbols in current chunk
+  Allocator for all symbols used in the current chunk.
   */
-  pub used_names: FxHashSet<Atom>,
+  pub name_allocator: ConcatenationNameAllocator,
 }
 
 impl ChunkLinkContext {
@@ -355,7 +356,7 @@ impl ChunkLinkContext {
       hashbang: None,
       directives: Default::default(),
       refs: Default::default(),
-      used_names: Default::default(),
+      name_allocator: Default::default(),
       exported_symbols: Default::default(),
       raw_import_stmts: Default::default(),
       module_external_namespace_imports: Default::default(),

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -4,37 +4,32 @@ use std::{
   sync::{Arc, LazyLock},
 };
 
-use rayon::{iter::Either, prelude::*};
+use rayon::iter::Either;
 use rspack_collections::{IdentifierIndexMap, IdentifierIndexSet, IdentifierMap};
 use rspack_core::{
-  BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph, ChunkInitFragments, ChunkRenderContext,
-  ChunkUkey, CodeGenerationDataChunkInitFragments, CodeGenerationDataConcatenationScopeOutput,
+  ChunkGraph, ChunkInitFragments, ChunkRenderContext, ChunkUkey,
+  CodeGenerationDataChunkInitFragments, CodeGenerationDataConcatenationScopeOutput,
   CodeGenerationDataPreservedAssetImport, CodeGenerationPublicPathAutoReplace, Compilation,
-  ConcatenatedModuleIdent, ConditionalInitFragment, DependencyType, ExportInfo, ExportMode,
-  ExportProvided, ExportsInfoArtifact, ExportsType, FindTargetResult, ImportSpec, InitFragmentKey,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT,
-  RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeTemplateRenderMode, RuntimeVariable,
-  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
-  all_runtime_module_variables, collect_ident, escape_name_atom_ref, find_new_name, find_target,
-  get_cached_readable_identifier, get_module_directives, get_module_hashbang, property_access,
-  property_name, reserved_names::RESERVED_NAMES_ATOM_SET, rspack_sources::ReplaceSource,
-  split_readable_identifier, to_normal_comment,
+  ConcatenationBindingPlan, ConcatenationBindingResolver, ConcatenationBindingTarget,
+  ConcatenationContext, ConcatenationInterop, ConcatenationNameAllocator, ConditionalInitFragment,
+  DependencyType, ExportInfo, ExportMode, ExportProvided, ExportsInfoArtifact, ExportsType,
+  FindTargetResult, ImportSpec, InitFragmentKey, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, RuntimeGlobals, RuntimeGlobalsRenderMode,
+  RuntimeTemplateRenderMode, RuntimeVariable, SideEffectsStateArtifact, SourceType, URLStaticMode,
+  UsageState, UsedName, UsedNameItem, all_runtime_module_variables, analyze_module_scope,
+  find_new_name, find_target, get_cached_readable_identifier, get_module_directives,
+  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
+  rspack_sources::ReplaceSource, to_normal_comment,
 };
-use rspack_error::{Diagnostic, Error, Result};
+use rspack_error::{Diagnostic, Result};
 use rspack_plugin_javascript::{
   JsPlugin, RenderSource, dependency::ESMExportImportedSpecifierDependency,
 };
 use rspack_plugin_runtime::should_export_webpack_require_for_module_chunk_loading;
 use rspack_util::{
-  SpanExt,
   atom::Atom,
   fx_hash::{FxHashMap, FxHashSet, FxIndexMap, FxIndexSet},
 };
-use swc_core::common::SyntaxContext;
-use swc_experimental_allocator::Allocator;
-use swc_experimental_ecma_ast::{EsVersion, Program};
-use swc_experimental_ecma_parser::{EsSyntax, Parser, StringSource, Syntax};
-use swc_experimental_ecma_semantic::resolver::resolver;
 
 use crate::{
   EsmLibraryPlugin,
@@ -71,8 +66,7 @@ pub(crate) struct ExportsContext {
 
 struct DeconflictSymbolsContext<'a> {
   runtime_module_used_names: &'a FxHashSet<Atom>,
-  escaped_names: &'a FxHashMap<Atom, Atom>,
-  escaped_identifiers: &'a FxHashMap<String, Vec<Atom>>,
+  concatenation_context: &'a ConcatenationContext<'a>,
 }
 
 enum ExternalImportBinding {
@@ -80,6 +74,8 @@ enum ExternalImportBinding {
   Named(Atom),
   Namespace,
 }
+
+type AnalyzedModule = (ModuleInfo, Option<(ModuleIdentifier, ChunkInitFragments)>);
 
 impl EsmLibraryPlugin {
   fn collect_init_fragments_in_render_order<'a>(
@@ -602,96 +598,13 @@ impl EsmLibraryPlugin {
       })
       .collect::<FxHashSet<_>>();
 
-    let (escaped_name_entries, escaped_identifier_entries) = concate_modules_map
-      .par_values()
-      .map(|info| {
-        let (name_capacity, identifier_capacity) = match info {
-          ModuleInfo::Concatenated(info) => {
-            let import_map = info.import_map.as_ref();
-            let import_sources = import_map.map_or(0, |map| map.len());
-            let imported_names = import_map.map_or(0, |map| {
-              map
-                .values()
-                .map(|imported| {
-                  imported.specifiers.len() + usize::from(imported.namespace.is_some())
-                })
-                .sum::<usize>()
-            });
-            (
-              info.binding_to_ref.len() + imported_names,
-              1 + import_sources,
-            )
-          }
-          ModuleInfo::External(_) => (0, 1),
-        };
-        let mut escaped_names =
-          FxHashMap::with_capacity_and_hasher(name_capacity, Default::default());
-        let mut escaped_identifiers = Vec::with_capacity(identifier_capacity);
-        let readable_identifier = get_cached_readable_identifier(
-          &info.id(),
-          module_graph,
-          &compilation.module_static_cache,
-          &compilation.options.context,
-        );
-        let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-        escaped_identifiers.push((readable_identifier, splitted_readable_identifier));
-
-        match info {
-          ModuleInfo::Concatenated(info) => {
-            for (id, _) in info.binding_to_ref.iter() {
-              escaped_names
-                .entry(id.0.clone())
-                .or_insert_with(|| escape_name_atom_ref(&id.0));
-            }
-
-            if let Some(import_map) = &info.import_map {
-              for ((source, _), imported_atoms) in import_map.iter() {
-                escaped_identifiers
-                  .push((source.clone(), split_readable_identifier(source.as_str())));
-                for atom in &imported_atoms.specifiers {
-                  escaped_names
-                    .entry(atom.clone())
-                    .or_insert_with(|| escape_name_atom_ref(atom));
-                }
-                if let Some(ns_import) = &imported_atoms.namespace {
-                  escaped_names
-                    .entry(ns_import.clone())
-                    .or_insert_with(|| escape_name_atom_ref(ns_import));
-                }
-              }
-            }
-          }
-          ModuleInfo::External(_) => (),
-        }
-        (
-          escaped_names.into_iter().collect::<Vec<_>>(),
-          escaped_identifiers,
-        )
-      })
-      .reduce(
-        || (Vec::new(), Vec::new()),
-        |mut a, mut b| {
-          a.0.append(&mut b.0);
-          a.1.append(&mut b.1);
-          a
-        },
-      );
-    let mut escaped_names =
-      FxHashMap::with_capacity_and_hasher(escaped_name_entries.len(), Default::default());
-    for (name, escaped_name) in escaped_name_entries {
-      escaped_names.insert(name, escaped_name);
-    }
-    let mut escaped_identifiers =
-      FxHashMap::with_capacity_and_hasher(escaped_identifier_entries.len(), Default::default());
-    for (identifier, parts) in escaped_identifier_entries {
-      escaped_identifiers.insert(identifier, parts);
-    }
+    let concatenation_context =
+      ConcatenationContext::prepare(&concate_modules_map, compilation, None);
 
     let runtime_module_used_names = Self::collect_rspack_export_runtime_used_names(compilation);
     let deconflict_context = DeconflictSymbolsContext {
       runtime_module_used_names: &runtime_module_used_names,
-      escaped_names: &escaped_names,
-      escaped_identifiers: &escaped_identifiers,
+      concatenation_context: &concatenation_context,
     };
 
     for chunk_link in link.values_mut() {
@@ -704,15 +617,32 @@ impl EsmLibraryPlugin {
       );
     }
 
+    let mut binding_resolver = ConcatenationBindingResolver {
+      context: &concatenation_context,
+      module_to_info_map: &mut concate_modules_map,
+      normalize_export_name: |module_graph, module, export_name| {
+        let is_source_phase_external = module_graph
+          .module_by_identifier(module)
+          .and_then(|module| module.as_external_module())
+          .is_some_and(|external_module| external_module.get_import_phase().is_source());
+        if is_source_phase_external
+          && export_name
+            .first()
+            .is_some_and(|name| name.as_str() == "default")
+        {
+          export_name.remove(0);
+        }
+      },
+    };
+
     // link imported specifier with exported symbol
     let mut needed_namespace_objects_by_ukey = FxHashMap::default();
     diagnostics.extend(self.link_imports_and_exports(
       compilation,
+      &mut binding_resolver,
       &mut link,
       &runtime_chunks_exporting_require_via_runtime_module,
-      &mut concate_modules_map,
       &mut needed_namespace_objects_by_ukey,
-      &escaped_identifiers,
     ));
 
     let mut namespace_object_sources: IdentifierMap<String> = IdentifierMap::default();
@@ -738,10 +668,9 @@ impl EsmLibraryPlugin {
             .expect("index is within the current worklist");
           let module_info_id = &module_info_id;
 
-          let module_info = concate_modules_map[module_info_id].as_concatenated();
+          let module_info = binding_resolver.module_to_info_map[module_info_id].as_concatenated();
           let mut runtime_template = compilation.runtime_template.create_module_code_template();
 
-          let module_graph = compilation.get_module_graph();
           let box_module = module_graph
             .module_by_identifier(module_info_id)
             .expect("should have box module");
@@ -759,7 +688,8 @@ impl EsmLibraryPlugin {
           }
 
           let mut ns_obj = Vec::new();
-          for export_info in compilation
+          for export_info in binding_resolver
+            .context
             .exports_info_artifact
             .get_exports_info_data(module_info_id)
             .exports()
@@ -775,20 +705,16 @@ impl EsmLibraryPlugin {
             }
 
             if let Some(UsedNameItem::Str(used_name)) = export_info.get_used_name(None, None) {
-              let Some(mut binding) = Self::get_binding(
+              let Some(mut binding) = self.get_binding(
                 None,
-                compilation.get_module_graph(),
-                &compilation.module_graph_cache_artifact,
-                &compilation.exports_info_artifact,
+                &mut binding_resolver,
                 module_info_id,
                 vec![export_info.name().cloned().unwrap_or("".into())],
-                &mut concate_modules_map,
                 &mut needed_namespace_objects,
                 false,
                 false,
                 strict_esm_module,
                 Some(true),
-                &mut Default::default(),
                 &mut chunk_link.required,
                 &mut chunk_link.used_names,
               ) else {
@@ -796,7 +722,9 @@ impl EsmLibraryPlugin {
               };
 
               if let Ref::Symbol(symbol_binding) = &mut binding {
-                let target_info = concate_modules_map.get(&symbol_binding.module);
+                let target_info = binding_resolver
+                  .module_to_info_map
+                  .get(&symbol_binding.module);
                 if matches!(target_info, Some(ModuleInfo::External(_))) {
                   chunk_link.imports.entry(symbol_binding.module).or_default();
                 } else if symbol_binding.ids.is_empty()
@@ -807,13 +735,13 @@ impl EsmLibraryPlugin {
                   // When ids is empty, the symbol is directly referenced (not via property
                   // access like ns.readFile), so we need to add an import from the external
                   // source to make the binding available.
-                  let module_graph = compilation.get_module_graph();
                   if let Some(ext) = module_graph
                     .module_by_identifier(&symbol_binding.module)
                     .and_then(|m| m.as_external_module())
                     && ext.resolve_external_type() == "module"
                   {
-                    let Some((raw_import_source, import_binding)) = concate_modules_map
+                    let Some((raw_import_source, import_binding)) = binding_resolver
+                      .module_to_info_map
                       .get(&symbol_binding.module)
                       .and_then(|target_info| match target_info {
                         ModuleInfo::Concatenated(target_info) => {
@@ -895,11 +823,11 @@ impl EsmLibraryPlugin {
           let star_re_export_binding = Self::resolve_single_star_re_export_target(
             *module_info_id,
             module_graph,
-            &compilation.module_graph_cache_artifact,
+            binding_resolver.context.module_graph_cache,
             &compilation
               .build_module_graph_artifact
               .side_effects_state_artifact,
-            &compilation.exports_info_artifact,
+            binding_resolver.context.exports_info_artifact,
             &mut namespace_re_export_star_cache,
           )
           .and_then(|target_module| {
@@ -909,20 +837,16 @@ impl EsmLibraryPlugin {
               .build_meta()
               .strict_esm_module();
 
-            Self::get_binding(
+            self.get_binding(
               None,
-              module_graph,
-              &compilation.module_graph_cache_artifact,
-              &compilation.exports_info_artifact,
+              &mut binding_resolver,
               &target_module,
               vec![],
-              &mut concate_modules_map,
               &mut needed_namespace_objects,
               false,
               false,
               target_strict_esm_module,
               None,
-              &mut Default::default(),
               &mut chunk_link.required,
               &mut chunk_link.used_names,
             )
@@ -992,7 +916,8 @@ var {} = {{}};
               )
             };
 
-          let module_info = concate_modules_map[module_info_id].as_concatenated_mut();
+          let module_info =
+            binding_resolver.module_to_info_map[module_info_id].as_concatenated_mut();
 
           namespace_object_sources.insert(*module_info_id, namespace_object_source);
 
@@ -1098,9 +1023,9 @@ var {} = {{}};
     let context = &compilation.options.context;
     let DeconflictSymbolsContext {
       runtime_module_used_names,
-      escaped_names,
-      escaped_identifiers,
+      concatenation_context,
     } = deconflict_context;
+    let escaped_identifiers = &concatenation_context.escaped_identifiers;
 
     let module_graph = compilation.get_module_graph();
 
@@ -1176,6 +1101,7 @@ var {} = {{}};
       &mut all_used_names,
       escaped_identifiers,
     );
+    let mut name_allocator = ConcatenationNameAllocator(all_used_names, concatenation_context);
 
     // deconflict top level symbols
     for id in chunk_link
@@ -1183,22 +1109,13 @@ var {} = {{}};
       .iter()
       .chain(chunk_link.decl_modules.iter())
     {
-      let module = module_graph
-        .module_by_identifier(id)
-        .expect("should have module");
-      let exports_type = module.build_meta().exports_type();
-      let default_object = module.build_meta().default_object();
-
       let info = &mut concate_modules_map[id];
-      let readable_identifier =
-        get_cached_readable_identifier(id, module_graph, &compilation.module_static_cache, context);
-
       if let ModuleInfo::Concatenated(concate_info) = info {
-        let mut internal_names = FxHashMap::default();
+        concate_info.internal_names.clear();
 
         // registered import map
-        if let Some(import_map) = &concate_info.import_map {
-          for ((source, attr), imported_atoms) in import_map.iter() {
+        if let Some(import_map) = concate_info.import_map.take() {
+          for ((source, attr), imported_atoms) in &import_map {
             let raw_import_source = RawImportSource::Source((source.clone(), attr.clone()));
             let existing_namespace_import = chunk_link
               .module_external_namespace_imports
@@ -1221,7 +1138,9 @@ var {} = {{}};
             if let Some(ns_import) = &imported_atoms.namespace {
               if let Some(existing_local) = existing_namespace_import.as_ref() {
                 if existing_local != ns_import {
-                  internal_names.insert(ns_import.clone(), existing_local.clone());
+                  concate_info
+                    .internal_names
+                    .insert(ns_import.clone(), existing_local.clone());
                 }
               } else {
                 total_imported_atoms = Some(
@@ -1249,8 +1168,7 @@ var {} = {{}};
               let total_imported_atoms = total_imported_atoms
                 .as_mut()
                 .expect("should have import spec");
-              // already import this symbol
-              if let Some(internal_atom) = total_imported_atoms.atoms.get(atom).or_else(|| {
+              let existing_name = total_imported_atoms.atoms.get(atom).or_else(|| {
                 if atom == "default"
                   && let Some(default_symbol) = &total_imported_atoms.default_import
                 {
@@ -1258,81 +1176,27 @@ var {} = {{}};
                 } else {
                   None
                 }
-              }) {
-                internal_names.insert(atom.clone(), internal_atom.clone());
-                // if the imported symbol is exported, we rename the export as well
-                if let Some(raw_export_map) = concate_info.raw_export_map.as_mut()
-                  && raw_export_map.contains_key(atom)
-                {
-                  raw_export_map.insert(atom.clone(), internal_atom.to_string());
-                }
-                continue;
-              }
+              });
+              let new_name = name_allocator.assign_import_binding_name(
+                atom,
+                existing_name,
+                source,
+                concate_info,
+              );
 
-              let new_name = if all_used_names.contains(atom) {
-                let new_name = if atom == "default" {
-                  find_new_name("", &all_used_names, &escaped_identifiers[source])
+              if existing_name.is_none() {
+                if atom == "default" {
+                  total_imported_atoms.default_import = Some(new_name);
                 } else {
-                  find_new_name(
-                    escaped_names
-                      .get(atom)
-                      .expect("should have escaped name")
-                      .as_ref(),
-                    &all_used_names,
-                    &escaped_identifiers[&readable_identifier],
-                  )
-                };
-                all_used_names.insert(new_name.clone());
-                // if the imported symbol is exported, we rename the export as well
-                if let Some(raw_export_map) = concate_info.raw_export_map.as_mut()
-                  && raw_export_map.contains_key(atom)
-                {
-                  raw_export_map.insert(atom.clone(), new_name.to_string());
+                  total_imported_atoms.atoms.insert(atom.clone(), new_name);
                 }
-                new_name
-              } else {
-                all_used_names.insert(atom.clone());
-                atom.clone()
-              };
-
-              internal_names.insert(atom.clone(), new_name.clone());
-
-              if atom == "default" {
-                total_imported_atoms.default_import = Some(new_name.clone());
-              } else {
-                total_imported_atoms
-                  .atoms
-                  .insert(atom.clone(), new_name.clone());
               }
             }
           }
+          concate_info.import_map = Some(import_map);
         }
 
-        for (atom, ctxt) in concate_info.binding_to_ref.keys() {
-          // only need to handle top level scope
-          if ctxt != &concate_info.module_ctxt {
-            continue;
-          }
-
-          if all_used_names.contains(atom) {
-            let new_name = find_new_name(
-              escaped_names
-                .get(atom)
-                .expect("should have escaped name")
-                .as_ref(),
-              &all_used_names,
-              &escaped_identifiers[&readable_identifier],
-            );
-
-            all_used_names.insert(new_name.clone());
-            internal_names.insert(atom.clone(), new_name);
-          } else {
-            all_used_names.insert(atom.clone());
-            internal_names.insert(atom.clone(), atom.clone());
-          }
-        }
-
-        concate_info.internal_names = internal_names;
+        name_allocator.assign_module_binding_names(concate_info);
 
         // Handle the name passed through by namespace_export_symbol
         if let Some(ref namespace_export_symbol) = concate_info.namespace_export_symbol
@@ -1341,7 +1205,7 @@ var {} = {{}};
         {
           let name: Atom =
             Atom::from(namespace_export_symbol[NAMESPACE_OBJECT_EXPORT.len()..].to_string());
-          all_used_names.insert(name.clone());
+          name_allocator.insert(name.clone());
           concate_info
             .internal_names
             .insert(namespace_export_symbol.clone(), name.clone());
@@ -1355,66 +1219,25 @@ var {} = {{}};
             ns_map.get(id).cloned()
           };
           if let Some(pre_assigned) = pre_assigned {
+            name_allocator.insert(pre_assigned.clone());
             pre_assigned
           } else if let Some(ref namespace_export_symbol) = concate_info.namespace_export_symbol {
             concate_info
               .get_internal_name(namespace_export_symbol)
               .cloned()
               .unwrap_or_else(|| {
-                find_new_name(
-                  "namespaceObject",
-                  &all_used_names,
-                  &escaped_identifiers[&readable_identifier],
-                )
+                name_allocator.find_new_module_name("namespaceObject", &concate_info.module)
               })
           } else {
-            find_new_name(
-              "namespaceObject",
-              &all_used_names,
-              &escaped_identifiers[&readable_identifier],
-            )
+            name_allocator.find_new_module_name("namespaceObject", &concate_info.module)
           }
         };
-        all_used_names.insert(namespace_object_name.clone());
         concate_info.namespace_object_name = Some(namespace_object_name.clone());
 
-        // Handle additional logic based on module build meta
-        if exports_type != BuildMetaExportsType::Namespace {
-          let external_name_interop: Atom = find_new_name(
-            "namespaceObject",
-            &all_used_names,
-            &escaped_identifiers[&readable_identifier],
-          );
-          all_used_names.insert(external_name_interop.clone());
-          info.set_interop_namespace_object_name(Some(external_name_interop.clone()));
-        }
-
-        if exports_type == BuildMetaExportsType::Default
-          && !matches!(default_object, BuildMetaDefaultObject::Redirect)
-        {
-          let external_name_interop: Atom = find_new_name(
-            "namespaceObject2",
-            &all_used_names,
-            &escaped_identifiers[&readable_identifier],
-          );
-          all_used_names.insert(external_name_interop.clone());
-          info.set_interop_namespace_object2_name(Some(external_name_interop.clone()));
-        }
-
-        if matches!(
-          exports_type,
-          BuildMetaExportsType::Dynamic | BuildMetaExportsType::Unset
-        ) {
-          let external_name_interop: Atom = find_new_name(
-            "default",
-            &all_used_names,
-            &escaped_identifiers[&readable_identifier],
-          );
-          all_used_names.insert(external_name_interop.clone());
-          info.set_interop_default_access_name(Some(external_name_interop.clone()));
-        }
+        name_allocator.assign_interop_names(info);
       }
     }
+    let mut all_used_names = name_allocator.0;
 
     // Build a targeted set for external module name deconfliction:
     // Start from chunk_link.used_names (cross-chunk accumulated names) and add
@@ -1529,203 +1352,133 @@ var {} = {{}};
       for (m, info) in concate_modules_map {
         // SAFETY: caller will poll the futures
         let s = unsafe { token.used((compilation, m, info, &runtime_template)) };
-        s.spawn(async move |(compilation, id, info, runtime_template)| {
-          if compilation
-            .build_chunk_graph_artifact
-            .chunk_graph
-            .get_module_chunks(m)
-            .is_empty()
-          {
-            // orphan module
-            return Ok((info, None));
-          }
-
-          let chunk_ukey = Self::get_module_chunk(m, compilation)?;
-
-          let module_graph = compilation.get_module_graph();
-
-          match info {
-            rspack_core::ModuleInfo::External(mut external_module_info) => {
-              let codegen_res = compilation.code_generation_results.get(&id, None);
-              let has_javascript_source = compilation
-                .code_generation_results
-                .get(&id, None)
-                .get(&SourceType::JavaScript)
-                .is_some();
-              let used_in_chunk = !compilation
-                .build_chunk_graph_artifact
-                .chunk_graph
-                .get_module_chunks(id)
-                .is_empty();
-              if has_javascript_source && used_in_chunk {
-                // we use __rspack_require.add({...}) to register modules
-                external_module_info
-                  .runtime_requirements
-                  .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
-              }
-              let chunk_init_fragments = codegen_res
-                .data()
-                .get::<CodeGenerationDataChunkInitFragments>()
-                .map(|fragments| fragments.inner().clone())
-                .unwrap_or_default();
-              Ok((
-                ModuleInfo::External(external_module_info),
-                if chunk_init_fragments.is_empty() {
-                  None
-                } else {
-                  Some((id, chunk_init_fragments))
-                },
-              ))
+        s.spawn(
+          async move |(compilation, id, info, runtime_template)| -> Result<AnalyzedModule> {
+            if compilation
+              .build_chunk_graph_artifact
+              .chunk_graph
+              .get_module_chunks(m)
+              .is_empty()
+            {
+              // orphan module
+              return Ok((info, None));
             }
-            rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
-              let hooks = JsPlugin::get_compilation_hooks(compilation.id());
-              let hooks = hooks.read().await;
 
-              let module = module_graph
-                .module_by_identifier(&id)
-                .expect("should have module");
-              let codegen_res = compilation.code_generation_results.get(&id, None);
-              let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
-                return Ok((ModuleInfo::Concatenated(concate_info), None));
-              };
-              let concatenation_scope_output = codegen_res
-                .data()
-                .get::<CodeGenerationDataConcatenationScopeOutput>()
-                .expect("should have concatenation scope output for scope hoisted module");
+            let chunk_ukey = Self::get_module_chunk(m, compilation)?;
 
-              let mut render_source = RenderSource {
-                source: js_source.clone(),
-              };
-              let mut runtime_requirements = *codegen_res.runtime_requirements();
+            let module_graph = compilation.get_module_graph();
 
-              let mut chunk_init_fragments = vec![];
-              hooks
-                .render_module_content
-                .call(
-                  compilation,
-                  &chunk_ukey,
-                  module.as_ref(),
-                  &mut render_source,
-                  &mut runtime_requirements,
-                  &mut chunk_init_fragments,
-                  runtime_template,
-                )
-                .await?;
-              concatenation_scope_output.apply_to(&mut concate_info);
-
-              let jsx = module
-                .as_ref()
-                .as_normal_module()
-                .and_then(|normal_module| normal_module.get_parser_options())
-                .and_then(|options| {
-                  options
-                    .get_javascript()
-                    .and_then(|js_options| js_options.jsx)
-                })
-                .unwrap_or(false);
-              let source_str = render_source
-                .source
-                .source()
-                .into_string_lossy()
-                .into_owned();
-              let allocator = Allocator::new();
-              let lexer = swc_experimental_ecma_parser::Lexer::new(
-                &allocator,
-                Syntax::Es(EsSyntax {
-                  jsx,
-                  ..Default::default()
-                }),
-                EsVersion::EsNext,
-                StringSource::new(&source_str),
-                None,
-              );
-              let mut parser = Parser::new_from(&allocator, lexer);
-              let module = match parser.parse_module() {
-                Ok(module) => module,
-                Err(err) => {
-                  return Err(Error::from_string(
-                    Some(source_str.clone()),
-                    err.span().real_lo() as usize,
-                    err.span().real_hi() as usize,
-                    "JavaScript parse error:\n".to_string(),
-                    err.kind().msg().to_string(),
-                  ));
+            match info {
+              rspack_core::ModuleInfo::External(mut external_module_info) => {
+                let codegen_res = compilation.code_generation_results.get(&id, None);
+                let has_javascript_source = compilation
+                  .code_generation_results
+                  .get(&id, None)
+                  .get(&SourceType::JavaScript)
+                  .is_some();
+                let used_in_chunk = !compilation
+                  .build_chunk_graph_artifact
+                  .chunk_graph
+                  .get_module_chunks(id)
+                  .is_empty();
+                if has_javascript_source && used_in_chunk {
+                  // we use __rspack_require.add({...}) to register modules
+                  external_module_info
+                    .runtime_requirements
+                    .insert(RuntimeGlobals::REQUIRE | RuntimeGlobals::MODULE_FACTORIES);
                 }
-              };
-              let program = Program::Module(allocator.boxed(module));
-              let semantic = resolver(&program);
-              let ids = collect_ident(&allocator, &program);
-
-              concate_info.module_ctxt =
-                SyntaxContext::from_u32(semantic.top_level_scope_id().raw());
-              concate_info.global_ctxt =
-                SyntaxContext::from_u32(semantic.unresolved_scope_id().raw());
-
-              let top_level_scope_id = semantic.top_level_scope_id();
-              let mut all_used_names = FxHashSet::default();
-              all_used_names.reserve(ids.len());
-              concate_info.idents.reserve(ids.len());
-              concate_info.global_scope_ident.reserve(ids.len());
-              let mut binding_to_ref: FxIndexMap<
-                (Atom, SyntaxContext),
-                Vec<ConcatenatedModuleIdent>,
-              > = Default::default();
-              binding_to_ref.reserve(ids.len());
-
-              for ident in ids {
-                let scope = semantic.node_scope(&ident.id);
-                let is_global = SyntaxContext::from_u32(scope.raw()) == concate_info.global_ctxt;
-                let legacy = if is_global {
-                  let leg = ident.to_legacy(&semantic);
-                  concate_info.global_scope_ident.push(leg.clone());
-                  all_used_names.insert(leg.id.sym.clone());
-                  Some(leg)
-                } else {
-                  None
-                };
-                if ident.is_class_expr_with_ident {
-                  all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                  continue;
-                }
-                if scope != top_level_scope_id {
-                  all_used_names.insert(Atom::from(ident.id.sym.as_str()));
-                }
-                let legacy = legacy.unwrap_or_else(|| ident.to_legacy(&semantic));
-                concate_info.idents.push(legacy.clone());
-                binding_to_ref
-                  .entry((legacy.id.sym.clone(), legacy.id.ctxt))
-                  .or_default()
-                  .push(legacy);
-              }
-
-              concate_info.all_used_names = all_used_names;
-              concate_info.binding_to_ref = binding_to_ref;
-              concate_info.has_ast = true;
-              concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
-              concate_info.internal_source = Some(render_source.source.clone());
-              concate_info.runtime_requirements = runtime_requirements;
-              concate_info.chunk_init_fragments = codegen_res
-                .data()
-                .get::<CodeGenerationDataChunkInitFragments>()
-                .map(|fragments| fragments.inner().clone())
-                .unwrap_or_default();
-              concate_info
-                .chunk_init_fragments
-                .extend(chunk_init_fragments);
-              if let Some(CodeGenerationPublicPathAutoReplace(true)) =
-                codegen_res
+                let chunk_init_fragments = codegen_res
                   .data()
-                  .get::<CodeGenerationPublicPathAutoReplace>()
-              {
-                concate_info.public_path_auto_replacement = Some(true);
+                  .get::<CodeGenerationDataChunkInitFragments>()
+                  .map(|fragments| fragments.inner().clone())
+                  .unwrap_or_default();
+                Ok((
+                  ModuleInfo::External(external_module_info),
+                  if chunk_init_fragments.is_empty() {
+                    None
+                  } else {
+                    Some((id, chunk_init_fragments))
+                  },
+                ))
               }
-              if codegen_res.data().contains::<URLStaticMode>() {
-                concate_info.static_url_replacement = true;
+              rspack_core::ModuleInfo::Concatenated(mut concate_info) => {
+                let hooks = JsPlugin::get_compilation_hooks(compilation.id());
+                let hooks = hooks.read().await;
+
+                let module = module_graph
+                  .module_by_identifier(&id)
+                  .expect("should have module");
+                let codegen_res = compilation.code_generation_results.get(&id, None);
+                let Some(js_source) = codegen_res.get(&SourceType::JavaScript) else {
+                  return Ok((ModuleInfo::Concatenated(concate_info), None));
+                };
+                let concatenation_scope_output = codegen_res
+                  .data()
+                  .get::<CodeGenerationDataConcatenationScopeOutput>()
+                  .expect("should have concatenation scope output for scope hoisted module");
+
+                let mut render_source = RenderSource {
+                  source: js_source.clone(),
+                };
+                let mut runtime_requirements = *codegen_res.runtime_requirements();
+
+                let mut chunk_init_fragments = vec![];
+                hooks
+                  .render_module_content
+                  .call(
+                    compilation,
+                    &chunk_ukey,
+                    module.as_ref(),
+                    &mut render_source,
+                    &mut runtime_requirements,
+                    &mut chunk_init_fragments,
+                    runtime_template,
+                  )
+                  .await?;
+                concatenation_scope_output.apply_to(&mut concate_info);
+
+                let jsx = module
+                  .as_ref()
+                  .as_normal_module()
+                  .and_then(|normal_module| normal_module.get_parser_options())
+                  .and_then(|options| {
+                    options
+                      .get_javascript()
+                      .and_then(|js_options| js_options.jsx)
+                  })
+                  .unwrap_or(false);
+                let source_str = render_source
+                  .source
+                  .source()
+                  .into_string_lossy()
+                  .into_owned();
+                analyze_module_scope(&source_str, jsx, &mut concate_info)?;
+                concate_info.source = Some(ReplaceSource::new(render_source.source.clone()));
+                concate_info.internal_source = Some(render_source.source.clone());
+                concate_info.runtime_requirements = runtime_requirements;
+                concate_info.chunk_init_fragments = codegen_res
+                  .data()
+                  .get::<CodeGenerationDataChunkInitFragments>()
+                  .map(|fragments| fragments.inner().clone())
+                  .unwrap_or_default();
+                concate_info
+                  .chunk_init_fragments
+                  .extend(chunk_init_fragments);
+                if let Some(CodeGenerationPublicPathAutoReplace(true)) =
+                  codegen_res
+                    .data()
+                    .get::<CodeGenerationPublicPathAutoReplace>()
+                {
+                  concate_info.public_path_auto_replacement = Some(true);
+                }
+                if codegen_res.data().contains::<URLStaticMode>() {
+                  concate_info.static_url_replacement = true;
+                }
+                Ok((ModuleInfo::Concatenated(concate_info), None))
               }
-              Ok((ModuleInfo::Concatenated(concate_info), None))
             }
-          }
-        })
+          },
+        )
       }
     })
     .await;
@@ -2044,22 +1797,21 @@ var {} = {{}};
     current_chunk: ChunkUkey,
     entry_chunk: ChunkUkey,
     compilation: &Compilation,
-    concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
+    binding_resolver: &mut ConcatenationBindingResolver,
     required: &mut IdentifierIndexMap<ExternalInterop>,
     link: &mut FxHashMap<ChunkUkey, ChunkLinkContext>,
     needed_namespace_objects: &mut IdentifierIndexSet,
     entry_imports: &mut IdentifierIndexMap<FxHashMap<Atom, Atom>>,
     exports: &mut FxHashMap<ChunkUkey, ExportsContext>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
     allow_rename: bool,
     filter_unused: bool,
     re_export_star_cache: &mut IdentifierMap<FxIndexSet<Either<Atom, ModuleIdentifier>>>,
   ) -> Vec<Diagnostic> {
     let mut errors = vec![];
-    let context = &compilation.options.context;
-    let module_graph = compilation.get_module_graph();
+    let module_graph = binding_resolver.context.module_graph;
 
-    let exports_info = compilation
+    let exports_info = binding_resolver
+      .context
       .exports_info_artifact
       .get_exports_info_data(&entry_module);
 
@@ -2081,11 +1833,11 @@ var {} = {{}};
     Self::resolve_re_export_star_from_unknown(
       entry_module,
       module_graph,
-      &compilation.module_graph_cache_artifact,
+      binding_resolver.context.module_graph_cache,
       &compilation
         .build_module_graph_artifact
         .side_effects_state_artifact,
-      &compilation.exports_info_artifact,
+      binding_resolver.context.exports_info_artifact,
       // When filter_unused is true, own exports are already collected and filtered
       // by usage above — only collect `export *` targets here.
       // When filter_unused is false (entry modules), also collect own exports.
@@ -2106,14 +1858,14 @@ var {} = {{}};
 
     let exports_type = module.get_exports_type(
       module_graph,
-      &compilation.module_graph_cache_artifact,
-      &compilation.exports_info_artifact,
+      binding_resolver.context.module_graph_cache,
+      binding_resolver.context.exports_info_artifact,
       module.build_meta().strict_esm_module(),
     );
 
     if matches!(exports_type, ExportsType::DefaultOnly) {
       Self::export_namespace_as_default(
-        concate_modules_map,
+        &mut *binding_resolver.module_to_info_map,
         entry_module,
         current_chunk,
         entry_chunk,
@@ -2131,20 +1883,16 @@ var {} = {{}};
         }
 
         let chunk_link = link.get_mut_unwrap(&current_chunk);
-        let Some(binding) = Self::get_binding(
+        let Some(binding) = self.get_binding(
           None,
-          module_graph,
-          &compilation.module_graph_cache_artifact,
-          &compilation.exports_info_artifact,
+          binding_resolver,
           &entry_module,
           vec![name.clone()],
-          concate_modules_map,
           needed_namespace_objects,
           false,
           false,
           module.build_meta().strict_esm_module(),
           None,
-          &mut Default::default(),
           required,
           &mut chunk_link.used_names,
         ) else {
@@ -2160,7 +1908,7 @@ var {} = {{}};
                 continue;
               }
             };
-            let ref_info = &mut concate_modules_map[&symbol_binding.module];
+            let ref_info = &mut binding_resolver.module_to_info_map[&symbol_binding.module];
 
             match ref_info {
               ModuleInfo::External(_) => {
@@ -2252,11 +2000,11 @@ var {} = {{}};
               .expect("should have current chunk link");
             if let Some(local_name) = Self::get_same_chunk_inlined_export_binding(
               module_graph,
-              &compilation.exports_info_artifact,
+              binding_resolver.context.exports_info_artifact,
               &entry_module,
               vec![name.clone()],
               current_chunk_link,
-              concate_modules_map,
+              binding_resolver.module_to_info_map,
               &mut Default::default(),
             ) {
               let exported = Self::add_chunk_export_alias(
@@ -2300,12 +2048,7 @@ var {} = {{}};
             let new_name = find_new_name(
               &name,
               &entry_chunk_link.used_names,
-              &escaped_identifiers[&get_cached_readable_identifier(
-                &entry_module,
-                module_graph,
-                &compilation.module_static_cache,
-                context,
-              )],
+              binding_resolver.context.module_identifier(&entry_module),
             );
             if Self::add_chunk_export(
               entry_chunk,
@@ -2327,7 +2070,7 @@ var {} = {{}};
 
       if matches!(exports_type, ExportsType::DefaultWithNamed) {
         Self::export_namespace_as_default(
-          concate_modules_map,
+          &mut *binding_resolver.module_to_info_map,
           entry_module,
           current_chunk,
           entry_chunk,
@@ -2358,7 +2101,7 @@ var {} = {{}};
         .insert(START_EXPORTS.clone());
     }
 
-    if concate_modules_map[&entry_module].is_external() {
+    if binding_resolver.module_to_info_map[&entry_module].is_external() {
       // execute
       Self::add_require(
         entry_module,
@@ -2376,15 +2119,13 @@ var {} = {{}};
   fn link_imports_and_exports(
     &self,
     compilation: &Compilation,
+    binding_resolver: &mut ConcatenationBindingResolver,
     link: &mut FxHashMap<ChunkUkey, ChunkLinkContext>,
     runtime_chunks_exporting_require_via_runtime_module: &FxHashSet<ChunkUkey>,
-    concate_modules_map: &mut IdentifierIndexMap<ModuleInfo>,
     needed_namespace_objects_by_ukey: &mut FxHashMap<ChunkUkey, IdentifierIndexSet>,
-    escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
   ) -> Vec<Diagnostic> {
     let mut errors = vec![];
-    let context = &compilation.options.context;
-    let module_graph = compilation.get_module_graph();
+    let module_graph = binding_resolver.context.module_graph;
 
     // Cache for resolve_re_export_star_from_unknown to avoid redundant
     // traversals of the same module's export * chains across entry modules.
@@ -2478,13 +2219,12 @@ var {} = {{}};
           entry_module_chunk,
           entry_chunk_ukey,
           compilation,
-          concate_modules_map,
+          binding_resolver,
           required,
           link,
           needed_namespace,
           entry_imports,
           &mut exports,
-          escaped_identifiers,
           false,
           false,
           &mut re_export_star_cache,
@@ -2541,7 +2281,7 @@ var {} = {{}};
 
           entry_imports.entry(*entry_module).or_default();
 
-          if concate_modules_map[entry_module].is_external() {
+          if binding_resolver.module_to_info_map[entry_module].is_external() {
             let require_info = Self::add_require(
               *entry_module,
               None,
@@ -2632,13 +2372,12 @@ var {} = {{}};
           module_chunk,
           module_chunk,
           compilation,
-          concate_modules_map,
+          binding_resolver,
           required,
           link,
           needed_namespace,
           module_imports,
           &mut exports,
-          escaped_identifiers,
           false,
           false,
           &mut re_export_star_cache,
@@ -2742,13 +2481,12 @@ var {} = {{}};
             source_chunk,
             target_chunk,
             compilation,
-            concate_modules_map,
+            binding_resolver,
             required,
             link,
             needed_namespace,
             target_imports,
             &mut exports,
-            escaped_identifiers,
             allow_rename,
             true,
             &mut re_export_star_cache,
@@ -2771,7 +2509,7 @@ var {} = {{}};
         .iter()
         .chain(chunk_link.hoisted_modules.iter())
       {
-        let info = &concate_modules_map[m];
+        let info = &binding_resolver.module_to_info_map[m];
         let runtime_requirements = info.get_runtime_requirements();
         if !runtime_requirements.is_empty() && runtime_chunk != *chunk {
           if compilation.runtime_template.render_mode() == RuntimeTemplateRenderMode::RspackExport {
@@ -2840,11 +2578,11 @@ var {} = {{}};
               && conn.is_target_active(
                 module_graph,
                 None,
-                &compilation.module_graph_cache_artifact,
+                binding_resolver.context.module_graph_cache,
                 &compilation
                   .build_module_graph_artifact
                   .side_effects_state_artifact,
-                &compilation.exports_info_artifact,
+                binding_resolver.context.exports_info_artifact,
               )
             {
               chunk_imports.entry(ref_module).or_default();
@@ -2855,16 +2593,16 @@ var {} = {{}};
           if !conn.is_target_active(
             module_graph,
             None,
-            &compilation.module_graph_cache_artifact,
+            binding_resolver.context.module_graph_cache,
             &compilation
               .build_module_graph_artifact
               .side_effects_state_artifact,
-            &compilation.exports_info_artifact,
+            binding_resolver.context.exports_info_artifact,
           ) {
             continue;
           }
 
-          let outgoing_module_info = &concate_modules_map[conn.module_identifier()];
+          let outgoing_module_info = &binding_resolver.module_to_info_map[conn.module_identifier()];
 
           //ensure chunk
           chunk_imports.entry(ref_module).or_default();
@@ -2904,20 +2642,16 @@ var {} = {{}};
               continue;
             }
 
-            let Some(binding) = Self::get_binding(
+            let Some(binding) = self.get_binding(
               Some(*m),
-              module_graph,
-              &compilation.module_graph_cache_artifact,
-              &compilation.exports_info_artifact,
+              binding_resolver,
               ref_module,
               options.ids.clone(),
-              concate_modules_map,
               needed_namespace_objects,
               options.call,
               !options.direct_import,
               module.build_meta().strict_esm_module(),
               options.asi_safe,
-              &mut Default::default(),
               required,
               &mut chunk_link.used_names,
             ) else {
@@ -2969,7 +2703,7 @@ var {} = {{}};
             continue;
           }
         };
-        let info = &concate_modules_map[&m];
+        let info = &binding_resolver.module_to_info_map[&m];
         let from_external = matches!(info, ModuleInfo::External(_));
         let needs_import_chunk = ref_chunk != *chunk;
 
@@ -2979,17 +2713,11 @@ var {} = {{}};
         }
 
         if needs_import_chunk && !from_external {
-          let readable_identifier = get_cached_readable_identifier(
-            &m,
-            module_graph,
-            &compilation.module_static_cache,
-            context,
-          );
           let (orig_symbol, local_symbol) = if all_used_names.contains(&symbol) {
             let new_symbol = find_new_name(
               &symbol,
               all_used_names,
-              &escaped_identifiers[&readable_identifier],
+              binding_resolver.context.module_identifier(&m),
             );
             all_used_names.insert(new_symbol.clone());
 
@@ -3041,11 +2769,11 @@ var {} = {{}};
           if !conn.is_target_active(
             module_graph,
             None,
-            &compilation.module_graph_cache_artifact,
+            binding_resolver.context.module_graph_cache,
             &compilation
               .build_module_graph_artifact
               .side_effects_state_artifact,
-            &compilation.exports_info_artifact,
+            binding_resolver.context.exports_info_artifact,
           ) {
             continue;
           }
@@ -3193,202 +2921,233 @@ var {} = {{}};
   // the final name is the exact symbol in ref chunk
   #[allow(clippy::too_many_arguments)]
   fn get_binding(
+    &self,
     from: Option<ModuleIdentifier>,
-    mg: &ModuleGraph,
-    mg_cache: &ModuleGraphCacheArtifact,
-    exports_info_artifact: &ExportsInfoArtifact,
+    binding_resolver: &mut ConcatenationBindingResolver,
     info_id: &ModuleIdentifier,
-    mut export_name: Vec<Atom>,
-    module_to_info_map: &mut IdentifierIndexMap<ModuleInfo>,
+    export_name: Vec<Atom>,
     needed_namespace_objects: &mut IdentifierIndexSet,
     as_call: bool,
     call_context: bool,
     strict_esm_module: bool,
     asi_safe: Option<bool>,
-    already_visited: &mut FxHashSet<ExportInfo>,
     required: &mut IdentifierIndexMap<ExternalInterop>,
     all_used_names: &mut FxHashSet<Atom>,
   ) -> Option<Ref> {
-    let module = mg
-      .module_by_identifier(info_id)
-      .expect("should have module");
-    let exports_type =
-      module.get_exports_type(mg, mg_cache, exports_info_artifact, strict_esm_module);
-    if Self::is_source_phase_external(mg, info_id)
-      && export_name
-        .first()
-        .is_some_and(|name| name.as_str() == "default")
-    {
-      export_name.remove(0);
-    }
-    let info = &mut module_to_info_map[info_id];
+    let ConcatenationBindingPlan {
+      info_id,
+      export_name,
+      target,
+      ..
+    } = binding_resolver.resolve(info_id, export_name, strict_esm_module);
+    let module_to_info_map = &mut *binding_resolver.module_to_info_map;
 
-    if export_name.is_empty() {
-      match exports_type {
-        ExportsType::DefaultOnly => {
-          info.set_interop_namespace_object2_used(true);
-          let symbol = match info {
-            ModuleInfo::External(info) => {
-              let required_info = Self::add_require(
-                *info_id,
+    match target {
+      ConcatenationBindingTarget::InteropNamespace(kind) => {
+        let info = &mut module_to_info_map[&info_id];
+        let symbol = match kind {
+          ConcatenationInterop::Namespace => {
+            info.set_interop_namespace_object_used(true);
+            match info {
+              ModuleInfo::External(info) => Self::add_require(
+                info_id,
                 from,
                 Some(info.name.clone().expect("should have name")),
                 all_used_names,
                 required,
-              );
-              required_info.namespace2(all_used_names)
-            }
-            ModuleInfo::Concatenated(info) => info
-              .interop_namespace_object2_name
-              .clone()
-              .expect("should already set interop namespace"),
-          };
-
-          return Some(Ref::Symbol(SymbolRef::new(
-            *info_id,
-            symbol,
-            export_name.clone(),
-            Arc::new(move |binding| binding.symbol.to_string()),
-          )));
-        }
-        ExportsType::DefaultWithNamed => {
-          info.set_interop_namespace_object_used(true);
-          let symbol = match info {
-            ModuleInfo::External(external_info) => {
-              let required_info = Self::add_require(
-                *info_id,
-                from,
-                Some(external_info.name.clone().expect("should have name")),
-                all_used_names,
-                required,
-              );
-              required_info.namespace(all_used_names)
-            }
-            ModuleInfo::Concatenated(info) => info
-              .interop_namespace_object_name
-              .clone()
-              .expect("should already set interop namespace"),
-          };
-
-          return Some(Ref::Symbol(SymbolRef::new(
-            *info_id,
-            symbol,
-            export_name.clone(),
-            Arc::new(|binding| binding.symbol.to_string()),
-          )));
-        }
-        _ => {}
-      }
-    } else {
-      match exports_type {
-        // normal case
-        ExportsType::Namespace => {}
-        ExportsType::DefaultWithNamed => match export_name.first().map(|atom| atom.as_str()) {
-          Some("default") => {
-            export_name = export_name[1..].to_vec();
-          }
-          Some("__esModule") => {
-            return Some(es_module_binding());
-          }
-          _ => {}
-        },
-        ExportsType::DefaultOnly => {
-          if export_name.first().map(|item| item.as_str()) == Some("__esModule") {
-            return Some(es_module_binding());
-          }
-
-          let first_export_id = export_name.remove(0);
-          if first_export_id != "default" {
-            return Some(Ref::Inline(
-              "/* non-default import from default-exporting module */undefined".into(),
-            ));
-          }
-        }
-        ExportsType::Dynamic => match export_name.first().map(|atom| atom.as_str()) {
-          Some("default") => {
-            // shadowing the previous immutable ref to avoid violating rustc borrow rules
-            info.set_interop_default_access_used(true);
-            let symbol = match info {
-              ModuleInfo::External(info) => {
-                let required_info = Self::add_require(
-                  *info_id,
-                  from,
-                  Some(info.name.clone().expect("should have name")),
-                  all_used_names,
-                  required,
-                );
-                required_info.default_access(all_used_names)
-              }
+              )
+              .namespace(all_used_names),
               ModuleInfo::Concatenated(info) => info
-                .interop_default_access_name
+                .interop_namespace_object_name
                 .clone()
                 .expect("should already set interop namespace"),
+            }
+          }
+          ConcatenationInterop::Namespace2 => {
+            info.set_interop_namespace_object2_used(true);
+            match info {
+              ModuleInfo::External(info) => Self::add_require(
+                info_id,
+                from,
+                Some(info.name.clone().expect("should have name")),
+                all_used_names,
+                required,
+              )
+              .namespace2(all_used_names),
+              ModuleInfo::Concatenated(info) => info
+                .interop_namespace_object2_name
+                .clone()
+                .expect("should already set interop namespace"),
+            }
+          }
+        };
+
+        return Some(Ref::Symbol(SymbolRef::new(
+          info_id,
+          symbol,
+          export_name,
+          Arc::new(|binding| binding.symbol.to_string()),
+        )));
+      }
+      ConcatenationBindingTarget::InteropDefault => {
+        let info = &mut module_to_info_map[&info_id];
+        info.set_interop_default_access_used(true);
+        let symbol = match info {
+          ModuleInfo::External(info) => Self::add_require(
+            info_id,
+            from,
+            Some(info.name.clone().expect("should have name")),
+            all_used_names,
+            required,
+          )
+          .default_access(all_used_names),
+          ModuleInfo::Concatenated(info) => info
+            .interop_default_access_name
+            .clone()
+            .expect("should already set interop namespace"),
+        };
+
+        return Some(Ref::Symbol(SymbolRef::new(
+          info_id,
+          symbol,
+          export_name,
+          Arc::new(move |binding| {
+            let default_access_name = &binding.symbol;
+            let default_export = if as_call {
+              format!("{default_access_name}()")
+            } else if let Some(true) = asi_safe {
+              format!("({default_access_name}())")
+            } else if let Some(false) = asi_safe {
+              format!(";({default_access_name}())")
+            } else {
+              format!("{default_access_name}.a")
             };
 
-            export_name = export_name[1..].to_vec();
+            let exports = format!("{default_export}{}", property_access(&binding.ids, 0));
 
-            return Some(Ref::Symbol(SymbolRef::new(
-              *info_id,
-              symbol,
-              export_name.clone(),
-              Arc::new(move |binding| {
-                let default_access_name = &binding.symbol;
-                let default_export = if as_call {
-                  format!("{default_access_name}()")
-                } else if let Some(true) = asi_safe {
-                  format!("({default_access_name}())")
-                } else if let Some(false) = asi_safe {
-                  format!(";({default_access_name}())")
-                } else {
-                  format!("{default_access_name}.a")
-                };
+            if !binding.ids.is_empty() && as_call && !call_context {
+              return if asi_safe.unwrap_or_default() {
+                format!("(0,{exports})")
+              } else if let Some(_asi_safe) = asi_safe {
+                format!(";(0,{exports})")
+              } else {
+                format!("/*#__PURE__*/Object({exports})")
+              };
+            }
 
-                let exports = format!("{default_export}{}", property_access(&binding.ids, 0));
-
-                if !binding.ids.is_empty() && as_call && !call_context {
-                  return if asi_safe.unwrap_or_default() {
-                    format!("(0,{exports})")
-                  } else if let Some(_asi_safe) = asi_safe {
-                    format!(";(0,{exports})")
-                  } else {
-                    format!("/*#__PURE__*/Object({exports})")
-                  };
-                }
-
-                exports
-              }),
-            )));
-          }
-          Some("__esModule") => {
-            return Some(es_module_binding());
-          }
-          _ => {}
-        },
+            exports
+          }),
+        )));
       }
-    }
-
-    let exports_info = exports_info_artifact.get_exports_info_data(info_id);
-
-    if export_name.is_empty() {
-      let info = module_to_info_map.get_mut_unwrap(info_id);
-      match info {
+      ConcatenationBindingTarget::EsModule(_) => return Some(es_module_binding()),
+      ConcatenationBindingTarget::UnsupportedDefaultImport => {
+        return Some(Ref::Inline(
+          "/* non-default import from default-exporting module */undefined".into(),
+        ));
+      }
+      ConcatenationBindingTarget::Namespace => match module_to_info_map.get_mut_unwrap(&info_id) {
         ModuleInfo::Concatenated(info) => {
           needed_namespace_objects.insert(info.module);
-          return Some(Ref::Symbol(SymbolRef::new(
+          Some(Ref::Symbol(SymbolRef::new(
             info.module,
             info
               .namespace_object_name
               .clone()
               .expect("should have namespace_object_name"),
-            vec![],
+            export_name,
             Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-          )));
+          )))
         }
-        ModuleInfo::External(info) => {
-          return Some(Ref::Symbol(SymbolRef::new(
-            info.module,
+        ModuleInfo::External(info) => Some(Ref::Symbol(SymbolRef::new(
+          info.module,
+          Self::add_require(
+            info_id,
+            from,
+            Some(info.name.clone().expect("should have symbol")),
+            all_used_names,
+            required,
+          )
+          .required_symbol
+          .clone()
+          .expect("should have name"),
+          export_name,
+          Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
+        ))),
+      },
+      ConcatenationBindingTarget::Circular => Some(Ref::Inline(
+        "/* circular reexport */ Object(function x() { x() }())".into(),
+      )),
+      ConcatenationBindingTarget::Direct { symbol, used_name } => match used_name {
+        Some(UsedName::Normal(used_name)) => {
+          let info = module_to_info_map[&info_id].as_concatenated();
+          let symbol = info
+            .get_internal_name(&symbol)
+            .unwrap_or_else(|| panic!("should set internal name for {symbol}"));
+          Some(Ref::Symbol(SymbolRef::new(
+            info_id,
+            symbol.clone(),
+            used_name[1..].to_vec(),
+            Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
+          )))
+        }
+        Some(UsedName::Inlined(inlined)) => Some(Ref::Inline(inlined.render(&to_normal_comment(
+          &format!("inlined export {}", property_access(&export_name, 0)),
+        )))),
+        None => Some(Ref::Inline("/* unused export */ undefined".into())),
+      },
+      ConcatenationBindingTarget::Raw(symbol) => {
+        let info = module_to_info_map[&info_id].as_concatenated();
+        let name = info.get_internal_name(&symbol).unwrap_or(&symbol);
+        Some(Ref::Symbol(SymbolRef::new(
+          info_id,
+          name.clone(),
+          export_name[1..].to_vec(),
+          Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
+        )))
+      }
+      ConcatenationBindingTarget::Inlined(used_name) => {
+        let UsedName::Inlined(inlined) = used_name else {
+          unreachable!("inlined binding plan should contain an inlined used name")
+        };
+        Some(Ref::Inline(inlined.inlined_value().render(
+          &to_normal_comment(&format!(
+            "inlined export {}",
+            property_access(&export_name, 0)
+          )),
+        )))
+      }
+      ConcatenationBindingTarget::NamespaceExport(used_name) => {
+        let info = module_to_info_map[&info_id].as_concatenated();
+        Some(match used_name {
+          UsedName::Normal(used_name) => Ref::Symbol(SymbolRef::new(
+            info_id,
+            info
+              .namespace_object_name
+              .clone()
+              .expect("should have namespace_object_name"),
+            used_name,
+            Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
+          )),
+          UsedName::Inlined(inlined) => Ref::Inline(inlined.render("")),
+        })
+      }
+      ConcatenationBindingTarget::Missing(used_name) => {
+        if let Some(UsedName::Inlined(inlined)) = used_name {
+          Some(Ref::Inline(inlined.render(&to_normal_comment(&format!(
+            "inlined export {}",
+            property_access(&export_name, 0)
+          )))))
+        } else {
+          None
+        }
+      }
+      ConcatenationBindingTarget::External(used_name) => {
+        let info = module_to_info_map[&info_id].as_external();
+        Some(match used_name {
+          Some(UsedName::Normal(used_name)) => Ref::Symbol(SymbolRef::new(
+            info_id,
             Self::add_require(
-              *info_id,
+              info_id,
               from,
               Some(info.name.clone().expect("should have symbol")),
               all_used_names,
@@ -3396,219 +3155,17 @@ var {} = {{}};
             )
             .required_symbol
             .clone()
-            .expect("should have name"),
-            vec![],
+            .expect("should have symbol"),
+            used_name,
             Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-          )));
-        }
+          )),
+          Some(UsedName::Inlined(inlined)) => Ref::Inline(inlined.render(&to_normal_comment(
+            &format!("inlined export {}", property_access(&export_name, 0)),
+          ))),
+          None => Ref::Inline("/* unused export */ undefined".into()),
+        })
       }
     }
-
-    let export_info = exports_info.get_export_info_without_mut_module_graph(&export_name[0]);
-    let export_info_id = export_info.id();
-
-    if already_visited.contains(&export_info_id) {
-      return Some(Ref::Inline(
-        "/* circular reexport */ Object(function x() { x() }())".into(),
-      ));
-    }
-
-    already_visited.insert(export_info_id);
-
-    let info = &module_to_info_map[info_id];
-    match info {
-      ModuleInfo::Concatenated(info) => {
-        let export_id = export_name.first().cloned();
-        if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {
-          let info = module_to_info_map
-            .get_mut_unwrap(info_id)
-            .as_concatenated_mut();
-          needed_namespace_objects.insert(info.module);
-
-          return Some(Ref::Symbol(SymbolRef::new(
-            info.module,
-            info
-              .namespace_object_name
-              .clone()
-              .expect("should have namespace_object"),
-            export_name.clone(),
-            Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-          )));
-        }
-
-        let used_name = exports_info.get_used_name(exports_info_artifact, None, &export_name);
-        if let Some(ref export_id) = export_id
-          && let Some(direct_export) = info.export_map.as_ref().and_then(|map| map.get(export_id))
-        {
-          if let Some(used_name) = used_name {
-            match used_name {
-              UsedName::Normal(used_name) => {
-                let direct_export = Atom::new(direct_export.clone());
-                let symbol = info
-                  .get_internal_name(&direct_export)
-                  .unwrap_or_else(|| panic!("should set internal name for {direct_export}"));
-
-                return Some(Ref::Symbol(SymbolRef::new(
-                  info.module,
-                  symbol.clone(),
-                  used_name[1..].to_vec(),
-                  Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-                )));
-              }
-              UsedName::Inlined(inlined) => {
-                return Some(Ref::Inline(inlined.render(&to_normal_comment(&format!(
-                  "inlined export {}",
-                  property_access(&export_name, 0)
-                )))));
-              }
-            }
-          } else {
-            return Some(Ref::Inline("/* unused export */ undefined".into()));
-          }
-        }
-
-        if let Some(ref export_id) = export_id
-          && let Some(raw_export) = info
-            .raw_export_map
-            .as_ref()
-            .and_then(|map| map.get(export_id))
-        {
-          let raw_export_symbol: Atom = raw_export.clone().into();
-          let name = info
-            .get_internal_name(&raw_export_symbol)
-            .unwrap_or(&raw_export_symbol);
-          return Some(Ref::Symbol(SymbolRef::new(
-            info.module,
-            name.clone(),
-            export_name[1..].to_vec(),
-            Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-          )));
-        }
-
-        let reexport = find_target(
-          &export_info,
-          mg,
-          exports_info_artifact,
-          Arc::new(|module: &ModuleIdentifier| module_to_info_map.contains_key(module)),
-          &mut Default::default(),
-        );
-        match reexport {
-          FindTargetResult::NoTarget => {}
-          FindTargetResult::InvalidTarget(target) => {
-            if let Some(export) = target.export {
-              let exports_info = exports_info_artifact.get_exports_info_data(&target.module);
-              if let Some(UsedName::Inlined(inlined)) =
-                exports_info.get_used_name(exports_info_artifact, None, &export)
-              {
-                return Some(Ref::Inline(inlined.inlined_value().render(
-                  &to_normal_comment(&format!(
-                    "inlined export {}",
-                    property_access(&export_name, 0)
-                  )),
-                )));
-              }
-            }
-            panic!(
-              "Target module of reexport is not part of the concatenation (export '{:?}')",
-              &export_id
-            );
-          }
-          FindTargetResult::ValidTarget(reexport) => {
-            if let Some(ref_info) = module_to_info_map.get(&reexport.module) {
-              let build_meta = mg
-                .module_by_identifier(info_id)
-                .expect("should have module")
-                .build_meta();
-
-              return Self::get_binding(
-                from,
-                mg,
-                mg_cache,
-                exports_info_artifact,
-                &ref_info.id(),
-                if let Some(reexport_export) = reexport.export {
-                  [reexport_export, export_name[1..].to_vec()].concat()
-                } else {
-                  export_name[1..].to_vec()
-                },
-                module_to_info_map,
-                needed_namespace_objects,
-                as_call,
-                call_context,
-                build_meta.strict_esm_module(),
-                asi_safe,
-                already_visited,
-                required,
-                all_used_names,
-              );
-            }
-          }
-        }
-
-        if info.namespace_export_symbol.is_some() {
-          // That's how webpack write https://github.com/webpack/webpack/blob/1f99ad6367f2b8a6ef17cce0e058f7a67fb7db18/lib/optimize/ConcatenatedModule.js#L463-L471
-          let used_name = exports_info
-            .get_used_name(exports_info_artifact, None, &export_name)
-            .expect("should have export name");
-          return Some(match used_name {
-            UsedName::Normal(used_name) => Ref::Symbol(SymbolRef::new(
-              info.module,
-              info
-                .namespace_object_name
-                .clone()
-                .expect("should have namespace_object_name"),
-              used_name,
-              Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-            )),
-            // Inlined namespace export symbol is not possible for now but we compat it here
-            UsedName::Inlined(inlined) => Ref::Inline(inlined.render("")),
-          });
-        }
-
-        if let Some(UsedName::Inlined(inlined)) = used_name {
-          return Some(Ref::Inline(inlined.render(&to_normal_comment(&format!(
-            "inlined export {}",
-            property_access(&export_name, 0)
-          )))));
-        }
-
-        None
-      }
-      ModuleInfo::External(info) => {
-        if let Some(used_name) =
-          exports_info.get_used_name(exports_info_artifact, None, &export_name)
-        {
-          Some(match used_name {
-            UsedName::Normal(used_name) => Ref::Symbol(SymbolRef::new(
-              info.module,
-              Self::add_require(
-                *info_id,
-                from,
-                Some(info.name.clone().expect("should have symbol")),
-                all_used_names,
-                required,
-              )
-              .required_symbol
-              .clone()
-              .expect("should have symbol"),
-              used_name,
-              Arc::new(move |binding| normal_render(binding, as_call, call_context, asi_safe)),
-            )),
-            UsedName::Inlined(inlined) => Ref::Inline(inlined.render(&to_normal_comment(
-              &format!("inlined export {}", property_access(&export_name, 0)),
-            ))),
-          })
-        } else {
-          Some(Ref::Inline("/* unused export */ undefined".into()))
-        }
-      }
-    }
-  }
-
-  fn is_source_phase_external(mg: &ModuleGraph, module_id: &ModuleIdentifier) -> bool {
-    mg.module_by_identifier(module_id)
-      .and_then(|module| module.as_external_module())
-      .is_some_and(|external_module| external_module.get_import_phase().is_source())
   }
 }
 

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1219,17 +1219,15 @@ var {} = {{}};
               .get_internal_name(namespace_export_symbol)
               .cloned()
               .unwrap_or_else(|| {
-                name_allocator.find_new_module_name(
+                name_allocator.find_new_name(
                   "namespaceObject",
-                  &concate_info.module,
-                  concatenation_context,
+                  concatenation_context.module_identifier(&concate_info.module),
                 )
               })
           } else {
-            name_allocator.find_new_module_name(
+            name_allocator.find_new_name(
               "namespaceObject",
-              &concate_info.module,
-              concatenation_context,
+              concatenation_context.module_identifier(&concate_info.module),
             )
           }
         };

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -17,8 +17,8 @@ use rspack_core::{
   ModuleIdentifier, ModuleInfo, NAMESPACE_OBJECT_EXPORT, RuntimeGlobals, RuntimeGlobalsRenderMode,
   RuntimeTemplateRenderMode, RuntimeVariable, SideEffectsStateArtifact, SourceType, URLStaticMode,
   UsageState, UsedName, UsedNameItem, all_runtime_module_variables, analyze_module_scope,
-  find_new_name, find_target, get_cached_readable_identifier, get_module_directives,
-  get_module_hashbang, property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
+  find_target, get_cached_readable_identifier, get_module_directives, get_module_hashbang,
+  property_access, property_name, reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::ReplaceSource, to_normal_comment,
 };
 use rspack_error::{Diagnostic, Result};
@@ -279,22 +279,16 @@ impl EsmLibraryPlugin {
 
   fn assign_external_candidate_name(
     readable_identifier: &str,
-    candidate_used_names: &mut FxHashSet<Atom>,
+    name_allocator: &mut ConcatenationNameAllocator,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
   ) -> Atom {
-    let name = find_new_name(
-      "",
-      candidate_used_names,
-      &escaped_identifiers[readable_identifier],
-    );
-    candidate_used_names.insert(name.clone());
-    name
+    name_allocator.find_new_name("", &escaped_identifiers[readable_identifier])
   }
 
   fn register_preserved_asset_imports(
     compilation: &Compilation,
     chunk_link: &mut ChunkLinkContext,
-    used_names: &mut FxHashSet<Atom>,
+    name_allocator: &mut ConcatenationNameAllocator,
     escaped_identifiers: &FxHashMap<String, Vec<Atom>>,
   ) {
     // Follow module externals: imports are owned by the chunk link context, so their bindings are
@@ -328,7 +322,8 @@ impl EsmLibraryPlugin {
             &compilation.module_static_cache,
             &compilation.options.context,
           );
-          let binding = find_new_name("", used_names, &escaped_identifiers[&readable_identifier]);
+          let binding =
+            name_allocator.find_new_name("", &escaped_identifiers[&readable_identifier]);
           chunk_link
             .raw_import_stmts
             .entry(source)
@@ -337,7 +332,7 @@ impl EsmLibraryPlugin {
           binding
         });
 
-      used_names.insert(binding);
+      name_allocator.insert(binding);
     }
   }
 
@@ -716,7 +711,7 @@ impl EsmLibraryPlugin {
                 strict_esm_module,
                 Some(true),
                 &mut chunk_link.required,
-                &mut chunk_link.used_names,
+                &mut chunk_link.name_allocator,
               ) else {
                 continue;
               };
@@ -781,17 +776,14 @@ impl EsmLibraryPlugin {
                     if let Some(existing_local) = existing_local {
                       symbol_binding.symbol = existing_local.clone();
                     } else {
-                      let local_name = if chunk_link.used_names.contains(&symbol_binding.symbol) {
-                        let new_name = find_new_name(
-                          symbol_binding.symbol.as_str(),
-                          &chunk_link.used_names,
-                          &[],
-                        );
-                        chunk_link.used_names.insert(new_name.clone());
-                        new_name
+                      let local_name = if chunk_link.name_allocator.contains(&symbol_binding.symbol)
+                      {
+                        chunk_link
+                          .name_allocator
+                          .find_new_name(symbol_binding.symbol.as_str(), &[])
                       } else {
                         let local_name = symbol_binding.symbol.clone();
-                        chunk_link.used_names.insert(local_name.clone());
+                        chunk_link.name_allocator.insert(local_name.clone());
                         local_name
                       };
 
@@ -848,14 +840,14 @@ impl EsmLibraryPlugin {
               target_strict_esm_module,
               None,
               &mut chunk_link.required,
-              &mut chunk_link.used_names,
+              &mut chunk_link.name_allocator,
             )
           });
           let star_re_export_getters = if let Some(binding) = star_re_export_binding {
             let star_exports_base = format!("{name}_starExports");
-            let star_exports_name =
-              find_new_name(star_exports_base.as_str(), &chunk_link.used_names, &[]);
-            chunk_link.used_names.insert(star_exports_name.clone());
+            let star_exports_name = chunk_link
+              .name_allocator
+              .find_new_name(star_exports_base.as_str(), &[]);
 
             format!(
               r#"var {} = {};
@@ -1095,13 +1087,13 @@ var {} = {{}};
       init_fragment_groups.iter().copied(),
       &mut all_used_names,
     );
+    let mut name_allocator = ConcatenationNameAllocator::new(all_used_names);
     Self::register_preserved_asset_imports(
       compilation,
       chunk_link,
-      &mut all_used_names,
+      &mut name_allocator,
       escaped_identifiers,
     );
-    let mut name_allocator = ConcatenationNameAllocator(all_used_names, concatenation_context);
 
     // deconflict top level symbols
     for id in chunk_link
@@ -1182,6 +1174,7 @@ var {} = {{}};
                 existing_name,
                 source,
                 concate_info,
+                concatenation_context,
               );
 
               if existing_name.is_none() {
@@ -1196,7 +1189,7 @@ var {} = {{}};
           concate_info.import_map = Some(import_map);
         }
 
-        name_allocator.assign_module_binding_names(concate_info);
+        name_allocator.assign_module_binding_names(concate_info, concatenation_context);
 
         // Handle the name passed through by namespace_export_symbol
         if let Some(ref namespace_export_symbol) = concate_info.namespace_export_symbol
@@ -1226,26 +1219,32 @@ var {} = {{}};
               .get_internal_name(namespace_export_symbol)
               .cloned()
               .unwrap_or_else(|| {
-                name_allocator.find_new_module_name("namespaceObject", &concate_info.module)
+                name_allocator.find_new_module_name(
+                  "namespaceObject",
+                  &concate_info.module,
+                  concatenation_context,
+                )
               })
           } else {
-            name_allocator.find_new_module_name("namespaceObject", &concate_info.module)
+            name_allocator.find_new_module_name(
+              "namespaceObject",
+              &concate_info.module,
+              concatenation_context,
+            )
           }
         };
         concate_info.namespace_object_name = Some(namespace_object_name.clone());
 
-        name_allocator.assign_interop_names(info);
+        name_allocator.assign_interop_names(info, concatenation_context);
       }
     }
-    let mut all_used_names = name_allocator.0;
-
     // Build a targeted set for external module name deconfliction:
-    // Start from chunk_link.used_names (cross-chunk accumulated names) and add
+    // Start from chunk_link.name_allocator (cross-chunk accumulated names) and add
     // names that will actually be emitted at the chunk top level. We intentionally
-    // avoid using all_used_names directly because it also contains transient
+    // avoid using the full name allocator directly because it also contains transient
     // binding_to_ref keys (e.g. `cjs`, `foo`) that are rewritten during rendering
     // and should not block external module names.
-    let mut emitted_external_used_names = chunk_link.used_names.clone();
+    let mut emitted_external_name_allocator = chunk_link.name_allocator.clone();
     for module in chunk_link
       .hoisted_modules
       .iter()
@@ -1254,66 +1253,66 @@ var {} = {{}};
       match &concate_modules_map[module] {
         ModuleInfo::Concatenated(info) => {
           if let Some(name) = &info.namespace_object_name {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.interop_namespace_object_used
             && let Some(name) = &info.interop_namespace_object_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.interop_namespace_object2_used
             && let Some(name) = &info.interop_namespace_object2_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.interop_default_access_used
             && let Some(name) = &info.interop_default_access_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
         }
         ModuleInfo::External(info) => {
           if info.interop_namespace_object_used
             && let Some(name) = &info.interop_namespace_object_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.interop_namespace_object2_used
             && let Some(name) = &info.interop_namespace_object2_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.interop_default_access_used
             && let Some(name) = &info.interop_default_access_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.deferred
             && let Some(name) = &info.deferred_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
           if info.deferred_namespace_object_used
             && let Some(name) = &info.deferred_namespace_object_name
           {
-            emitted_external_used_names.insert(name.clone());
+            emitted_external_name_allocator.insert(name.clone());
           }
         }
       }
     }
     for import_spec in chunk_link.raw_import_stmts.values() {
       if let Some(ns) = &import_spec.ns_import {
-        emitted_external_used_names.insert(ns.clone());
+        emitted_external_name_allocator.insert(ns.clone());
       }
       for atom in import_spec.atoms.values() {
-        emitted_external_used_names.insert(atom.clone());
+        emitted_external_name_allocator.insert(atom.clone());
       }
       if let Some(default_import) = &import_spec.default_import {
-        emitted_external_used_names.insert(default_import.clone());
+        emitted_external_name_allocator.insert(default_import.clone());
       }
     }
 
-    let mut external_candidate_used_names = emitted_external_used_names.clone();
+    let mut external_candidate_name_allocator = emitted_external_name_allocator.clone();
     for external_module in chunk_link.decl_modules.iter() {
       let ModuleInfo::External(info) = &mut concate_modules_map[external_module] else {
         unreachable!("should be un-scope-hoisted module");
@@ -1329,15 +1328,15 @@ var {} = {{}};
 
         let name = Self::assign_external_candidate_name(
           &readable_identifier,
-          &mut external_candidate_used_names,
+          &mut external_candidate_name_allocator,
           escaped_identifiers,
         );
         info.name = Some(name);
       }
     }
 
-    all_used_names.extend(emitted_external_used_names);
-    chunk_link.used_names = all_used_names;
+    name_allocator.merge(emitted_external_name_allocator);
+    chunk_link.name_allocator = name_allocator;
   }
 
   async fn analyze_module(
@@ -1504,7 +1503,7 @@ var {} = {{}};
     m: ModuleIdentifier,
     from: Option<ModuleIdentifier>,
     symbol: Option<Atom>,
-    all_used_names: &mut FxHashSet<Atom>,
+    name_allocator: &mut ConcatenationNameAllocator,
     required: &'a mut IdentifierIndexMap<ExternalInterop>,
   ) -> &'a mut ExternalInterop {
     let require_info: &mut ExternalInterop = required.entry(m).or_insert(ExternalInterop {
@@ -1526,12 +1525,10 @@ var {} = {{}};
     if require_info.required_symbol.is_none()
       && let Some(symbol) = symbol
     {
-      let new_name = if all_used_names.contains(&symbol) {
-        let new_name = find_new_name(&symbol, all_used_names, &[]);
-        all_used_names.insert(new_name.clone());
-        new_name
+      let new_name = if name_allocator.contains(&symbol) {
+        name_allocator.find_new_name(&symbol, &[])
       } else {
-        all_used_names.insert(symbol.clone());
+        name_allocator.insert(symbol.clone());
         symbol
       };
 
@@ -1710,12 +1707,12 @@ var {} = {{}};
           info.module,
           None,
           Some(info.name.clone().expect("should have required symbol")),
-          &mut chunk_link.used_names,
+          &mut chunk_link.name_allocator,
           required,
         );
 
-        required_info.default_access(&mut chunk_link.used_names);
-        let symbol = required_info.default_exported(&mut chunk_link.used_names);
+        required_info.default_access(&mut chunk_link.name_allocator);
+        let symbol = required_info.default_exported(&mut chunk_link.name_allocator);
         Self::add_chunk_export(
           entry_chunk,
           symbol,
@@ -1894,7 +1891,7 @@ var {} = {{}};
           module.build_meta().strict_esm_module(),
           None,
           required,
-          &mut chunk_link.used_names,
+          &mut chunk_link.name_allocator,
         ) else {
           continue;
         };
@@ -1918,11 +1915,11 @@ var {} = {{}};
                 let required_info = &mut required[&symbol_binding.module];
 
                 let export_name = if let Some(id) = symbol_binding.ids.first() {
-                  required_info.property_access(id, &mut chunk_link.used_names)
+                  required_info.property_access(id, &mut chunk_link.name_allocator)
                 } else if let Some(default_access) = &required_info.default_access
                   && default_access == &symbol_binding.symbol
                 {
-                  required_info.default_exported(&mut chunk_link.used_names)
+                  required_info.default_exported(&mut chunk_link.name_allocator)
                 } else {
                   symbol_binding.symbol
                 };
@@ -1949,8 +1946,7 @@ var {} = {{}};
                   symbol_binding.render().into()
                 } else {
                   let ref_chunk_link = link.get_mut_unwrap(&ref_chunk);
-                  let new_name = find_new_name(&name, &ref_chunk_link.used_names, &[]);
-                  ref_chunk_link.used_names.insert(new_name.clone());
+                  let new_name = ref_chunk_link.name_allocator.find_new_name(&name, &[]);
                   ref_chunk_link
                     .decl_before_exports
                     .insert(format!("var {new_name} = {};\n", symbol_binding.render()));
@@ -2045,9 +2041,8 @@ var {} = {{}};
             }
 
             let entry_chunk_link = link.get_mut_unwrap(&entry_chunk);
-            let new_name = find_new_name(
+            let new_name = entry_chunk_link.name_allocator.find_new_name(
               &name,
-              &entry_chunk_link.used_names,
               binding_resolver.context.module_identifier(&entry_module),
             );
             if Self::add_chunk_export(
@@ -2059,7 +2054,6 @@ var {} = {{}};
             )
             .is_some()
             {
-              entry_chunk_link.used_names.insert(new_name.clone());
               entry_chunk_link
                 .decl_before_exports
                 .insert(format!("var {new_name} = {inlined_value};\n"));
@@ -2107,7 +2101,7 @@ var {} = {{}};
         entry_module,
         None,
         None,
-        &mut FxHashSet::default(),
+        &mut ConcatenationNameAllocator::default(),
         required,
       );
     }
@@ -2286,7 +2280,7 @@ var {} = {{}};
               *entry_module,
               None,
               None,
-              &mut FxHashSet::default(),
+              &mut ConcatenationNameAllocator::default(),
               required.entry(*chunk_ukey).or_default(),
             );
             require_info.set_entry_module_id |= code_generation_result
@@ -2622,7 +2616,7 @@ var {} = {{}};
               modified later by get_binding
               */
               None,
-              &mut chunk_link.used_names,
+              &mut chunk_link.name_allocator,
               required,
             );
           }
@@ -2653,7 +2647,7 @@ var {} = {{}};
               module.build_meta().strict_esm_module(),
               options.asi_safe,
               required,
-              &mut chunk_link.used_names,
+              &mut chunk_link.name_allocator,
             ) else {
               continue;
             };
@@ -2693,7 +2687,7 @@ var {} = {{}};
         });
 
       let mut refs = inline_refs;
-      let all_used_names = &mut chunk_link.used_names;
+      let name_allocator = &mut chunk_link.name_allocator;
 
       for ((symbol, m), mut all_refs) in ref_by_symbol {
         let ref_chunk = match Self::get_module_chunk(m, compilation) {
@@ -2713,13 +2707,9 @@ var {} = {{}};
         }
 
         if needs_import_chunk && !from_external {
-          let (orig_symbol, local_symbol) = if all_used_names.contains(&symbol) {
-            let new_symbol = find_new_name(
-              &symbol,
-              all_used_names,
-              binding_resolver.context.module_identifier(&m),
-            );
-            all_used_names.insert(new_symbol.clone());
+          let (orig_symbol, local_symbol) = if name_allocator.contains(&symbol) {
+            let new_symbol =
+              name_allocator.find_new_name(&symbol, binding_resolver.context.module_identifier(&m));
 
             for (_, cur_ref) in &mut all_refs {
               cur_ref.symbol = new_symbol.clone();
@@ -2727,7 +2717,7 @@ var {} = {{}};
 
             (symbol.clone(), new_symbol)
           } else {
-            all_used_names.insert(symbol.clone());
+            name_allocator.insert(symbol.clone());
             (symbol.clone(), symbol.clone())
           };
 
@@ -2932,7 +2922,7 @@ var {} = {{}};
     strict_esm_module: bool,
     asi_safe: Option<bool>,
     required: &mut IdentifierIndexMap<ExternalInterop>,
-    all_used_names: &mut FxHashSet<Atom>,
+    name_allocator: &mut ConcatenationNameAllocator,
   ) -> Option<Ref> {
     let ConcatenationBindingPlan {
       info_id,
@@ -2953,10 +2943,10 @@ var {} = {{}};
                 info_id,
                 from,
                 Some(info.name.clone().expect("should have name")),
-                all_used_names,
+                name_allocator,
                 required,
               )
-              .namespace(all_used_names),
+              .namespace(name_allocator),
               ModuleInfo::Concatenated(info) => info
                 .interop_namespace_object_name
                 .clone()
@@ -2970,10 +2960,10 @@ var {} = {{}};
                 info_id,
                 from,
                 Some(info.name.clone().expect("should have name")),
-                all_used_names,
+                name_allocator,
                 required,
               )
-              .namespace2(all_used_names),
+              .namespace2(name_allocator),
               ModuleInfo::Concatenated(info) => info
                 .interop_namespace_object2_name
                 .clone()
@@ -2997,10 +2987,10 @@ var {} = {{}};
             info_id,
             from,
             Some(info.name.clone().expect("should have name")),
-            all_used_names,
+            name_allocator,
             required,
           )
-          .default_access(all_used_names),
+          .default_access(name_allocator),
           ModuleInfo::Concatenated(info) => info
             .interop_default_access_name
             .clone()
@@ -3062,7 +3052,7 @@ var {} = {{}};
             info_id,
             from,
             Some(info.name.clone().expect("should have symbol")),
-            all_used_names,
+            name_allocator,
             required,
           )
           .required_symbol
@@ -3148,7 +3138,7 @@ var {} = {{}};
               info_id,
               from,
               Some(info.name.clone().expect("should have symbol")),
-              all_used_names,
+              name_allocator,
               required,
             )
             .required_symbol
@@ -3195,7 +3185,9 @@ fn normal_render(
 
 #[cfg(test)]
 mod tests {
-  use rspack_core::{ChunkInitFragments, ChunkUkey, InitFragmentKey, ModuleIdentifier};
+  use rspack_core::{
+    ChunkInitFragments, ChunkUkey, ConcatenationNameAllocator, InitFragmentKey, ModuleIdentifier,
+  };
   use rspack_util::{
     atom::Atom,
     fx_hash::{FxHashMap, FxHashSet},
@@ -3401,15 +3393,16 @@ mod tests {
       InitFragmentKey::ModuleExternal("../compiled/webpack-sources/index.js".into()),
       None,
     ))];
-    let mut chunk_used_names = FxHashSet::default();
+    let mut reserved_names = FxHashSet::default();
     let mut namespace_imports = FxHashMap::default();
     let mut required = Default::default();
 
     EsmLibraryPlugin::reserve_module_external_namespace_import_locals(
       &init_fragments,
-      &mut chunk_used_names,
+      &mut reserved_names,
       Some(&mut namespace_imports),
     );
+    let mut chunk_used_names = ConcatenationNameAllocator::new(reserved_names);
 
     let required_info = EsmLibraryPlugin::add_require(
       module,
@@ -3558,8 +3551,8 @@ mod tests {
   #[test]
   fn external_candidate_name_does_not_claim_chunk_top_level_name() {
     let module = ModuleIdentifier::from("test_module");
-    let mut candidate_used_names = FxHashSet::default();
-    let mut chunk_used_names = FxHashSet::default();
+    let mut candidate_used_names = ConcatenationNameAllocator::default();
+    let mut chunk_used_names = ConcatenationNameAllocator::default();
     let mut required = Default::default();
     let escaped_identifiers =
       FxHashMap::from_iter([("./lib.js".to_string(), vec![Atom::from("lib")])]);

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -620,7 +620,7 @@ impl EsmLibraryPlugin {
     let mut binding_resolver = ConcatenationBindingResolver {
       context: &concatenation_context,
       module_to_info_map: &mut concate_modules_map,
-      normalize_export_name: |module_graph, module, export_name| {
+      normalize_export_name: Some(|module_graph, module, export_name| {
         let is_source_phase_external = module_graph
           .module_by_identifier(module)
           .and_then(|module| module.as_external_module())
@@ -632,7 +632,7 @@ impl EsmLibraryPlugin {
         {
           export_name.remove(0);
         }
-      },
+      }),
     };
 
     // link imported specifier with exported symbol
@@ -2982,12 +2982,12 @@ var {} = {{}};
           }
         };
 
-        return Some(Ref::Symbol(SymbolRef::new(
+        Some(Ref::Symbol(SymbolRef::new(
           info_id,
           symbol,
           export_name,
           Arc::new(|binding| binding.symbol.to_string()),
-        )));
+        )))
       }
       ConcatenationBindingTarget::InteropDefault => {
         let info = &mut module_to_info_map[&info_id];
@@ -3007,7 +3007,7 @@ var {} = {{}};
             .expect("should already set interop namespace"),
         };
 
-        return Some(Ref::Symbol(SymbolRef::new(
+        Some(Ref::Symbol(SymbolRef::new(
           info_id,
           symbol,
           export_name,
@@ -3037,14 +3037,12 @@ var {} = {{}};
 
             exports
           }),
-        )));
+        )))
       }
-      ConcatenationBindingTarget::EsModule(_) => return Some(es_module_binding()),
-      ConcatenationBindingTarget::UnsupportedDefaultImport => {
-        return Some(Ref::Inline(
-          "/* non-default import from default-exporting module */undefined".into(),
-        ));
-      }
+      ConcatenationBindingTarget::EsModule(_) => Some(es_module_binding()),
+      ConcatenationBindingTarget::UnsupportedDefaultImport => Some(Ref::Inline(
+        "/* non-default import from default-exporting module */undefined".into(),
+      )),
       ConcatenationBindingTarget::Namespace => match module_to_info_map.get_mut_unwrap(&info_id) {
         ModuleInfo::Concatenated(info) => {
           needed_namespace_objects.insert(info.module);

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -4,8 +4,8 @@ use atomic_refcell::AtomicRefCell;
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  ChunkGroupUkey, ChunkUkey, Compilation, DependenciesBlock, DependencyType, ExportProvided,
-  ModuleIdentifier, UsageState, find_new_name, get_cached_readable_identifier,
+  ChunkGroupUkey, ChunkUkey, Compilation, ConcatenationNameAllocator, DependenciesBlock,
+  DependencyType, ExportProvided, ModuleIdentifier, UsageState, get_cached_readable_identifier,
   incremental::Mutation, split_readable_identifier,
 };
 use rspack_util::{
@@ -641,7 +641,7 @@ pub(crate) fn analyze_dyn_import_targets(
   }
 
   // Pre-assign namespace object names for scope-hoisted dyn targets in non-strict chunks.
-  // Use the same naming scheme as regular namespace objects (find_new_name("namespaceObject", ...))
+  // Use the same naming scheme as regular namespace objects.
   // so the name matches what deconflict_symbols would produce.
   // These names must be determined before code generation so the dynamic import template
   // can emit `.then(m => m.<ns_name>)`.
@@ -716,7 +716,8 @@ pub(crate) fn analyze_dyn_import_targets(
 
     // Step 3: Only assign namespace names when needed (namespace used as a whole or has conflicts)
     // Track used names per chunk to avoid collisions between multiple dyn targets
-    let mut chunk_used_names: FxHashMap<ChunkUkey, FxHashSet<Atom>> = FxHashMap::default();
+    let mut chunk_name_allocators: FxHashMap<ChunkUkey, ConcatenationNameAllocator> =
+      FxHashMap::default();
 
     for module_id in &sorted_targets {
       if !concatenated_modules.contains(module_id) {
@@ -751,9 +752,8 @@ pub(crate) fn analyze_dyn_import_targets(
         &compilation.options.context,
       );
       let escaped_idents = split_readable_identifier(&readable_identifier);
-      let used_names = chunk_used_names.entry(chunk_ukey).or_default();
-      let ns_name = find_new_name("namespaceObject", used_names, &escaped_idents);
-      used_names.insert(ns_name.clone());
+      let name_allocator = chunk_name_allocators.entry(chunk_ukey).or_default();
+      let ns_name = name_allocator.find_new_name("namespaceObject", &escaped_idents);
       ns_map.insert(*module_id, ns_name);
     }
   }

--- a/crates/rspack_plugin_javascript/src/plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mod.rs
@@ -30,8 +30,9 @@ use rspack_collections::{Identifier, IdentifierDashMap, IdentifierLinkedMap, Ide
 use rspack_core::{
   ChunkGraph, ChunkGroupUkey, ChunkInitFragments, ChunkRenderContext, ChunkUkey,
   CodeGenerationDataTopLevelDeclarations, Compilation, CompilationId, ConcatenatedModuleIdent,
-  ExportsArgument, Module, RuntimeCodeTemplate, RuntimeGlobals, RuntimeVariable, SourceType,
-  concatenated_module::{collect_ident, find_new_name},
+  ConcatenationNameAllocator, ExportsArgument, Module, RuntimeCodeTemplate, RuntimeGlobals,
+  RuntimeVariable, SourceType,
+  concatenated_module::collect_ident,
   render_init_fragments,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   rspack_sources::{BoxSource, ConcatSource, RawStringSource, ReplaceSource, Source, SourceExt},
@@ -1307,6 +1308,7 @@ var {} = {{}};
       }
       Err(e) => return Err(e),
     }
+    let mut name_allocator = ConcatenationNameAllocator::new(all_used_names);
 
     for (_ident, info) in inlined_modules_to_info.iter_mut() {
       for module_scope_ident in info.module_scope_idents.iter() {
@@ -1368,7 +1370,7 @@ var {} = {{}};
           let context = compilation.options.context.clone();
           let readable_identifier = module.readable_identifier(&context).to_string();
           let splitted_readable_identifier = split_readable_identifier(&readable_identifier);
-          let new_name = find_new_name(name, &all_used_names, &splitted_readable_identifier);
+          let new_name = name_allocator.find_new_name(name, &splitted_readable_identifier);
 
           for identifier in refs.iter() {
             let span = identifier.id.span;
@@ -1382,8 +1384,6 @@ var {} = {{}};
 
             replace_source.replace(low, high, new_name.to_string(), None);
           }
-
-          all_used_names.insert(new_name);
         }
       }
 


### PR DESCRIPTION
## Summary

This PR extracts the backend-independent parts of module concatenation into `rspack_core::concatenation_backend` and reuses them from both `ConcatenatedModule` and the ESM library linker.

Both consumers need the same semantic pipeline: analyze JavaScript scopes, reserve and deconflict top-level names, follow exports and re-exports, apply used-name information, and decide whether a reference resolves to a direct binding, namespace object, interop helper, inlined value, missing export, circular re-export, or external module. Previously, that behavior was implemented separately in the two backends, so fixes could drift and had to be made twice.

The extraction makes that semantic decision layer shared while keeping output-specific rendering in each backend:

- `ConcatenatedModule` still rewrites its `ReplaceSource` and converts resolved plans into its `Binding` / `FinalBindingResult` representation.
- The ESM library linker still converts plans into `Ref`, manages chunk links, cross-chunk requirements, external imports, and namespace-object scheduling.
- ESM-only source-phase external handling is supplied through `normalize_export_name`; it does not leak into the generic resolver or affect `ConcatenatedModule`.

## Shared logic

1. `analyze_module_scope` parses generated JavaScript, resolves lexical scopes, and fills `ConcatenatedModuleInfo` with top-level/global contexts, identifier references, bindings, and used names.
2. `ConcatenationContext::prepare` gathers the module graph, export metadata, runtime/cache inputs, escaped binding names, import-source identifier parts, and module identifier parts used by both later phases.
3. `ConcatenationNameAllocator` assigns collision-free names for module bindings, imported bindings, namespace objects, and interop helpers.
4. `ConcatenationBindingResolver` follows exports and re-exports and returns a backend-neutral `ConcatenationBindingPlan`.
5. Each consumer translates that plan into its own output model and performs its own rendering and bookkeeping.

## Extracted types and responsibilities

| Type | Shared responsibility | `ConcatenatedModule` usage | ESM library usage |
| --- | --- | --- | --- |
| `ConcatenationContext<'a>` | Read-only graph/export/cache inputs plus precomputed escaped names and identifier segments. | Prepared per concatenated-module code generation with its runtime; borrowed by naming and binding resolution. | Prepared for the chunk-linking module map without a runtime; also reused while deconflicting every chunk. |
| `ConcatenationNameAllocator<'a>` | Owns the current used-name set and applies the common collision-avoidance policy for local bindings, imports, namespace objects, and interop helper names. | Renames module bindings and imports, then allocates external, deferred, namespace, and interop names. | Deconflicts hoisted/declared module bindings and imports, then allocates namespace and interop names; ESM-specific external-name policy remains local. |
| `ConcatenationBindingResolver<'a>` | Resolves an `(info_id, export path)` through export type handling, used-name lookup, re-export chains, deferred edges, inlining, circular detection, and internal/external module boundaries. | Called while replacing module references; no export-name normalization hook is installed. | Called while linking imports and exports; installs the source-phase-external `normalize_export_name` hook. |
| `ConcatenationBindingPlan` | Backend-neutral handoff containing the resolved module, remaining export path, nearest deferred re-export flag, and target kind. | Converted into `FinalBindingResult` / `Binding` and rendered into source replacements. | Converted into `Ref` while updating required externals and needed namespace objects. |
| `ConcatenationBindingTarget` | Enumerates the semantic result: interop namespace/default, `__esModule`, unsupported default import, namespace, circular, direct/raw, inlined, namespace export, missing, or external. | Maps each case to concatenated-module runtime expressions and usage flags. | Maps each case to linker symbols or inline expressions and chunk-level requirements. |
| `ConcatenationInterop` | Distinguishes the two namespace interop modes. | Selects the corresponding generated runtime helper binding. | Selects and records the corresponding external or concatenated namespace symbol. |

## Architecture

```mermaid
flowchart TB
  CM["ConcatenatedModule<br/>module code generation"]
  ESM["ESM library linker<br/>chunk linking"]

  subgraph Shared["rspack_core::concatenation_backend"]
    Scope["analyze_module_scope<br/>parse + semantic scope collection"]
    Info["ConcatenatedModuleInfo / ModuleInfo"]
    Context["ConcatenationContext<br/>graph inputs + naming caches"]
    Allocator["ConcatenationNameAllocator<br/>shared name deconfliction"]
    Resolver["ConcatenationBindingResolver<br/>export / re-export traversal"]
    Plan["ConcatenationBindingPlan<br/>+ BindingTarget / Interop"]

    Scope --> Info
    Info --> Context
    Context --> Allocator
    Context --> Resolver
    Info --> Resolver
    Resolver --> Plan
  end

  CM --> Scope
  ESM --> Scope
  CM --> Context
  ESM --> Context

  Allocator --> CMRender["Convert to Binding<br/>+ ReplaceSource rewrites"]
  Plan --> CMRender
  CMRender --> CMOut["Concatenated JavaScript"]

  Allocator --> ESMRender["Convert to Ref<br/>+ chunk-link bookkeeping"]
  Plan --> ESMRender
  ESMRender --> ESMOut["Linked ESM chunks"]

  Normalize["ESM-only normalize_export_name<br/>source-phase externals"] -.-> Resolver
```

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

