### PR TITLE
fix(dll): set DLL factory_meta in the factory phase

### DIFF
--- a/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
+++ b/crates/rspack_plugin_dll/src/flag_all_modules_as_used_plugin.rs
@@ -1,8 +1,8 @@
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  BoxModule, Compilation, CompilationBuildModule, CompilationId, CompilationOptimizeDependencies,
-  CompilerId, ExportsInfoArtifact, FactoryMeta, Plugin, RuntimeSpec, SideEffectsOptimizeArtifact,
-  build_module_graph::BuildModuleGraphArtifact, get_entry_runtime,
+  BoxModule, Compilation, CompilationOptimizeDependencies, ExportsInfoArtifact, FactoryMeta,
+  ModuleFactoryCreateData, NormalModuleCreateData, NormalModuleFactoryModule, Plugin, RuntimeSpec,
+  SideEffectsOptimizeArtifact, build_module_graph::BuildModuleGraphArtifact, get_entry_runtime,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -31,15 +31,18 @@ impl Plugin for FlagAllModulesAsUsedPlugin {
       .tap(optimize_dependencies::new(self));
 
     ctx
-      .compilation_hooks
-      .build_module
-      .tap(build_module::new(self));
+      .normal_module_factory_hooks
+      .module
+      .tap(nmf_module::new(self));
 
     Ok(())
   }
 }
 
-#[plugin_hook(CompilationOptimizeDependencies for FlagAllModulesAsUsedPlugin)]
+// Write the concatenation bailout at a negative stage so it lands before other
+// `optimize_dependencies` taps that read it back, such as `EsmLibraryPlugin`,
+// which calls `get_concatenation_bailout_reason` from the same hook.
+#[plugin_hook(CompilationOptimizeDependencies for FlagAllModulesAsUsedPlugin, stage = -10)]
 async fn optimize_dependencies(
   &self,
   compilation: &Compilation,
@@ -59,44 +62,59 @@ async fn optimize_dependencies(
       a
     });
 
-  let mg = build_module_graph_artifact.get_module_graph_mut();
+  let module_id_list: IdentifierSet = build_module_graph_artifact
+    .get_module_graph_mut()
+    .modules_keys()
+    .copied()
+    .collect();
 
-  let module_id_list: IdentifierSet = mg.modules_keys().copied().collect();
-
-  for module_id in module_id_list {
+  for module_id in &module_id_list {
     exports_info_artifact
-      .get_exports_info_data_mut(&module_id)
+      .get_exports_info_data_mut(module_id)
       .set_used_in_unknown_way(Some(&runtime));
+  }
+
+  // webpack avoids concatenating these modules by adding a virtual
+  // module_graph_connection.
+  // see: https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/FlagAllModulesAsUsedPlugin.js#L44
+  // Rspack needs incremental build, so we should not add a virtual connection to
+  // the module. We can add a bail reason to avoid those modules being
+  // concatenated.
+  let mg = build_module_graph_artifact.get_module_graph_mut();
+  for module_id in &module_id_list {
+    if let Some(module) = mg.module_by_identifier_mut(module_id) {
+      let build_info = module.build_info_mut();
+      if build_info.module_concatenation_bailout.is_none() {
+        build_info.module_concatenation_bailout = Some(format!(
+          "Module {} is referenced by {}",
+          module_id, &self.explanation
+        ));
+      }
+    }
   }
 
   Ok(None)
 }
 
-#[plugin_hook(CompilationBuildModule for FlagAllModulesAsUsedPlugin)]
-async fn build_module(
+// Set all modules as having side effects, so tree shaking keeps them.
+//
+// This runs in the factory phase rather than in `optimizeDependencies`, matching
+// webpack: lazy barrel classification reads `factory_meta` while the module
+// graph is still being built, which is long before the seal phase.
+// see: https://github.com/webpack/webpack/blob/ce97d583e1cd8f3e47b70737de72e91b567a8497/lib/dll/DllPlugin.js#L72-L88
+//
+// The stage keeps this after `SideEffectsFlagPlugin`, whose tap runs at the
+// default stage and would otherwise overwrite this value.
+#[plugin_hook(NormalModuleFactoryModule for FlagAllModulesAsUsedPlugin, stage = 10, tracing=false)]
+async fn nmf_module(
   &self,
-  _compiler_id: CompilerId,
-  _compilation_id: CompilationId,
+  _data: &mut ModuleFactoryCreateData,
+  _create_data: &NormalModuleCreateData,
   module: &mut BoxModule,
 ) -> Result<()> {
-  // set all modules have effects. To avoid any module remove by tree shaking.
-  // see: https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/FlagAllModulesAsUsedPlugin.js#L43-L47
   module.set_factory_meta(FactoryMeta {
     side_effect_free: Some(false),
   });
-
-  let module_identifier = module.identifier();
-  let build_info = module.build_info_mut();
-  if build_info.module_concatenation_bailout.is_none() {
-    // webpack avoid those modules be concatenated using add a virtual module_graph_connection.
-    // see: https://github.com/webpack/webpack/blob/4b4ca3bb53f36a5b8fc6bc1bd976ed7af161bd80/lib/FlagAllModulesAsUsedPlugin.js#L42
-    // Rspack need incremental build, so we should not add virtual connection to module.
-    // We can add a bail reason to avoid those modules be concatenated.
-    build_info.module_concatenation_bailout = Some(format!(
-      "Module {} is referenced by {}",
-      module_identifier, &self.explanation
-    ));
-  }
 
   Ok(())
 }


### PR DESCRIPTION
## Problem

`FlagAllModulesAsUsedPlugin` set `factory_meta.side_effect_free = Some(false)` from the `build_module` hook, which only fires for modules that are actually built. So the value was:

- **too late for lazy barrel** — `skip_side_effect_free_esm_import_side_effect_dependencies` reads `factory_meta` in `FactorizeResultTask` (`factorize.rs:183`), before `BuildTask` calls `build_module` (`build.rs:62`);
- **missing entirely** for modules an incremental rebuild leaves untouched, which never enter `BuildTask`.

webpack hit this when porting lazy barrel and moved the same assignment into `DllPlugin`'s `normalModuleFactory.hooks.module` tap (stage 10) — webpack/webpack#21165.

## Changes

**`set_factory_meta` → `NormalModuleFactoryModule`, `stage = 10`.** Factory hooks run before `AddTask`, so the value is in place before any lazy barrel or side-effects decision, whether or not the module is built. Stage 10 keeps it after `SideEffectsFlagPlugin` and `DelegatedPlugin`, which both tap at stage 0 and would otherwise clobber it — same stage webpack uses.

**`module_concatenation_bailout` → `optimize_dependencies`, `stage = -10`.** Now covers every module instead of only rebuilt ones. Negative stage keeps the write ahead of `EsmLibraryPlugin`, which reads it back from the same hook at stage 0 (`esm_library/src/plugin.rs:793`). Still well before `OptimizeChunkModulesPass`, and `is_none()` keeps it idempotent.

## Behavior note

Two module kinds no longer get `Some(false)`, since they bypass `NormalModuleFactory`:

- **ContextModule / ExternalModule / DllModule** — no change in behavior: every consumer treats `None` and `Some(false)` the same (`.unwrap_or_default()`, `== Some(true)`, `.unwrap_or(false)`), and `set_used_in_unknown_way` still walks the whole graph, so manifests are unaffected.
- **Ignored modules** (`resolve.alias: { x: false }`, IgnorePlugin) — keep the `Some(true)` set at `normal_module_factory.rs:950` instead of being overwritten. This matches webpack, whose ignored module is a singleton with `sideEffectFree: true` that also bypasses `hooks.module`. Verified: a DLL build with an ignored request produces identical output before and after.

## Testing

Full `tests/rspack-test`: 9187 passed. The 3 `browserslist-*-extends` failures reproduce identically on an unpatched build (missing fixture package locally) and are unrelated.

DLL coverage green: `serialCases/dll-plugin{,-side-effects,-context,-entry,-format}`, `configCases/dll`, `exampleCases/dll-entry-only`, `lib-manifest-plugin`, plus `treeShakingCases` and `scope-hoisting`. `cargo fmt` and `clippy -p rspack_plugin_dll -- --deny warnings` clean.

No new test case — `dll-plugin-side-effects` and `dll-plugin-context` already cover `entryOnly: false`, and the reordering has no externally observable effect on its own. Can add one if you'd like the lazy barrel + DllPlugin interaction pinned down.

## Related

Found while reviewing #15380 (persistent module cache), which makes this worse: once modules restore from cache and skip `BuildTask`, a `build_module`-based write is silently dropped. Independent of that PR.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
