### PR TITLE
feat(core): expose import attributes on NormalModuleFactory ResolveData

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -1069,6 +1069,8 @@ export interface JsResolveData {
   request: string
   context: string
   contextInfo: ContextInfo
+  /** The import attributes of the dependency that triggered this resolution, read-only. */
+  attributes?: Record<string, string>
   fileDependencies: Array<string>
   contextDependencies: Array<string>
   missingDependencies: Array<string>

--- a/crates/rspack_binding_api/src/normal_module_factory.rs
+++ b/crates/rspack_binding_api/src/normal_module_factory.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use napi::{
   Env,
   bindgen_prelude::{Object, ToNapiValue},
@@ -79,6 +81,8 @@ pub struct JsResolveData {
   pub request: String,
   pub context: String,
   pub context_info: ContextInfo,
+  /// The import attributes of the dependency that triggered this resolution, read-only.
+  pub attributes: Option<HashMap<String, String>>,
   pub file_dependencies: Vec<String>,
   pub context_dependencies: Vec<String>,
   pub missing_dependencies: Vec<String>,
@@ -101,6 +105,16 @@ impl JsResolveData {
           .unwrap_or_default(),
         issuer_layer: data.issuer_layer.clone(),
       },
+      attributes: data
+        .dependencies
+        .first()
+        .and_then(|dependency| dependency.get_attributes())
+        .map(|attributes| {
+          attributes
+            .iter()
+            .map(|(key, value)| (key.to_owned(), value.to_owned()))
+            .collect()
+        }),
       file_dependencies: data
         .file_dependencies
         .iter()
@@ -129,7 +143,7 @@ impl JsResolveData {
     data: &mut ModuleFactoryCreateData,
     create_data: Option<&mut NormalModuleCreateData>,
   ) {
-    // only supports update request for now
+    // only supports update request for now, `attributes` is read-only
     data.request = self.request;
     data.context = self.context.into();
     if let Some(new_data) = self.create_data

--- a/crates/rspack_binding_api/src/normal_module_factory.rs
+++ b/crates/rspack_binding_api/src/normal_module_factory.rs
@@ -1,11 +1,10 @@
-use std::collections::HashMap;
-
 use napi::{
   Env,
   bindgen_prelude::{Object, ToNapiValue},
 };
 use napi_derive::napi;
 use rspack_core::{ModuleFactoryCreateData, NormalModuleCreateData, ResourceData, parse_resource};
+use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::resource_data::JsResourceData;

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/dynamic.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/dynamic.js
@@ -1,0 +1,1 @@
+export default 'dynamic';

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/index.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/index.js
@@ -1,0 +1,42 @@
+import fs from 'fs';
+import path from 'path';
+import plain from './plain.js';
+import withAttributes from './with-attributes.js' with {
+	type: 'custom',
+	flavor: 'spicy'
+};
+
+const readSeen = () =>
+	JSON.parse(
+		fs.readFileSync(path.resolve(__dirname, './attributes.json'), 'utf-8')
+	);
+
+const hooks = ['beforeResolve', 'factorize', 'resolve', 'afterResolve'];
+
+it("should expose a static import's attributes to every NormalModuleFactory hook", () => {
+	expect(withAttributes).toBe('with-attributes');
+	const seen = readSeen();
+	for (const hook of hooks) {
+		expect(seen['./with-attributes.js'][hook]).toEqual({
+			type: 'custom',
+			flavor: 'spicy'
+		});
+	}
+});
+
+it("should expose a dynamic import's attributes to every NormalModuleFactory hook", async () => {
+	const dynamic = await import('./dynamic.js', { with: { level: '2' } });
+	expect(dynamic.default).toBe('dynamic');
+	const seen = readSeen();
+	for (const hook of hooks) {
+		expect(seen['./dynamic.js'][hook]).toEqual({ level: '2' });
+	}
+});
+
+it('should leave attributes undefined for an import without attributes', () => {
+	expect(plain).toBe('plain');
+	const seen = readSeen();
+	for (const hook of hooks) {
+		expect(seen['./plain.js'][hook]).toBe('<undefined>');
+	}
+});

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/index.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/index.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import plain from './plain.js';
+import readonly from './readonly.js' with { type: 'original' };
 import withAttributes from './with-attributes.js' with {
 	type: 'custom',
 	flavor: 'spicy'
@@ -30,6 +31,16 @@ it("should expose a dynamic import's attributes to every NormalModuleFactory hoo
 	const seen = readSeen();
 	for (const hook of hooks) {
 		expect(seen['./dynamic.js'][hook]).toEqual({ level: '2' });
+	}
+});
+
+it('should ignore an attributes rewrite performed inside a hook', () => {
+	expect(readonly).toBe('readonly');
+	const seen = readSeen();
+	// `beforeResolve` rewrote the attributes to `{ type: 'rewritten' }`; the
+	// later hooks must still observe the ones the import actually declared.
+	for (const hook of hooks.slice(1)) {
+		expect(seen['./readonly.js'][hook]).toEqual({ type: 'original' });
 	}
 });
 

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/plain.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/plain.js
@@ -1,0 +1,1 @@
+export default 'plain';

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/readonly.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/readonly.js
@@ -1,0 +1,1 @@
+export default 'readonly';

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/rspack.config.js
@@ -29,6 +29,11 @@ module.exports = {
             ]) {
               normalModuleFactory.hooks[hook].tap(pluginName, (resolveData) => {
                 record(hook, resolveData);
+                // `attributes` is read-only; this rewrite must not reach the
+                // later hooks, and must not reach the module rules either.
+                if (hook === 'beforeResolve' && resolveData.attributes) {
+                  resolveData.attributes = { type: 'rewritten' };
+                }
               });
             }
 

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/rspack.config.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/rspack.config.js
@@ -1,0 +1,55 @@
+const pluginName = 'attributes-plugin';
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  plugins: [
+    {
+      apply(compiler) {
+        /** @type {Record<string, Record<string, unknown>>} */
+        const seen = {};
+
+        const record = (hook, resolveData) => {
+          const perHook = (seen[resolveData.request] ??= {});
+          perHook[hook] =
+            resolveData.attributes === undefined
+              ? '<undefined>'
+              : resolveData.attributes === null
+                ? '<null>'
+                : resolveData.attributes;
+        };
+
+        compiler.hooks.compilation.tap(
+          pluginName,
+          (compilation, { normalModuleFactory }) => {
+            for (const hook of [
+              'beforeResolve',
+              'factorize',
+              'resolve',
+              'afterResolve',
+            ]) {
+              normalModuleFactory.hooks[hook].tap(pluginName, (resolveData) => {
+                record(hook, resolveData);
+              });
+            }
+
+            compilation.hooks.processAssets.tap(
+              {
+                name: pluginName,
+                stage:
+                  compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+              },
+              () => {
+                compilation.emitAsset(
+                  'attributes.json',
+                  new compiler.rspack.sources.RawSource(
+                    JSON.stringify(seen, null, 2),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/with-attributes.js
+++ b/tests/rspack-test/configCases/hooks/normal-module-factory-attributes/with-attributes.js
@@ -1,0 +1,1 @@
+export default 'with-attributes';

--- a/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
@@ -3,6 +3,7 @@ description: 'NormalModuleFactory is used by the Compiler to generate modules (N
 ---
 
 import ResolveDataType from '../../types/resolve-data.mdx';
+import { ApiMeta } from '@components/ApiMeta';
 import { Collapse, CollapsePanel } from '@components/Collapse';
 
 # NormalModuleFactory
@@ -16,6 +17,29 @@ NormalModuleFactory.hooks.someHook.tap(/* ... */);
 ```
 
 All hooks inherit from `Tapable`. In addition to `tap()`, you can also use `tapAsync()` and `tapPromise()`, depending on the type of the hook.
+
+## Import attributes
+
+<ApiMeta addedVersion="2.2.3" />
+
+`ResolveData.attributes` holds the [import attributes](https://github.com/tc39/proposal-import-attributes) of the dependency that triggered the resolution, for example `{ type: 'json' }` for `import data from './data.json' with { type: 'json' }`. It is available on all four hooks below, and is `undefined` when the request carries no attributes.
+
+```js
+compiler.hooks.compilation.tap(
+  'MyPlugin',
+  (compilation, { normalModuleFactory }) => {
+    normalModuleFactory.hooks.beforeResolve.tap('MyPlugin', (resolveData) => {
+      if (resolveData.attributes?.type === 'json') {
+        // ...
+      }
+    });
+  },
+);
+```
+
+:::warning
+`attributes` is read-only. Assigning to it inside a hook has no effect on how the module is resolved or built.
+:::
 
 ## `beforeResolve`
 

--- a/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
@@ -22,6 +22,8 @@ All hooks inherit from `Tapable`. In addition to `tap()`, you can also use `tapA
 
 <ApiMeta addedVersion="2.2.3" />
 
+**Type:** `Readonly<Record<string, string>>`
+
 `ResolveData.attributes` holds the [import attributes](https://github.com/tc39/proposal-import-attributes) of the dependency that triggered the resolution, for example `{ type: 'json' }` for `import data from './data.json' with { type: 'json' }`. It is available on the [`beforeResolve`](#beforeresolve), [`factorize`](#factorize), [`resolve`](#resolve) and [`afterResolve`](#afterresolve) hooks, and is `undefined` when the request carries no attributes.
 
 ```js
@@ -36,10 +38,6 @@ compiler.hooks.compilation.tap(
   },
 );
 ```
-
-:::warning
-`attributes` is read-only: assigning to it inside a hook has no effect on how the module is resolved or built. It still has to hold a string map when the hook returns, so replacing it with values of another type fails the build.
-:::
 
 ## `beforeResolve`
 

--- a/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/en/api/plugin-api/normal-module-factory-hooks.mdx
@@ -22,7 +22,7 @@ All hooks inherit from `Tapable`. In addition to `tap()`, you can also use `tapA
 
 <ApiMeta addedVersion="2.2.3" />
 
-`ResolveData.attributes` holds the [import attributes](https://github.com/tc39/proposal-import-attributes) of the dependency that triggered the resolution, for example `{ type: 'json' }` for `import data from './data.json' with { type: 'json' }`. It is available on all four hooks below, and is `undefined` when the request carries no attributes.
+`ResolveData.attributes` holds the [import attributes](https://github.com/tc39/proposal-import-attributes) of the dependency that triggered the resolution, for example `{ type: 'json' }` for `import data from './data.json' with { type: 'json' }`. It is available on the [`beforeResolve`](#beforeresolve), [`factorize`](#factorize), [`resolve`](#resolve) and [`afterResolve`](#afterresolve) hooks, and is `undefined` when the request carries no attributes.
 
 ```js
 compiler.hooks.compilation.tap(
@@ -38,7 +38,7 @@ compiler.hooks.compilation.tap(
 ```
 
 :::warning
-`attributes` is read-only. Assigning to it inside a hook has no effect on how the module is resolved or built.
+`attributes` is read-only: assigning to it inside a hook has no effect on how the module is resolved or built. It still has to hold a string map when the hook returns, so replacing it with values of another type fails the build.
 :::
 
 ## `beforeResolve`

--- a/website/docs/en/types/resolve-data.mdx
+++ b/website/docs/en/types/resolve-data.mdx
@@ -8,6 +8,7 @@ export type ResolveData = {
   };
   context: string;
   request: string;
+  attributes?: Record<string, string>;
   fileDependencies: string[];
   missingDependencies: string[];
   contextDependencies: string[];

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -39,7 +39,6 @@ compiler.hooks.compilation.tap(
 );
 ```
 
-
 ## `beforeResolve`
 
 `AsyncSeriesBailHook<[ResolveData]>`

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -3,6 +3,7 @@ description: 'NormalModuleFactory 被 Compiler 用来生成模块（NormalModule
 ---
 
 import ResolveDataType from '../../types/resolve-data.mdx';
+import { ApiMeta } from '@components/ApiMeta';
 import { Collapse, CollapsePanel } from '@components/Collapse';
 
 # NormalModuleFactory 钩子
@@ -16,6 +17,29 @@ NormalModuleFactory.hooks.someHook.tap(/* ... */);
 ```
 
 所有钩子均继承自 `Tapable`，除了 `tap()`，你还可以使用 `tapAsync()` 和 `tapPromise()`，具体取决于钩子的类型。
+
+## 导入属性
+
+<ApiMeta addedVersion="2.2.3" />
+
+`ResolveData.attributes` 保存触发本次解析的依赖上的[导入属性](https://github.com/tc39/proposal-import-attributes)，例如 `import data from './data.json' with { type: 'json' }` 对应 `{ type: 'json' }`。下面四个钩子均可读取该字段；当请求不带任何导入属性时，它的值为 `undefined`。
+
+```js
+compiler.hooks.compilation.tap(
+  'MyPlugin',
+  (compilation, { normalModuleFactory }) => {
+    normalModuleFactory.hooks.beforeResolve.tap('MyPlugin', (resolveData) => {
+      if (resolveData.attributes?.type === 'json') {
+        // ...
+      }
+    });
+  },
+);
+```
+
+:::warning
+`attributes` 是只读的，在钩子中对它赋值不会影响模块的解析与构建。
+:::
 
 ## `beforeResolve`
 

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -22,6 +22,8 @@ NormalModuleFactory.hooks.someHook.tap(/* ... */);
 
 <ApiMeta addedVersion="2.2.3" />
 
+**类型：** `Readonly<Record<string, string>>`
+
 `ResolveData.attributes` 保存触发本次解析的依赖上的[导入属性](https://github.com/tc39/proposal-import-attributes)，例如 `import data from './data.json' with { type: 'json' }` 对应 `{ type: 'json' }`。[`beforeResolve`](#beforeresolve)、[`factorize`](#factorize)、[`resolve`](#resolve) 和 [`afterResolve`](#afterresolve) 四个钩子均可读取该字段；当请求不带任何导入属性时，它的值为 `undefined`。
 
 ```js
@@ -37,9 +39,6 @@ compiler.hooks.compilation.tap(
 );
 ```
 
-:::warning
-`attributes` 是只读的：在钩子中对它赋值不会影响模块的解析与构建。但钩子返回时它仍必须是一个字符串映射，替换成其他类型的值会导致构建失败。
-:::
 
 ## `beforeResolve`
 

--- a/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
+++ b/website/docs/zh/api/plugin-api/normal-module-factory-hooks.mdx
@@ -22,7 +22,7 @@ NormalModuleFactory.hooks.someHook.tap(/* ... */);
 
 <ApiMeta addedVersion="2.2.3" />
 
-`ResolveData.attributes` 保存触发本次解析的依赖上的[导入属性](https://github.com/tc39/proposal-import-attributes)，例如 `import data from './data.json' with { type: 'json' }` 对应 `{ type: 'json' }`。下面四个钩子均可读取该字段；当请求不带任何导入属性时，它的值为 `undefined`。
+`ResolveData.attributes` 保存触发本次解析的依赖上的[导入属性](https://github.com/tc39/proposal-import-attributes)，例如 `import data from './data.json' with { type: 'json' }` 对应 `{ type: 'json' }`。[`beforeResolve`](#beforeresolve)、[`factorize`](#factorize)、[`resolve`](#resolve) 和 [`afterResolve`](#afterresolve) 四个钩子均可读取该字段；当请求不带任何导入属性时，它的值为 `undefined`。
 
 ```js
 compiler.hooks.compilation.tap(
@@ -38,7 +38,7 @@ compiler.hooks.compilation.tap(
 ```
 
 :::warning
-`attributes` 是只读的，在钩子中对它赋值不会影响模块的解析与构建。
+`attributes` 是只读的：在钩子中对它赋值不会影响模块的解析与构建。但钩子返回时它仍必须是一个字符串映射，替换成其他类型的值会导致构建失败。
 :::
 
 ## `beforeResolve`

--- a/website/docs/zh/types/resolve-data.mdx
+++ b/website/docs/zh/types/resolve-data.mdx
@@ -8,6 +8,7 @@ export type ResolveData = {
   };
   context: string;
   request: string;
+  attributes?: Record<string, string>;
   fileDependencies: string[];
   missingDependencies: string[];
   contextDependencies: string[];


### PR DESCRIPTION
## Summary

Closes #8770.

`NormalModuleFactory`'s JS hooks receive a `ResolveData` that has never carried the import attributes of the request being resolved, so a plugin cannot tell `import data from './data.json' with { type: 'json' }` apart from a plain `import data from './data.json'`.

The data is already there on the Rust side. `ModuleFactoryCreateData` holds the triggering dependency, and `Dependency::get_attributes()` is read a few lines away in `NormalModuleFactory::calculate_module_rules` to match `module.rules[].with`. Nothing on that path was ever handed to JS.

This adds `attributes?: Record<string, string>` to `JsResolveData`, sourced from the first dependency of the factory call — the same `data.dependencies[0]` that `resolve_normal_module` already uses for `dependency_type` / `category` / `phase`.

```js
normalModuleFactory.hooks.beforeResolve.tap('MyPlugin', (resolveData) => {
  if (resolveData.attributes?.type === 'json') {
    // ...
  }
});
```

It is populated on `beforeResolve`, `factorize`, `resolve` and `afterResolve` (all four go through `JsResolveData::from_nmf_data`), and on the `NormalModuleReplacementPlugin` replacer, which uses the same constructor. It is `undefined` when the request carries no attributes.

## Alignment with webpack

webpack 5.110.3 exposes the same thing under the same name — `ResolveData.attributes`, read from `dependency.attributes` in `NormalModuleFactory#create`. (It was `assertions` when #8770 was filed and has since been renamed, so the field name the issue proposed is now also the webpack-parity one.)

## Read-only

`update_nmf_data` ignores `attributes`, matching the existing "only supports update request for now" limitation for the rest of the struct. Verified end-to-end: assigning `resolveData.attributes = { type: 'rewritten' }` in `beforeResolve` leaves `factorize` / `resolve` / `afterResolve` seeing the declared attributes, and so does `delete resolveData.attributes`. There is a regression case for this.

Since `JsResolveData` round-trips back through `FromNapiValue`, the field does still have to hold a string map when the hook returns; replacing it with values of another type fails the build with `Failed to convert JavaScript value ... on JsResolveData.attributes`. That is the same failure mode as every other field on this struct, and the docs say so.

## Tests

`configCases/hooks/normal-module-factory-attributes` covers, across all four hooks:

- a static import with two attributes (`with { type: 'custom', flavor: 'spicy' }`)
- a dynamic import (`import('./dynamic.js', { with: { level: '2' } })`), which goes through a different dependency type
- an import with no attributes — `undefined`
- the read-only guarantee described above

The plugin records what each hook saw and emits it as a JSON asset; the bundle reads it back and asserts, following `configCases/hooks/create-module`. Deliberately breaking one expected value fails the case, so the assertions are live.

`configCases/**` runs under both `Config.*` and `RuntimeModeConfig.*`, so this is exercised in both runtime modes.

## Out of scope

webpack's `ResolveData` also carries `phase` (`dependency.get_phase()` exists in rspack too, and is read at the same call site). That is a separate gap and is not part of this PR.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

Local: full `rspack-test` suite green apart from the pre-existing `configCases/url/self` failure caused by the non-ASCII checkout path on my machine (9196 passed / 2 failed, both that case). `cargo clippy -p rspack_binding_api --all-targets` clean, `pnpm run test:type` and `pnpm run lint:js` pass.
