### PR TITLE
feat(core): expose ChunkGraph.getChunkGroupBlocks to JS

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -156,6 +156,7 @@ export declare class ChunkGraph {
   getModuleId(module: Module): string | number | null
   _getModuleHash(module: Module, runtime: string | string[] | undefined): string | null
   getBlockChunkGroup(jsBlock: AsyncDependenciesBlock): ChunkGroup | null
+  getChunkGroupBlocks(chunkGroup: ChunkGroup): AsyncDependenciesBlock[]
 }
 
 export declare class ChunkGroup {

--- a/crates/rspack_binding_api/src/chunk_graph.rs
+++ b/crates/rspack_binding_api/src/chunk_graph.rs
@@ -3,9 +3,9 @@ use napi_derive::napi;
 use rspack_core::{Compilation, CompilationId, ModuleId, SourceType};
 
 use crate::{
-  async_dependency_block::AsyncDependenciesBlock,
+  async_dependency_block::{AsyncDependenciesBlock, AsyncDependenciesBlockWrapper},
   chunk::{Chunk, ChunkWrapper},
-  chunk_group::ChunkGroupWrapper,
+  chunk_group::{ChunkGroup, ChunkGroupWrapper},
   module::{ModuleObject, ModuleObjectRef},
   runtime::JsRuntimeSpec,
   with_compilation,
@@ -228,6 +228,32 @@ impl ChunkGraph {
             &compilation.build_chunk_graph_artifact.chunk_group_by_ukey,
           )
           .map(|chunk_group| ChunkGroupWrapper::new(chunk_group.ukey, compilation)),
+      )
+    })
+  }
+
+  #[napi(
+    ts_args_type = "chunkGroup: ChunkGroup",
+    ts_return_type = "AsyncDependenciesBlock[]"
+  )]
+  pub fn get_chunk_group_blocks(
+    &self,
+    js_chunk_group: &ChunkGroup,
+  ) -> napi::Result<Vec<AsyncDependenciesBlockWrapper>> {
+    self.with_compilation(|compilation| {
+      let module_graph = compilation.get_module_graph();
+      Ok(
+        compilation
+          .build_chunk_graph_artifact
+          .chunk_graph
+          .get_chunk_group_blocks(js_chunk_group.chunk_group_ukey)
+          .into_iter()
+          .filter_map(|block_id| {
+            module_graph
+              .block_by_id(&block_id)
+              .map(|block| AsyncDependenciesBlockWrapper::new(block, compilation))
+          })
+          .collect::<Vec<_>>(),
       )
     })
   }

--- a/crates/rspack_binding_api/src/chunk_graph.rs
+++ b/crates/rspack_binding_api/src/chunk_graph.rs
@@ -241,12 +241,23 @@ impl ChunkGraph {
     js_chunk_group: &ChunkGroup,
   ) -> napi::Result<Vec<AsyncDependenciesBlockWrapper>> {
     self.with_compilation(|compilation| {
+      let chunk_group_ukey = js_chunk_group.chunk_group_ukey;
+      if !compilation
+        .build_chunk_graph_artifact
+        .chunk_group_by_ukey
+        .contains(&chunk_group_ukey)
+      {
+        return Err(napi::Error::from_reason(format!(
+          "Unable to access chunk_group with id = {chunk_group_ukey:?} now. The chunk group has been removed on the Rust side."
+        )));
+      }
+
       let module_graph = compilation.get_module_graph();
       Ok(
         compilation
           .build_chunk_graph_artifact
           .chunk_graph
-          .get_chunk_group_blocks(js_chunk_group.chunk_group_ukey)
+          .get_chunk_group_blocks(chunk_group_ukey)
           .into_iter()
           .filter_map(|block_id| {
             module_graph

--- a/crates/rspack_binding_api/src/chunk_group.rs
+++ b/crates/rspack_binding_api/src/chunk_group.rs
@@ -15,7 +15,7 @@ use crate::{
 
 #[napi]
 pub struct ChunkGroup {
-  chunk_group_ukey: rspack_core::ChunkGroupUkey,
+  pub(crate) chunk_group_ukey: rspack_core::ChunkGroupUkey,
   compilation_id: CompilationId,
 }
 

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -290,6 +290,28 @@ impl ChunkGraph {
     self.block_to_chunk_group_ukey.insert(block, chunk_group);
   }
 
+  /// The reverse of [`ChunkGraph::get_block_chunk_group`]: the async blocks that
+  /// this chunk group was created for.
+  ///
+  /// A chunk group is usually created by a single block, but several blocks are
+  /// merged into one group when they resolve to the same chunk name. Entrypoints
+  /// are not created by a block at all and therefore have none.
+  ///
+  /// The blocks are sorted by identifier so that repeated builds return them in
+  /// the same order.
+  pub fn get_chunk_group_blocks(
+    &self,
+    chunk_group: ChunkGroupUkey,
+  ) -> Vec<AsyncDependenciesBlockIdentifier> {
+    let mut blocks = self
+      .block_to_chunk_group_ukey
+      .iter()
+      .filter_map(|(block, ukey)| (*ukey == chunk_group).then_some(*block))
+      .collect::<Vec<_>>();
+    blocks.sort_unstable_by(|a, b| a.as_str().cmp(b.as_str()));
+    blocks
+  }
+
   pub fn get_module_hash<'c>(
     compilation: &'c Compilation,
     module_identifier: ModuleIdentifier,

--- a/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_module.rs
@@ -294,11 +294,14 @@ impl ChunkGraph {
   /// this chunk group was created for.
   ///
   /// A chunk group is usually created by a single block, but several blocks are
-  /// merged into one group when they resolve to the same chunk name. Entrypoints
-  /// are not created by a block at all and therefore have none.
+  /// merged into one group when they resolve to the same chunk name. Async
+  /// entrypoints (a worker, or any block carrying entry options) are created by
+  /// a block as well; only the initial entrypoints have none.
   ///
   /// The blocks are sorted by identifier so that repeated builds return them in
-  /// the same order.
+  /// the same order. Note that this scans every block/chunk group pair, so
+  /// callers that need the mapping for the whole graph are better off inverting
+  /// [`ChunkGraph::get_block_chunk_group`] once themselves.
   pub fn get_chunk_group_blocks(
     &self,
     chunk_group: ChunkGroupUkey,

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -53,6 +53,12 @@ pub fn dependencies_block_update_hash(
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AsyncDependenciesBlockIdentifier(Identifier);
 
+impl AsyncDependenciesBlockIdentifier {
+  pub fn as_str(&self) -> &str {
+    self.0.as_str()
+  }
+}
+
 impl rspack_hash::RspackHash for AsyncDependenciesBlockIdentifier {
   fn hash(&self, state: &mut RspackHasher) {
     self.0.as_str().hash(state);

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/bar.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/bar.js
@@ -1,0 +1,1 @@
+export default "bar";

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/baz.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/baz.js
@@ -1,0 +1,1 @@
+export default "baz";

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/foo.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/foo.js
@@ -1,0 +1,1 @@
+export default "foo";

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/index.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/index.js
@@ -1,0 +1,5 @@
+// Two blocks sharing one chunk name are merged into a single chunk group,
+// while the third gets a group of its own.
+import(/* webpackChunkName: "shared" */ "./foo");
+import(/* webpackChunkName: "shared" */ "./bar");
+import(/* webpackChunkName: "lonely" */ "./baz");

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/rspack.config.js
@@ -38,7 +38,7 @@ class Plugin {
           blocks[2],
         ]);
 
-        // An entrypoint is not created by a block, so it has none.
+        // The initial entrypoint is not created by a block, so it has none.
         const entrypoint = compilation.entrypoints.get('main');
         expect(chunkGraph.getChunkGroupBlocks(entrypoint)).toEqual([]);
       });

--- a/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks/rspack.config.js
@@ -1,0 +1,63 @@
+class Plugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap('Test', (compilation) => {
+      compilation.hooks.processAssets.tap('Test', () => {
+        const { chunkGraph, moduleGraph } = compilation;
+        const entry = compilation.entries.get('main');
+        const entryModule = moduleGraph.getModule(entry.dependencies[0]);
+
+        const blocks = entryModule.blocks;
+        expect(blocks.length).toBe(3);
+
+        // The first two `import()` calls share a chunk name, so they end up in
+        // one group.
+        const chunkGroup = chunkGraph.getBlockChunkGroup(blocks[0]);
+        expect(chunkGroup.name).toBe('shared');
+        expect(chunkGraph.getBlockChunkGroup(blocks[1])).toBe(chunkGroup);
+
+        // Only the blocks of the requested group come back, not every block.
+        const groupBlocks = chunkGraph.getChunkGroupBlocks(chunkGroup);
+        expect(groupBlocks.length).toBe(2);
+
+        // Blocks come back as the same JS instances the module exposes, and each
+        // one still points back at the group it was read from.
+        for (const block of groupBlocks) {
+          expect(blocks).toContain(block);
+          expect(chunkGraph.getBlockChunkGroup(block)).toBe(chunkGroup);
+        }
+
+        // Reaching the imported module from the group is the point of the API.
+        const requests = groupBlocks.map(
+          (block) => block.dependencies[0].request,
+        );
+        expect(requests.slice().sort()).toEqual(['./bar', './foo']);
+
+        const lonelyGroup = chunkGraph.getBlockChunkGroup(blocks[2]);
+        expect(lonelyGroup.name).toBe('lonely');
+        expect(chunkGraph.getChunkGroupBlocks(lonelyGroup)).toEqual([
+          blocks[2],
+        ]);
+
+        // An entrypoint is not created by a block, so it has none.
+        const entrypoint = compilation.entrypoints.get('main');
+        expect(chunkGraph.getChunkGroupBlocks(entrypoint)).toEqual([]);
+      });
+    });
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  node: false,
+  entry: {
+    main: './index.js',
+  },
+  output: {
+    filename: '[name].js',
+  },
+  optimization: {
+    sideEffects: false,
+  },
+  plugins: [new Plugin()],
+};


### PR DESCRIPTION
## Summary

Closes #12416.

Adds `chunkGraph.getChunkGroupBlocks(chunkGroup)`, the reverse of the existing
`chunkGraph.getBlockChunkGroup(block)`: given a chunk group, return the
`AsyncDependenciesBlock`s it was created for.

@upupming asked in the issue for this to be revived, with a concrete consumer:
lynx-family/lynx-stack#2961 deduplicates lazy bundles by mapping each async chunk group
back to the resolved module of the `import()` that created it. Without a forward API,
every plugin that needs chunk-group attribution has to scan all modules per compilation
and build the reverse mapping through `module.blocks` → `getBlockChunkGroup(block)` →
`moduleGraph.getResolvedModule(dep)`. With this, the group → block → dependency →
module walk is direct.

The API shape is the one named in the issue and prototyped in #12418 — on `ChunkGraph`
rather than on `ChunkGroup`, since Rspack keeps the block/chunk-group mapping in
`ChunkGraph` and webpack has been planning the same move.

## Implementation

- `ChunkGraph::get_chunk_group_blocks` in `rspack_core` filters
  `block_to_chunk_group_ukey` by the group's ukey.
- Results are sorted by block identifier. The map is hashed, so without this the order
  varies between builds, which would leak into any plugin output derived from it. Note
  that `AsyncDependenciesBlockIdentifier`'s derived `Ord` comes from `Ustr` and is *not*
  string order, hence the new `as_str()` accessor and the explicit comparator.
- The binding drops blocks that are no longer in the module graph (the same way
  `getBlockChunkGroup` returns `null` for a group that is gone) and rejects a chunk group
  that does not belong to this compilation with the same error text
  `ChunkGroup` methods already use.

## Notes for review

- **Complexity.** Each call scans `block_to_chunk_group_ukey`, so inverting the whole
  graph one group at a time is quadratic. I kept the straightforward scan rather than
  maintaining a reverse index: the map has one entry per async block, and the doc comment
  points callers who want the full mapping at inverting `getBlockChunkGroup` themselves.
  Happy to add the index if you would rather have the O(1) lookup.
- **Pre-existing, not addressed here.** `invalidate_chunk_group`
  (`build_chunk_graph/incremental.rs`) removes the chunk group but never removes its
  blocks from `block_to_chunk_group_ukey`, so in watch mode that map keeps entries for
  dead groups. Readers are unaffected (`get_block_chunk_group` resolves through
  `chunk_group_by_ukey` and returns `None`, and this new API filters on a live group's
  ukey), but the map grows across rebuilds and so does the scan above. It looked like it
  belongs in its own change rather than in a feature PR — say the word if you want it
  here.
- **Docs.** Neither `ChunkGraph` nor `ModuleGraph` has a page on the website today —
  `getBlockChunkGroup` is undocumented as well — so I did not add one for a single
  method. Glad to write a `ChunkGraph` page covering the existing methods too if that is
  wanted.

## Test

`tests/rspack-test/configCases/chunk-graph/get-chunk-group-blocks` uses three dynamic
imports, two of which share a chunk name and are therefore merged into one chunk group.
It asserts that only that group's two blocks come back (an implementation returning every
block fails here), that they are the same JS instances `module.blocks` exposes, that each
round-trips through `getBlockChunkGroup`, that the imported requests are reachable from
them, that the third group returns only its own block, and that the initial entrypoint —
which is not created by a block — returns `[]`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
