### PR TITLE
fix: support side-effect-free star reexport passthrough

### DIFF
--- a/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
+++ b/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
@@ -12,13 +12,21 @@ use crate::{
 pub struct SideEffectsDoOptimize {
   pub ids: Vec<Atom>,
   pub target_module: ModuleIdentifier,
-  pub need_move_target: Option<SideEffectsDoOptimizeMoveTarget>,
+  pub move_targets: SideEffectsDoOptimizeMoveTargets,
 }
 
 #[derive(Debug, Clone)]
 pub struct SideEffectsDoOptimizeMoveTarget {
   pub export_info: ExportInfo,
   pub target_export: Option<Vec<Atom>>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub enum SideEffectsDoOptimizeMoveTargets {
+  #[default]
+  None,
+  Single(SideEffectsDoOptimizeMoveTarget),
+  Multiple(Vec<SideEffectsDoOptimizeMoveTarget>),
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -273,6 +273,7 @@ async fn optimize_dependencies(
       .collect()
   };
   let module_graph = build_module_graph_artifact.get_module_graph();
+  let defer_enabled = compilation.options.experiments.defer_import;
 
   if self.analyze_side_effects_free {
     // `finish_modules` may change the side-effect state of modules that were not part of the
@@ -372,6 +373,7 @@ async fn optimize_dependencies(
           module_graph,
           exports_info_artifact,
           &single_star_reexport_cache,
+          defer_enabled,
         ),
       )
     })
@@ -418,6 +420,7 @@ async fn optimize_dependencies(
           module_graph,
           exports_info_artifact,
           &single_star_reexport_cache,
+          defer_enabled,
         )
         .map(|i| (connection.dependency_id, i))
       })
@@ -530,6 +533,13 @@ fn module_has_single_star_reexport(
   result
 }
 
+fn is_deferred_target(target: &ResolvedExportInfoTarget, module_graph: &ModuleGraph) -> bool {
+  module_graph
+    .dependency_by_id(&target.dependency)
+    .get_phase()
+    .is_defer()
+}
+
 #[tracing::instrument("can_optimize_connection", level = "trace", skip_all)]
 fn can_optimize_connection(
   connection: &ModuleGraphConnection,
@@ -537,6 +547,7 @@ fn can_optimize_connection(
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
   single_star_reexport_cache: &OnceLock<IdentifierDashMap<bool>>,
+  defer_enabled: bool,
 ) -> Option<SideEffectsDoOptimize> {
   let original_module = connection.original_module_identifier?;
   let dependency_id = connection.dependency_id;
@@ -548,6 +559,7 @@ fn can_optimize_connection(
       let export_info = exports_info.get_export_info_without_mut_module_graph(name);
       let resolve_filter = |target: &ResolvedExportInfoTarget| {
         side_effects_state_map[&target.module] == ConnectionState::Active(false)
+          && (!defer_enabled || !is_deferred_target(target, module_graph))
       };
       let target = can_move_target(
         &export_info,
@@ -555,6 +567,9 @@ fn can_optimize_connection(
         exports_info_artifact,
         &resolve_filter,
       )?;
+      if defer_enabled && is_deferred_target(&target, module_graph) {
+        return None;
+      }
       let pending_move_target = match export_info {
         Cow::Borrowed(export_info) => Some(export_info.id()),
         Cow::Owned { .. } => None,
@@ -575,6 +590,7 @@ fn can_optimize_connection(
 
       let resolve_filter = |target: &ResolvedExportInfoTarget| {
         side_effects_state_map[&target.module] == ConnectionState::Active(false)
+          && (!defer_enabled || !is_deferred_target(target, module_graph))
           && module_has_single_star_reexport(
             &target.module,
             module_graph,
@@ -599,6 +615,9 @@ fn can_optimize_connection(
         ) else {
           continue;
         };
+        if defer_enabled && is_deferred_target(&target, module_graph) {
+          continue;
+        }
         if resolved_target
           .as_ref()
           .is_some_and(|resolved: &ResolvedExportInfoTarget| resolved.module != target.module)
@@ -666,6 +685,7 @@ fn can_optimize_connection(
 
     let resolve_filter = |target: &ResolvedExportInfoTarget| {
       side_effects_state_map[&target.module] == ConnectionState::Active(false)
+        && (!defer_enabled || !is_deferred_target(target, module_graph))
     };
     let Some(GetTargetResult::Target(target)) = get_target(
       &export_info,
@@ -676,6 +696,9 @@ fn can_optimize_connection(
     ) else {
       return None;
     };
+    if defer_enabled && is_deferred_target(&target, module_graph) {
+      return None;
+    }
 
     if !module_graph.can_update_module(&dependency_id, &target.module) {
       return None;

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -1,15 +1,15 @@
-use std::{borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug, sync::OnceLock};
 
 use rayon::prelude::*;
-use rspack_collections::{IdentifierMap, IdentifierSet};
+use rspack_collections::{IdentifierDashMap, IdentifierMap, IdentifierSet};
 use rspack_core::{
   AsyncModulesArtifact, BoxModule, Compilation, CompilationFinishModules,
   CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta, DependencyId,
   ExportsInfoArtifact, FactoryMeta, GetTargetResult, Logger, ModuleFactoryCreateData, ModuleGraph,
   ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule,
   OptimizationBailoutItem, Plugin, ResolvedExportInfoTarget, SideEffectsDoOptimize,
-  SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact, SideEffectsState,
-  SideEffectsStateArtifact,
+  SideEffectsDoOptimizeMoveTarget, SideEffectsDoOptimizeMoveTargets, SideEffectsOptimizeArtifact,
+  SideEffectsState, SideEffectsStateArtifact,
   build_module_graph::BuildModuleGraphArtifact,
   can_move_target, get_target,
   incremental::{self, IncrementalPasses, Mutation},
@@ -22,7 +22,10 @@ use swc_experimental_ecma_ast::{ClassMember, Key, PropName};
 
 use crate::{
   FLAG_DEPENDENCY_EXPORTS_STAGE, deferred_pure_check_is_impure,
-  dependency::{ESMExportImportedSpecifierDependency, ESMImportSpecifierDependency},
+  dependency::{
+    ESMExportExpressionDependency, ESMExportImportedSpecifierDependency,
+    ESMImportSpecifierDependency,
+  },
 };
 
 pub static SIDE_EFFECTS_FLAG_PLUGIN_STAGE: i32 = FLAG_DEPENDENCY_EXPORTS_STAGE + 10;
@@ -350,6 +353,7 @@ async fn optimize_dependencies(
   };
   logger.time_end(inner_start);
 
+  let single_star_reexport_cache = OnceLock::new();
   let inner_start = logger.time("find optimizable connections");
   let mut optimized_connections = modules
     .par_iter()
@@ -367,6 +371,7 @@ async fn optimize_dependencies(
           &side_effects_state_map,
           module_graph,
           exports_info_artifact,
+          &single_star_reexport_cache,
         ),
       )
     })
@@ -412,6 +417,7 @@ async fn optimize_dependencies(
           &side_effects_state_map,
           module_graph,
           exports_info_artifact,
+          &single_star_reexport_cache,
         )
         .map(|i| (connection.dependency_id, i))
       })
@@ -439,7 +445,7 @@ fn do_optimize_connection(
   let SideEffectsDoOptimize {
     ids,
     target_module,
-    need_move_target,
+    move_targets,
   } = do_optimize;
   module_graph.do_update_module(&dependency, &target_module);
   module_graph.set_dependency_extra_meta(
@@ -449,16 +455,79 @@ fn do_optimize_connection(
       explanation: Some("(skipped side-effect-free modules)"),
     },
   );
-  if let Some(SideEffectsDoOptimizeMoveTarget {
-    export_info,
-    target_export,
-  }) = need_move_target
-  {
+  let move_target = |SideEffectsDoOptimizeMoveTarget {
+                       export_info,
+                       target_export,
+                     }: SideEffectsDoOptimizeMoveTarget,
+                     exports_info_artifact: &mut ExportsInfoArtifact| {
     export_info
       .as_data_mut(exports_info_artifact)
       .do_move_target(dependency, target_export);
+  };
+  match move_targets {
+    SideEffectsDoOptimizeMoveTargets::None => {}
+    SideEffectsDoOptimizeMoveTargets::Single(target) => {
+      move_target(target, exports_info_artifact);
+    }
+    SideEffectsDoOptimizeMoveTargets::Multiple(targets) => {
+      for target in targets {
+        move_target(target, exports_info_artifact);
+      }
+    }
   }
   (dependency, target_module)
+}
+
+/// Returns whether the module's complete export surface is a single `export *`.
+/// Such a module can be skipped without changing which names the star contributes.
+fn module_has_single_star_reexport_uncached(
+  module_identifier: &ModuleIdentifier,
+  module_graph: &ModuleGraph,
+) -> bool {
+  let Some(module) = module_graph.module_by_identifier(module_identifier) else {
+    return false;
+  };
+  let build_info = module.build_info();
+  if !build_info.esm_named_exports.is_empty() || build_info.all_star_exports.len() != 1 {
+    return false;
+  }
+  // Default export declarations and default exports of imported namespaces are
+  // not recorded in `esm_named_exports`, while webpack's `activeExports`
+  // includes them. Check their dependencies explicitly.
+  if module_graph
+    .module_graph_module_by_identifier(module_identifier)
+    .is_some_and(|module| {
+      module.all_dependencies().iter().any(|dependency_id| {
+        let dependency = module_graph.dependency_by_id(dependency_id);
+        dependency
+          .downcast_ref::<ESMExportExpressionDependency>()
+          .is_some()
+          || dependency
+            .downcast_ref::<ESMExportImportedSpecifierDependency>()
+            .is_some_and(|dependency| dependency.name.is_some())
+      })
+    })
+  {
+    return false;
+  }
+  module_graph
+    .dependency_by_id(&build_info.all_star_exports[0])
+    .downcast_ref::<ESMExportImportedSpecifierDependency>()
+    .is_some_and(|dependency| dependency.name.is_none())
+}
+
+fn module_has_single_star_reexport(
+  module_identifier: &ModuleIdentifier,
+  module_graph: &ModuleGraph,
+  cache: &OnceLock<IdentifierDashMap<bool>>,
+) -> bool {
+  let cache = cache.get_or_init(IdentifierDashMap::default);
+  if let Some(result) = cache.get(module_identifier) {
+    return *result;
+  }
+  let result = module_has_single_star_reexport_uncached(module_identifier, module_graph);
+  cache.insert(*module_identifier, result);
+  result
 }
 
 #[tracing::instrument("can_optimize_connection", level = "trace", skip_all)]
@@ -467,51 +536,123 @@ fn can_optimize_connection(
   side_effects_state_map: &IdentifierMap<ConnectionState>,
   module_graph: &ModuleGraph,
   exports_info_artifact: &ExportsInfoArtifact,
+  single_star_reexport_cache: &OnceLock<IdentifierDashMap<bool>>,
 ) -> Option<SideEffectsDoOptimize> {
   let original_module = connection.original_module_identifier?;
   let dependency_id = connection.dependency_id;
   let dep = module_graph.dependency_by_id(&dependency_id);
 
-  if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
-    && let Some(name) = &dep.name
-  {
+  if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>() {
     let exports_info = exports_info_artifact.get_exports_info_data(&original_module);
-    let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+    let (target, pending_move_target, mut move_targets) = if let Some(name) = &dep.name {
+      let export_info = exports_info.get_export_info_without_mut_module_graph(name);
+      let resolve_filter = |target: &ResolvedExportInfoTarget| {
+        side_effects_state_map[&target.module] == ConnectionState::Active(false)
+      };
+      let target = can_move_target(
+        &export_info,
+        module_graph,
+        exports_info_artifact,
+        &resolve_filter,
+      )?;
+      let pending_move_target = match export_info {
+        Cow::Borrowed(export_info) => Some(export_info.id()),
+        Cow::Owned { .. } => None,
+      };
+      (
+        target,
+        pending_move_target,
+        SideEffectsDoOptimizeMoveTargets::None,
+      )
+    } else {
+      if !module_has_single_star_reexport(
+        connection.module_identifier(),
+        module_graph,
+        single_star_reexport_cache,
+      ) {
+        return None;
+      }
 
-    let resolve_filter = |target: &ResolvedExportInfoTarget| {
-      side_effects_state_map[&target.module] == ConnectionState::Active(false)
+      let resolve_filter = |target: &ResolvedExportInfoTarget| {
+        side_effects_state_map[&target.module] == ConnectionState::Active(false)
+          && module_has_single_star_reexport(
+            &target.module,
+            module_graph,
+            single_star_reexport_cache,
+          )
+      };
+      let mut resolved_target = None;
+      let mut move_targets = SideEffectsDoOptimizeMoveTargets::None;
+      for export_info in exports_info.exports().values() {
+        if !export_info
+          .get_max_target()
+          .values()
+          .any(|target| target.dependency == Some(dependency_id))
+        {
+          continue;
+        }
+        let Some(target) = can_move_target(
+          export_info,
+          module_graph,
+          exports_info_artifact,
+          &resolve_filter,
+        ) else {
+          continue;
+        };
+        if resolved_target
+          .as_ref()
+          .is_some_and(|resolved: &ResolvedExportInfoTarget| resolved.module != target.module)
+        {
+          return None;
+        }
+        let move_target = SideEffectsDoOptimizeMoveTarget {
+          export_info: export_info.id(),
+          target_export: target.export.clone(),
+        };
+        move_targets = match move_targets {
+          SideEffectsDoOptimizeMoveTargets::None => {
+            SideEffectsDoOptimizeMoveTargets::Single(move_target)
+          }
+          SideEffectsDoOptimizeMoveTargets::Single(first) => {
+            SideEffectsDoOptimizeMoveTargets::Multiple(vec![first, move_target])
+          }
+          SideEffectsDoOptimizeMoveTargets::Multiple(mut targets) => {
+            targets.push(move_target);
+            SideEffectsDoOptimizeMoveTargets::Multiple(targets)
+          }
+        };
+        resolved_target = Some(target);
+      }
+      let target = resolved_target?;
+      (target, None, move_targets)
     };
-    let target = can_move_target(
-      &export_info,
-      module_graph,
-      exports_info_artifact,
-      &resolve_filter,
-    )?;
     if !module_graph.can_update_module(&dependency_id, &target.module) {
       return None;
     }
 
     let ids = dep.get_ids(module_graph);
-    let processed_ids = target.export.as_ref().map_or_else(
-      || ids.get(1..).unwrap_or_default().to_vec(),
-      |item| {
-        let mut ret = item.clone();
-        ret.extend_from_slice(ids.get(1..).unwrap_or_default());
-        ret
-      },
-    );
-    let need_move_target = match export_info {
-      Cow::Borrowed(export_info) => Some(SideEffectsDoOptimizeMoveTarget {
-        export_info: export_info.id(),
-        target_export: target.export,
-      }),
-      Cow::Owned { .. } => None,
+    let processed_ids = if dep.name.is_none() {
+      ids.to_vec()
+    } else {
+      target.export.as_ref().map_or_else(
+        || ids.get(1..).unwrap_or_default().to_vec(),
+        |item| {
+          let mut ret = item.clone();
+          ret.extend_from_slice(ids.get(1..).unwrap_or_default());
+          ret
+        },
+      )
     };
-
+    if let Some(export_info) = pending_move_target {
+      move_targets = SideEffectsDoOptimizeMoveTargets::Single(SideEffectsDoOptimizeMoveTarget {
+        export_info,
+        target_export: target.export,
+      });
+    }
     return Some(SideEffectsDoOptimize {
       ids: processed_ids,
       target_module: target.module,
-      need_move_target,
+      move_targets,
     });
   }
 
@@ -551,7 +692,7 @@ fn can_optimize_connection(
     return Some(SideEffectsDoOptimize {
       ids: processed_ids,
       target_module: target.module,
-      need_move_target: None,
+      move_targets: SideEffectsDoOptimizeMoveTargets::None,
     });
   }
 

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/barrel.js
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/barrel.js
@@ -1,0 +1,3 @@
+import defer * as reexported from "./dep.js";
+
+export { reexported };

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/dep.js
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/dep.js
@@ -1,0 +1,3 @@
+globalThis.deferReexportEvaluationCount++;
+
+export const value = 42;

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/index.js
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/index.js
@@ -1,0 +1,11 @@
+import "./setup.js";
+import defer * as direct from "./dep.js";
+import { reexported } from "./barrel.js";
+
+it("should preserve the identity of a deferred namespace re-exported through a side-effect-free barrel", () => {
+	expect(globalThis.deferReexportEvaluationCount).toBe(0);
+	expect(direct).toBe(reexported);
+	expect(globalThis.deferReexportEvaluationCount).toBe(0);
+	expect(direct.value).toBe(42);
+	expect(globalThis.deferReexportEvaluationCount).toBe(1);
+});

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/package.json
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/package.json
@@ -1,0 +1,1 @@
+{ "sideEffects": ["./setup.js"] }

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/rspack.config.js
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/rspack.config.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: [`async-node${process.versions.node.split('.').map(Number)[0]}`],
+  mode: 'production',
+  optimization: {
+    concatenateModules: true,
+    usedExports: true,
+    sideEffects: true,
+    minimize: false,
+  },
+  experiments: {
+    deferImport: true,
+  },
+};

--- a/tests/rspack-test/configCases/defer-import/defer-reexport-identity/setup.js
+++ b/tests/rspack-test/configCases/defer-import/defer-reexport-identity/setup.js
@@ -1,0 +1,1 @@
+globalThis.deferReexportEvaluationCount = 0;

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/index.js
@@ -1,0 +1,23 @@
+import * as ns from "lib";
+
+const SKIP = "(skipped side-effect-free modules)";
+const stats = __STATS__.children[__STATS_I__];
+const find = (suffix) => stats.modules.find((module) => module.name.endsWith(suffix));
+const skippedFrom = (suffix) =>
+	new Set(
+		find(suffix)
+			.reasons.filter((reason) => reason.explanation === SKIP)
+			.map((reason) => reason.moduleName)
+	);
+
+it("should resolve fan-out named imports to their distinct real source modules", () => {
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(ns.baz()).toBe(3);
+	expect(Object.keys(ns).length).toBe(3);
+});
+
+it("should repoint each name past the passthrough and reconnect to its real module", () => {
+	expect(skippedFrom("lib/b-source.js").has("./node_modules/lib/b.js")).toBe(true);
+	expect(skippedFrom("lib/b-source.js").has("./node_modules/lib/b-1.js")).toBe(true);
+});

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/a.js
@@ -1,0 +1,6 @@
+export function foo() {
+	return 1;
+}
+export function baz() {
+	return 3;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-1.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-1.js
@@ -1,0 +1,1 @@
+export * from "./b-2";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-2.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-2.js
@@ -1,0 +1,1 @@
+export * from "./b-source";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-source.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b-source.js
@@ -1,0 +1,3 @@
+export function bar() {
+	return 2;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./b-1";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/index.js
@@ -1,0 +1,1 @@
+export * from "./mid.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/mid.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/mid.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export * from "./b.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": ["./index.js", "./b.js"]
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/rspack.config.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const optimization = {
+  sideEffects: true,
+  usedExports: true,
+  providedExports: true,
+  minimize: false,
+};
+
+/** @type {import("../../../../").Configuration[]} */
+module.exports = [
+  {
+    mode: 'production',
+    output: { filename: 'bundle0.js' },
+    optimization: { ...optimization, concatenateModules: false },
+  },
+  {
+    mode: 'production',
+    output: { filename: 'bundle1.js' },
+    optimization: { ...optimization, concatenateModules: true },
+  },
+];

--- a/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/test.config.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-fan-out-skip/test.config.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+	findBundle(index) {
+		return [`./bundle${index}.js`];
+	}
+};

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/index.js
@@ -1,0 +1,30 @@
+import * as ns from "lib";
+import { foo } from "lib";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+it("should resolve named and namespace imports through a star and named barrel", () => {
+	expect(foo()).toBe(1);
+	expect(ns.foo()).toBe(1);
+	expect(ns.c()).toBe(3);
+	expect(Object.keys(ns).sort()).toEqual(["c", "foo"]);
+});
+
+it("should skip only the single-star sub-chains", () => {
+	const reasons = (suffix) => {
+		const module = __STATS__.modules.find((item) => item.name.endsWith(suffix));
+		return new Set(
+			module.reasons
+				.filter((reason) => reason.explanation === SKIP)
+				.map((reason) => reason.moduleName)
+		);
+	};
+	expect(reasons("lib/real-a.js").has("./node_modules/lib/index.js")).toBe(true);
+	expect(reasons("lib/real-c.js").has("./node_modules/lib/index.js")).toBe(true);
+});
+
+it("should leave the intermediate single-star passthroughs unused", () => {
+	for (const suffix of ["lib/a.js", "lib/c.js"]) {
+		expect(__STATS__.modules.find((module) => module.name.endsWith(suffix)).usedExports).toBe(false);
+	}
+});

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./real-a.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/c.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/c.js
@@ -1,0 +1,1 @@
+export * from "./real-c.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/index.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export { c } from "./c.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-a.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 1;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-c.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/node_modules/lib/real-c.js
@@ -1,0 +1,3 @@
+export function c() {
+	return 3;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-mixed/rspack.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    sideEffects: true,
+    usedExports: true,
+    providedExports: true,
+    concatenateModules: false,
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/index.js
@@ -1,0 +1,41 @@
+import * as ns from "lib";
+import * as reexportedNs from "./reexport.js";
+import { foo, bar } from "lib";
+import { foo as reexportedFoo } from "./reexport.js";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+it("should resolve imports through a multi-star barrel", () => {
+	expect(foo()).toBe(1);
+	expect(bar()).toBe(2);
+	expect(reexportedFoo()).toBe(1);
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(Object.keys(ns).sort()).toEqual(["bar", "foo"]);
+	expect(reexportedNs.foo()).toBe(1);
+	expect(reexportedNs.bar()).toBe(2);
+	expect(Object.keys(reexportedNs).sort()).toEqual(["bar", "foo"]);
+});
+
+it("should skip only the single-star sub-chains", () => {
+	const reasons = (suffix) => {
+		const module = __STATS__.modules.find((item) => item.name.endsWith(suffix));
+		return new Set(
+			module.reasons
+				.filter((reason) => reason.explanation === SKIP)
+				.map((reason) => reason.moduleName)
+		);
+	};
+	expect(reasons("lib/real-a.js").has("./node_modules/lib/index.js")).toBe(true);
+	expect(reasons("lib/real-b.js").has("./node_modules/lib/index.js")).toBe(true);
+	expect(reasons("lib/real-a.js").has("./reexport.js")).toBe(false);
+	expect(reasons("lib/real-b.js").has("./reexport.js")).toBe(false);
+	const barrel = __STATS__.modules.find((item) => item.name.endsWith("lib/index.js"));
+	expect(barrel.reasons.some((reason) => reason.moduleName === "./reexport.js")).toBe(true);
+});
+
+it("should leave the intermediate single-star passthroughs unused", () => {
+	for (const suffix of ["lib/a.js", "lib/b.js"]) {
+		expect(__STATS__.modules.find((module) => module.name.endsWith(suffix)).usedExports).toBe(false);
+	}
+});

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./real-a.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/b.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./real-b.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/index.js
@@ -1,0 +1,2 @@
+export * from "./a.js";
+export * from "./b.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-a.js
@@ -1,0 +1,3 @@
+export function foo() {
+	return 1;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-b.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/node_modules/lib/real-b.js
@@ -1,0 +1,3 @@
+export function bar() {
+	return 2;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/reexport.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/reexport.js
@@ -1,0 +1,1 @@
+export * from "lib";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip-multi/rspack.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    sideEffects: true,
+    usedExports: true,
+    providedExports: true,
+    concatenateModules: false,
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/index.js
@@ -1,0 +1,54 @@
+import * as ns from "lib";
+import * as defaultNs from "lib-default";
+import * as defaultNamespaceNs from "lib-default-namespace";
+import { foo, bar } from "./named.js";
+
+const SKIP = "(skipped side-effect-free modules)";
+
+it("should resolve named and namespace imports through a pure star passthrough chain", () => {
+	expect(foo()).toBe(1);
+	expect(bar()).toBe(2);
+	expect(ns.foo()).toBe(1);
+	expect(ns.bar()).toBe(2);
+	expect(ns.baz()).toBe(3);
+	expect(Object.keys(ns).sort()).toEqual(["bar", "baz", "foo"]);
+});
+
+it("should not collapse a passthrough target with its own default export", () => {
+	expect(defaultNs.value()).toBe("value");
+	expect(Object.keys(defaultNs)).toEqual(["value"]);
+	expect(defaultNamespaceNs.value()).toBe("value");
+	expect(Object.keys(defaultNamespaceNs)).toEqual(["value"]);
+
+	for (const packageName of ["lib-default", "lib-default-namespace"]) {
+		const real = __STATS__.modules.find((module) =>
+			module.name.endsWith(`${packageName}/real.js`)
+		);
+		const skippedFrom = new Set(
+			real.reasons
+				.filter((reason) => reason.explanation === SKIP)
+				.map((reason) => reason.moduleName)
+		);
+		expect(skippedFrom.has(`./node_modules/${packageName}/index.js`)).toBe(false);
+	}
+});
+
+it("should repoint consumers past the passthrough chain onto the real module", () => {
+	const real = __STATS__.modules.find((m) => m.name.endsWith("lib/real.js"));
+	const skippedFrom = new Set(
+		real.reasons.filter((r) => r.explanation === SKIP).map((r) => r.moduleName)
+	);
+	expect(skippedFrom.has("./index.js")).toBe(true);
+	expect(skippedFrom.has("./named.js")).toBe(true);
+	expect(skippedFrom.has("./node_modules/lib/a.js")).toBe(true);
+});
+
+it("should leave the intermediate star passthrough modules unused", () => {
+	const intermediates = __STATS__.modules.filter(
+		(m) => m.name.endsWith("lib/a.js") || m.name.endsWith("lib/b.js")
+	);
+	expect(intermediates).toHaveLength(2);
+	for (const module of intermediates) {
+		expect(module.usedExports).toBe(false);
+	}
+});

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/named.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/named.js
@@ -1,0 +1,1 @@
+export { foo, bar } from "lib";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/a.js
@@ -1,0 +1,4 @@
+import * as defaultNamespace from "./default.js";
+
+export default defaultNamespace;
+export * from "./real.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/default.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/default.js
@@ -1,0 +1,1 @@
+export const marker = "default";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/index.js
@@ -1,0 +1,1 @@
+export * from "./a.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib-default-namespace",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/real.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default-namespace/real.js
@@ -1,0 +1,3 @@
+export function value() {
+	return "value";
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/a.js
@@ -1,0 +1,5 @@
+export default function defaultValue() {
+	return "default";
+}
+
+export * from "./real.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/index.js
@@ -1,0 +1,1 @@
+export * from "./a.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib-default",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/real.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib-default/real.js
@@ -1,0 +1,3 @@
+export function value() {
+	return "value";
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/a.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/a.js
@@ -1,0 +1,1 @@
+export * from "./b.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/b.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/b.js
@@ -1,0 +1,1 @@
+export * from "./real.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/index.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/index.js
@@ -1,0 +1,1 @@
+export * from "./a.js";

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/package.json
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "lib",
+	"version": "0.0.1",
+	"sideEffects": false
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/real.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/node_modules/lib/real.js
@@ -1,0 +1,9 @@
+export function foo() {
+	return 1;
+}
+export function bar() {
+	return 2;
+}
+export function baz() {
+	return 3;
+}

--- a/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/star-reexport-passthrough-skip/rspack.config.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/** @type {import("../../../../").Configuration} */
+module.exports = {
+  mode: 'production',
+  optimization: {
+    sideEffects: true,
+    usedExports: true,
+    providedExports: true,
+    concatenateModules: false,
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
+++ b/tests/rspack-test/treeShakingCases/export-star-chain/__snapshots__/treeshaking.snap.txt
@@ -17,15 +17,6 @@ const blue = "blue";
 
 
 },
-"./colors/c.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
-__webpack_require__.d(__webpack_exports__, {
-  result: () => (/* reexport safe */ _result__rspack_import_0.result)
-});
-/* import */ var _result__rspack_import_0 = __webpack_require__("./colors/result.js");
-
-
-
-},
 "./colors/index.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
@@ -35,7 +26,7 @@ __webpack_require__.d(__webpack_exports__, {
 });
 /* import */ var _a__rspack_import_0 = __webpack_require__("./colors/a.js");
 /* import */ var _b__rspack_import_1 = __webpack_require__("./colors/b.js");
-/* import */ var _c__rspack_import_2 = __webpack_require__("./colors/c.js");
+/* import */ var _c__rspack_import_2 = __webpack_require__("./colors/result.js");
 
 
 


### PR DESCRIPTION
## Summary

Port webpack's side-effect-free ESM star-reexport passthrough optimization and its follow-up correctness fixes.

## Ported webpack PRs

- **[webpack/webpack#21085](https://github.com/webpack/webpack/pull/21085)** — skip side-effect-free `export *` passthrough modules, including nested namespace re-exports
- **[webpack/webpack#21105](https://github.com/webpack/webpack/pull/21105)** — port the comprehensive pure passthrough-chain regression coverage for named and namespace consumers, connection repointing, and unused intermediate barrels
- **[webpack/webpack#21148](https://github.com/webpack/webpack/pull/21148)** — preserve mixed and multi-star barrels as merge boundaries while still collapsing their single-star sub-chains
- **[webpack/webpack#21149](https://github.com/webpack/webpack/pull/21149)** — move every affected export target instead of a single target, cache single-star eligibility within each optimization pass, and port the fan-out regression case
- **[webpack/webpack#21446](https://github.com/webpack/webpack/pull/21446)** — keep `import defer` re-export barrels from being collapsed so deferred namespace identity and lazy evaluation semantics are preserved; port the `defer-reexport-identity` regression case with an additional evaluation-count assertion for Rspack

## Rspack-specific details

- represent pending export-target moves as none, one, or multiple targets
- conservatively stop at named, default-bearing, namespace-bearing, mixed, and multi-star boundaries
- apply the `import defer` guard to named re-exports, star target traversal, and regular import-specifier rewrites
- cover both normal and runtime-mode config runners; fan-out is tested with and without module concatenation

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
