### PR TITLE
docs: correct collection types in API docs

### DIFF
--- a/website/docs/en/api/javascript-api/compiler.mdx
+++ b/website/docs/en/api/javascript-api/compiler.mdx
@@ -101,7 +101,7 @@ const watching = compiler.watch(
 The Watching object provides the following methods:
 
 - `watch`:
-  - **Type**: `(files: string[], dirs: string[], missing: string[]): void`
+  - **Type**: `(files: Iterable<string>, dirs: Iterable<string>, missing: Iterable<string>): void`
   - **Usage**: Adds files and directories to watch.
 - `invalidate`:
   - **Type**: `(callback: () => void): void`

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -457,9 +457,9 @@ Executed when a module has been built successfully.
 
 Called when all modules have been built without errors.
 
-- **Type:** `AsyncSeriesHook<[Module[]]>`
+- **Type:** `AsyncSeriesHook<[Iterable<Module>]>`
 - **Arguments:**
-  - `Module[]`: List of module instances
+  - `Iterable<Module>`: iterable of module instances
 
 <Collapse>
   <CollapsePanel
@@ -483,9 +483,9 @@ Called when the compilation stops accepting new modules and starts to optimize m
 
 Called at the beginning of the module optimization phase.
 
-- **Type:** `SyncBailHook<[Module[]]>`
+- **Type:** `SyncBailHook<[Iterable<Module>]>`
 - **Arguments:**
-  - `Module[]`: list of module instances
+  - `Iterable<Module>`: iterable of module instances
 
 <Collapse>
   <CollapsePanel
@@ -503,9 +503,9 @@ Called at the beginning of the module optimization phase.
 
 Called after modules optimization has completed.
 
-- **Type:** `SyncBailHook<[Module[]]>`
+- **Type:** `SyncBailHook<[Iterable<Module>]>`
 - **Arguments:**
-  - `Module[]`: list of module instances
+  - `Iterable<Module>`: iterable of module instances
 
 <Collapse>
   <CollapsePanel
@@ -523,10 +523,10 @@ Called after modules optimization has completed.
 
 Called before optimizing the dependency tree.
 
-- **Type:** `AsyncSeriesHook<[Chunk[], Module[]]>`
+- **Type:** `AsyncSeriesHook<[Iterable<Chunk>, Iterable<Module>]>`
 - **Arguments:**
-  - `Chunk[]`: list of chunk instances
-  - `Module[]`: list of module instances
+  - `Iterable<Chunk>`: iterable of chunk instances
+  - `Iterable<Module>`: iterable of module instances
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
@@ -547,10 +547,10 @@ Called before optimizing the dependency tree.
 
 Called after the tree optimization, at the beginning of the chunk modules optimization.
 
-- **Type:** `AsyncSeriesBailHook<[Chunk[], Module[]]>`
+- **Type:** `AsyncSeriesBailHook<[Iterable<Chunk>, Iterable<Module>]>`
 - **Arguments:**
-  - `Chunk[]`: list of chunk instances
-  - `Module[]`: list of module instances
+  - `Iterable<Chunk>`: iterable of chunk instances
+  - `Iterable<Module>`: iterable of module instances
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
@@ -573,9 +573,9 @@ Called after the tree optimization, at the beginning of the chunk modules optimi
 
 Called after the chunk ids optimization phase has completed.
 
-- **Type:** `SyncHook<[Chunk[]]>`
+- **Type:** `SyncHook<[Iterable<Chunk>]>`
 - **Arguments:**
-  - `Chunk[]`: list of chunk instances
+  - `Iterable<Chunk>`: iterable of chunk instances
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">

--- a/website/docs/en/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/en/api/plugin-api/compilation-hooks.mdx
@@ -503,7 +503,7 @@ Called at the beginning of the module optimization phase.
 
 Called after modules optimization has completed.
 
-- **Type:** `SyncBailHook<[Iterable<Module>]>`
+- **Type:** `SyncHook<[Iterable<Module>]>`
 - **Arguments:**
   - `Iterable<Module>`: iterable of module instances
 

--- a/website/docs/en/types/chunk-group.mdx
+++ b/website/docs/en/types/chunk-group.mdx
@@ -2,10 +2,10 @@
 
 ```ts
 type ChunkGroup = {
-  name?: Readonly<string>; // name of this chunk group
-  index?: Readonly<number>; // creating index of chunk group
-  chunks: ReadonlyArray<Chunk>; // chunks in this chunk group
-  origins: ReadonlyArray<{
+  readonly name?: string; // name of this chunk group
+  readonly index?: number; // creating index of chunk group
+  readonly chunks: Chunk[]; // chunks in this chunk group
+  readonly origins: Array<{
     // where this chunk group is imported
     module?: Module;
     request?: string;

--- a/website/docs/zh/api/javascript-api/compiler.mdx
+++ b/website/docs/zh/api/javascript-api/compiler.mdx
@@ -101,7 +101,7 @@ const watching = compiler.watch(
 Watching 对象提供如下方法：
 
 - `watch`:
-  - **类型：** `(files: string[], dirs: string[], missing: string[]): void`
+  - **类型：** `(files: Iterable<string>, dirs: Iterable<string>, missing: Iterable<string>): void`
   - **用途：** 添加需要被监听的文件和目录
 - `invalidate`:
   - **类型：** `(callback: () => void): void`

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -458,9 +458,9 @@ type ExecuteModuleContext = {
 
 当所有模块都没有错误地构建完成时调用。
 
-- **类型：** `AsyncSeriesHook<[Module[]]>`
+- **类型：** `AsyncSeriesHook<[Iterable<Module>]>`
 - **参数：**
-  - `Module[]`：所有模块列表
+  - `Iterable<Module>`：模块实例的可迭代对象
 
 <Collapse>
   <CollapsePanel
@@ -478,9 +478,9 @@ type ExecuteModuleContext = {
 
 在模块优化阶段开始时调用。
 
-- **类型：** `SyncBailHook<[Module[]]>`
+- **类型：** `SyncBailHook<[Iterable<Module>]>`
 - **参数：**
-  - `Module[]`：所有模块列表
+  - `Iterable<Module>`：模块实例的可迭代对象
 
 <Collapse>
   <CollapsePanel
@@ -504,9 +504,9 @@ type ExecuteModuleContext = {
 
 在模块优化完成之后调用。
 
-- **类型：** `SyncBailHook<[Module[]]>`
+- **类型：** `SyncBailHook<[Iterable<Module>]>`
 - **参数：**
-  - `Module[]`：所有模块列表
+  - `Iterable<Module>`：模块实例的可迭代对象
 
 <Collapse>
   <CollapsePanel
@@ -524,10 +524,10 @@ type ExecuteModuleContext = {
 
 在优化依赖树之前调用。
 
-- **类型：** `AsyncSeriesHook<[Chunk[], Module[]]>`
+- **类型：** `AsyncSeriesHook<[Iterable<Chunk>, Iterable<Module>]>`
 - **参数：**
-  - `Chunk[]`：Chunk 列表：
-  - `Module[]`：模块列表
+  - `Iterable<Chunk>`：Chunk 实例的可迭代对象
+  - `Iterable<Module>`：模块实例的可迭代对象
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
@@ -548,10 +548,10 @@ type ExecuteModuleContext = {
 
 在树优化之后，chunk 模块优化开始时调用。
 
-- **类型：** `AsyncSeriesBailHook<[Chunk[], Module[]]>`
+- **类型：** `AsyncSeriesBailHook<[Iterable<Chunk>, Iterable<Module>]>`
 - **参数：**
-  - `Chunk[]`：Chunk 列表：
-  - `Module[]`：模块列表
+  - `Iterable<Chunk>`：Chunk 实例的可迭代对象
+  - `Iterable<Module>`：模块实例的可迭代对象
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">
@@ -574,9 +574,9 @@ type ExecuteModuleContext = {
 
 在 chunk id 优化阶段结束之后调用。
 
-- **类型：** `SyncHook<[Chunk[]]>`
+- **类型：** `SyncHook<[Iterable<Chunk>]>`
 - **参数：**
-  - `Chunk[]`：所有 chunk 列表
+  - `Iterable<Chunk>`：Chunk 实例的可迭代对象
 
 <Collapse>
   <CollapsePanel className="collapse-code-panel" header="Chunk.ts" key="Chunk">

--- a/website/docs/zh/api/plugin-api/compilation-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/compilation-hooks.mdx
@@ -504,7 +504,7 @@ type ExecuteModuleContext = {
 
 在模块优化完成之后调用。
 
-- **类型：** `SyncBailHook<[Iterable<Module>]>`
+- **类型：** `SyncHook<[Iterable<Module>]>`
 - **参数：**
   - `Iterable<Module>`：模块实例的可迭代对象
 

--- a/website/docs/zh/types/chunk-group.mdx
+++ b/website/docs/zh/types/chunk-group.mdx
@@ -2,10 +2,10 @@
 
 ```ts
 type ChunkGroup = {
-  name?: Readonly<string>; // 名称
-  index?: Readonly<number>; // 索引序
-  chunks: ReadonlyArray<Chunk>; // 包含的 chunk 列表
-  origins: ReadonlyArray<{
+  readonly name?: string; // 名称
+  readonly index?: number; // 索引序
+  readonly chunks: Chunk[]; // 包含的 chunk 列表
+  readonly origins: Array<{
     // chunk group 被引入的来源模块信息
     module?: Module;
     request?: string;


### PR DESCRIPTION
## Summary

- Correct compilation hook collection parameters to use `Iterable<Module>` and `Iterable<Chunk>` instead of array types.
- Align the documented `Watching.watch` parameters and `ChunkGroup` readonly properties with their public API contracts.
- Keep the English and Chinese API documentation in sync.

Validation:

- `pnpm --dir website build`
- staged-file formatting and spell checks

## Related links

Follow-up to #15372.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
