### PR TITLE
feat(css): support CSS import and asset URL externals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4536,6 +4536,7 @@ dependencies = [
 name = "rspack_macros"
 version = "0.102.2"
 dependencies = [
+ "cow-utils",
  "heck",
  "proc-macro2",
  "quote",

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -433,6 +433,13 @@ fn resolve_external_type<'a>(
         "module"
       }
     }
+    "asset" | "asset-url" | "css-url" => {
+      if dependency_meta.source_type == Some(SourceType::CssUrl) {
+        "asset-url"
+      } else {
+        "asset"
+      }
+    }
 
     import_or_module => import_or_module,
   }
@@ -1100,17 +1107,10 @@ impl Module for ExternalModule {
   }
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
-    if self.external_type == "asset"
-      && self
-        .dependency_meta
-        .source_type
-        .is_some_and(|t| t == SourceType::CssUrl)
-    {
-      EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES
-    } else if self.external_type == "css-import" {
-      EXTERNAL_MODULE_CSS_SOURCE_TYPES
-    } else {
-      EXTERNAL_MODULE_JS_SOURCE_TYPES
+    match self.resolve_external_type() {
+      "asset-url" => EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES,
+      "css-import" => EXTERNAL_MODULE_CSS_SOURCE_TYPES,
+      _ => EXTERNAL_MODULE_JS_SOURCE_TYPES,
     }
   }
 
@@ -1228,7 +1228,7 @@ impl Module for ExternalModule {
 
     let mut cgr = CodeGenerationResultBuilder::default();
     let (request, external_type) = self.get_request_and_external_type();
-    match self.external_type.as_str() {
+    match self.resolve_external_type() {
       "asset" if request.is_some() => {
         let request = request.expect("request should be some");
         cgr.add(
@@ -1240,6 +1240,12 @@ impl Module for ExternalModule {
           ))
           .boxed(),
         );
+        cgr
+          .data_mut()
+          .insert(CodeGenerationDataUrl::new(request.primary().to_string()));
+      }
+      "asset-url" if request.is_some() => {
+        let request = request.expect("request should be some");
         cgr
           .data_mut()
           .insert(CodeGenerationDataUrl::new(request.primary().to_string()));

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -433,7 +433,7 @@ fn resolve_external_type<'a>(
         "module"
       }
     }
-    "asset" | "asset-url" | "css-url" => {
+    "asset" | "asset-url" => {
       if dependency_meta.source_type == Some(SourceType::CssUrl) {
         "asset-url"
       } else {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -27,7 +27,7 @@ use crate::{
 
 static EXTERNAL_MODULE_JS_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
 static EXTERNAL_MODULE_CSS_SOURCE_TYPES: &[SourceType] = &[SourceType::CssImport];
-static EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES: &[SourceType] = &[SourceType::CssUrl];
+static EXTERNAL_MODULE_ASSET_URL_SOURCE_TYPES: &[SourceType] = &[SourceType::AssetUrl];
 
 define_hook!(ExternalModuleChunkCondition: SeriesBail(
   chunk_ukey: &ChunkUkey,
@@ -434,7 +434,7 @@ fn resolve_external_type<'a>(
       }
     }
     "asset" | "asset-url" => {
-      if dependency_meta.source_type == Some(SourceType::CssUrl) {
+      if dependency_meta.source_type == Some(SourceType::AssetUrl) {
         "asset-url"
       } else {
         "asset"
@@ -1108,7 +1108,7 @@ impl Module for ExternalModule {
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     match self.resolve_external_type() {
-      "asset-url" => EXTERNAL_MODULE_CSS_URL_SOURCE_TYPES,
+      "asset-url" => EXTERNAL_MODULE_ASSET_URL_SOURCE_TYPES,
       "css-import" => EXTERNAL_MODULE_CSS_SOURCE_TYPES,
       _ => EXTERNAL_MODULE_JS_SOURCE_TYPES,
     }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -130,7 +130,7 @@ pub mod debug_info;
 pub enum SourceType {
   JavaScript,
   Css,
-  CssUrl,
+  AssetUrl,
   Wasm,
   Asset,
   Expose,
@@ -162,7 +162,7 @@ impl SourceType {
     match self {
       SourceType::JavaScript => "javascript",
       SourceType::Css => "css",
-      SourceType::CssUrl => "css-url",
+      SourceType::AssetUrl => "asset-url",
       SourceType::Wasm => "wasm",
       SourceType::Asset => "asset",
       SourceType::Expose => "expose",
@@ -183,6 +183,7 @@ impl From<&str> for SourceType {
     match value {
       "javascript" => Self::JavaScript,
       "css" => Self::Css,
+      "asset-url" => Self::AssetUrl,
       "wasm" => Self::Wasm,
       "asset" => Self::Asset,
       "expose" => Self::Expose,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -126,21 +126,30 @@ pub use rspack_sources;
 pub mod debug_info;
 
 #[cacheable]
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(
+  Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, rspack_macros::StringEnum,
+)]
 pub enum SourceType {
+  #[string_enum(rename = "javascript")]
   JavaScript,
   Css,
+  #[string_enum(rename = "asset-url")]
   AssetUrl,
   Wasm,
   Asset,
   Expose,
   Remote,
+  #[string_enum(rename = "share-init")]
   ShareInit,
+  #[string_enum(rename = "consume-shared")]
   ConsumeShared,
+  #[string_enum(rename = "share-container-shared")]
   ShareContainerShared,
+  #[string_enum(fallback)]
   Custom(#[cacheable(with=AsPreset)] Ustr),
   #[default]
   Unknown,
+  #[string_enum(rename = "css-import")]
   CssImport,
   Runtime,
 }
@@ -154,47 +163,6 @@ impl std::fmt::Display for SourceType {
 impl RspackHash for SourceType {
   fn hash(&self, state: &mut RspackHasher) {
     self.as_str().hash(state);
-  }
-}
-
-impl SourceType {
-  fn as_str(&self) -> &str {
-    match self {
-      SourceType::JavaScript => "javascript",
-      SourceType::Css => "css",
-      SourceType::AssetUrl => "asset-url",
-      SourceType::Wasm => "wasm",
-      SourceType::Asset => "asset",
-      SourceType::Expose => "expose",
-      SourceType::Remote => "remote",
-      SourceType::ShareInit => "share-init",
-      SourceType::ConsumeShared => "consume-shared",
-      SourceType::ShareContainerShared => "share-container-shared",
-      SourceType::Unknown => "unknown",
-      SourceType::CssImport => "css-import",
-      SourceType::Custom(source_type) => source_type,
-      SourceType::Runtime => "runtime",
-    }
-  }
-}
-
-impl From<&str> for SourceType {
-  fn from(value: &str) -> Self {
-    match value {
-      "javascript" => Self::JavaScript,
-      "css" => Self::Css,
-      "asset-url" => Self::AssetUrl,
-      "wasm" => Self::Wasm,
-      "asset" => Self::Asset,
-      "expose" => Self::Expose,
-      "remote" => Self::Remote,
-      "share-init" => Self::ShareInit,
-      "consume-shared" => Self::ConsumeShared,
-      "share-container-shared" => Self::ShareContainerShared,
-      "unknown" => Self::Unknown,
-      "css-import" => Self::CssImport,
-      other => SourceType::Custom(other.into()),
-    }
   }
 }
 

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -129,27 +129,23 @@ pub mod debug_info;
 #[derive(
   Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, rspack_macros::StringEnum,
 )]
+#[string_enum(rename_all = "kebab-case")]
 pub enum SourceType {
   #[string_enum(rename = "javascript")]
   JavaScript,
   Css,
-  #[string_enum(rename = "asset-url")]
   AssetUrl,
   Wasm,
   Asset,
   Expose,
   Remote,
-  #[string_enum(rename = "share-init")]
   ShareInit,
-  #[string_enum(rename = "consume-shared")]
   ConsumeShared,
-  #[string_enum(rename = "share-container-shared")]
   ShareContainerShared,
   #[string_enum(fallback)]
   Custom(#[cacheable(with=AsPreset)] Ustr),
   #[default]
   Unknown,
-  #[string_enum(rename = "css-import")]
   CssImport,
   Runtime,
 }

--- a/crates/rspack_core/src/utils/source_size_cache.rs
+++ b/crates/rspack_core/src/utils/source_size_cache.rs
@@ -40,7 +40,7 @@ impl SourceSizeCache {
     match source_type {
       SourceType::JavaScript => Some(0),
       SourceType::Css => Some(1),
-      SourceType::CssUrl => Some(2),
+      SourceType::AssetUrl => Some(2),
       SourceType::Wasm => Some(3),
       SourceType::Asset => Some(4),
       SourceType::Expose => Some(5),

--- a/crates/rspack_macros/Cargo.toml
+++ b/crates/rspack_macros/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 test       = false
 
 [dependencies]
+cow-utils   = { workspace = true }
 heck        = { workspace = true }
 proc-macro2 = { workspace = true }
 quote       = { workspace = true }

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -63,9 +63,11 @@ pub fn define_hook(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Derives `as_str` and `From<&str>` for a string enum.
 ///
-/// Variant names use `snake_case` by default. Use `#[string_enum(rename = "...")]` to override a
-/// value and mark exactly one variant with `#[string_enum(fallback)]` for unknown strings. The
-/// fallback may be a unit variant or a newtype variant that can store the unknown string.
+/// Variant names use `snake_case` by default. Use `#[string_enum(rename_all = "...")]` on the enum
+/// to select a serde-style rename rule, or `#[string_enum(rename = "...")]` on a variant to
+/// override its value. Mark exactly one variant with `#[string_enum(fallback)]` for unknown
+/// strings. The fallback may be a unit variant or a newtype variant that can store the unknown
+/// string.
 #[proc_macro_derive(StringEnum, attributes(string_enum))]
 pub fn string_enum_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   let input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/crates/rspack_macros/src/lib.rs
+++ b/crates/rspack_macros/src/lib.rs
@@ -61,10 +61,11 @@ pub fn define_hook(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   .into()
 }
 
-/// Derives `as_str` and `From<&str>` for a fieldless enum.
+/// Derives `as_str` and `From<&str>` for a string enum.
 ///
 /// Variant names use `snake_case` by default. Use `#[string_enum(rename = "...")]` to override a
-/// value and mark exactly one variant with `#[string_enum(fallback)]` for unknown strings.
+/// value and mark exactly one variant with `#[string_enum(fallback)]` for unknown strings. The
+/// fallback may be a unit variant or a newtype variant that can store the unknown string.
 #[proc_macro_derive(StringEnum, attributes(string_enum))]
 pub fn string_enum_derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
   let input = syn::parse_macro_input!(input as syn::DeriveInput);

--- a/crates/rspack_macros/src/string_enum.rs
+++ b/crates/rspack_macros/src/string_enum.rs
@@ -195,7 +195,7 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
     }
   });
 
-  let (as_str_return_type, fallback_as_str_arm, fallback_from_str) = match fallback {
+  let (as_str_return_type, fallback_as_str_arm, fallback_constructor) = match fallback {
     Fallback::Unit(variant) => (
       quote!(&'static str),
       quote! {
@@ -226,7 +226,7 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
       fn from(value: &str) -> Self {
         match value {
           #(#from_str_arms)*
-          _ => #fallback_from_str,
+          _ => #fallback_constructor,
         }
       }
     }

--- a/crates/rspack_macros/src/string_enum.rs
+++ b/crates/rspack_macros/src/string_enum.rs
@@ -1,3 +1,4 @@
+use cow_utils::CowUtils;
 use heck::ToSnakeCase;
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -8,6 +9,63 @@ enum Fallback {
   Newtype(syn::Ident),
 }
 
+#[derive(Clone, Copy, Default)]
+enum RenameRule {
+  Lower,
+  Upper,
+  Pascal,
+  Camel,
+  #[default]
+  Snake,
+  ScreamingSnake,
+  Kebab,
+  ScreamingKebab,
+}
+
+impl RenameRule {
+  fn parse(value: &LitStr) -> Result<Self> {
+    match value.value().as_str() {
+      "lowercase" => Ok(Self::Lower),
+      "UPPERCASE" => Ok(Self::Upper),
+      "PascalCase" => Ok(Self::Pascal),
+      "camelCase" => Ok(Self::Camel),
+      "snake_case" => Ok(Self::Snake),
+      "SCREAMING_SNAKE_CASE" => Ok(Self::ScreamingSnake),
+      "kebab-case" => Ok(Self::Kebab),
+      "SCREAMING-KEBAB-CASE" => Ok(Self::ScreamingKebab),
+      _ => Err(Error::new(
+        value.span(),
+        "unknown rename rule, expected one of `lowercase`, `UPPERCASE`, `PascalCase`, \
+         `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`, or \
+         `SCREAMING-KEBAB-CASE`",
+      )),
+    }
+  }
+
+  fn apply(self, value: &str) -> String {
+    let snake_case = || value.to_snake_case();
+    match self {
+      Self::Lower => value.cow_to_ascii_lowercase().into_owned(),
+      Self::Upper => value.cow_to_ascii_uppercase().into_owned(),
+      Self::Pascal => value.to_string(),
+      Self::Camel => {
+        let mut chars = value.chars();
+        chars
+          .next()
+          .map(|first| first.to_lowercase().collect::<String>() + chars.as_str())
+          .unwrap_or_default()
+      }
+      Self::Snake => snake_case(),
+      Self::ScreamingSnake => snake_case().cow_to_ascii_uppercase().into_owned(),
+      Self::Kebab => snake_case().cow_replace('_', "-").into_owned(),
+      Self::ScreamingKebab => snake_case()
+        .cow_replace('_', "-")
+        .cow_to_ascii_uppercase()
+        .into_owned(),
+    }
+  }
+}
+
 pub fn expand(input: DeriveInput) -> Result<TokenStream> {
   let name = &input.ident;
   let Data::Enum(data) = &input.data else {
@@ -16,6 +74,26 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
       "StringEnum can only be derived for enums",
     ));
   };
+
+  let mut rename_all = None;
+  for attribute in &input.attrs {
+    if !attribute.path().is_ident("string_enum") {
+      continue;
+    }
+    attribute.parse_nested_meta(|meta| {
+      if meta.path.is_ident("rename_all") {
+        if rename_all.is_some() {
+          return Err(meta.error("duplicate string_enum rename_all option"));
+        }
+        let value = meta.value()?.parse::<LitStr>()?;
+        rename_all = Some(RenameRule::parse(&value)?);
+        Ok(())
+      } else {
+        Err(meta.error("unsupported string_enum container option"))
+      }
+    })?;
+  }
+  let rename_all = rename_all.unwrap_or_default();
 
   let mut fallback = None;
   let mut mappings = Vec::new();
@@ -83,7 +161,7 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
 
     let value = rename.unwrap_or_else(|| {
       LitStr::new(
-        &variant.ident.to_string().to_snake_case(),
+        &rename_all.apply(&variant.ident.to_string()),
         variant.ident.span(),
       )
     });

--- a/crates/rspack_macros/src/string_enum.rs
+++ b/crates/rspack_macros/src/string_enum.rs
@@ -3,6 +3,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Error, Fields, LitStr, Result, spanned::Spanned};
 
+enum Fallback {
+  Unit(syn::Ident),
+  Newtype(syn::Ident),
+}
+
 pub fn expand(input: DeriveInput) -> Result<TokenStream> {
   let name = &input.ident;
   let Data::Enum(data) = &input.data else {
@@ -16,13 +21,6 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
   let mut mappings = Vec::new();
 
   for variant in &data.variants {
-    if !matches!(variant.fields, Fields::Unit) {
-      return Err(Error::new(
-        variant.fields.span(),
-        "string enum variants must not contain fields",
-      ));
-    }
-
     let mut is_fallback = false;
     let mut rename = None;
     for attribute in &variant.attrs {
@@ -55,13 +53,32 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
           "string enum fallback cannot be renamed",
         ));
       }
-      if fallback.replace(variant.ident.clone()).is_some() {
+      let fallback_variant = match &variant.fields {
+        Fields::Unit => Fallback::Unit(variant.ident.clone()),
+        Fields::Unnamed(fields) if fields.unnamed.len() == 1 => {
+          Fallback::Newtype(variant.ident.clone())
+        }
+        _ => {
+          return Err(Error::new(
+            variant.fields.span(),
+            "string enum fallback must be a unit variant or contain exactly one unnamed field",
+          ));
+        }
+      };
+      if fallback.replace(fallback_variant).is_some() {
         return Err(Error::new(
           variant.span(),
           "string enum must have exactly one fallback variant",
         ));
       }
       continue;
+    }
+
+    if !matches!(variant.fields, Fields::Unit) {
+      return Err(Error::new(
+        variant.fields.span(),
+        "string enum non-fallback variants must not contain fields",
+      ));
     }
 
     let value = rename.unwrap_or_else(|| {
@@ -100,12 +117,29 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
     }
   });
 
+  let (as_str_return_type, fallback_as_str_arm, fallback_from_str) = match fallback {
+    Fallback::Unit(variant) => (
+      quote!(&'static str),
+      quote! {
+        Self::#variant => unreachable!("string enum fallback has no string representation"),
+      },
+      quote!(Self::#variant),
+    ),
+    Fallback::Newtype(variant) => (
+      quote!(&str),
+      quote! {
+        Self::#variant(value) => value,
+      },
+      quote!(Self::#variant(value.into())),
+    ),
+  };
+
   Ok(quote! {
     impl #impl_generics #name #type_generics #where_clause {
-      pub fn as_str(&self) -> &'static str {
+      pub fn as_str(&self) -> #as_str_return_type {
         match self {
           #(#as_str_arms)*
-          Self::#fallback => unreachable!("string enum fallback has no string representation"),
+          #fallback_as_str_arm
         }
       }
     }
@@ -114,7 +148,7 @@ pub fn expand(input: DeriveInput) -> Result<TokenStream> {
       fn from(value: &str) -> Self {
         match value {
           #(#from_str_arms)*
-          _ => Self::#fallback,
+          _ => #fallback_from_str,
         }
       }
     }

--- a/crates/rspack_macros_test/tests/string_enum.rs
+++ b/crates/rspack_macros_test/tests/string_enum.rs
@@ -3,6 +3,7 @@ use rspack_macros::StringEnum;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
 enum TestStringEnum {
   First,
+  DefaultMultipleWords,
   #[string_enum(rename = "multiple-words")]
   MultipleWords,
   #[string_enum(fallback)]
@@ -16,15 +17,33 @@ enum TestStringEnumWithValueFallback {
   Custom(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, StringEnum)]
+#[string_enum(rename_all = "kebab-case")]
+enum TestStringEnumWithRenameAll {
+  MultipleWords,
+  #[string_enum(rename = "renamed")]
+  ExplicitRename,
+  #[string_enum(fallback)]
+  Unknown,
+}
+
 #[test]
 fn converts_between_enum_and_str() {
   assert_eq!(TestStringEnum::from("first"), TestStringEnum::First);
+  assert_eq!(
+    TestStringEnum::from("default_multiple_words"),
+    TestStringEnum::DefaultMultipleWords
+  );
   assert_eq!(
     TestStringEnum::from("multiple-words"),
     TestStringEnum::MultipleWords
   );
   assert_eq!(TestStringEnum::from("unknown"), TestStringEnum::Unknown);
   assert_eq!(TestStringEnum::First.as_str(), "first");
+  assert_eq!(
+    TestStringEnum::DefaultMultipleWords.as_str(),
+    "default_multiple_words"
+  );
   assert_eq!(TestStringEnum::MultipleWords.as_str(), "multiple-words");
 }
 
@@ -37,4 +56,24 @@ fn preserves_unknown_string_in_fallback() {
   );
   assert_eq!(value.as_str(), "custom-value");
   assert_eq!(TestStringEnumWithValueFallback::First.as_str(), "first");
+}
+
+#[test]
+fn applies_rename_all_before_variant_rename() {
+  assert_eq!(
+    TestStringEnumWithRenameAll::from("multiple-words"),
+    TestStringEnumWithRenameAll::MultipleWords
+  );
+  assert_eq!(
+    TestStringEnumWithRenameAll::MultipleWords.as_str(),
+    "multiple-words"
+  );
+  assert_eq!(
+    TestStringEnumWithRenameAll::from("renamed"),
+    TestStringEnumWithRenameAll::ExplicitRename
+  );
+  assert_eq!(
+    TestStringEnumWithRenameAll::ExplicitRename.as_str(),
+    "renamed"
+  );
 }

--- a/crates/rspack_macros_test/tests/string_enum.rs
+++ b/crates/rspack_macros_test/tests/string_enum.rs
@@ -9,6 +9,13 @@ enum TestStringEnum {
   Unknown,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, StringEnum)]
+enum TestStringEnumWithValueFallback {
+  First,
+  #[string_enum(fallback)]
+  Custom(String),
+}
+
 #[test]
 fn converts_between_enum_and_str() {
   assert_eq!(TestStringEnum::from("first"), TestStringEnum::First);
@@ -19,4 +26,15 @@ fn converts_between_enum_and_str() {
   assert_eq!(TestStringEnum::from("unknown"), TestStringEnum::Unknown);
   assert_eq!(TestStringEnum::First.as_str(), "first");
   assert_eq!(TestStringEnum::MultipleWords.as_str(), "multiple-words");
+}
+
+#[test]
+fn preserves_unknown_string_in_fallback() {
+  let value = TestStringEnumWithValueFallback::from("custom-value");
+  assert_eq!(
+    value,
+    TestStringEnumWithValueFallback::Custom("custom-value".to_string())
+  );
+  assert_eq!(value.as_str(), "custom-value");
+  assert_eq!(TestStringEnumWithValueFallback::First.as_str(), "first");
 }

--- a/crates/rspack_plugin_asset/src/lib.rs
+++ b/crates/rspack_plugin_asset/src/lib.rs
@@ -30,17 +30,17 @@ pub const AUTO_PUBLIC_PATH_PLACEHOLDER: &str = "__RSPACK_PLUGIN_ASSET_AUTO_PUBLI
 #[derive(Debug, Default)]
 pub struct AssetPlugin;
 
-static JS_AND_CSS_URL_TYPES: &[SourceType; 2] = &[SourceType::JavaScript, SourceType::CssUrl];
+static JS_AND_ASSET_URL_TYPES: &[SourceType; 2] = &[SourceType::JavaScript, SourceType::AssetUrl];
 static JS_TYPES: &[SourceType; 1] = &[SourceType::JavaScript];
-static CSS_URL_TYPES: &[SourceType; 1] = &[SourceType::CssUrl];
+static ASSET_URL_TYPES: &[SourceType; 1] = &[SourceType::AssetUrl];
 
-static ASSET_AND_JS_AND_CSS_URL_TYPES: &[SourceType; 3] = &[
+static ASSET_AND_JS_AND_ASSET_URL_TYPES: &[SourceType; 3] = &[
   SourceType::Asset,
   SourceType::JavaScript,
-  SourceType::CssUrl,
+  SourceType::AssetUrl,
 ];
 static ASSET_AND_JS_TYPES: &[SourceType; 2] = &[SourceType::Asset, SourceType::JavaScript];
-static ASSET_AND_CSS_URL_TYPES: &[SourceType; 2] = &[SourceType::Asset, SourceType::CssUrl];
+static ASSET_AND_ASSET_URL_TYPES: &[SourceType; 2] = &[SourceType::Asset, SourceType::AssetUrl];
 static ASSET_TYPES: &[SourceType; 1] = &[SourceType::Asset];
 
 const DEFAULT_ENCODING: &str = "base64";
@@ -399,9 +399,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
         let has_js = source_types.contains(&SourceType::JavaScript);
         let has_css = source_types.contains(&SourceType::Css);
         if has_js && has_css {
-          return JS_AND_CSS_URL_TYPES;
+          return JS_AND_ASSET_URL_TYPES;
         } else if has_css {
-          return CSS_URL_TYPES;
+          return ASSET_URL_TYPES;
         } else {
           return JS_TYPES;
         }
@@ -419,9 +419,9 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let has_js = source_types.contains(&SourceType::JavaScript);
     let has_css = source_types.contains(&SourceType::Css);
     if has_js && has_css {
-      ASSET_AND_JS_AND_CSS_URL_TYPES
+      ASSET_AND_JS_AND_ASSET_URL_TYPES
     } else if has_css {
-      ASSET_AND_CSS_URL_TYPES
+      ASSET_AND_ASSET_URL_TYPES
     } else {
       ASSET_AND_JS_TYPES
     }
@@ -431,7 +431,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let original_source_size = module.source().map_or(0, |source| source.size()) as f64;
     match source_type.unwrap_or(&SourceType::Asset) {
       SourceType::Asset => original_source_size,
-      SourceType::JavaScript | SourceType::CssUrl => {
+      SourceType::JavaScript | SourceType::AssetUrl => {
         if module.source().is_none() {
           return 0.0;
         }
@@ -545,11 +545,11 @@ impl ParserAndGenerator for AssetParserAndGenerator {
     let import_mode = self.get_import_mode(module_generator_options)?;
 
     match generate_context.requested_source_type {
-      SourceType::JavaScript | SourceType::CssUrl => {
+      SourceType::JavaScript | SourceType::AssetUrl => {
         let mut preserved_import_request = None;
         let exported_content = if parsed_asset_config.is_bytes() {
           let mut encoded_source = base64::encode_to_string(source.buffer());
-          if generate_context.requested_source_type == SourceType::CssUrl {
+          if generate_context.requested_source_type == SourceType::AssetUrl {
             encoded_source = format!("data:application/octet-stream;base64,{encoded_source}");
             generate_context
               .data
@@ -656,7 +656,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
             PublicPath::Auto => AUTO_PUBLIC_PATH_PLACEHOLDER.to_string(),
           };
 
-          if generate_context.requested_source_type == SourceType::CssUrl {
+          if generate_context.requested_source_type == SourceType::AssetUrl {
             // `filename` includes outputPath for emission, while CSS URLs only use the original
             // filename so their public path stays independent from the output directory.
             generate_context
@@ -680,7 +680,7 @@ impl ParserAndGenerator for AssetParserAndGenerator {
           unreachable!()
         };
 
-        if generate_context.requested_source_type == SourceType::CssUrl {
+        if generate_context.requested_source_type == SourceType::AssetUrl {
           return Ok(RawStringSource::from_static("").boxed());
         }
 

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -148,10 +148,8 @@ impl ExternalsPlugin {
     };
 
     let external_module_type = r#type.unwrap_or(external_module_type);
-    if matches!(
-      external_module_type.as_str(),
-      "asset" | "asset-url" | "css-url"
-    ) && matches!(dependency.dependency_type(), DependencyType::CssUrl)
+    if matches!(external_module_type.as_str(), "asset" | "asset-url")
+      && matches!(dependency.dependency_type(), DependencyType::CssUrl)
     {
       dependency_meta.source_type = Some(SourceType::CssUrl);
     }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -151,7 +151,7 @@ impl ExternalsPlugin {
     if matches!(external_module_type.as_str(), "asset" | "asset-url")
       && matches!(dependency.dependency_type(), DependencyType::CssUrl)
     {
-      dependency_meta.source_type = Some(SourceType::CssUrl);
+      dependency_meta.source_type = Some(SourceType::AssetUrl);
     }
 
     if external_module_type == "modern-module"

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -147,13 +147,15 @@ impl ExternalsPlugin {
       source_type: None,
     };
 
-    if r#type.as_ref().is_some_and(|t| t == "asset")
-      && matches!(dependency.dependency_type(), DependencyType::CssUrl)
+    let external_module_type = r#type.unwrap_or(external_module_type);
+    if matches!(
+      external_module_type.as_str(),
+      "asset" | "asset-url" | "css-url"
+    ) && matches!(dependency.dependency_type(), DependencyType::CssUrl)
     {
       dependency_meta.source_type = Some(SourceType::CssUrl);
     }
 
-    let external_module_type = r#type.unwrap_or(external_module_type);
     if external_module_type == "modern-module"
       && matches!(
         dependency_type,

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1815,8 +1815,7 @@ export type ExternalsType =
   | 'commonjs-import'
   | 'asset'
   | 'asset-url'
-  | 'css-import'
-  | 'css-url';
+  | 'css-import';
 //#endregion
 
 //#region Externals

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -1812,7 +1812,11 @@ export type ExternalsType =
   | 'modern-module'
   | 'script'
   | 'node-commonjs'
-  | 'commonjs-import';
+  | 'commonjs-import'
+  | 'asset'
+  | 'asset-url'
+  | 'css-import'
+  | 'css-url';
 //#endregion
 
 //#region Externals

--- a/tests/rspack-test/configCases/externals/asset-url/index.js
+++ b/tests/rspack-test/configCases/externals/asset-url/index.js
@@ -5,12 +5,10 @@ const path = require('path');
 
 const jsAsset = new URL('js-asset', import.meta.url);
 const jsAssetUrl = new URL('js-asset-url', import.meta.url);
-const jsCssUrl = new URL('js-css-url', import.meta.url);
 
 it('should resolve an asset external from javascript, whichever type it is', () => {
   expect(jsAsset.toString()).toBe('https://example.test/js-asset.png');
   expect(jsAssetUrl.toString()).toBe('https://example.test/js-asset-url.png');
-  expect(jsCssUrl.toString()).toBe('https://example.test/js-css-url.png');
 });
 
 it('should keep an asset external in the stylesheet, whichever type it is', () => {
@@ -21,5 +19,4 @@ it('should keep an asset external in the stylesheet, whichever type it is', () =
 
   expect(css).toContain('url("https://example.test/css-asset.png")');
   expect(css).toContain('url("https://example.test/css-asset-url.png")');
-  expect(css).toContain('url("https://example.test/css-css-url.png")');
 });

--- a/tests/rspack-test/configCases/externals/asset-url/index.js
+++ b/tests/rspack-test/configCases/externals/asset-url/index.js
@@ -1,0 +1,25 @@
+import './style.css';
+
+const fs = require('fs');
+const path = require('path');
+
+const jsAsset = new URL('js-asset', import.meta.url);
+const jsAssetUrl = new URL('js-asset-url', import.meta.url);
+const jsCssUrl = new URL('js-css-url', import.meta.url);
+
+it('should resolve an asset external from javascript, whichever type it is', () => {
+  expect(jsAsset.toString()).toBe('https://example.test/js-asset.png');
+  expect(jsAssetUrl.toString()).toBe('https://example.test/js-asset-url.png');
+  expect(jsCssUrl.toString()).toBe('https://example.test/js-css-url.png');
+});
+
+it('should keep an asset external in the stylesheet, whichever type it is', () => {
+  const css = fs.readFileSync(
+    path.join(__STATS__.outputPath, 'bundle0.css'),
+    'utf-8',
+  );
+
+  expect(css).toContain('url("https://example.test/css-asset.png")');
+  expect(css).toContain('url("https://example.test/css-asset-url.png")');
+  expect(css).toContain('url("https://example.test/css-css-url.png")');
+});

--- a/tests/rspack-test/configCases/externals/asset-url/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/asset-url/rspack.config.js
@@ -27,10 +27,7 @@ module.exports = {
     path: 'node-commonjs path',
     'css-asset': 'asset https://example.test/css-asset.png',
     'css-asset-url': 'asset-url https://example.test/css-asset-url.png',
-    // TODO webpack 6 remove, `css-url` is the old spelling of `asset-url`
-    'css-css-url': 'css-url https://example.test/css-css-url.png',
     'js-asset': 'asset https://example.test/js-asset.png',
     'js-asset-url': 'asset-url https://example.test/js-asset-url.png',
-    'js-css-url': 'css-url https://example.test/js-css-url.png',
   },
 };

--- a/tests/rspack-test/configCases/externals/asset-url/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/asset-url/rspack.config.js
@@ -1,0 +1,36 @@
+'use strict';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  experiments: {
+    css: true,
+  },
+  optimization: {
+    minimize: false,
+  },
+  module: {
+    generator: {
+      'css/auto': {
+        exportsOnly: false,
+      },
+    },
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/auto',
+      },
+    ],
+  },
+  externals: {
+    fs: 'node-commonjs fs',
+    path: 'node-commonjs path',
+    'css-asset': 'asset https://example.test/css-asset.png',
+    'css-asset-url': 'asset-url https://example.test/css-asset-url.png',
+    // TODO webpack 6 remove, `css-url` is the old spelling of `asset-url`
+    'css-css-url': 'css-url https://example.test/css-css-url.png',
+    'js-asset': 'asset https://example.test/js-asset.png',
+    'js-asset-url': 'asset-url https://example.test/js-asset-url.png',
+    'js-css-url': 'css-url https://example.test/js-css-url.png',
+  },
+};

--- a/tests/rspack-test/configCases/externals/asset-url/style.css
+++ b/tests/rspack-test/configCases/externals/asset-url/style.css
@@ -1,5 +1,4 @@
 body {
   background: url('css-asset');
   border-image: url('css-asset-url');
-  mask-image: url('css-css-url');
 }

--- a/tests/rspack-test/configCases/externals/asset-url/style.css
+++ b/tests/rspack-test/configCases/externals/asset-url/style.css
@@ -1,0 +1,5 @@
+body {
+  background: url('css-asset');
+  border-image: url('css-asset-url');
+  mask-image: url('css-css-url');
+}

--- a/tests/rspack-test/configCases/externals/asset-url/test.config.js
+++ b/tests/rspack-test/configCases/externals/asset-url/test.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  moduleScope(scope, stats) {
+    const link = scope.window.document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = `bundle${stats().__index__ ?? 0}.css`;
+    scope.window.document.head.appendChild(link);
+  },
+};

--- a/tests/rspack-test/configCases/externals/custom-url/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/custom-url/rspack.config.js
@@ -11,7 +11,8 @@ module.exports = {
       if (/^(\/\/|custom?:\/\/)/.test(request)) {
         if (dependencyType === 'css-import')
           return callback(null, request, 'css-import');
-        if (dependencyType === 'url') return callback(null, request, 'css-url');
+        if (dependencyType === 'url')
+          return callback(null, request, 'asset-url');
         return callback(null, `var '${request}'`);
       }
       return callback();

--- a/tests/rspack-test/configCases/externals/custom-url/rspack.config.js
+++ b/tests/rspack-test/configCases/externals/custom-url/rspack.config.js
@@ -10,8 +10,8 @@ module.exports = {
     function ({ request, dependencyType }, callback) {
       if (/^(\/\/|custom?:\/\/)/.test(request)) {
         if (dependencyType === 'css-import')
-          return callback(null, `css-import ${request}`);
-        if (dependencyType === 'url') return callback(null, `asset ${request}`);
+          return callback(null, request, 'css-import');
+        if (dependencyType === 'url') return callback(null, request, 'css-url');
         return callback(null, `var '${request}'`);
       }
       return callback();


### PR DESCRIPTION
## Summary

- add `asset`, `asset-url`, and `css-import` to the public `ExternalsType` options
- resolve an asset external as `asset-url` when it is consumed by CSS `url()`, while keeping JavaScript `new URL()` behavior as `asset`
- rename the internal URL source type from `SourceType::CssUrl` to `SourceType::AssetUrl`
- extend `StringEnum` with:
  - a newtype fallback that preserves unknown strings
  - serde-style `rename_all` rules, with `snake_case` as the default and per-variant `rename` taking precedence
- derive the complete `SourceType` string mappings with `rename_all = "kebab-case"`
- preserve external CSS URLs in generated CSS instead of emitting a JavaScript wrapper
- port webpack's `configCases/externals/asset-url` coverage

The deprecated webpack `css-url` alias is intentionally not supported.

## Example

```js
module.exports = {
  externalsType: "asset-url",
  externals: {
    "external-image": "https://example.com/image.png"
  }
};
```

Given:

```css
.logo {
  background: url(external-image);
}
```

Rspack now keeps the external URL in the emitted CSS. Before this fix, the external was treated as a JavaScript source and could not be generated correctly for the CSS consumer.

The new `StringEnum` forms keep mappings concise and custom source types round-trippable:

```rust
#[string_enum(rename_all = "kebab-case")]
enum SourceType {
  #[string_enum(rename = "javascript")]
  JavaScript,
  AssetUrl,
  #[string_enum(fallback)]
  Custom(Ustr),
}
```

Unknown strings are converted to `Custom(value)`, and `as_str()` returns the preserved value.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test -t 'externals/asset-url'`
- `pnpm run test -t 'custom-url'`
- `pnpm run test -t 'css/import'`
- `cargo test -p rspack_macros_test`
- `cargo clippy -p rspack_macros -p rspack_macros_test -p rspack_core -p rspack_plugin_asset -p rspack_plugin_externals --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- webpack gap tracker: no webpack-only files remain for `configCases/css/import` and `configCases/externals/asset-url`

## Checklist

- [x] Tests added or updated
- [x] Relevant tests pass
- [x] Deprecated `css-url` is not exposed

---
_by OpenAI Codex_