### PR TITLE
fix(types): improve loader context filesystem types

### DIFF
--- a/packages/rspack/src/config/adapterRuleUse.ts
+++ b/packages/rspack/src/config/adapterRuleUse.ts
@@ -8,6 +8,7 @@ import type { Logger } from '../logging/Logger';
 import type { Module } from '../Module';
 import type { ResolveRequest } from '../Resolver';
 import { isNil } from '../util';
+import type { InputFileSystem } from '../util/fs';
 import type Hash from '../util/hash';
 import { parseResource } from '../util/identifier';
 import type { RspackOptionsNormalized } from './normalization';
@@ -380,7 +381,7 @@ export interface LoaderContext<OptionsType = {}> {
   /**
    * Access to the `compilation` object's `inputFileSystem` property.
    */
-  fs: any;
+  fs: InputFileSystem;
   /**
    * This is an experimental API and maybe subject to change.
    * @experimental

--- a/packages/rspack/src/exports.ts
+++ b/packages/rspack/src/exports.ts
@@ -139,7 +139,11 @@ export { default as EntryOptionPlugin } from './lib/EntryOptionPlugin';
 export { EnvironmentPlugin } from './lib/EnvironmentPlugin';
 export { LoaderOptionsPlugin } from './lib/LoaderOptionsPlugin';
 export { LoaderTargetPlugin } from './lib/LoaderTargetPlugin';
-export type { OutputFileSystem, WatchFileSystem } from './util/fs';
+export type {
+  InputFileSystem,
+  OutputFileSystem,
+  WatchFileSystem,
+} from './util/fs';
 
 import {
   FetchCompileAsyncWasmPlugin,

--- a/packages/rspack/src/loader-runner/index.ts
+++ b/packages/rspack/src/loader-runner/index.ts
@@ -618,7 +618,7 @@ export async function runLoaders(
     }
     loaderContext._module.emitFile(name, source!, assetInfo);
   };
-  loaderContext.fs = compiler.inputFileSystem;
+  loaderContext.fs = compiler.inputFileSystem!;
   loaderContext.experiments = {
     emitDiagnostic: (diagnostic: Diagnostic) => {
       const d = Object.assign({}, diagnostic, {

--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -324,7 +324,7 @@ export type Readdir = {
   (
     path: PathLike,
     options:
-      | (ObjectEncodingOptions & { withFileTypes: true; recursive?: boolean })
+      | (ObjectEncodingOptions & { withFileTypes?: false; recursive?: boolean })
       | BufferEncoding
       | null
       | undefined,


### PR DESCRIPTION
## Summary

The loader context filesystem was typed as `any`, preventing loader authors from getting type safety for filesystem operations. This PR types it as `InputFileSystem`, corrects the `readdir` overload so Node's filesystem remains compatible, and exports `InputFileSystem` alongside `OutputFileSystem` from `@rspack/core`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).