### PR TITLE
chore: support single-target preview releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,17 +323,3 @@ jobs:
           script: |
             const upload = require('./.github/actions/binary-limit/upload-binary-size.js');
             upload({ sha: context.sha, token: process.env.PERF_DATA_TOKEN });
-
-  # TODO: enable it after self hosted runners are ready
-  # pkg-preview:
-  #   name: Pkg Preview
-  #   needs:
-  #     - test-linux
-  #     - test-windows
-  #     - cargo-deny
-  #     - lint
-  #     - rust_check
-  #     - rust_test
-  #   # after merged to main branch
-  #   if: ${{ !failure() && github.event_name == 'push' }}
-  #   uses: ./.github/workflows/preview-commit.yml

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -2,7 +2,6 @@
 name: Preview Commit
 
 on:
-  workflow_call:
   workflow_dispatch:
     inputs:
       commit:
@@ -50,11 +49,10 @@ jobs:
     with:
       force-use-github-runner: false
 
-  check-changed:
+  resolve-ref:
     runs-on: ubuntu-latest
-    name: Check Changed
+    name: Resolve Ref
     outputs:
-      changed: ${{ steps.filter.outputs.changed == 'true' }}
       sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -63,39 +61,22 @@ jobs:
       - name: Resolve ref
         id: resolve
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
-        id: filter
-        with:
-          filters: |
-            changed:
-              - "crates/**"
-              - "packages/rspack/**"
-              - "packages/rspack-cli/**"
 
   build:
-    needs: [get-runner-labels, check-changed]
-    if: github.event_name == 'workflow_dispatch' || needs.check-changed.outputs.changed == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ${{ fromJSON(
-          github.event_name == 'workflow_dispatch'
-          && format('["{0}"]', inputs.target)
-          || '["x86_64-unknown-linux-gnu","aarch64-unknown-linux-gnu","riscv64gc-unknown-linux-gnu","x86_64-unknown-linux-musl","aarch64-unknown-linux-musl","riscv64gc-unknown-linux-musl","powerpc64le-unknown-linux-gnu","s390x-unknown-linux-gnu","i686-pc-windows-msvc","x86_64-pc-windows-msvc","aarch64-pc-windows-msvc","x86_64-apple-darwin","aarch64-apple-darwin"]'
-          ) }}
+    needs: [get-runner-labels, resolve-ref]
     uses: ./.github/workflows/reusable-build.yml
     with:
-      ref: ${{ needs.check-changed.outputs.sha }}
-      target: ${{ matrix.target }}
+      ref: ${{ needs.resolve-ref.outputs.sha }}
+      target: ${{ inputs.target }}
       runner: ${{
-        contains(matrix.target, 'windows-msvc') && needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS ||
-        contains(matrix.target, 'apple-darwin') && needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS ||
-        (matrix.target == 'x86_64-unknown-linux-gnu' ||
-        matrix.target == 'x86_64-unknown-linux-musl' ||
-        matrix.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
+        contains(inputs.target, 'windows-msvc') && needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS ||
+        contains(inputs.target, 'apple-darwin') && needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS ||
+        (inputs.target == 'x86_64-unknown-linux-gnu' ||
+        inputs.target == 'x86_64-unknown-linux-musl' ||
+        inputs.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
         '"ubuntu-latest"'
         }}
-      profile: ${{ inputs.profile || 'release' }}
+      profile: ${{ inputs.profile }}
       test: false
 
   publish:
@@ -104,11 +85,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-      - check-changed
+      - resolve-ref
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ needs.check-changed.outputs.sha }}
+          ref: ${{ needs.resolve-ref.outputs.sha }}
 
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm/setup
@@ -120,7 +101,7 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
-          pattern: bindings-${{ github.event_name == 'workflow_dispatch' && inputs.target || '*' }}
+          pattern: bindings-${{ inputs.target }}
 
       - name: Clean artifacts
         run: find artifacts -type f -name '*.d.ts' -delete

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -3,6 +3,31 @@ name: Preview Commit
 
 on:
   workflow_call:
+  workflow_dispatch:
+    inputs:
+      commit:
+        type: string
+        required: false
+        description: 'Commit SHA or ref (defaults to the selected workflow ref)'
+      target:
+        type: choice
+        required: true
+        default: x86_64-unknown-linux-gnu
+        description: 'Rust target to build and publish'
+        options:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+          - riscv64gc-unknown-linux-musl
+          - powerpc64le-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+          - i686-pc-windows-msvc
+          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
+          - x86_64-apple-darwin
+          - aarch64-apple-darwin
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`
@@ -33,41 +58,27 @@ jobs:
 
   build:
     needs: [get-runner-labels, check-changed]
-    if: needs.check-changed.outputs.changed == 'true'
+    if: github.event_name == 'workflow_dispatch' || needs.check-changed.outputs.changed == 'true'
     strategy:
       fail-fast: false
       matrix:
-        array:
-          - target: x86_64-unknown-linux-gnu
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: aarch64-unknown-linux-gnu
-            runner: "'ubuntu-latest'"
-          - target: riscv64gc-unknown-linux-gnu
-            runner: "'ubuntu-latest'"
-          - target: x86_64-unknown-linux-musl
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: aarch64-unknown-linux-musl
-            runner: ${{ needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS }}
-          - target: riscv64gc-unknown-linux-musl
-            runner: "'ubuntu-latest'"
-          - target: powerpc64le-unknown-linux-gnu
-            runner: "'ubuntu-latest'"
-          - target: s390x-unknown-linux-gnu
-            runner: "'ubuntu-latest'"
-          - target: i686-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: x86_64-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: aarch64-pc-windows-msvc
-            runner: ${{ needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS }}
-          - target: x86_64-apple-darwin
-            runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
-          - target: aarch64-apple-darwin
-            runner: ${{ needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS }}
+        target: ${{ fromJSON(
+          github.event_name == 'workflow_dispatch'
+          && format('["{0}"]', inputs.target)
+          || '["x86_64-unknown-linux-gnu","aarch64-unknown-linux-gnu","riscv64gc-unknown-linux-gnu","x86_64-unknown-linux-musl","aarch64-unknown-linux-musl","riscv64gc-unknown-linux-musl","powerpc64le-unknown-linux-gnu","s390x-unknown-linux-gnu","i686-pc-windows-msvc","x86_64-pc-windows-msvc","aarch64-pc-windows-msvc","x86_64-apple-darwin","aarch64-apple-darwin"]'
+          ) }}
     uses: ./.github/workflows/reusable-build.yml
     with:
-      target: ${{ matrix.array.target }}
-      runner: ${{ matrix.array.runner }}
+      ref: ${{ inputs.commit || github.sha }}
+      target: ${{ matrix.target }}
+      runner: ${{
+        contains(matrix.target, 'windows-msvc') && needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS ||
+        contains(matrix.target, 'apple-darwin') && needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS ||
+        (matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'x86_64-unknown-linux-musl' ||
+          matrix.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
+        '"ubuntu-latest"'
+        }}
       profile: 'release'
       test: false
 
@@ -79,6 +90,8 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.commit || github.sha }}
 
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm/setup
@@ -90,6 +103,10 @@ jobs:
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: artifacts
+          pattern: bindings-${{ github.event_name == 'workflow_dispatch' && inputs.target || '*' }}
+
+      - name: Clean artifacts
+        run: find artifacts -type f -name '*.d.ts' -delete
 
       - name: Build node packages
         run: pnpm run build:js
@@ -101,4 +118,4 @@ jobs:
         run: ls -R npm
 
       - name: Release
-        run: npx pkg-pr-new publish --compact --pnpm './npm/*' './crates/node_binding' './packages/rspack' './packages/rspack-cli'
+        run: npx --yes pkg-pr-new@0.0.88 publish --compact --commentWithSha --pnpm './npm/*' './crates/node_binding' './packages/rspack' './packages/rspack-cli'

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -8,7 +8,7 @@ on:
       commit:
         type: string
         required: false
-        description: 'Commit SHA or ref (defaults to the selected workflow ref)'
+        description: 'Full commit SHA or ref (defaults to the selected workflow ref)'
       target:
         type: choice
         required: true

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -75,8 +75,8 @@ jobs:
         contains(matrix.target, 'windows-msvc') && needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS ||
         contains(matrix.target, 'apple-darwin') && needs.get-runner-labels.outputs.MACOS_RUNNER_LABELS ||
         (matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'x86_64-unknown-linux-musl' ||
-          matrix.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
+        matrix.target == 'x86_64-unknown-linux-musl' ||
+        matrix.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
         '"ubuntu-latest"'
         }}
       profile: 'release'

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -9,6 +9,16 @@ on:
         type: string
         required: false
         description: 'Full commit SHA or ref (defaults to the selected workflow ref)'
+      profile:
+        type: choice
+        required: true
+        default: release
+        description: 'Rust build profile'
+        options:
+          - release
+          - profiling
+          - ci
+          - debug
       target:
         type: choice
         required: true
@@ -45,8 +55,14 @@ jobs:
     name: Check Changed
     outputs:
       changed: ${{ steps.filter.outputs.changed == 'true' }}
+      sha: ${{ steps.resolve.outputs.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.commit || github.sha }}
+      - name: Resolve ref
+        id: resolve
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: filter
         with:
@@ -69,7 +85,7 @@ jobs:
           ) }}
     uses: ./.github/workflows/reusable-build.yml
     with:
-      ref: ${{ inputs.commit || github.sha }}
+      ref: ${{ needs.check-changed.outputs.sha }}
       target: ${{ matrix.target }}
       runner: ${{
         contains(matrix.target, 'windows-msvc') && needs.get-runner-labels.outputs.WINDOWS_RUNNER_LABELS ||
@@ -79,7 +95,7 @@ jobs:
         matrix.target == 'aarch64-unknown-linux-musl') && needs.get-runner-labels.outputs.LINUX_RUNNER_LABELS ||
         '"ubuntu-latest"'
         }}
-      profile: 'release'
+      profile: ${{ inputs.profile || 'release' }}
       test: false
 
   publish:
@@ -88,10 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+      - check-changed
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ inputs.commit || github.sha }}
+          ref: ${{ needs.check-changed.outputs.sha }}
 
       - name: Pnpm Setup
         uses: ./.github/actions/pnpm/setup


### PR DESCRIPTION
## Summary

Support publishing a Rspack preview for one selected native target instead of building every platform.

## AI prompt

> Trigger the `Preview Commit` workflow for `<commit-or-ref>` and target `<rust-target>`. Wait for the `Pkg Preview` job to complete, then return the pkg.pr.new install URLs for `@rspack/core` and `@rspack/cli`.

Example:

> Trigger the `Preview Commit` workflow for the current branch and target `x86_64-unknown-linux-gnu`. Wait for the `Pkg Preview` job to complete, then return the pkg.pr.new install URLs for `@rspack/core` and `@rspack/cli`.