### PR TITLE
fix(types): allow optionless filesystem sync calls

### DIFF
--- a/packages/rspack/src/util/fs.ts
+++ b/packages/rspack/src/util/fs.ts
@@ -248,8 +248,8 @@ export type ReadFile = {
 export type ReadFileSync = {
   (
     path: PathOrFileDescriptor,
-    options: {
-      encoding: null | undefined;
+    options?: {
+      encoding?: null | undefined;
       flag?: string;
     } | null,
   ): Buffer;
@@ -259,7 +259,7 @@ export type ReadFileSync = {
   ): string;
   (
     path: PathOrFileDescriptor,
-    options:
+    options?:
       (ObjectEncodingOptions & { flag?: string }) | BufferEncoding | null,
   ): string | Buffer;
 };
@@ -294,9 +294,9 @@ export type Readlink = {
 };
 
 export type ReadlinkSync = {
-  (path: PathLike, options: EncodingOption): string;
+  (path: PathLike, options?: EncodingOption): string;
   (path: PathLike, options: BufferEncodingOption): Buffer;
-  (path: PathLike, options: EncodingOption): string | Buffer;
+  (path: PathLike, options?: EncodingOption): string | Buffer;
 };
 
 export type Readdir = {
@@ -343,7 +343,7 @@ export type Readdir = {
 export type ReaddirSync = {
   (
     path: PathLike,
-    options:
+    options?:
       | {
           encoding: BufferEncoding | null;
           withFileTypes?: false;
@@ -360,7 +360,7 @@ export type ReaddirSync = {
   ): Buffer[];
   (
     path: PathLike,
-    options:
+    options?:
       | (ObjectEncodingOptions & { withFileTypes?: false; recursive?: boolean })
       | BufferEncoding
       | null,


### PR DESCRIPTION
## Summary

This PR restores Node.js-compatible optionless calls for the synchronous `InputFileSystem` read methods. `readFileSync(path)`, `readlinkSync(path)`, and `readdirSync(path)` now preserve their default return types without requiring an `options` argument.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15437#discussion_r3913682784

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).