### PR TITLE
refactor(javascript): internalize side effects analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5003,7 +5003,6 @@ dependencies = [
  "swc_experimental_ecma_parser",
  "swc_experimental_ecma_semantic",
  "swc_experimental_ecma_transforms_base",
- "swc_experimental_ecma_utils",
  "tokio",
  "tracing",
  "url",
@@ -7280,16 +7279,6 @@ dependencies = [
  "rustc-hash",
  "swc_experimental_allocator",
  "swc_experimental_ecma_ast",
-]
-
-[[package]]
-name = "swc_experimental_ecma_utils"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d4620c8e29665bbd21e286087b3b8dd4927ac34e3531453eb24e6286a88c61"
-dependencies = [
- "swc_experimental_ecma_ast",
- "swc_experimental_ecma_semantic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,7 +161,6 @@ swc_experimental_ecma_ast             = { version = "0.11.0", default-features =
 swc_experimental_ecma_parser          = { version = "0.11.0", default-features = false }
 swc_experimental_ecma_semantic        = { version = "0.11.0", default-features = false }
 swc_experimental_ecma_transforms_base = { version = "0.11.0", default-features = false }
-swc_experimental_ecma_utils           = { version = "0.11.0", default-features = false }
 
 tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }
 wasi-common  = { version = "36.0.13", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -46,7 +46,6 @@ swc_experimental_ecma_ast             = { workspace = true }
 swc_experimental_ecma_parser          = { workspace = true, features = ["unstable"] }
 swc_experimental_ecma_semantic        = { workspace = true }
 swc_experimental_ecma_transforms_base = { workspace = true }
-swc_experimental_ecma_utils           = { workspace = true }
 tokio                                 = { workspace = true, features = ["sync"] }
 tracing                               = { workspace = true }
 url                                   = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/mod.rs
@@ -23,6 +23,7 @@ pub mod node_stuff_plugin;
 mod override_strict_plugin;
 mod require_context_dependency_parser_plugin;
 mod require_ensure_dependencies_block_parse_plugin;
+mod side_effects_analysis;
 mod r#trait;
 mod url_plugin;
 mod use_strict_plugin;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
@@ -1,0 +1,480 @@
+/**
+ * Some code is modified based on
+ * https://github.com/CPunisher/swc-experimental/blob/57cf78c4bc1b963d4e4946492b88164958e6f764/crates/swc_ecma_utils/src/lib.rs
+ * Apache-2.0 licensed
+ */
+// Conservative, syntax-level side-effects analysis.
+//
+// Rspack-specific policies such as `/*#__PURE__*/`, `pureFunctions`, parser hooks, and deferred
+// import checks stay in `side_effects_parser_plugin`.
+use swc_experimental_ecma_ast::{
+  Callee, Class, ClassMember, Decl, Expr, Lit, MemberProp, MethodKind, OptChainBase, Pat, Prop,
+  PropName, PropOrSpread, Stmt, UnaryOp, VarDeclKind,
+};
+use swc_experimental_ecma_semantic::resolver::Semantic;
+
+#[derive(Clone, Copy)]
+pub(super) struct SideEffectsContext<'a> {
+  semantic: &'a Semantic,
+  is_unresolved_ref_safe: bool,
+  in_strict: bool,
+  remaining_depth: u8,
+}
+
+impl<'a> SideEffectsContext<'a> {
+  pub(super) fn new(semantic: &'a Semantic, is_unresolved_ref_safe: bool) -> Self {
+    Self {
+      semantic,
+      is_unresolved_ref_safe,
+      in_strict: false,
+      remaining_depth: 4,
+    }
+  }
+
+  fn consume_depth(self) -> Option<Self> {
+    if self.remaining_depth == 0 {
+      return None;
+    }
+
+    Some(Self {
+      remaining_depth: self.remaining_depth - 1,
+      ..self
+    })
+  }
+}
+
+pub(super) trait MayHaveSideEffects {
+  fn is_pure_callee(&self, ctx: SideEffectsContext<'_>) -> bool;
+  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool;
+  fn is_global_ref_to(&self, ctx: SideEffectsContext<'_>, id: &str) -> bool;
+}
+
+impl MayHaveSideEffects for Expr<'_> {
+  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool {
+    let Some(ctx) = ctx.consume_depth() else {
+      return true;
+    };
+
+    if self.is_pure_callee(ctx) {
+      return false;
+    }
+
+    match self {
+      Expr::Ident(ident) => {
+        if ctx.is_unresolved_ref_safe {
+          return false;
+        }
+
+        if ctx.semantic.node_scope(ident) == ctx.semantic.unresolved_scope_id() {
+          !matches!(
+            ident.sym.as_str(),
+            "Infinity"
+              | "NaN"
+              | "Math"
+              | "undefined"
+              | "Object"
+              | "Array"
+              | "Promise"
+              | "Boolean"
+              | "Number"
+              | "String"
+              | "BigInt"
+              | "Error"
+              | "RegExp"
+              | "Function"
+              | "document"
+          )
+        } else {
+          false
+        }
+      }
+      Expr::Lit(..) | Expr::This(..) | Expr::PrivateName(..) => false,
+      Expr::Paren(parenthesized) => parenthesized.expr.may_have_side_effects(ctx),
+      Expr::Fn(..) | Expr::Arrow(..) => false,
+      Expr::Class(class) => class_has_side_effects(ctx, &class.class),
+      Expr::Array(array) => array
+        .elems
+        .iter()
+        .flatten()
+        .any(|element| element.spread.is_some() || element.expr.may_have_side_effects(ctx)),
+      Expr::Unary(unary) => match unary.op {
+        UnaryOp::Delete => true,
+        _ => unary.arg.may_have_side_effects(ctx),
+      },
+      Expr::Bin(binary) => {
+        binary.left.may_have_side_effects(ctx) || binary.right.may_have_side_effects(ctx)
+      }
+      Expr::Member(member)
+        if matches!(
+          &member.obj,
+          Expr::Object(_) | Expr::Fn(_) | Expr::Arrow(_) | Expr::Class(_)
+        ) =>
+      {
+        let object = &member.obj;
+        if object.may_have_side_effects(ctx) {
+          return true;
+        }
+
+        match object {
+          Expr::Class(class)
+            if class.class.body.iter().any(|member| {
+              matches!(
+                member,
+                ClassMember::Method(method)
+                  if (method.kind == MethodKind::Getter || method.kind == MethodKind::Setter)
+                    && method.is_static
+              )
+            }) =>
+          {
+            return true;
+          }
+          Expr::Object(object) => {
+            let can_have_side_effects = |property: &PropOrSpread<'_>| match property {
+              PropOrSpread::Spread(_) => true,
+              PropOrSpread::Prop(property) => match &**property {
+                Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) => true,
+                Prop::Shorthand(identifier) => identifier.sym == "__proto__",
+                Prop::KeyValue(key_value) => match &key_value.key {
+                  PropName::Ident(identifier) => identifier.sym == "__proto__",
+                  PropName::Str(string) => string.value.as_wtf8().as_str() == Some("__proto__"),
+                  PropName::Computed(_) => true,
+                  _ => false,
+                },
+                _ => false,
+              },
+            };
+            if object.props.iter().any(can_have_side_effects) {
+              return true;
+            }
+          }
+          _ => {}
+        }
+
+        match &member.prop {
+          MemberProp::Computed(computed) => computed.expr.may_have_side_effects(ctx),
+          MemberProp::Ident(_) | MemberProp::PrivateName(_) => false,
+        }
+      }
+      Expr::Tpl(_) | Expr::TaggedTpl(_) | Expr::MetaProp(_) => true,
+      Expr::Await(_)
+      | Expr::Yield(_)
+      | Expr::Member(_)
+      | Expr::SuperProp(_)
+      | Expr::Update(_)
+      | Expr::Assign(_) => true,
+      Expr::OptChain(optional_chain) if matches!(&optional_chain.base, OptChainBase::Member(_)) => {
+        true
+      }
+      Expr::New(new_expression) if is_pure_new_callee(&new_expression.callee, ctx) => {
+        new_expression.args.as_ref().is_some_and(|arguments| {
+          arguments
+            .iter()
+            .any(|argument| argument.expr.may_have_side_effects(ctx))
+        })
+      }
+      Expr::New(_) => true,
+      Expr::Call(call_expression) => {
+        let Callee::Expr(callee) = &call_expression.callee else {
+          return true;
+        };
+
+        if callee.is_pure_callee(ctx) {
+          call_expression
+            .args
+            .iter()
+            .any(|argument| argument.expr.may_have_side_effects(ctx))
+        } else {
+          true
+        }
+      }
+      Expr::OptChain(optional_chain) => match &optional_chain.base {
+        OptChainBase::Call(call) if call.callee.is_pure_callee(ctx) => call
+          .args
+          .iter()
+          .any(|argument| argument.expr.may_have_side_effects(ctx)),
+        _ => true,
+      },
+      Expr::Seq(sequence) => sequence
+        .exprs
+        .iter()
+        .any(|expression| expression.may_have_side_effects(ctx)),
+      Expr::Cond(conditional) => {
+        conditional.test.may_have_side_effects(ctx)
+          || conditional.cons.may_have_side_effects(ctx)
+          || conditional.alt.may_have_side_effects(ctx)
+      }
+      Expr::Object(object) => object.props.iter().any(|property| match property {
+        PropOrSpread::Prop(property) => match &**property {
+          Prop::Shorthand(..) => false,
+          Prop::KeyValue(key_value) => {
+            let key_has_side_effects = match &key_value.key {
+              PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
+              _ => false,
+            };
+            key_has_side_effects || key_value.value.may_have_side_effects(ctx)
+          }
+          Prop::Getter(getter) => match &getter.key {
+            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
+            _ => false,
+          },
+          Prop::Setter(setter) => match &setter.key {
+            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
+            _ => false,
+          },
+          Prop::Method(method) => match &method.key {
+            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
+            _ => false,
+          },
+          Prop::Assign(_) => true,
+        },
+        PropOrSpread::Spread(_) => true,
+      }),
+      Expr::JSXMember(..)
+      | Expr::JSXNamespacedName(..)
+      | Expr::JSXEmpty(..)
+      | Expr::JSXElement(..)
+      | Expr::JSXFragment(..)
+      | Expr::Invalid(..) => true,
+    }
+  }
+
+  fn is_pure_callee(&self, ctx: SideEffectsContext<'_>) -> bool {
+    if self.is_global_ref_to(ctx, "Date") {
+      return true;
+    }
+
+    match self {
+      Expr::Member(member) => {
+        let object = &member.obj;
+        let property = &member.prop;
+
+        if let MemberProp::Ident(property) = property {
+          if object.is_global_ref_to(ctx, "Math") {
+            return true;
+          }
+
+          match object {
+            Expr::Ident(identifier) => identifier.sym == "Math",
+            Expr::Lit(literal) if matches!(&**literal, Lit::Str(..)) => {
+              is_pure_string_method(property.sym.as_str())
+            }
+            Expr::Tpl(template) if template.exprs.is_empty() => {
+              is_pure_string_method(property.sym.as_str())
+            }
+            _ => false,
+          }
+        } else {
+          false
+        }
+      }
+      Expr::Fn(function) => {
+        let function = &function.function;
+        function
+          .params
+          .iter()
+          .all(|parameter| matches!(&parameter.pat, Pat::Ident(_)))
+          && function
+            .body
+            .as_ref()
+            .is_some_and(|body| body.stmts.is_empty())
+      }
+      _ => false,
+    }
+  }
+
+  fn is_global_ref_to(&self, ctx: SideEffectsContext<'_>, id: &str) -> bool {
+    match self {
+      Expr::Ident(identifier) => {
+        ctx.semantic.node_scope(identifier) == ctx.semantic.unresolved_scope_id()
+          && identifier.sym == id
+      }
+      _ => false,
+    }
+  }
+}
+
+trait StatementMayHaveSideEffects {
+  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool;
+}
+
+impl StatementMayHaveSideEffects for Stmt<'_> {
+  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool {
+    match self {
+      Stmt::Block(block) => block
+        .stmts
+        .iter()
+        .any(|statement| statement.may_have_side_effects(ctx)),
+      Stmt::Empty(_) => false,
+      Stmt::Labeled(labeled) => labeled.body.may_have_side_effects(ctx),
+      Stmt::If(if_statement) => {
+        if_statement.test.may_have_side_effects(ctx)
+          || if_statement.cons.may_have_side_effects(ctx)
+          || if_statement
+            .alt
+            .as_ref()
+            .is_some_and(|statement| statement.may_have_side_effects(ctx))
+      }
+      Stmt::Switch(switch) => {
+        switch.discriminant.may_have_side_effects(ctx)
+          || switch.cases.iter().any(|case| {
+            case
+              .test
+              .as_ref()
+              .is_some_and(|expression| expression.may_have_side_effects(ctx))
+              || case
+                .cons
+                .iter()
+                .any(|statement| statement.may_have_side_effects(ctx))
+          })
+      }
+      Stmt::Try(try_statement) => {
+        try_statement
+          .block
+          .stmts
+          .iter()
+          .any(|statement| statement.may_have_side_effects(ctx))
+          || try_statement.handler.as_ref().is_some_and(|handler| {
+            handler
+              .body
+              .stmts
+              .iter()
+              .any(|statement| statement.may_have_side_effects(ctx))
+          })
+          || try_statement.finalizer.as_ref().is_some_and(|finalizer| {
+            finalizer
+              .stmts
+              .iter()
+              .any(|statement| statement.may_have_side_effects(ctx))
+          })
+      }
+      Stmt::Decl(declaration) => match &**declaration {
+        Decl::Class(class) => class_has_side_effects(ctx, &class.class),
+        Decl::Fn(_) => !ctx.in_strict,
+        Decl::Var(variable) => variable.kind == VarDeclKind::Var,
+        _ => false,
+      },
+      Stmt::Expr(expression) => expression.expr.may_have_side_effects(ctx),
+      _ => true,
+    }
+  }
+}
+
+fn class_has_side_effects(ctx: SideEffectsContext<'_>, class: &Class<'_>) -> bool {
+  if let Some(super_class) = &class.super_class
+    && super_class.may_have_side_effects(ctx)
+  {
+    return true;
+  }
+
+  for member in &class.body {
+    match member {
+      ClassMember::Method(method) => {
+        if let PropName::Computed(key) = &method.key
+          && key.expr.may_have_side_effects(ctx)
+        {
+          return true;
+        }
+      }
+      ClassMember::ClassProp(property) => {
+        if let PropName::Computed(key) = &property.key
+          && key.expr.may_have_side_effects(ctx)
+        {
+          return true;
+        }
+        if let Some(value) = &property.value
+          && value.may_have_side_effects(ctx)
+        {
+          return true;
+        }
+      }
+      ClassMember::PrivateProp(property) => {
+        if let Some(value) = &property.value
+          && value.may_have_side_effects(ctx)
+        {
+          return true;
+        }
+      }
+      ClassMember::StaticBlock(block)
+        if block
+          .body
+          .stmts
+          .iter()
+          .any(|statement| statement.may_have_side_effects(ctx)) =>
+      {
+        return true;
+      }
+      _ => {}
+    }
+  }
+
+  false
+}
+
+fn is_pure_new_callee(expression: &Expr<'_>, ctx: SideEffectsContext<'_>) -> bool {
+  match expression {
+    Expr::Fn(function) => {
+      let function = &function.function;
+      function
+        .params
+        .iter()
+        .all(|parameter| matches!(&parameter.pat, Pat::Ident(_)))
+        && function
+          .body
+          .as_ref()
+          .is_some_and(|body| body.stmts.is_empty())
+    }
+    Expr::Class(class) => {
+      let class = &class.class;
+      if class.super_class.is_some() || class_has_side_effects(ctx, class) {
+        return false;
+      }
+
+      for member in &class.body {
+        match member {
+          ClassMember::ClassProp(property) if !property.is_static => return false,
+          ClassMember::PrivateProp(property) if !property.is_static => return false,
+          _ => {}
+        }
+      }
+
+      for member in &class.body {
+        if let ClassMember::Constructor(constructor) = member
+          && let Some(body) = &constructor.body
+          && !body.stmts.is_empty()
+        {
+          return false;
+        }
+      }
+
+      true
+    }
+    _ => false,
+  }
+}
+
+fn is_pure_string_method(method: &str) -> bool {
+  matches!(
+    method,
+    "charAt"
+      | "charCodeAt"
+      | "concat"
+      | "endsWith"
+      | "includes"
+      | "indexOf"
+      | "lastIndexOf"
+      | "localeCompare"
+      | "slice"
+      | "split"
+      | "startsWith"
+      | "substr"
+      | "substring"
+      | "toLocaleLowerCase"
+      | "toLocaleUpperCase"
+      | "toLowerCase"
+      | "toString"
+      | "toUpperCase"
+      | "trim"
+      | "trimEnd"
+      | "trimStart"
+  )
+}

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
@@ -43,325 +43,311 @@ impl<'a> SideEffectsContext<'a> {
   }
 }
 
-pub(super) trait MayHaveSideEffects {
-  fn is_pure_callee(&self, ctx: SideEffectsContext<'_>) -> bool;
-  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool;
-  fn is_global_ref_to(&self, ctx: SideEffectsContext<'_>, id: &str) -> bool;
+pub(super) fn may_have_side_effects(expression: &Expr<'_>, ctx: SideEffectsContext<'_>) -> bool {
+  let Some(ctx) = ctx.consume_depth() else {
+    return true;
+  };
+
+  if is_pure_callee(expression, ctx) {
+    return false;
+  }
+
+  match expression {
+    Expr::Ident(ident) => {
+      if ctx.is_unresolved_ref_safe {
+        return false;
+      }
+
+      if ctx.semantic.node_scope(ident) == ctx.semantic.unresolved_scope_id() {
+        !matches!(
+          ident.sym.as_str(),
+          "Infinity"
+            | "NaN"
+            | "Math"
+            | "undefined"
+            | "Object"
+            | "Array"
+            | "Promise"
+            | "Boolean"
+            | "Number"
+            | "String"
+            | "BigInt"
+            | "Error"
+            | "RegExp"
+            | "Function"
+            | "document"
+        )
+      } else {
+        false
+      }
+    }
+    Expr::Lit(..) | Expr::This(..) | Expr::PrivateName(..) => false,
+    Expr::Paren(parenthesized) => may_have_side_effects(&parenthesized.expr, ctx),
+    Expr::Fn(..) | Expr::Arrow(..) => false,
+    Expr::Class(class) => class_has_side_effects(ctx, &class.class),
+    Expr::Array(array) => array
+      .elems
+      .iter()
+      .flatten()
+      .any(|element| element.spread.is_some() || may_have_side_effects(&element.expr, ctx)),
+    Expr::Unary(unary) => match unary.op {
+      UnaryOp::Delete => true,
+      _ => may_have_side_effects(&unary.arg, ctx),
+    },
+    Expr::Bin(binary) => {
+      may_have_side_effects(&binary.left, ctx) || may_have_side_effects(&binary.right, ctx)
+    }
+    Expr::Member(member)
+      if matches!(
+        &member.obj,
+        Expr::Object(_) | Expr::Fn(_) | Expr::Arrow(_) | Expr::Class(_)
+      ) =>
+    {
+      let object = &member.obj;
+      if may_have_side_effects(object, ctx) {
+        return true;
+      }
+
+      match object {
+        Expr::Class(class)
+          if class.class.body.iter().any(|member| {
+            matches!(
+              member,
+              ClassMember::Method(method)
+                if (method.kind == MethodKind::Getter || method.kind == MethodKind::Setter)
+                  && method.is_static
+            )
+          }) =>
+        {
+          return true;
+        }
+        Expr::Object(object) => {
+          let can_have_side_effects = |property: &PropOrSpread<'_>| match property {
+            PropOrSpread::Spread(_) => true,
+            PropOrSpread::Prop(property) => match &**property {
+              Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) => true,
+              Prop::Shorthand(identifier) => identifier.sym == "__proto__",
+              Prop::KeyValue(key_value) => match &key_value.key {
+                PropName::Ident(identifier) => identifier.sym == "__proto__",
+                PropName::Str(string) => string.value.as_wtf8().as_str() == Some("__proto__"),
+                PropName::Computed(_) => true,
+                _ => false,
+              },
+              _ => false,
+            },
+          };
+          if object.props.iter().any(can_have_side_effects) {
+            return true;
+          }
+        }
+        _ => {}
+      }
+
+      match &member.prop {
+        MemberProp::Computed(computed) => may_have_side_effects(&computed.expr, ctx),
+        MemberProp::Ident(_) | MemberProp::PrivateName(_) => false,
+      }
+    }
+    Expr::Tpl(_) | Expr::TaggedTpl(_) | Expr::MetaProp(_) => true,
+    Expr::Await(_)
+    | Expr::Yield(_)
+    | Expr::Member(_)
+    | Expr::SuperProp(_)
+    | Expr::Update(_)
+    | Expr::Assign(_) => true,
+    Expr::OptChain(optional_chain) if matches!(&optional_chain.base, OptChainBase::Member(_)) => {
+      true
+    }
+    Expr::New(new_expression) if is_pure_new_callee(&new_expression.callee, ctx) => {
+      new_expression.args.as_ref().is_some_and(|arguments| {
+        arguments
+          .iter()
+          .any(|argument| may_have_side_effects(&argument.expr, ctx))
+      })
+    }
+    Expr::New(_) => true,
+    Expr::Call(call_expression) => {
+      let Callee::Expr(callee) = &call_expression.callee else {
+        return true;
+      };
+
+      if is_pure_callee(callee, ctx) {
+        call_expression
+          .args
+          .iter()
+          .any(|argument| may_have_side_effects(&argument.expr, ctx))
+      } else {
+        true
+      }
+    }
+    Expr::OptChain(optional_chain) => match &optional_chain.base {
+      OptChainBase::Call(call) if is_pure_callee(&call.callee, ctx) => call
+        .args
+        .iter()
+        .any(|argument| may_have_side_effects(&argument.expr, ctx)),
+      _ => true,
+    },
+    Expr::Seq(sequence) => sequence
+      .exprs
+      .iter()
+      .any(|expression| may_have_side_effects(expression, ctx)),
+    Expr::Cond(conditional) => {
+      may_have_side_effects(&conditional.test, ctx)
+        || may_have_side_effects(&conditional.cons, ctx)
+        || may_have_side_effects(&conditional.alt, ctx)
+    }
+    Expr::Object(object) => object.props.iter().any(|property| match property {
+      PropOrSpread::Prop(property) => match &**property {
+        Prop::Shorthand(..) => false,
+        Prop::KeyValue(key_value) => {
+          let key_has_side_effects = match &key_value.key {
+            PropName::Computed(computed) => may_have_side_effects(&computed.expr, ctx),
+            _ => false,
+          };
+          key_has_side_effects || may_have_side_effects(&key_value.value, ctx)
+        }
+        Prop::Getter(getter) => match &getter.key {
+          PropName::Computed(computed) => may_have_side_effects(&computed.expr, ctx),
+          _ => false,
+        },
+        Prop::Setter(setter) => match &setter.key {
+          PropName::Computed(computed) => may_have_side_effects(&computed.expr, ctx),
+          _ => false,
+        },
+        Prop::Method(method) => match &method.key {
+          PropName::Computed(computed) => may_have_side_effects(&computed.expr, ctx),
+          _ => false,
+        },
+        Prop::Assign(_) => true,
+      },
+      PropOrSpread::Spread(_) => true,
+    }),
+    Expr::JSXMember(..)
+    | Expr::JSXNamespacedName(..)
+    | Expr::JSXEmpty(..)
+    | Expr::JSXElement(..)
+    | Expr::JSXFragment(..)
+    | Expr::Invalid(..) => true,
+  }
 }
 
-impl MayHaveSideEffects for Expr<'_> {
-  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool {
-    let Some(ctx) = ctx.consume_depth() else {
-      return true;
-    };
+fn is_pure_callee(expression: &Expr<'_>, ctx: SideEffectsContext<'_>) -> bool {
+  if is_global_ref_to(expression, ctx, "Date") {
+    return true;
+  }
 
-    if self.is_pure_callee(ctx) {
-      return false;
-    }
+  match expression {
+    Expr::Member(member) => {
+      let object = &member.obj;
+      let property = &member.prop;
 
-    match self {
-      Expr::Ident(ident) => {
-        if ctx.is_unresolved_ref_safe {
-          return false;
-        }
-
-        if ctx.semantic.node_scope(ident) == ctx.semantic.unresolved_scope_id() {
-          !matches!(
-            ident.sym.as_str(),
-            "Infinity"
-              | "NaN"
-              | "Math"
-              | "undefined"
-              | "Object"
-              | "Array"
-              | "Promise"
-              | "Boolean"
-              | "Number"
-              | "String"
-              | "BigInt"
-              | "Error"
-              | "RegExp"
-              | "Function"
-              | "document"
-          )
-        } else {
-          false
-        }
-      }
-      Expr::Lit(..) | Expr::This(..) | Expr::PrivateName(..) => false,
-      Expr::Paren(parenthesized) => parenthesized.expr.may_have_side_effects(ctx),
-      Expr::Fn(..) | Expr::Arrow(..) => false,
-      Expr::Class(class) => class_has_side_effects(ctx, &class.class),
-      Expr::Array(array) => array
-        .elems
-        .iter()
-        .flatten()
-        .any(|element| element.spread.is_some() || element.expr.may_have_side_effects(ctx)),
-      Expr::Unary(unary) => match unary.op {
-        UnaryOp::Delete => true,
-        _ => unary.arg.may_have_side_effects(ctx),
-      },
-      Expr::Bin(binary) => {
-        binary.left.may_have_side_effects(ctx) || binary.right.may_have_side_effects(ctx)
-      }
-      Expr::Member(member)
-        if matches!(
-          &member.obj,
-          Expr::Object(_) | Expr::Fn(_) | Expr::Arrow(_) | Expr::Class(_)
-        ) =>
-      {
-        let object = &member.obj;
-        if object.may_have_side_effects(ctx) {
+      if let MemberProp::Ident(property) = property {
+        if is_global_ref_to(object, ctx, "Math") {
           return true;
         }
 
         match object {
-          Expr::Class(class)
-            if class.class.body.iter().any(|member| {
-              matches!(
-                member,
-                ClassMember::Method(method)
-                  if (method.kind == MethodKind::Getter || method.kind == MethodKind::Setter)
-                    && method.is_static
-              )
-            }) =>
-          {
-            return true;
+          Expr::Ident(identifier) => identifier.sym == "Math",
+          Expr::Lit(literal) if matches!(&**literal, Lit::Str(..)) => {
+            is_pure_string_method(property.sym.as_str())
           }
-          Expr::Object(object) => {
-            let can_have_side_effects = |property: &PropOrSpread<'_>| match property {
-              PropOrSpread::Spread(_) => true,
-              PropOrSpread::Prop(property) => match &**property {
-                Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) => true,
-                Prop::Shorthand(identifier) => identifier.sym == "__proto__",
-                Prop::KeyValue(key_value) => match &key_value.key {
-                  PropName::Ident(identifier) => identifier.sym == "__proto__",
-                  PropName::Str(string) => string.value.as_wtf8().as_str() == Some("__proto__"),
-                  PropName::Computed(_) => true,
-                  _ => false,
-                },
-                _ => false,
-              },
-            };
-            if object.props.iter().any(can_have_side_effects) {
-              return true;
-            }
+          Expr::Tpl(template) if template.exprs.is_empty() => {
+            is_pure_string_method(property.sym.as_str())
           }
-          _ => {}
+          _ => false,
         }
-
-        match &member.prop {
-          MemberProp::Computed(computed) => computed.expr.may_have_side_effects(ctx),
-          MemberProp::Ident(_) | MemberProp::PrivateName(_) => false,
-        }
+      } else {
+        false
       }
-      Expr::Tpl(_) | Expr::TaggedTpl(_) | Expr::MetaProp(_) => true,
-      Expr::Await(_)
-      | Expr::Yield(_)
-      | Expr::Member(_)
-      | Expr::SuperProp(_)
-      | Expr::Update(_)
-      | Expr::Assign(_) => true,
-      Expr::OptChain(optional_chain) if matches!(&optional_chain.base, OptChainBase::Member(_)) => {
-        true
-      }
-      Expr::New(new_expression) if is_pure_new_callee(&new_expression.callee, ctx) => {
-        new_expression.args.as_ref().is_some_and(|arguments| {
-          arguments
-            .iter()
-            .any(|argument| argument.expr.may_have_side_effects(ctx))
-        })
-      }
-      Expr::New(_) => true,
-      Expr::Call(call_expression) => {
-        let Callee::Expr(callee) = &call_expression.callee else {
-          return true;
-        };
-
-        if callee.is_pure_callee(ctx) {
-          call_expression
-            .args
-            .iter()
-            .any(|argument| argument.expr.may_have_side_effects(ctx))
-        } else {
-          true
-        }
-      }
-      Expr::OptChain(optional_chain) => match &optional_chain.base {
-        OptChainBase::Call(call) if call.callee.is_pure_callee(ctx) => call
-          .args
-          .iter()
-          .any(|argument| argument.expr.may_have_side_effects(ctx)),
-        _ => true,
-      },
-      Expr::Seq(sequence) => sequence
-        .exprs
+    }
+    Expr::Fn(function) => {
+      let function = &function.function;
+      function
+        .params
         .iter()
-        .any(|expression| expression.may_have_side_effects(ctx)),
-      Expr::Cond(conditional) => {
-        conditional.test.may_have_side_effects(ctx)
-          || conditional.cons.may_have_side_effects(ctx)
-          || conditional.alt.may_have_side_effects(ctx)
-      }
-      Expr::Object(object) => object.props.iter().any(|property| match property {
-        PropOrSpread::Prop(property) => match &**property {
-          Prop::Shorthand(..) => false,
-          Prop::KeyValue(key_value) => {
-            let key_has_side_effects = match &key_value.key {
-              PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
-              _ => false,
-            };
-            key_has_side_effects || key_value.value.may_have_side_effects(ctx)
-          }
-          Prop::Getter(getter) => match &getter.key {
-            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
-            _ => false,
-          },
-          Prop::Setter(setter) => match &setter.key {
-            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
-            _ => false,
-          },
-          Prop::Method(method) => match &method.key {
-            PropName::Computed(computed) => computed.expr.may_have_side_effects(ctx),
-            _ => false,
-          },
-          Prop::Assign(_) => true,
-        },
-        PropOrSpread::Spread(_) => true,
-      }),
-      Expr::JSXMember(..)
-      | Expr::JSXNamespacedName(..)
-      | Expr::JSXEmpty(..)
-      | Expr::JSXElement(..)
-      | Expr::JSXFragment(..)
-      | Expr::Invalid(..) => true,
+        .all(|parameter| matches!(&parameter.pat, Pat::Ident(_)))
+        && function
+          .body
+          .as_ref()
+          .is_some_and(|body| body.stmts.is_empty())
     }
+    _ => false,
   }
+}
 
-  fn is_pure_callee(&self, ctx: SideEffectsContext<'_>) -> bool {
-    if self.is_global_ref_to(ctx, "Date") {
-      return true;
+fn is_global_ref_to(expression: &Expr<'_>, ctx: SideEffectsContext<'_>, id: &str) -> bool {
+  match expression {
+    Expr::Ident(identifier) => {
+      ctx.semantic.node_scope(identifier) == ctx.semantic.unresolved_scope_id()
+        && identifier.sym == id
     }
+    _ => false,
+  }
+}
 
-    match self {
-      Expr::Member(member) => {
-        let object = &member.obj;
-        let property = &member.prop;
-
-        if let MemberProp::Ident(property) = property {
-          if object.is_global_ref_to(ctx, "Math") {
-            return true;
-          }
-
-          match object {
-            Expr::Ident(identifier) => identifier.sym == "Math",
-            Expr::Lit(literal) if matches!(&**literal, Lit::Str(..)) => {
-              is_pure_string_method(property.sym.as_str())
-            }
-            Expr::Tpl(template) if template.exprs.is_empty() => {
-              is_pure_string_method(property.sym.as_str())
-            }
-            _ => false,
-          }
-        } else {
-          false
-        }
-      }
-      Expr::Fn(function) => {
-        let function = &function.function;
-        function
-          .params
-          .iter()
-          .all(|parameter| matches!(&parameter.pat, Pat::Ident(_)))
-          && function
-            .body
+fn statement_may_have_side_effects(statement: &Stmt<'_>, ctx: SideEffectsContext<'_>) -> bool {
+  match statement {
+    Stmt::Block(block) => block
+      .stmts
+      .iter()
+      .any(|statement| statement_may_have_side_effects(statement, ctx)),
+    Stmt::Empty(_) => false,
+    Stmt::Labeled(labeled) => statement_may_have_side_effects(&labeled.body, ctx),
+    Stmt::If(if_statement) => {
+      may_have_side_effects(&if_statement.test, ctx)
+        || statement_may_have_side_effects(&if_statement.cons, ctx)
+        || if_statement
+          .alt
+          .as_ref()
+          .is_some_and(|statement| statement_may_have_side_effects(statement, ctx))
+    }
+    Stmt::Switch(switch) => {
+      may_have_side_effects(&switch.discriminant, ctx)
+        || switch.cases.iter().any(|case| {
+          case
+            .test
             .as_ref()
-            .is_some_and(|body| body.stmts.is_empty())
-      }
-      _ => false,
+            .is_some_and(|expression| may_have_side_effects(expression, ctx))
+            || case
+              .cons
+              .iter()
+              .any(|statement| statement_may_have_side_effects(statement, ctx))
+        })
     }
-  }
-
-  fn is_global_ref_to(&self, ctx: SideEffectsContext<'_>, id: &str) -> bool {
-    match self {
-      Expr::Ident(identifier) => {
-        ctx.semantic.node_scope(identifier) == ctx.semantic.unresolved_scope_id()
-          && identifier.sym == id
-      }
-      _ => false,
-    }
-  }
-}
-
-trait StatementMayHaveSideEffects {
-  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool;
-}
-
-impl StatementMayHaveSideEffects for Stmt<'_> {
-  fn may_have_side_effects(&self, ctx: SideEffectsContext<'_>) -> bool {
-    match self {
-      Stmt::Block(block) => block
+    Stmt::Try(try_statement) => {
+      try_statement
+        .block
         .stmts
         .iter()
-        .any(|statement| statement.may_have_side_effects(ctx)),
-      Stmt::Empty(_) => false,
-      Stmt::Labeled(labeled) => labeled.body.may_have_side_effects(ctx),
-      Stmt::If(if_statement) => {
-        if_statement.test.may_have_side_effects(ctx)
-          || if_statement.cons.may_have_side_effects(ctx)
-          || if_statement
-            .alt
-            .as_ref()
-            .is_some_and(|statement| statement.may_have_side_effects(ctx))
-      }
-      Stmt::Switch(switch) => {
-        switch.discriminant.may_have_side_effects(ctx)
-          || switch.cases.iter().any(|case| {
-            case
-              .test
-              .as_ref()
-              .is_some_and(|expression| expression.may_have_side_effects(ctx))
-              || case
-                .cons
-                .iter()
-                .any(|statement| statement.may_have_side_effects(ctx))
-          })
-      }
-      Stmt::Try(try_statement) => {
-        try_statement
-          .block
-          .stmts
-          .iter()
-          .any(|statement| statement.may_have_side_effects(ctx))
-          || try_statement.handler.as_ref().is_some_and(|handler| {
-            handler
-              .body
-              .stmts
-              .iter()
-              .any(|statement| statement.may_have_side_effects(ctx))
-          })
-          || try_statement.finalizer.as_ref().is_some_and(|finalizer| {
-            finalizer
-              .stmts
-              .iter()
-              .any(|statement| statement.may_have_side_effects(ctx))
-          })
-      }
-      Stmt::Decl(declaration) => match &**declaration {
-        Decl::Class(class) => class_has_side_effects(ctx, &class.class),
-        Decl::Fn(_) => !ctx.in_strict,
-        Decl::Var(variable) => variable.kind == VarDeclKind::Var,
-        _ => false,
-      },
-      Stmt::Expr(expression) => expression.expr.may_have_side_effects(ctx),
-      _ => true,
+        .any(|statement| statement_may_have_side_effects(statement, ctx))
+        || try_statement.handler.as_ref().is_some_and(|handler| {
+          handler
+            .body
+            .stmts
+            .iter()
+            .any(|statement| statement_may_have_side_effects(statement, ctx))
+        })
+        || try_statement.finalizer.as_ref().is_some_and(|finalizer| {
+          finalizer
+            .stmts
+            .iter()
+            .any(|statement| statement_may_have_side_effects(statement, ctx))
+        })
     }
+    Stmt::Decl(declaration) => match &**declaration {
+      Decl::Class(class) => class_has_side_effects(ctx, &class.class),
+      Decl::Fn(_) => !ctx.in_strict,
+      Decl::Var(variable) => variable.kind == VarDeclKind::Var,
+      _ => false,
+    },
+    Stmt::Expr(expression) => may_have_side_effects(&expression.expr, ctx),
+    _ => true,
   }
 }
 
 fn class_has_side_effects(ctx: SideEffectsContext<'_>, class: &Class<'_>) -> bool {
   if let Some(super_class) = &class.super_class
-    && super_class.may_have_side_effects(ctx)
+    && may_have_side_effects(super_class, ctx)
   {
     return true;
   }
@@ -370,26 +356,26 @@ fn class_has_side_effects(ctx: SideEffectsContext<'_>, class: &Class<'_>) -> boo
     match member {
       ClassMember::Method(method) => {
         if let PropName::Computed(key) = &method.key
-          && key.expr.may_have_side_effects(ctx)
+          && may_have_side_effects(&key.expr, ctx)
         {
           return true;
         }
       }
       ClassMember::ClassProp(property) => {
         if let PropName::Computed(key) = &property.key
-          && key.expr.may_have_side_effects(ctx)
+          && may_have_side_effects(&key.expr, ctx)
         {
           return true;
         }
         if let Some(value) = &property.value
-          && value.may_have_side_effects(ctx)
+          && may_have_side_effects(value, ctx)
         {
           return true;
         }
       }
       ClassMember::PrivateProp(property) => {
         if let Some(value) = &property.value
-          && value.may_have_side_effects(ctx)
+          && may_have_side_effects(value, ctx)
         {
           return true;
         }
@@ -399,7 +385,7 @@ fn class_has_side_effects(ctx: SideEffectsContext<'_>, class: &Class<'_>) -> boo
           .body
           .stmts
           .iter()
-          .any(|statement| statement.may_have_side_effects(ctx)) =>
+          .any(|statement| statement_may_have_side_effects(statement, ctx)) =>
       {
         return true;
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -15,7 +15,7 @@ use swc_experimental_ecma_ast::{
   VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
 };
 
-use super::side_effects_analysis::{MayHaveSideEffects, SideEffectsContext};
+use super::side_effects_analysis::{SideEffectsContext, may_have_side_effects};
 use crate::{
   ClassExt, JavascriptParserPlugin,
   dependency::ESMImportSideEffectDependency,
@@ -863,7 +863,7 @@ fn is_pure_call_expr(
     }
   }
 
-  !expr.may_have_side_effects(expr_ctx(parser, false))
+  !may_have_side_effects(expr, expr_ctx(parser, false))
 }
 
 #[inline(never)]
@@ -1023,7 +1023,7 @@ fn is_pure_new_expr(
   };
   let pure_flag = has_pure_comment(comments, expr.span().start);
   if !pure_flag {
-    !expr.may_have_side_effects(expr_ctx(parser, false))
+    !may_have_side_effects(expr, expr_ctx(parser, false))
   } else {
     are_pure_args(
       parser,
@@ -1368,18 +1368,18 @@ fn stmt_may_have_side_effects(parser: &JavascriptParser, stmt: &Stmt) -> bool {
 
   match stmt {
     Stmt::Empty(_) => false,
-    Stmt::Expr(expr_stmt) => expr_stmt.expr.may_have_side_effects(expr_ctx),
+    Stmt::Expr(expr_stmt) => may_have_side_effects(&expr_stmt.expr, expr_ctx),
     Stmt::Return(return_stmt) => return_stmt
       .arg
       .as_ref()
-      .is_some_and(|arg| arg.may_have_side_effects(expr_ctx)),
+      .is_some_and(|arg| may_have_side_effects(arg, expr_ctx)),
     Stmt::Decl(decl) => match &**decl {
       Decl::Var(var_decl) => var_decl.decls.iter().any(|declarator| {
         declarator.name.as_ident().is_none()
           || declarator
             .init
             .as_ref()
-            .is_some_and(|init| init.may_have_side_effects(expr_ctx))
+            .is_some_and(|init| may_have_side_effects(init, expr_ctx))
       }),
       _ => true,
     },
@@ -1615,7 +1615,7 @@ pub fn is_pure_expression<'a>(
         true
       }
       _ => {
-        if !expr.may_have_side_effects(expr_ctx(parser, true)) {
+        if !may_have_side_effects(expr, expr_ctx(parser, true)) {
           return true;
         }
         // could_have_side_effects is true by default, so here we test if it's modified by other plugins to return false.

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -14,8 +14,8 @@ use swc_experimental_ecma_ast::{
   ObjectPatProp, Pat, Program, PropName, SimpleAssignTarget, Span, Span as AstSpan, Stmt, VarDecl,
   VarDeclKind, VarDeclOrExpr, Visit, VisitWith,
 };
-use swc_experimental_ecma_utils::{ExprCtx, ExprExt};
 
+use super::side_effects_analysis::{MayHaveSideEffects, SideEffectsContext};
 use crate::{
   ClassExt, JavascriptParserPlugin,
   dependency::ESMImportSideEffectDependency,
@@ -51,13 +51,11 @@ fn has_no_side_effects_notation(comments: &Comments<'_>, span: AstSpan) -> bool 
   comments.has_flag(span.start, "NO_SIDE_EFFECTS")
 }
 
-fn expr_ctx<'a>(parser: &'a JavascriptParser<'_>, is_unresolved_ref_safe: bool) -> ExprCtx<'a> {
-  ExprCtx {
-    semantic: parser.ast.semantic,
-    is_unresolved_ref_safe,
-    in_strict: false,
-    remaining_depth: 4,
-  }
+fn expr_ctx<'a>(
+  parser: &'a JavascriptParser<'_>,
+  is_unresolved_ref_safe: bool,
+) -> SideEffectsContext<'a> {
+  SideEffectsContext::new(parser.ast.semantic, is_unresolved_ref_safe)
 }
 
 impl<'a> Visit<'a> for PureAnnotation<'a> {


### PR DESCRIPTION
## Summary

- Move the conservative syntax-level side-effects analysis from `swc_experimental_ecma_utils` into `rspack_plugin_javascript`.
- Keep Rspack-specific policies such as pure annotations, `pureFunctions`, parser hooks, and deferred import checks in the existing parser plugin.
- Preserve the existing semantic context, global-reference rules, pure-callee rules, and recursion-depth limit.
- Remove the now-unused `swc_experimental_ecma_utils` dependency.

This is a preparatory refactor for #15331 that separates side-effects behavior ownership from the SWC Next AST migration.

## Related links

- #15331

## Validation

- `cargo check -p rspack_plugin_javascript`
- `pnpm run build:binding:dev`
- Targeted `configCases/tree-shaking/auto-analyze-side-effects-free` tests
- `pnpm run test:unit` (9,196 passed, 4 skipped)

## Checklist

- [x] Tests updated (not required; existing side-effects coverage passes unchanged).
- [x] Documentation updated (not required; this is an internal refactor).

