### PR TITLE
fix: preserve leading zeros in string module ids

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -66,7 +66,7 @@ impl Serialize for ModuleId {
 
 impl ModuleId {
   pub fn as_number(&self) -> Option<u32> {
-    self.0.as_str().parse::<u32>().ok()
+    rspack_util::numeric_id_value(self.0.as_str())
   }
 
   pub fn as_str(&self) -> &str {

--- a/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/index.js
+++ b/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/index.js
@@ -1,0 +1,6 @@
+const context = require.context('./', false, /lazy-a\.js$/, 'lazy');
+
+it('should preserve a leading-zero string module id', async () => {
+  const module = await context('./lazy-a.js');
+  expect(module.default).toBe('lazy-a');
+});

--- a/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/lazy-a.js
+++ b/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/lazy-a.js
@@ -1,0 +1,1 @@
+export default 'lazy-a';

--- a/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/before-module-ids-leading-zero/rspack.config.js
@@ -1,0 +1,29 @@
+class LeadingZeroModuleIdPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      'LeadingZeroModuleIdPlugin',
+      (compilation) => {
+        compilation.hooks.beforeModuleIds.tap(
+          'LeadingZeroModuleIdPlugin',
+          (modules) => {
+            for (const module of modules) {
+              if (module.resource?.endsWith('lazy-a.js')) {
+                module.id = '0795';
+              }
+            }
+          },
+        );
+      },
+    );
+  }
+}
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  target: 'node',
+  mode: 'production',
+  optimization: {
+    minimize: false,
+  },
+  plugins: [new LeadingZeroModuleIdPlugin()],
+};


### PR DESCRIPTION
## Summary

- preserve leading-zero string module IDs when rendering JavaScript module factories
- reuse the existing round-trip-safe numeric ID detection used by chunk IDs
- add a lazy require.context regression case for a module assigned the ID "0795"

## Related links

Fixes #15426

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).