### PR TITLE
test: cover isolated declarations across persistent cache modes

### DIFF
--- a/tests/rspack-test/compilerCases/persistent-isolated-dts.js
+++ b/tests/rspack-test/compilerCases/persistent-isolated-dts.js
@@ -5,117 +5,153 @@ const {
 } = require("@rspack/core");
 
 const CASE_DIR = "persistent-isolated-dts";
-const CACHE_DIR = ".cache";
-const OUTPUT_DIR = "output";
-const WORK_DIR = "workdir";
 
-function getDtsPath(context) {
-  return context.getDist(path.join(WORK_DIR, "dist/types/index.d.ts"));
+async function buildAndCountLoaderRuns(context, counterFile) {
+  const before = fs.existsSync(counterFile)
+    ? fs.readFileSync(counterFile, "utf-8").length
+    : 0;
+  const stats = await context.getCompiler().build();
+  expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+  return fs.readFileSync(counterFile, "utf-8").length - before;
 }
 
-function readDts(context) {
-  return fs.readFileSync(getDtsPath(context), "utf-8");
-}
-
-async function recreateCompiler(context) {
-  const compilerManager = context.getCompiler();
-  await compilerManager.close();
-  const compiler = compilerManager.createCompiler();
-  compiler.outputFileSystem = fs;
-}
-
-/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
-module.exports = {
-  description:
-    "should restore declaration metadata from the persistent loader cache",
-  options(context) {
-    const sourceDir = path.resolve(__dirname, "../fixtures", CASE_DIR);
-    const workDir = context.getDist(WORK_DIR);
-    fs.rmSync(workDir, { recursive: true, force: true });
-    fs.cpSync(sourceDir, workDir, { recursive: true });
-
-    return {
-      context: workDir,
-      entry: "./index.ts",
-      target: "node",
-      output: {
-        path: workDir,
-        filename: `${OUTPUT_DIR}/main.js`,
-        library: {
-          type: "commonjs"
-        }
-      },
-      cache: {
-        type: "persistent",
-        buildDependencies: [__filename],
-        storage: {
-          type: "filesystem",
-          location: context.getDist(CACHE_DIR)
-        }
-      },
-      experiments: {
-        newCache: {
-          codeGeneration: false,
-          loader: true,
-          minimize: false
-        }
-      },
-      module: {
-        rules: [
-          {
-            test: /\.ts$/,
-            type: "javascript/auto",
-            use: {
-              loader: "builtin:swc-loader",
-              cache: true,
-              options: {
-                collectTypeScriptInfo: {
-                  exportedEnum: true
-                },
-                jsc: {
-                  parser: {
-                    syntax: "typescript"
-                  },
-                  experimental: {
-                    emitIsolatedDts: true
-                  }
-                }
-              }
-            }
-          }
-        ]
-      },
-      plugins: [
-        new RslibPlugin({
-          emitDts: {
-            rootDir: workDir,
-            declarationDir: "./dist/types"
-          }
-        })
-      ]
-    };
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  {
+    name: "legacy-cache",
+    newCache: false,
+    warmLoaderRuns: 0
   },
-  async compiler(_, compiler) {
-    compiler.outputFileSystem = fs;
+  {
+    name: "new-cache-without-loader-cache",
+    newCache: { loader: false },
+    warmLoaderRuns: 1
   },
-  async build(context) {
-    const compilerManager = context.getCompiler();
-    await compilerManager.build();
-    context.setValue("firstOutput", readDts(context));
-
-    fs.rmSync(getDtsPath(context), { force: true });
-
-    await recreateCompiler(context);
-    await compilerManager.build();
-    context.setValue("secondOutput", readDts(context));
-  },
-  async check({ context }) {
-    const firstOutput = context.getValue("firstOutput");
-    const secondOutput = context.getValue("secondOutput");
-
-    expect(firstOutput).toContain("export interface Foo");
-    expect(firstOutput).toContain("export declare const foo: Foo;");
-    expect(secondOutput).toContain("export interface Foo");
-    expect(secondOutput).toContain("export declare const foo: Foo;");
+  {
+    name: "loader-cache-only",
+    newCache: {
+      codeGeneration: false,
+      devtool: false,
+      loader: true,
+      minimize: false
+    },
+    warmLoaderRuns: 0
   }
-};
+].map(({ name, newCache, warmLoaderRuns }) => {
+  let root;
+  let dtsPath;
+  let counterFile;
+
+  function configureCompiler(compiler) {
+    compiler.outputFileSystem = fs;
+    expect(compiler.options.cache.type).toBe("persistent");
+    if (newCache === false) {
+      expect(compiler.options.experiments.newCache).toBe(false);
+    } else {
+      expect(compiler.options.experiments.newCache).toMatchObject(newCache);
+    }
+  }
+
+  return {
+    description: `should emit isolated declarations across persistent builds with ${name}`,
+    options(context) {
+      root = context.getDist(name);
+      const sourceDir = path.resolve(__dirname, "../fixtures", CASE_DIR);
+      const workDir = path.join(root, "workdir");
+      dtsPath = path.join(workDir, "dist/types/index.d.ts");
+      counterFile = path.join(root, "loader-runs.txt");
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.cpSync(sourceDir, workDir, { recursive: true });
+
+      return {
+        context: workDir,
+        mode: "production",
+        entry: "./index.ts",
+        target: "node",
+        incremental: false,
+        output: {
+          path: workDir,
+          filename: "output/main.js",
+          library: {
+            type: "commonjs"
+          }
+        },
+        cache: {
+          type: "persistent",
+          buildDependencies: [__filename],
+          storage: {
+            type: "filesystem",
+            location: path.join(root, ".cache")
+          }
+        },
+        experiments: {
+          newCache
+        },
+        module: {
+          rules: [
+            {
+              test: /\.ts$/,
+              type: "javascript/auto",
+              use: [
+                {
+                  loader: "builtin:swc-loader",
+                  cache: true,
+                  options: {
+                    jsc: {
+                      parser: {
+                        syntax: "typescript"
+                      },
+                      experimental: {
+                        emitIsolatedDts: true
+                      }
+                    }
+                  }
+                },
+                {
+                  loader: path.join(workDir, "count-loader.js"),
+                  cache: true,
+                  options: { counterFile }
+                }
+              ]
+            }
+          ]
+        },
+        plugins: [
+          new RslibPlugin({
+            emitDts: {
+              rootDir: workDir,
+              declarationDir: "./dist/types"
+            }
+          })
+        ]
+      };
+    },
+    compiler(_, compiler) {
+      configureCompiler(compiler);
+    },
+    async build(context) {
+      const compilerManager = context.getCompiler();
+      expect(await buildAndCountLoaderRuns(context, counterFile)).toBe(1);
+      context.setValue("firstOutput", fs.readFileSync(dtsPath, "utf-8"));
+
+      // Flush persistent cache and remove the declaration so the next compiler
+      // must emit it again, even when SWC does not run.
+      await compilerManager.close();
+      fs.rmSync(dtsPath);
+      configureCompiler(compilerManager.createCompiler());
+
+      expect(await buildAndCountLoaderRuns(context, counterFile)).toBe(
+        warmLoaderRuns
+      );
+      context.setValue("secondOutput", fs.readFileSync(dtsPath, "utf-8"));
+    },
+    check({ context }) {
+      const firstOutput = context.getValue("firstOutput");
+      const secondOutput = context.getValue("secondOutput");
+
+      expect(firstOutput).toContain("export interface Foo");
+      expect(firstOutput).toContain("export declare const foo: Foo;");
+      expect(secondOutput).toBe(firstOutput);
+    }
+  };
+});

--- a/tests/rspack-test/fixtures/persistent-isolated-dts/count-loader.js
+++ b/tests/rspack-test/fixtures/persistent-isolated-dts/count-loader.js
@@ -1,0 +1,6 @@
+const fs = require("node:fs");
+
+module.exports = function (source, sourceMap, additionalData) {
+  fs.appendFileSync(this.getOptions().counterFile, "1");
+  this.callback(null, source, sourceMap, additionalData);
+};


### PR DESCRIPTION
## Summary

Split `persistent-isolated-dts` into three cases using the existing CompilerCase runner:

- Legacy persistent cache (`newCache: false`).
- New cache with loader caching disabled.
- Loader-only cache, explicitly disabling code generation, devtool, and minimization caches.

Each case uses its own work/cache directory, top-level persistent `cache`, and `incremental: false`. Close the first compiler to flush the cache, delete the generated declaration, then create a new compiler and require identical declaration output. Add a cacheable counting loader and configuration assertions; remove the unrelated TypeScript enum-collection option.

For example, checking the same `.d.ts` contents twice can pass even if both builds simply rerun every loader. The counting loader now requires one cold execution and warm execution counts of 0, 1, and 0 respectively, checking the intended cache behavior alongside declaration re-emission. This also restores legacy coverage that the previous loader-only case had replaced.

## Validation

- `pnpm run build:cli:dev` — passed.
- From `tests/rspack-test`: `pnpm run test:base Compiler.test.js -t persistent-isolated-dts` — 3 cases passed.
- Commit hooks: `rs lint` and `rs fmt` — passed.

Additional one-off diagnostics on the same scenarios observed:

| Scenario | Cold / warm `buildModule` calls | Cold / warm native SWC executions |
| --- | --- | --- |
| Legacy cache | 1 / 0 | 1 / 0 |
| New cache without loader cache | 1 / 1 | 1 / 1 |
| Loader-only cache | 1 / 1 | 1 / 0 |

The checked-in counter observes the JS helper loader, not the native SWC loader itself. In a control run, disabling only SWC's cache changed its executions to 1 / 1 while the helper assertions still passed. Direct native execution counts were verified separately using tracing in an isolated process; those tracing and `buildModule` checks are not yet permanent regression assertions in this draft.

## Related links

Follow-up to https://github.com/web-infra-dev/rspack/pull/15324.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; test-only change).

---
_by OpenAI Codex_