### PR TITLE
fix(copy-plugin): reuse cache for empty rebuilds

### DIFF
--- a/crates/rspack_plugin_copy/src/lib.rs
+++ b/crates/rspack_plugin_copy/src/lib.rs
@@ -723,7 +723,6 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
       let cached = &mut pattern_cache[index];
 
       if cacheable
-        && (!compilation.modified_files.is_empty() || !compilation.removed_files.is_empty())
         && let Some(cached) = cached.as_ref()
         && !cached.is_invalidated(
           compilation

--- a/tests/rspack-test/compilerCases/_copy-plugin-cache.js
+++ b/tests/rspack-test/compilerCases/_copy-plugin-cache.js
@@ -40,7 +40,7 @@ function useRealOutputFileSystem(_context, compiler) {
 	compiler.outputFileSystem = fs;
 }
 
-function compile(compiler) {
+function compile(compiler, options) {
 	return new Promise((resolve, reject) => {
 		compiler.run((error, stats) => {
 			if (error) return reject(error);
@@ -48,7 +48,7 @@ function compile(compiler) {
 				return reject(new Error(stats.toString({ all: false, errors: true })));
 			}
 			resolve(compiler._lastCompilation);
-		});
+		}, options);
 	});
 }
 

--- a/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
+++ b/tests/rspack-test/compilerCases/copy-plugin-cache-policy.js
@@ -95,7 +95,7 @@ function cacheablePatternsCase() {
 function separateRunsCase() {
 	let root;
 	return {
-		description: "should not reuse cached results across separate run calls",
+		description: "should reuse and invalidate cached results across run calls",
 		options(context) {
 			const project = createProject(context, "run-twice", [
 				{ from: "assets/source", to: "copied" }
@@ -109,8 +109,14 @@ function separateRunsCase() {
 			const initial = await compile(compiler);
 			expect(asset(initial, "copied/one.txt")).toBe("before\n");
 
-			write(root, "assets/source/one.txt", "after\n");
-			const updated = await compile(compiler);
+			const reused = await compile(compiler);
+			expect(asset(reused, "copied/one.txt")).toBe("before\n");
+			expect(reusedPatterns(reused)).toBe(1);
+
+			const source = write(root, "assets/source/one.txt", "after\n");
+			const updated = await compile(compiler, {
+				modifiedFiles: new Set([source])
+			});
 
 			expect(asset(updated, "copied/one.txt")).toBe("after\n");
 			expect(reusedPatterns(updated)).toBe(0);
@@ -121,7 +127,7 @@ function separateRunsCase() {
 function emptyRebuildCase() {
 	let root;
 	return {
-		description: "should not reuse cached results for an empty rebuild",
+		description: "should reuse cached results for an empty rebuild",
 		options(context) {
 			const project = createProject(context, "empty-rebuild", [
 				{ from: "assets/source", to: "copied" }
@@ -135,11 +141,10 @@ function emptyRebuildCase() {
 			const initial = await compile(compiler);
 			expect(asset(initial, "copied/one.txt")).toBe("before\n");
 
-			write(root, "assets/source/one.txt", "after\n");
 			const updated = await rebuild(compiler);
 
-			expect(asset(updated, "copied/one.txt")).toBe("after\n");
-			expect(reusedPatterns(updated)).toBe(0);
+			expect(asset(updated, "copied/one.txt")).toBe("before\n");
+			expect(reusedPatterns(updated)).toBe(1);
 		}
 	};
 }


### PR DESCRIPTION
## Summary

Close https://github.com/web-infra-dev/rspack/issues/14791

- reuse cached static CopyRspackPlugin pattern results when an incremental rebuild reports no modified or removed files
- continue invalidating cached patterns when an explicitly reported path intersects their file or context dependencies
- cover empty rebuilds, unchanged repeated run calls, and explicit invalidation across run calls

### Why the simple check is sufficient

modifiedFiles and removedFiles are the authoritative invalidation inputs for an incremental rebuild. The module graph and the existing in-memory caches already interpret empty sets as no reported changes, rather than as unknown filesystem state. CopyRspackPlugin should follow the same contract.

The pattern cache already records file and context dependencies. Its validity check only needs to determine whether any reported changed path intersects those dependencies. When the change iterator is empty, no cached dependency is invalidated, so the cached result is reusable.

This also covers lazy compilation without tracking its trigger provenance. A lazy activation may request an empty rebuild, while a real filesystem change is reported separately by the watcher and causes the corresponding cache entry to be invalidated. Adding state to Watching, Compilation, or MultiCompiler would duplicate scheduler state without improving the cache validity decision.

For manual incremental compiler.run() calls, callers that mutate files are expected to provide modifiedFiles or removedFiles. Without that information, the rest of incremental compilation may reuse cached state as well, so CopyRspackPlugin now behaves consistently with the existing incremental contract.

No public API is changed.

## Related links

- https://github.com/web-infra-dev/rspack/issues/14791#issuecomment-4976533200

## Validation

- pnpm run build:binding:dev
- pnpm run build:js
- pnpm run lint:js
- cargo fmt --all --check
- cd tests/rspack-test && pnpm run test -t "compilerCases/copy-plugin-cache" (12 passed)

## Checklist

- [x] Tests updated.
- [x] Documentation not required.