### PR TITLE
feat(tree-shaking): prune dynamic imports from unused exports

### DIFF
--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -1,27 +1,19 @@
-use std::{mem, sync::Arc};
+use std::mem;
 
 use futures::Future;
 use rspack_collections::IdentifierMap;
 use rspack_error::Result;
 use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use rustc_hash::FxHashMap as HashMap;
 use tracing::instrument;
 
 use crate::{
-  ArtifactExt, AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroupByUkey,
-  ChunkGroupUkey, ChunkUkey, Compilation, ConnectionState, DependenciesBlock, DependencyType,
-  Logger, ModuleIdentifier, RuntimeSpec,
+  ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
+  Logger,
   build_chunk_graph::code_splitter::CodeSplitter,
   fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
-
-#[derive(Debug, Default)]
-struct DependencyConditionSnapshot {
-  runtimes: Vec<Option<Arc<RuntimeSpec>>>,
-  async_states: HashMap<(AsyncDependenciesBlockIdentifier, usize), Vec<ConnectionState>>,
-  eager_states: HashMap<(ModuleIdentifier, usize), Vec<ConnectionState>>,
-}
 
 #[derive(Debug, Default)]
 pub struct BuildChunkGraphArtifact {
@@ -34,7 +26,6 @@ pub struct BuildChunkGraphArtifact {
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
   pub module_idx: IdentifierMap<(u32, u32)>,
-  dependency_condition_snapshot: DependencyConditionSnapshot,
 }
 
 impl BuildChunkGraphArtifact {
@@ -82,7 +73,7 @@ impl BuildChunkGraphArtifact {
     }
 
     let module_graph = this_compilation.get_module_graph();
-    let affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
+    let mut affected_modules = mutations.get_affected_modules_with_module_graph(module_graph);
     let previous_modules_map = &this_compilation
       .build_chunk_graph_artifact
       .code_splitter
@@ -93,31 +84,10 @@ impl BuildChunkGraphArtifact {
       return false;
     }
 
-    let current_condition_states = collect_async_dependency_condition_states(
-      this_compilation,
-      &self.dependency_condition_snapshot.runtimes,
-    );
-    if current_condition_states != self.dependency_condition_snapshot.async_states {
-      logger.log("async dependency condition change detected, rebuilding chunk graph");
-      return false;
-    }
-
-    let mut eager_modules = self
-      .dependency_condition_snapshot
-      .eager_states
-      .keys()
-      .map(|(module, _)| *module)
-      .collect::<HashSet<_>>();
-    eager_modules.extend(affected_modules.iter().copied());
-    let current_eager_condition_states = collect_eager_dependency_condition_states(
-      this_compilation,
-      &self.dependency_condition_snapshot.runtimes,
-      eager_modules,
-    );
-    if current_eager_condition_states != self.dependency_condition_snapshot.eager_states {
-      logger.log("eager dependency condition change detected, rebuilding chunk graph");
-      return false;
-    }
+    // A dependency condition may change when exports usage changes even if its
+    // owning module was not rebuilt. Revalidate every conditional module that
+    // contributed to the cached chunk graph in addition to mutated modules.
+    affected_modules.extend(self.code_splitter.cached_conditional_modules());
 
     for module in affected_modules {
       if !self
@@ -154,144 +124,6 @@ impl BuildChunkGraphArtifact {
     self.named_chunks.clear();
     self.set_code_splitter(Default::default());
     self.module_idx.clear();
-    self.dependency_condition_snapshot = Default::default();
-  }
-}
-
-fn collect_async_dependency_condition_states(
-  compilation: &Compilation,
-  runtimes: &[Option<Arc<RuntimeSpec>>],
-) -> HashMap<(AsyncDependenciesBlockIdentifier, usize), Vec<ConnectionState>> {
-  let module_graph = compilation.get_module_graph();
-  let module_graph_cache = &compilation.module_graph_cache_artifact;
-  let side_effects_state_artifact = &compilation
-    .build_module_graph_artifact
-    .side_effects_state_artifact;
-  let exports_info_artifact = &compilation.exports_info_artifact;
-  let mut states = HashMap::default();
-
-  for (block_id, block) in module_graph.blocks() {
-    for (dependency_index, dependency_id) in block.get_dependencies().iter().enumerate() {
-      let dependency = module_graph.dependency_by_id(dependency_id);
-      let has_condition = dependency
-        .as_module_dependency()
-        .and_then(|dependency| dependency.get_condition())
-        .is_some();
-      if !has_condition {
-        continue;
-      }
-
-      let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
-        continue;
-      };
-      let dependency_states = runtimes
-        .iter()
-        .map(|runtime| {
-          connection.active_state(
-            module_graph,
-            runtime.as_deref(),
-            module_graph_cache,
-            side_effects_state_artifact,
-            exports_info_artifact,
-          )
-        })
-        .collect();
-      states.insert((*block_id, dependency_index), dependency_states);
-    }
-  }
-
-  states
-}
-
-fn collect_eager_dependency_condition_states(
-  compilation: &Compilation,
-  runtimes: &[Option<Arc<RuntimeSpec>>],
-  modules: impl IntoIterator<Item = ModuleIdentifier>,
-) -> HashMap<(ModuleIdentifier, usize), Vec<ConnectionState>> {
-  let module_graph = compilation.get_module_graph();
-  let module_graph_cache = &compilation.module_graph_cache_artifact;
-  let side_effects_state_artifact = &compilation
-    .build_module_graph_artifact
-    .side_effects_state_artifact;
-  let exports_info_artifact = &compilation.exports_info_artifact;
-  let mut states = HashMap::default();
-
-  for module_identifier in modules {
-    let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
-      continue;
-    };
-    for (dependency_index, dependency_id) in module.get_dependencies().iter().enumerate() {
-      let dependency = module_graph.dependency_by_id(dependency_id);
-      if !matches!(
-        dependency.dependency_type(),
-        DependencyType::DynamicImportEager
-      ) || dependency
-        .as_module_dependency()
-        .and_then(|dependency| dependency.get_condition())
-        .is_none()
-      {
-        continue;
-      }
-
-      let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
-        continue;
-      };
-      let dependency_states = runtimes
-        .iter()
-        .map(|runtime| {
-          connection.active_state(
-            module_graph,
-            runtime.as_deref(),
-            module_graph_cache,
-            side_effects_state_artifact,
-            exports_info_artifact,
-          )
-        })
-        .collect();
-      states.insert((module_identifier, dependency_index), dependency_states);
-    }
-  }
-
-  states
-}
-
-fn create_dependency_condition_snapshot(compilation: &Compilation) -> DependencyConditionSnapshot {
-  let code_splitter = &compilation.build_chunk_graph_artifact.code_splitter;
-  let mut runtimes = Vec::new();
-  let mut seen_runtimes = HashSet::default();
-
-  for runtime in code_splitter
-    .block_modules_runtime_map
-    .keys()
-    .cloned()
-    .chain(
-      code_splitter
-        .chunk_group_infos
-        .values()
-        .map(|info| Some(info.runtime.clone())),
-    )
-  {
-    if seen_runtimes.insert(runtime.clone()) {
-      runtimes.push(runtime);
-    }
-  }
-
-  // A conditional async dependency implies that code splitting evaluated at
-  // least one runtime. Keep a conservative fallback for an empty graph cache.
-  if runtimes.is_empty() {
-    runtimes.push(None);
-  }
-
-  let async_states = collect_async_dependency_condition_states(compilation, &runtimes);
-  let eager_states = collect_eager_dependency_condition_states(
-    compilation,
-    &runtimes,
-    compilation.get_module_graph().modules_keys().copied(),
-  );
-  DependencyConditionSnapshot {
-    runtimes,
-    async_states,
-    eager_states,
   }
 }
 
@@ -350,10 +182,6 @@ where
     map.insert(*mid, (pre, post));
   }
   compilation.build_chunk_graph_artifact.module_idx = map;
-  let condition_snapshot = create_dependency_condition_snapshot(compilation);
-  compilation
-    .build_chunk_graph_artifact
-    .dependency_condition_snapshot = condition_snapshot;
   Ok(())
 }
 
@@ -364,7 +192,6 @@ impl ArtifactExt for BuildChunkGraphArtifact {
   }
   fn recover(_incremental: &crate::incremental::Incremental, new: &mut Self, old: &mut Self) {
     new.code_splitter = mem::take(&mut old.code_splitter);
-    new.dependency_condition_snapshot = mem::take(&mut old.dependency_condition_snapshot);
     rayon::scope(|s| {
       s.spawn(|_| new.chunk_by_ukey.clone_from(&old.chunk_by_ukey));
       s.spawn(|_| new.chunk_graph.clone_from(&old.chunk_graph));

--- a/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_chunk_graph_artifact.rs
@@ -1,19 +1,27 @@
-use std::mem;
+use std::{mem, sync::Arc};
 
 use futures::Future;
 use rspack_collections::IdentifierMap;
 use rspack_error::Result;
 use rspack_util::{fx_hash::FxIndexMap, tracing_preset::TRACING_BENCH_TARGET};
-use rustc_hash::FxHashMap as HashMap;
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use tracing::instrument;
 
 use crate::{
-  ArtifactExt, ChunkByUkey, ChunkGraph, ChunkGroupByUkey, ChunkGroupUkey, ChunkUkey, Compilation,
-  Logger,
+  ArtifactExt, AsyncDependenciesBlockIdentifier, ChunkByUkey, ChunkGraph, ChunkGroupByUkey,
+  ChunkGroupUkey, ChunkUkey, Compilation, ConnectionState, DependenciesBlock, DependencyType,
+  Logger, ModuleIdentifier, RuntimeSpec,
   build_chunk_graph::code_splitter::CodeSplitter,
   fast_set,
   incremental::{IncrementalPasses, Mutation},
 };
+
+#[derive(Debug, Default)]
+struct DependencyConditionSnapshot {
+  runtimes: Vec<Option<Arc<RuntimeSpec>>>,
+  async_states: HashMap<(AsyncDependenciesBlockIdentifier, usize), Vec<ConnectionState>>,
+  eager_states: HashMap<(ModuleIdentifier, usize), Vec<ConnectionState>>,
+}
 
 #[derive(Debug, Default)]
 pub struct BuildChunkGraphArtifact {
@@ -26,6 +34,7 @@ pub struct BuildChunkGraphArtifact {
   pub named_chunks: HashMap<String, ChunkUkey>,
   pub(crate) code_splitter: CodeSplitter,
   pub module_idx: IdentifierMap<(u32, u32)>,
+  dependency_condition_snapshot: DependencyConditionSnapshot,
 }
 
 impl BuildChunkGraphArtifact {
@@ -84,6 +93,32 @@ impl BuildChunkGraphArtifact {
       return false;
     }
 
+    let current_condition_states = collect_async_dependency_condition_states(
+      this_compilation,
+      &self.dependency_condition_snapshot.runtimes,
+    );
+    if current_condition_states != self.dependency_condition_snapshot.async_states {
+      logger.log("async dependency condition change detected, rebuilding chunk graph");
+      return false;
+    }
+
+    let mut eager_modules = self
+      .dependency_condition_snapshot
+      .eager_states
+      .keys()
+      .map(|(module, _)| *module)
+      .collect::<HashSet<_>>();
+    eager_modules.extend(affected_modules.iter().copied());
+    let current_eager_condition_states = collect_eager_dependency_condition_states(
+      this_compilation,
+      &self.dependency_condition_snapshot.runtimes,
+      eager_modules,
+    );
+    if current_eager_condition_states != self.dependency_condition_snapshot.eager_states {
+      logger.log("eager dependency condition change detected, rebuilding chunk graph");
+      return false;
+    }
+
     for module in affected_modules {
       if !self
         .code_splitter
@@ -119,6 +154,144 @@ impl BuildChunkGraphArtifact {
     self.named_chunks.clear();
     self.set_code_splitter(Default::default());
     self.module_idx.clear();
+    self.dependency_condition_snapshot = Default::default();
+  }
+}
+
+fn collect_async_dependency_condition_states(
+  compilation: &Compilation,
+  runtimes: &[Option<Arc<RuntimeSpec>>],
+) -> HashMap<(AsyncDependenciesBlockIdentifier, usize), Vec<ConnectionState>> {
+  let module_graph = compilation.get_module_graph();
+  let module_graph_cache = &compilation.module_graph_cache_artifact;
+  let side_effects_state_artifact = &compilation
+    .build_module_graph_artifact
+    .side_effects_state_artifact;
+  let exports_info_artifact = &compilation.exports_info_artifact;
+  let mut states = HashMap::default();
+
+  for (block_id, block) in module_graph.blocks() {
+    for (dependency_index, dependency_id) in block.get_dependencies().iter().enumerate() {
+      let dependency = module_graph.dependency_by_id(dependency_id);
+      let has_condition = dependency
+        .as_module_dependency()
+        .and_then(|dependency| dependency.get_condition())
+        .is_some();
+      if !has_condition {
+        continue;
+      }
+
+      let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
+        continue;
+      };
+      let dependency_states = runtimes
+        .iter()
+        .map(|runtime| {
+          connection.active_state(
+            module_graph,
+            runtime.as_deref(),
+            module_graph_cache,
+            side_effects_state_artifact,
+            exports_info_artifact,
+          )
+        })
+        .collect();
+      states.insert((*block_id, dependency_index), dependency_states);
+    }
+  }
+
+  states
+}
+
+fn collect_eager_dependency_condition_states(
+  compilation: &Compilation,
+  runtimes: &[Option<Arc<RuntimeSpec>>],
+  modules: impl IntoIterator<Item = ModuleIdentifier>,
+) -> HashMap<(ModuleIdentifier, usize), Vec<ConnectionState>> {
+  let module_graph = compilation.get_module_graph();
+  let module_graph_cache = &compilation.module_graph_cache_artifact;
+  let side_effects_state_artifact = &compilation
+    .build_module_graph_artifact
+    .side_effects_state_artifact;
+  let exports_info_artifact = &compilation.exports_info_artifact;
+  let mut states = HashMap::default();
+
+  for module_identifier in modules {
+    let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
+      continue;
+    };
+    for (dependency_index, dependency_id) in module.get_dependencies().iter().enumerate() {
+      let dependency = module_graph.dependency_by_id(dependency_id);
+      if !matches!(
+        dependency.dependency_type(),
+        DependencyType::DynamicImportEager
+      ) || dependency
+        .as_module_dependency()
+        .and_then(|dependency| dependency.get_condition())
+        .is_none()
+      {
+        continue;
+      }
+
+      let Some(connection) = module_graph.connection_by_dependency_id(dependency_id) else {
+        continue;
+      };
+      let dependency_states = runtimes
+        .iter()
+        .map(|runtime| {
+          connection.active_state(
+            module_graph,
+            runtime.as_deref(),
+            module_graph_cache,
+            side_effects_state_artifact,
+            exports_info_artifact,
+          )
+        })
+        .collect();
+      states.insert((module_identifier, dependency_index), dependency_states);
+    }
+  }
+
+  states
+}
+
+fn create_dependency_condition_snapshot(compilation: &Compilation) -> DependencyConditionSnapshot {
+  let code_splitter = &compilation.build_chunk_graph_artifact.code_splitter;
+  let mut runtimes = Vec::new();
+  let mut seen_runtimes = HashSet::default();
+
+  for runtime in code_splitter
+    .block_modules_runtime_map
+    .keys()
+    .cloned()
+    .chain(
+      code_splitter
+        .chunk_group_infos
+        .values()
+        .map(|info| Some(info.runtime.clone())),
+    )
+  {
+    if seen_runtimes.insert(runtime.clone()) {
+      runtimes.push(runtime);
+    }
+  }
+
+  // A conditional async dependency implies that code splitting evaluated at
+  // least one runtime. Keep a conservative fallback for an empty graph cache.
+  if runtimes.is_empty() {
+    runtimes.push(None);
+  }
+
+  let async_states = collect_async_dependency_condition_states(compilation, &runtimes);
+  let eager_states = collect_eager_dependency_condition_states(
+    compilation,
+    &runtimes,
+    compilation.get_module_graph().modules_keys().copied(),
+  );
+  DependencyConditionSnapshot {
+    runtimes,
+    async_states,
+    eager_states,
   }
 }
 
@@ -177,6 +350,10 @@ where
     map.insert(*mid, (pre, post));
   }
   compilation.build_chunk_graph_artifact.module_idx = map;
+  let condition_snapshot = create_dependency_condition_snapshot(compilation);
+  compilation
+    .build_chunk_graph_artifact
+    .dependency_condition_snapshot = condition_snapshot;
   Ok(())
 }
 
@@ -187,6 +364,7 @@ impl ArtifactExt for BuildChunkGraphArtifact {
   }
   fn recover(_incremental: &crate::incremental::Incremental, new: &mut Self, old: &mut Self) {
     new.code_splitter = mem::take(&mut old.code_splitter);
+    new.dependency_condition_snapshot = mem::take(&mut old.dependency_condition_snapshot);
     rayon::scope(|s| {
       s.spawn(|_| new.chunk_by_ukey.clone_from(&old.chunk_by_ukey));
       s.spawn(|_| new.chunk_graph.clone_from(&old.chunk_graph));

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -20,9 +20,10 @@ use crate::{
   AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierMap,
   AsyncDependenciesBlockIdentifierSet, ChunkGroup, ChunkGroupKind, ChunkGroupOptions,
   ChunkGroupUkey, ChunkLoading, ChunkUkey, Compilation, ConnectionState, DependenciesBlock,
-  DependencyId, DependencyLocation, EntryDependency, EntryRuntime, ExportsInfoArtifact,
-  GroupOptions, Logger, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier,
-  RuntimeSpec, SideEffectsStateArtifact, SyntheticDependencyLocation, assign_depths,
+  DependencyId, DependencyLocation, DependencyType, EntryDependency, EntryRuntime,
+  ExportsInfoArtifact, GroupOptions, Logger, ModuleDependency, ModuleGraph,
+  ModuleGraphCacheArtifact, ModuleIdentifier, RuntimeSpec, SideEffectsStateArtifact,
+  SyntheticDependencyLocation, assign_depths,
   dependencies_block::AsyncDependenciesToInitialChunkError,
   get_entry_runtime,
   incremental::{IncrementalPasses, Mutation},
@@ -380,6 +381,10 @@ pub(crate) struct CodeSplitter {
   prepared_blocks_map: DependenciesBlockIdentifierMap<Vec<AsyncDependenciesBlockIdentifier>>,
 
   prepared_block_group_options: AsyncDependenciesBlockIdentifierMap<GroupOptions>,
+
+  // Conditions on async and eager dynamic imports can change with exports
+  // usage even when their owning module is not part of the mutation set.
+  conditional_modules: IdentifierSet,
 }
 
 fn add_chunk_in_group(
@@ -451,6 +456,16 @@ fn get_active_state_of_connections(
 }
 
 impl CodeSplitter {
+  pub(crate) fn cached_conditional_modules(&self) -> impl Iterator<Item = ModuleIdentifier> + '_ {
+    self.conditional_modules.iter().copied().filter(|module| {
+      let module_block = DependenciesBlockIdentifier::Module(*module);
+      self
+        .block_modules_runtime_map
+        .values()
+        .any(|block_modules| block_modules.contains_key(&module_block))
+    })
+  }
+
   pub(crate) fn can_reuse_affected_module(
     &self,
     module: ModuleIdentifier,
@@ -2559,6 +2574,33 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
       .par_iter()
       .filter_map(|module| prepare_module_connection_map(*module, mg).map(|map| (*module, map)))
       .collect::<IdentifierMap<_>>();
+    self.conditional_modules = self
+      .prepared_connection_map
+      .iter()
+      .filter_map(|(module, connections)| {
+        connections
+          .iter()
+          .any(|connection| {
+            let is_async = matches!(
+              connection.block,
+              DependenciesBlockIdentifier::AsyncDependenciesBlock(_)
+            );
+            connection.connections.iter().any(|dependency_id| {
+              let dependency = mg.dependency_by_id(dependency_id);
+              (is_async
+                || matches!(
+                  dependency.dependency_type(),
+                  DependencyType::DynamicImportEager
+                ))
+                && dependency
+                  .as_module_dependency()
+                  .and_then(|dependency| dependency.get_condition())
+                  .is_some()
+            })
+          })
+          .then_some(*module)
+      })
+      .collect();
 
     let mut prepared_blocks_map = DependenciesBlockIdentifierMap::<
       Vec<AsyncDependenciesBlockIdentifier>,

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -163,6 +163,10 @@ impl AsyncDependenciesBlock {
     &mut self.dependencies
   }
 
+  pub fn blocks_mut(&mut self) -> &mut [Box<AsyncDependenciesBlock>] {
+    &mut self.blocks
+  }
+
   pub fn take_blocks(&mut self) -> Vec<Box<AsyncDependenciesBlock>> {
     std::mem::take(&mut self.blocks)
   }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
@@ -34,7 +34,7 @@ pub struct ImportDependency {
   pub comments: Vec<(bool, String)>,
   resource_identifier: ResourceIdentifier,
   optional: bool,
-  used_by_exports: Option<Arc<UsedByExports>>,
+  used_by_exports: Option<UsedByExports>,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guard: Option<DependencyBranchGuard>,
 }
@@ -86,12 +86,12 @@ impl ImportDependency {
     });
   }
 
-  pub fn set_used_by_exports(&mut self, used_by_exports: Option<Arc<UsedByExports>>) {
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {
     self.used_by_exports = used_by_exports;
   }
 
   pub(super) fn used_by_exports(&self) -> Option<&UsedByExports> {
-    self.used_by_exports.as_deref()
+    self.used_by_exports.as_ref()
   }
 }
 
@@ -180,7 +180,7 @@ impl ModuleDependency for ImportDependency {
 
   fn get_condition(&self) -> Option<DependencyCondition> {
     let inner_graph_condition =
-      get_import_dependency_inner_graph_condition(self.used_by_exports.as_deref());
+      get_import_dependency_inner_graph_condition(self.used_by_exports.as_ref());
     compose_dependency_condition(inner_graph_condition, self.branch_guard.as_ref())
   }
 }

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_dependency.rs
@@ -1,19 +1,22 @@
+use std::sync::{Arc, LazyLock};
+
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsCacheable, AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
-  DependencyCondition, DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType,
-  DependencyType, ExportsInfoArtifact, ImportAttributes, ImportPhase, ModuleDependency,
-  ModuleGraphCacheArtifact, ReferencedSpecifier, ResourceIdentifier, TemplateContext,
-  TemplateReplaceSource, create_exports_object_referenced,
+  AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyCondition, DependencyConditionFn, DependencyId, DependencyRange, DependencyTemplate,
+  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ImportAttributes, ImportPhase,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
+  ReferencedSpecifier, ResourceIdentifier, RuntimeSpec, SideEffectsStateArtifact, TemplateContext,
+  TemplateReplaceSource, UsedByExports, UsedByExportsCondition, create_exports_object_referenced,
   create_referenced_exports_by_referenced_specifiers,
 };
 
-use super::create_resource_identifier_for_esm_dependency;
+use super::{ImportEagerDependency, create_resource_identifier_for_esm_dependency};
 use crate::{
-  Atom,
+  Atom, connection_active_used_by_exports,
   dependency::{DependencyBranchGuard, compose_dependency_condition},
 };
 
@@ -31,6 +34,7 @@ pub struct ImportDependency {
   pub comments: Vec<(bool, String)>,
   resource_identifier: ResourceIdentifier,
   optional: bool,
+  used_by_exports: Option<Arc<UsedByExports>>,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guard: Option<DependencyBranchGuard>,
 }
@@ -56,6 +60,7 @@ impl ImportDependency {
       resource_identifier,
       optional,
       comments,
+      used_by_exports: None,
       branch_guard: None,
     }
   }
@@ -79,6 +84,14 @@ impl ImportDependency {
       Some(old_guard) => old_guard.and(guard),
       None => guard,
     });
+  }
+
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<Arc<UsedByExports>>) {
+    self.used_by_exports = used_by_exports;
+  }
+
+  pub(super) fn used_by_exports(&self) -> Option<&UsedByExports> {
+    self.used_by_exports.as_deref()
   }
 }
 
@@ -166,7 +179,58 @@ impl ModuleDependency for ImportDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    compose_dependency_condition(None, self.branch_guard.as_ref())
+    let inner_graph_condition =
+      get_import_dependency_inner_graph_condition(self.used_by_exports.as_deref());
+    compose_dependency_condition(inner_graph_condition, self.branch_guard.as_ref())
+  }
+}
+
+struct ImportDependencyCondition;
+
+static IMPORT_DEPENDENCY_CONDITION: LazyLock<DependencyCondition> =
+  LazyLock::new(|| DependencyCondition::new(ImportDependencyCondition));
+
+pub(super) fn get_import_dependency_inner_graph_condition(
+  used_by_exports: Option<&UsedByExports>,
+) -> Option<DependencyCondition> {
+  used_by_exports
+    // Bool(true) remains active even when a deferred purity check is impure, so wrapping it in a
+    // condition only sends an unconditional connection through runtime condition machinery.
+    .filter(|used_by_exports| {
+      !matches!(
+        used_by_exports.condition(),
+        UsedByExportsCondition::Bool(true)
+      )
+    })
+    .map(|_| IMPORT_DEPENDENCY_CONDITION.clone())
+}
+
+impl DependencyConditionFn for ImportDependencyCondition {
+  fn get_connection_state(
+    &self,
+    connection: &ModuleGraphConnection,
+    runtime: Option<&RuntimeSpec>,
+    module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
+    _side_effects_state_artifact: &SideEffectsStateArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+  ) -> ConnectionState {
+    let dependency = module_graph.dependency_by_id(&connection.dependency_id);
+    let used_by_exports = if let Some(dependency) = dependency.downcast_ref::<ImportDependency>() {
+      dependency.used_by_exports()
+    } else {
+      dependency
+        .downcast_ref::<ImportEagerDependency>()
+        .expect("should be ImportDependency or ImportEagerDependency")
+        .used_by_exports()
+    };
+    ConnectionState::Active(connection_active_used_by_exports(
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+      used_by_exports,
+    ))
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -1,16 +1,22 @@
+use std::sync::Arc;
+
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsCacheable, AsOption, AsPreset, AsVec},
 };
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact,
-  ImportAttributes, ImportPhase, ModuleDependency, ModuleGraphCacheArtifact, ReferencedSpecifier,
-  ResourceIdentifier, TemplateContext, TemplateReplaceSource, create_exports_object_referenced,
+  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyCondition, DependencyId, DependencyRange, DependencyTemplate, DependencyTemplateType,
+  DependencyType, ExportsInfoArtifact, ImportAttributes, ImportPhase, ModuleDependency,
+  ModuleGraphCacheArtifact, ReferencedSpecifier, ResourceIdentifier, TemplateContext,
+  TemplateReplaceSource, UsedByExports, create_exports_object_referenced,
   create_referenced_exports_by_referenced_specifiers,
 };
 
-use super::create_resource_identifier_for_esm_dependency;
+use super::{
+  create_resource_identifier_for_esm_dependency,
+  import_dependency::get_import_dependency_inner_graph_condition,
+};
 use crate::Atom;
 
 #[cacheable]
@@ -25,6 +31,7 @@ pub struct ImportEagerDependency {
   attributes: Option<ImportAttributes>,
   phase: ImportPhase,
   resource_identifier: ResourceIdentifier,
+  used_by_exports: Option<Arc<UsedByExports>>,
 }
 
 impl ImportEagerDependency {
@@ -44,6 +51,7 @@ impl ImportEagerDependency {
       attributes,
       phase,
       resource_identifier,
+      used_by_exports: None,
     }
   }
 
@@ -59,6 +67,14 @@ impl ImportEagerDependency {
       return;
     }
     self.referenced_specifiers = Some(referenced_specifiers);
+  }
+
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<Arc<UsedByExports>>) {
+    self.used_by_exports = used_by_exports;
+  }
+
+  pub(super) fn used_by_exports(&self) -> Option<&UsedByExports> {
+    self.used_by_exports.as_deref()
   }
 }
 
@@ -139,6 +155,10 @@ impl ModuleDependency for ImportEagerDependency {
 
   fn user_request(&self) -> &str {
     &self.request
+  }
+
+  fn get_condition(&self) -> Option<DependencyCondition> {
+    get_import_dependency_inner_graph_condition(self.used_by_exports.as_deref())
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/esm/import_eager_dependency.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsCacheable, AsOption, AsPreset, AsVec},
@@ -31,7 +29,7 @@ pub struct ImportEagerDependency {
   attributes: Option<ImportAttributes>,
   phase: ImportPhase,
   resource_identifier: ResourceIdentifier,
-  used_by_exports: Option<Arc<UsedByExports>>,
+  used_by_exports: Option<UsedByExports>,
 }
 
 impl ImportEagerDependency {
@@ -69,12 +67,12 @@ impl ImportEagerDependency {
     self.referenced_specifiers = Some(referenced_specifiers);
   }
 
-  pub fn set_used_by_exports(&mut self, used_by_exports: Option<Arc<UsedByExports>>) {
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {
     self.used_by_exports = used_by_exports;
   }
 
   pub(super) fn used_by_exports(&self) -> Option<&UsedByExports> {
-    self.used_by_exports.as_deref()
+    self.used_by_exports.as_ref()
   }
 }
 
@@ -158,7 +156,7 @@ impl ModuleDependency for ImportEagerDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    get_import_dependency_inner_graph_condition(self.used_by_exports.as_deref())
+    get_import_dependency_inner_graph_condition(self.used_by_exports.as_ref())
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -1,7 +1,7 @@
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, ChunkGroupOptions, ContextDependency,
-  ContextNameSpaceObject, ContextOptions, DependencyCategory, DependencyRange, DependencyType,
-  DynamicImportFetchPriority, DynamicImportMode, GroupOptions, ImportAttributes,
+  ContextNameSpaceObject, ContextOptions, Dependency, DependencyCategory, DependencyRange,
+  DependencyType, DynamicImportFetchPriority, DynamicImportMode, GroupOptions, ImportAttributes,
   ReferencedSpecifier, get_context,
 };
 use rspack_error::{Error, Severity};
@@ -12,9 +12,12 @@ use swc_experimental_ecma_ast::{
   BlockStmtOrExpr, CallExpr, Expr, GetSpan, Ident, MemberExpr, ObjectPat, Pat, Span, VarDeclarator,
 };
 
-use super::{JavascriptParserPlugin, import_phase::get_import_phase};
+use super::{
+  JavascriptParserPlugin, import_phase::get_import_phase,
+  inner_graph::state::InnerGraphUsageOperation,
+};
 use crate::{
-  Atom,
+  Atom, InnerGraphParserPlugin,
   dependency::{
     ImportContextDependency, ImportDependency, ImportEagerDependency, ImportWeakDependency,
   },
@@ -509,8 +512,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         if let Some(exports) = exports {
           dep.set_referenced_specifiers(exports, !is_statical && has_exports_magic_comment);
         }
+        let dep_id = *dep.id();
         let dep_idx = parser.next_dependency_idx();
         parser.add_dependency(BoxDependency::new(dep));
+        InnerGraphParserPlugin::on_usage(
+          parser,
+          InnerGraphUsageOperation::ImportDependency(dep_id),
+        );
         ImportDependencyLocator {
           block_idx: None,
           dep_idx,
@@ -553,6 +561,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         if let Some(export) = exports {
           dep.set_referenced_specifiers(export, !is_statical && has_exports_magic_comment);
         }
+        let dep_id = dep.id;
         let range = DependencyRange::from(import_call_span);
         let loc = parser.to_dependency_location(range);
         let mut block = AsyncDependenciesBlock::new(
@@ -570,6 +579,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         )));
         let block_idx = parser.next_block_idx();
         parser.add_block(Box::new(block));
+        InnerGraphParserPlugin::on_usage(
+          parser,
+          InnerGraphUsageOperation::ImportDependency(dep_id),
+        );
         ImportDependencyLocator {
           block_idx: Some(block_idx),
           dep_idx: 0,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -335,19 +335,6 @@ impl InnerGraphParserPlugin {
     }
 
     if !import_dependency_usage.is_empty() {
-      fn set_import_dependency_usage(
-        dependency: &mut BoxDependency,
-        used_by_exports: UsedByExports,
-      ) {
-        if let Some(dependency) = dependency.downcast_mut::<ImportDependency>() {
-          dependency.set_used_by_exports(Some(used_by_exports));
-        } else if let Some(dependency) = dependency.downcast_mut::<ImportEagerDependency>() {
-          dependency.set_used_by_exports(Some(used_by_exports));
-        } else {
-          unreachable!("inner graph import dependency should be a dynamic import dependency");
-        }
-      }
-
       fn apply_import_dependency_usage(
         blocks: &mut [Box<AsyncDependenciesBlock>],
         import_dependency_usage: &mut HashMap<DependencyId, UsedByExports>,
@@ -355,7 +342,11 @@ impl InnerGraphParserPlugin {
         for block in blocks {
           for dependency in block.dependencies_mut() {
             if let Some(used_by_exports) = import_dependency_usage.remove(dependency.id()) {
-              set_import_dependency_usage(dependency, used_by_exports);
+              if let Some(dependency) = dependency.downcast_mut::<ImportDependency>() {
+                dependency.set_used_by_exports(Some(used_by_exports));
+              } else {
+                unreachable!("dependencies in async blocks should be ImportDependency");
+              }
             }
           }
           apply_import_dependency_usage(block.blocks_mut(), import_dependency_usage);
@@ -364,7 +355,11 @@ impl InnerGraphParserPlugin {
 
       for dependency in dependencies {
         if let Some(used_by_exports) = import_dependency_usage.remove(dependency.id()) {
-          set_import_dependency_usage(dependency, used_by_exports);
+          if let Some(dependency) = dependency.downcast_mut::<ImportEagerDependency>() {
+            dependency.set_used_by_exports(Some(used_by_exports));
+          } else {
+            unreachable!("top-level import dependency should be ImportEagerDependency");
+          }
         }
       }
       apply_import_dependency_usage(blocks, &mut import_dependency_usage);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -1,8 +1,6 @@
-use std::sync::Arc;
-
 use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
-  UsedByExportsCondition, UsedByExportsDeferredPureCheck,
+  UsedByExportsDeferredPureCheck,
 };
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -103,7 +101,7 @@ impl InnerGraphParserPlugin {
   pub fn infer_dependency_usage(
     state: &mut InnerGraphState,
     deferred_pure_checks_by_symbol: &HashMap<TopLevelSymbol, Vec<UsedByExportsDeferredPureCheck>>,
-  ) -> Vec<(Vec<InnerGraphUsageOperation>, UsedByExports)> {
+  ) -> Vec<(InnerGraphUsageOperation, UsedByExports)> {
     let mut non_terminal = state.inner_graph.keys().copied().collect::<HashSet<_>>();
     let mut processed: HashMap<TopLevelSymbol, HashSet<InnerGraphMapSetValue>> = HashMap::default();
 
@@ -237,7 +235,9 @@ impl InnerGraphParserPlugin {
         UsedByExports::bool(false)
       }
       .with_deferred_pure_checks(deferred_pure_checks);
-      finalized.push((cbs, used_by_exports));
+      for cb in cbs {
+        finalized.push((cb, used_by_exports.clone()));
+      }
     }
 
     finalized
@@ -300,56 +300,36 @@ impl InnerGraphParserPlugin {
     }
 
     let mut import_dependency_usage = HashMap::default();
-    for (operations, used_by_exports) in
+    for (operation, used_by_exports) in
       Self::infer_dependency_usage(state, &deferred_pure_checks_by_symbol)
     {
-      let has_import_dependency = !matches!(
-        used_by_exports.condition(),
-        UsedByExportsCondition::Bool(true)
-      ) && operations
-        .iter()
-        .any(|operation| matches!(operation, InnerGraphUsageOperation::ImportDependency(_)));
-      let (owned_used_by_exports, shared_used_by_exports) = if has_import_dependency {
-        (None, Some(Arc::new(used_by_exports)))
-      } else {
-        (Some(used_by_exports), None)
-      };
-      let used_by_exports = shared_used_by_exports
-        .as_deref()
-        .or(owned_used_by_exports.as_ref())
-        .expect("used by exports should be owned or shared");
-
-      for operation in operations {
-        match operation {
-          InnerGraphUsageOperation::PureExpression(dep_idx) => {
-            let Some(dep) = dependencies.get_mut(dep_idx) else {
-              continue;
-            };
-            if let Some(dep) = dep.downcast_mut::<PureExpressionDependency>() {
-              dep.set_used_by_exports(Some(used_by_exports.clone()));
-            }
+      match operation {
+        InnerGraphUsageOperation::PureExpression(dep_idx) => {
+          let Some(dep) = dependencies.get_mut(dep_idx) else {
+            continue;
+          };
+          if let Some(dep) = dep.downcast_mut::<PureExpressionDependency>() {
+            dep.set_used_by_exports(Some(used_by_exports));
           }
-          InnerGraphUsageOperation::ESMImportSpecifier(dep_idx) => {
-            let Some(dep) = dependencies.get_mut(dep_idx) else {
-              continue;
-            };
-            if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
-              dep.set_used_by_exports(Some(used_by_exports.clone()));
-            }
+        }
+        InnerGraphUsageOperation::ESMImportSpecifier(dep_idx) => {
+          let Some(dep) = dependencies.get_mut(dep_idx) else {
+            continue;
+          };
+          if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
+            dep.set_used_by_exports(Some(used_by_exports));
           }
-          InnerGraphUsageOperation::URLDependency(dep_idx) => {
-            let Some(dep) = dependencies.get_mut(dep_idx) else {
-              continue;
-            };
-            if let Some(dep) = dep.downcast_mut::<URLDependency>() {
-              dep.set_used_by_exports(Some(used_by_exports.clone()));
-            }
+        }
+        InnerGraphUsageOperation::URLDependency(dep_idx) => {
+          let Some(dep) = dependencies.get_mut(dep_idx) else {
+            continue;
+          };
+          if let Some(dep) = dep.downcast_mut::<URLDependency>() {
+            dep.set_used_by_exports(Some(used_by_exports));
           }
-          InnerGraphUsageOperation::ImportDependency(dep_id) => {
-            if let Some(used_by_exports) = &shared_used_by_exports {
-              import_dependency_usage.insert(dep_id, used_by_exports.clone());
-            }
-          }
+        }
+        InnerGraphUsageOperation::ImportDependency(dep_id) => {
+          import_dependency_usage.insert(dep_id, used_by_exports);
         }
       }
     }
@@ -357,7 +337,7 @@ impl InnerGraphParserPlugin {
     if !import_dependency_usage.is_empty() {
       fn set_import_dependency_usage(
         dependency: &mut BoxDependency,
-        used_by_exports: Arc<UsedByExports>,
+        used_by_exports: UsedByExports,
       ) {
         if let Some(dependency) = dependency.downcast_mut::<ImportDependency>() {
           dependency.set_used_by_exports(Some(used_by_exports));
@@ -370,7 +350,7 @@ impl InnerGraphParserPlugin {
 
       fn apply_import_dependency_usage(
         blocks: &mut [Box<AsyncDependenciesBlock>],
-        import_dependency_usage: &mut HashMap<DependencyId, Arc<UsedByExports>>,
+        import_dependency_usage: &mut HashMap<DependencyId, UsedByExports>,
       ) {
         for block in blocks {
           for dependency in block.dependencies_mut() {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -1,6 +1,8 @@
+use std::sync::Arc;
+
 use rspack_core::{
-  BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
-  UsedByExportsDeferredPureCheck,
+  AsyncDependenciesBlock, BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
+  UsedByExportsCondition, UsedByExportsDeferredPureCheck,
 };
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -15,7 +17,10 @@ use super::state::{
 };
 use crate::{
   Atom,
-  dependency::{ESMImportSpecifierDependency, PureExpressionDependency, URLDependency},
+  dependency::{
+    ESMImportSpecifierDependency, ImportDependency, ImportEagerDependency,
+    PureExpressionDependency, URLDependency,
+  },
   parser_plugin::{DEFAULT_STAR_JS_WORD, JavascriptParserPlugin},
   side_effects_parser_plugin::{
     is_pure_class, is_pure_class_member, is_pure_expression, is_pure_function,
@@ -98,7 +103,7 @@ impl InnerGraphParserPlugin {
   pub fn infer_dependency_usage(
     state: &mut InnerGraphState,
     deferred_pure_checks_by_symbol: &HashMap<TopLevelSymbol, Vec<UsedByExportsDeferredPureCheck>>,
-  ) -> Vec<(InnerGraphUsageOperation, UsedByExports)> {
+  ) -> Vec<(Vec<InnerGraphUsageOperation>, UsedByExports)> {
     let mut non_terminal = state.inner_graph.keys().copied().collect::<HashSet<_>>();
     let mut processed: HashMap<TopLevelSymbol, HashSet<InnerGraphMapSetValue>> = HashMap::default();
 
@@ -232,9 +237,7 @@ impl InnerGraphParserPlugin {
         UsedByExports::bool(false)
       }
       .with_deferred_pure_checks(deferred_pure_checks);
-      for cb in cbs {
-        finalized.push((cb, used_by_exports.clone()));
-      }
+      finalized.push((cbs, used_by_exports));
     }
 
     finalized
@@ -243,6 +246,7 @@ impl InnerGraphParserPlugin {
   pub fn finalize_dependency_usage(
     state: &mut InnerGraphState,
     dependencies: &mut [BoxDependency],
+    blocks: &mut [Box<AsyncDependenciesBlock>],
   ) {
     if !state.is_enabled() || state.usage_map.is_empty() {
       return;
@@ -295,34 +299,99 @@ impl InnerGraphParserPlugin {
       }
     }
 
-    for (operation, used_by_exports) in
+    let mut import_dependency_usage = HashMap::default();
+    for (operations, used_by_exports) in
       Self::infer_dependency_usage(state, &deferred_pure_checks_by_symbol)
     {
-      let dep_idx = match operation {
-        InnerGraphUsageOperation::PureExpression(dep_idx)
-        | InnerGraphUsageOperation::ESMImportSpecifier(dep_idx)
-        | InnerGraphUsageOperation::URLDependency(dep_idx) => dep_idx,
+      let has_import_dependency = !matches!(
+        used_by_exports.condition(),
+        UsedByExportsCondition::Bool(true)
+      ) && operations
+        .iter()
+        .any(|operation| matches!(operation, InnerGraphUsageOperation::ImportDependency(_)));
+      let (owned_used_by_exports, shared_used_by_exports) = if has_import_dependency {
+        (None, Some(Arc::new(used_by_exports)))
+      } else {
+        (Some(used_by_exports), None)
       };
-      let Some(dep) = dependencies.get_mut(dep_idx) else {
-        continue;
-      };
-      match operation {
-        InnerGraphUsageOperation::PureExpression(_) => {
-          if let Some(dep) = dep.downcast_mut::<PureExpressionDependency>() {
-            dep.set_used_by_exports(Some(used_by_exports));
+      let used_by_exports = shared_used_by_exports
+        .as_deref()
+        .or(owned_used_by_exports.as_ref())
+        .expect("used by exports should be owned or shared");
+
+      for operation in operations {
+        match operation {
+          InnerGraphUsageOperation::PureExpression(dep_idx) => {
+            let Some(dep) = dependencies.get_mut(dep_idx) else {
+              continue;
+            };
+            if let Some(dep) = dep.downcast_mut::<PureExpressionDependency>() {
+              dep.set_used_by_exports(Some(used_by_exports.clone()));
+            }
           }
-        }
-        InnerGraphUsageOperation::ESMImportSpecifier(_) => {
-          if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
-            dep.set_used_by_exports(Some(used_by_exports));
+          InnerGraphUsageOperation::ESMImportSpecifier(dep_idx) => {
+            let Some(dep) = dependencies.get_mut(dep_idx) else {
+              continue;
+            };
+            if let Some(dep) = dep.downcast_mut::<ESMImportSpecifierDependency>() {
+              dep.set_used_by_exports(Some(used_by_exports.clone()));
+            }
           }
-        }
-        InnerGraphUsageOperation::URLDependency(_) => {
-          if let Some(dep) = dep.downcast_mut::<URLDependency>() {
-            dep.set_used_by_exports(Some(used_by_exports));
+          InnerGraphUsageOperation::URLDependency(dep_idx) => {
+            let Some(dep) = dependencies.get_mut(dep_idx) else {
+              continue;
+            };
+            if let Some(dep) = dep.downcast_mut::<URLDependency>() {
+              dep.set_used_by_exports(Some(used_by_exports.clone()));
+            }
+          }
+          InnerGraphUsageOperation::ImportDependency(dep_id) => {
+            if let Some(used_by_exports) = &shared_used_by_exports {
+              import_dependency_usage.insert(dep_id, used_by_exports.clone());
+            }
           }
         }
       }
+    }
+
+    if !import_dependency_usage.is_empty() {
+      fn set_import_dependency_usage(
+        dependency: &mut BoxDependency,
+        used_by_exports: Arc<UsedByExports>,
+      ) {
+        if let Some(dependency) = dependency.downcast_mut::<ImportDependency>() {
+          dependency.set_used_by_exports(Some(used_by_exports));
+        } else if let Some(dependency) = dependency.downcast_mut::<ImportEagerDependency>() {
+          dependency.set_used_by_exports(Some(used_by_exports));
+        } else {
+          unreachable!("inner graph import dependency should be a dynamic import dependency");
+        }
+      }
+
+      fn apply_import_dependency_usage(
+        blocks: &mut [Box<AsyncDependenciesBlock>],
+        import_dependency_usage: &mut HashMap<DependencyId, Arc<UsedByExports>>,
+      ) {
+        for block in blocks {
+          for dependency in block.dependencies_mut() {
+            if let Some(used_by_exports) = import_dependency_usage.remove(dependency.id()) {
+              set_import_dependency_usage(dependency, used_by_exports);
+            }
+          }
+          apply_import_dependency_usage(block.blocks_mut(), import_dependency_usage);
+        }
+      }
+
+      for dependency in dependencies {
+        if let Some(used_by_exports) = import_dependency_usage.remove(dependency.id()) {
+          set_import_dependency_usage(dependency, used_by_exports);
+        }
+      }
+      apply_import_dependency_usage(blocks, &mut import_dependency_usage);
+      assert!(
+        import_dependency_usage.is_empty(),
+        "inner graph import dependencies should exist in the module dependencies or an async dependencies block"
+      );
     }
   }
 
@@ -345,10 +414,10 @@ impl InnerGraphParserPlugin {
         .entry(symbol)
         .or_default()
         .push(operation);
-      // When inner graph is enabled but no top-level symbol, the expression is always used,
-      // so we skip adding PureExpressionDependency (same as UsedByExports::Bool(true))
+      // Without a top-level symbol, the dependency is always used, which is equivalent to not
+      // attaching UsedByExports (or attaching UsedByExports::Bool(true)).
     }
-    // When inner graph is disabled, we skip adding PureExpressionDependency (same as None)
+    // When inner graph is disabled, dependencies keep their default unconditional behavior.
   }
 
   pub fn tag_top_level_symbol(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
@@ -3,6 +3,7 @@ use std::{
   sync::atomic::{AtomicUsize, Ordering},
 };
 
+use rspack_core::DependencyId;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_experimental_ecma_ast::Span;
 
@@ -183,4 +184,5 @@ pub(crate) enum InnerGraphUsageOperation {
   PureExpression(usize),
   ESMImportSpecifier(usize),
   URLDependency(usize),
+  ImportDependency(DependencyId),
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -655,6 +655,7 @@ impl<'parser> JavascriptParser<'parser> {
       InnerGraphParserPlugin::finalize_dependency_usage(
         &mut self.inner_graph,
         &mut self.dependencies,
+        &mut self.blocks,
       );
       Ok(ScanDependenciesResult {
         dependencies: self.dependencies,

--- a/tests/rspack-test/compilerCases/persistent-cache-dynamic-import-inner-graph.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-dynamic-import-inner-graph.js
@@ -1,0 +1,98 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const CASE_DIR = 'persistent-cache-dynamic-import-inner-graph';
+const CACHE_DIR = '.cache';
+const OUTPUT_DIR = 'output';
+const WORK_DIR = 'workdir';
+
+function readAssets(context) {
+  return fs.readdirSync(context.getDist(OUTPUT_DIR)).sort();
+}
+
+function hasEagerFeature(context) {
+  return fs
+    .readFileSync(path.join(context.getDist(OUTPUT_DIR), 'main.js'), 'utf-8')
+    .includes('PERSISTENT_CACHE_EAGER_FEATURE_MARKER');
+}
+
+async function recreateCompiler(context) {
+  const compilerManager = context.getCompiler();
+  await compilerManager.close();
+  const compiler = compilerManager.createCompiler();
+  compiler.outputFileSystem = fs;
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+  description:
+    'should restore dynamic import inner graph conditions from persistent cache',
+  options(context) {
+    const sourceDir = path.resolve(__dirname, '../fixtures', CASE_DIR);
+    const workDir = context.getDist(WORK_DIR);
+    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.cpSync(sourceDir, workDir, { recursive: true });
+
+    return {
+      mode: 'production',
+      target: 'node',
+      context: workDir,
+      entry: './index.js',
+      experiments: {
+        cache: {
+          type: 'persistent',
+          buildDependencies: [__filename],
+          storage: {
+            type: 'filesystem',
+            location: context.getDist(CACHE_DIR),
+          },
+        },
+      },
+      optimization: {
+        concatenateModules: false,
+        innerGraph: true,
+        minimize: false,
+        providedExports: true,
+        sideEffects: true,
+        usedExports: true,
+      },
+      output: {
+        path: context.getDist(OUTPUT_DIR),
+        filename: 'main.js',
+        chunkFilename: '[name].js',
+        clean: true,
+      },
+    };
+  },
+  async compiler(_, compiler) {
+    compiler.outputFileSystem = fs;
+  },
+  async build(context) {
+    const compilerManager = context.getCompiler();
+    const workDir = context.getDist(WORK_DIR);
+
+    await compilerManager.build();
+    context.setValue('unusedAssets', readAssets(context));
+    context.setValue('unusedHasEagerFeature', hasEagerFeature(context));
+
+    fs.copyFileSync(path.join(workDir, 'index.used.js'), path.join(workDir, 'index.js'));
+    await recreateCompiler(context);
+    await compilerManager.build();
+    context.setValue('usedAssets', readAssets(context));
+    context.setValue('usedHasEagerFeature', hasEagerFeature(context));
+
+    fs.copyFileSync(path.join(workDir, 'index.unused.js'), path.join(workDir, 'index.js'));
+    await recreateCompiler(context);
+    await compilerManager.build();
+    context.setValue('unusedAgainAssets', readAssets(context));
+    context.setValue('unusedAgainHasEagerFeature', hasEagerFeature(context));
+  },
+  async check({ context }) {
+    expect(context.getValue('unusedAssets')).toEqual(['main.js']);
+    expect(context.getValue('unusedHasEagerFeature')).toBe(false);
+    expect(context.getValue('usedAssets')).toEqual(['feature.js', 'main.js']);
+    expect(context.getValue('usedHasEagerFeature')).toBe(true);
+    expect(context.getValue('unusedAgainAssets')).toEqual(['main.js']);
+    expect(context.getValue('unusedAgainHasEagerFeature')).toBe(false);
+  },
+};

--- a/tests/rspack-test/configCases/chunk-graph/issue-15173/rspack.config.js
+++ b/tests/rspack-test/configCases/chunk-graph/issue-15173/rspack.config.js
@@ -6,4 +6,8 @@ module.exports = {
   output: {
     filename: '[name].js',
   },
+  // Keep otherwise-unused entry exports in the chunk graph for this topology assertion.
+  optimization: {
+    innerGraph: false,
+  },
 };

--- a/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/rspack.config.js
+++ b/tests/rspack-test/configCases/rstest/mock-dynamic-import-external/rspack.config.js
@@ -26,6 +26,8 @@ module.exports = [
       'node:os': 'node:os',
     },
     optimization: {
+      // Keep otherwise-unused exported functions in the graph for these codegen assertions.
+      innerGraph: false,
       concatenateModules: false,
       minimize: false,
       moduleIds: 'named',

--- a/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/async.js
+++ b/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/async.js
@@ -1,0 +1,1 @@
+export const value = "async";

--- a/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/index.js
@@ -1,0 +1,9 @@
+import fs from "fs";
+import path from "path";
+import { effects, live } from "./module";
+
+it("should retain empty chunk graph metadata when removal is disabled", () => {
+  expect(effects).toEqual(["module evaluated"]);
+  expect(live).toBe("live");
+  expect(fs.existsSync(path.join(__dirname, "dead.js"))).toBe(false);
+});

--- a/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/module.js
+++ b/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/module.js
@@ -1,0 +1,7 @@
+export const effects = [];
+effects.push("module evaluated");
+
+export const unusedLoader = () =>
+  import(/* webpackChunkName: "dead" */ "./async");
+
+export const live = "live";

--- a/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/inactive-dynamic-import-remove-empty-disabled/rspack.config.js
@@ -1,0 +1,34 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  output: {
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    concatenateModules: false,
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    removeEmptyChunks: false,
+    sideEffects: true,
+    usedExports: true,
+  },
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.compilation.tap(
+          'InactiveDynamicImportRemoveEmptyDisabled',
+          (compilation) => {
+            compilation.hooks.afterSeal.tap(
+              'InactiveDynamicImportRemoveEmptyDisabled',
+              () => {
+                expect(compilation.namedChunks.get('dead')).toBeTruthy();
+                expect(compilation.namedChunkGroups.get('dead')).toBeTruthy();
+              },
+            );
+          },
+        );
+      },
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/bridge.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/bridge.js
@@ -1,0 +1,6 @@
+export async function loadFeature() {
+  const { loadFeature } = await import(
+    /* webpackChunkName: "shared" */ './shared'
+  );
+  return loadFeature();
+}

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/leaf.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/leaf.js
@@ -1,0 +1,1 @@
+export const value = 'leaf';

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/rspack.config.js
@@ -1,0 +1,20 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  entry: {
+    unused: './unused-entry.js',
+    used: './used-entry.js',
+    second: './second-used-entry.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    usedExports: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-bridge.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-bridge.js
@@ -1,0 +1,6 @@
+export async function loadSecondFeature() {
+  const { loadSecondFeature } = await import(
+    /* webpackChunkName: "shared" */ './shared'
+  );
+  return loadSecondFeature();
+}

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-leaf.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-leaf.js
@@ -1,0 +1,1 @@
+export const value = 'second-leaf';

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-used-entry.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/second-used-entry.js
@@ -1,0 +1,7 @@
+it('should restore a second nested import after another sibling activates', async () => {
+  const { loadSecondFeature } = await import(
+    /* webpackChunkName: "second-bridge" */ './second-bridge'
+  );
+  const imported = await loadSecondFeature();
+  expect(imported.value).toBe('second-leaf');
+});

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/shared.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/shared.js
@@ -1,0 +1,7 @@
+export const live = 'live';
+
+export const loadFeature = () =>
+  import(/* webpackChunkName: "leaf" */ './leaf');
+
+export const loadSecondFeature = () =>
+  import(/* webpackChunkName: "second-leaf" */ './second-leaf');

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/test.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return ['unused.js', 'used.js', 'second.js'];
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/unused-entry.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/unused-entry.js
@@ -1,0 +1,4 @@
+it('should initially use only the live export from the shared chunk', async () => {
+  const { live } = await import(/* webpackChunkName: "shared" */ './shared');
+  expect(live).toBe('live');
+});

--- a/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/used-entry.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-expansion-dynamic-import/used-entry.js
@@ -1,0 +1,5 @@
+it('should restore a nested import when the shared chunk gains this runtime', async () => {
+  const { loadFeature } = await import(/* webpackChunkName: "bridge" */ './bridge');
+  const imported = await loadFeature();
+  expect(imported.value).toBe('leaf');
+});

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/eager-feature.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/eager-feature.js
@@ -1,0 +1,1 @@
+export const value = "EAGER_RUNTIME_FEATURE_MARKER";

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/feature.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/feature.js
@@ -1,0 +1,1 @@
+export const value = "feature";

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/module.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/module.js
@@ -1,0 +1,7 @@
+export const loadFeature = () =>
+  import(/* webpackChunkName: "feature" */ "./feature");
+
+export const loadEagerFeature = () =>
+  import(/* webpackMode: "eager" */ "./eager-feature");
+
+export const live = "live";

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/rspack.config.js
@@ -1,0 +1,19 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  entry: {
+    unused: './unused-entry.js',
+    used: './used-entry.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    usedExports: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/test.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/test.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  findBundle() {
+    return ["unused.js", "used.js"];
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/unused-entry.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/unused-entry.js
@@ -1,0 +1,8 @@
+import fs from "fs";
+import { live } from "./module";
+
+it("should skip the dynamic import in a runtime that does not use it", () => {
+  expect(live).toBe("live");
+  const eagerMarker = ["EAGER", "RUNTIME", "FEATURE", "MARKER"].join("_");
+  expect(fs.readFileSync(__filename, "utf-8")).not.toContain(eagerMarker);
+});

--- a/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/used-entry.js
+++ b/tests/rspack-test/configCases/tree-shaking/runtime-specific-dynamic-import/used-entry.js
@@ -1,0 +1,10 @@
+import fs from "fs";
+import path from "path";
+import { loadEagerFeature, loadFeature } from "./module";
+
+it("should retain the dynamic import in a runtime that uses it", async () => {
+  const imported = await loadFeature();
+  expect(imported.value).toBe("feature");
+  expect(fs.existsSync(path.join(__dirname, "feature.js"))).toBe(true);
+  expect((await loadEagerFeature()).value).toBe("EAGER_RUNTIME_FEATURE_MARKER");
+});

--- a/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/index.js
+++ b/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/index.js
@@ -1,0 +1,12 @@
+import fs from "fs";
+import path from "path";
+import { live } from "./module";
+
+it("should not emit a chunk for a dynamic import in an unused pure declaration", () => {
+  expect(live).toBe("live");
+  expect(fs.existsSync(path.join(__dirname, "async.js"))).toBe(false);
+  const eagerMarker = ["UNUSED", "EAGER", "DYNAMIC", "IMPORT", "MARKER"].join(
+    "_",
+  );
+  expect(fs.readFileSync(__filename, "utf-8")).not.toContain(eagerMarker);
+});

--- a/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/module.js
+++ b/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/module.js
@@ -1,0 +1,6 @@
+export const unusedLoader = () => import("./unused");
+
+export const unusedEagerLoader = () =>
+  import(/* webpackMode: "eager" */ "./unused-eager");
+
+export const live = "live";

--- a/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/rspack.config.js
+++ b/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/rspack.config.js
@@ -1,0 +1,14 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'node',
+  output: {
+    chunkFilename: 'async.js',
+  },
+  optimization: {
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    usedExports: true,
+  },
+};

--- a/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/unused-eager.js
+++ b/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/unused-eager.js
@@ -1,0 +1,1 @@
+export const value = "UNUSED_EAGER_DYNAMIC_IMPORT_MARKER";

--- a/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/unused.js
+++ b/tests/rspack-test/configCases/tree-shaking/unused-pure-dynamic-import/unused.js
@@ -1,0 +1,1 @@
+export const value = "unused dynamic import";

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/eager-feature.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/eager-feature.js
@@ -1,0 +1,1 @@
+export const value = 'PERSISTENT_CACHE_EAGER_FEATURE_MARKER';

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/feature.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/feature.js
@@ -1,0 +1,1 @@
+export const value = 'feature';

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.js
@@ -1,0 +1,3 @@
+import { live } from './module';
+
+console.log(live);

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.unused.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.unused.js
@@ -1,0 +1,3 @@
+import { live } from './module';
+
+console.log(live);

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.used.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/index.used.js
@@ -1,0 +1,5 @@
+import { live, loadEagerFeature, loadFeature } from './module';
+
+console.log(live);
+loadFeature().then(({ value }) => console.log(value));
+loadEagerFeature().then(({ value }) => console.log(value));

--- a/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/module.js
+++ b/tests/rspack-test/fixtures/persistent-cache-dynamic-import-inner-graph/module.js
@@ -1,0 +1,7 @@
+export const loadFeature = () =>
+  import(/* webpackChunkName: "feature" */ './feature');
+
+export const loadEagerFeature = () =>
+  import(/* webpackMode: "eager" */ './eager-feature');
+
+export const live = 'live';

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/a.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/a.js
@@ -1,0 +1,5 @@
+import * as values from "./shared";
+
+it("should leave the dynamic import unused in runtime a", () => {
+	expect(values.live).toBe("live");
+});

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/b.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/b.js
@@ -1,0 +1,5 @@
+import * as values from "./shared";
+
+it("should use the dynamic import in runtime b", async () => {
+	expect((await values.feature()).value).toBe("feature");
+});

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/feature.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/feature.js
@@ -1,0 +1,1 @@
+export const value = "feature";

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/shared.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/0/shared.js
@@ -1,0 +1,4 @@
+export const feature = () =>
+	import(/* webpackChunkName: "feature" */ "./feature");
+
+export const live = "live";

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/1/a.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/1/a.js
@@ -1,0 +1,5 @@
+import * as values from "./shared";
+
+it("should add runtime a to the dynamic import chunk", async () => {
+	expect((await values.feature()).value).toBe("feature");
+});

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/2/a.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/2/a.js
@@ -1,0 +1,5 @@
+import * as values from "./shared";
+
+it("should remove runtime a from the dynamic import chunk", () => {
+	expect(values.live).toBe("live");
+});

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/rspack.config.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/rspack.config.js
@@ -1,0 +1,28 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  entry: {
+    a: './a.js',
+    b: './b.js',
+  },
+  output: {
+    filename: '[name].js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    concatenateModules: false,
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    splitChunks: false,
+    usedExports: true,
+  },
+  incremental: {
+    buildChunkGraph: true,
+  },
+  stats: {
+    loggingDebug: /codeSplittingCache/,
+  },
+};

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/test.config.js
@@ -1,0 +1,31 @@
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(`Assertion failed: ${message}`);
+	}
+}
+
+module.exports = {
+	findBundle() {
+		return ["a.js", "b.js"];
+	},
+	checkStats(step, _, stringStats) {
+		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
+		const conditionChanged = stringStats.includes(
+			"async dependency condition change detected"
+		);
+
+		if (step === "0") {
+			assert(rebuilt, "the cold build should build the chunk graph");
+		} else if (step === "1" || step === "2") {
+			assert(rebuilt, `runtime usage change at step ${step} should rebuild`);
+			assert(
+				conditionChanged,
+				`runtime-specific condition change at step ${step} should invalidate the cache`
+			);
+		} else {
+			throw new Error(`Unexpected watch step: ${step}`);
+		}
+
+		return true;
+	}
+};

--- a/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/dynamic-import-runtime-expansion-cache/test.config.js
@@ -10,8 +10,8 @@ module.exports = {
 	},
 	checkStats(step, _, stringStats) {
 		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
-		const conditionChanged = stringStats.includes(
-			"async dependency condition change detected"
+		const topologyChanged = stringStats.includes(
+			"module topology change detected"
 		);
 
 		if (step === "0") {
@@ -19,7 +19,7 @@ module.exports = {
 		} else if (step === "1" || step === "2") {
 			assert(rebuilt, `runtime usage change at step ${step} should rebuild`);
 			assert(
-				conditionChanged,
+				topologyChanged,
 				`runtime-specific condition change at step ${step} should invalidate the cache`
 			);
 		} else {

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/always.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/always.js
@@ -1,0 +1,1 @@
+export const value = "always";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/feature.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/feature.js
@@ -1,0 +1,1 @@
+export const value = "feature";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/index.js
@@ -1,0 +1,10 @@
+import * as values from "./module";
+import { leaf } from "./leaf";
+import "./side-effect";
+
+it("should omit a dynamic import owned by an unused export", async () => {
+	expect(values.live).toBe("live");
+	expect(leaf).toBe(WATCH_STEP === "0" ? "before" : "after");
+	expect(globalThis.sideEffectValue).toBe("stable");
+	expect((await values.always()).value).toBe("always");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/leaf.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/leaf.js
@@ -1,0 +1,2 @@
+eval("");
+export const leaf = "before";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/module.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/module.js
@@ -1,0 +1,7 @@
+export const feature = () =>
+	import(/* webpackChunkName: "feature" */ "./feature");
+
+export const always = () =>
+	import(/* webpackChunkName: "always" */ "./always");
+
+export const live = "live";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/side-effect.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/0/side-effect.js
@@ -1,0 +1,1 @@
+globalThis.sideEffectValue = "stable";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/1/leaf.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/1/leaf.js
@@ -1,0 +1,2 @@
+eval("");
+export const leaf = "after";

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/2/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/2/index.js
@@ -1,0 +1,11 @@
+import * as values from "./module";
+import { leaf } from "./leaf";
+import "./side-effect";
+
+it("should restore the dynamic import when its export becomes used", async () => {
+	expect(values.live).toBe("live");
+	expect(leaf).toBe("after");
+	expect(globalThis.sideEffectValue).toBe("stable");
+	expect((await values.always()).value).toBe("always");
+	expect((await values.feature()).value).toBe("feature");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/3/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/3/index.js
@@ -1,0 +1,10 @@
+import * as values from "./module";
+import { leaf } from "./leaf";
+import "./side-effect";
+
+it("should omit the dynamic import when its export becomes unused again", async () => {
+	expect(values.live).toBe("live");
+	expect(leaf).toBe("after");
+	expect(globalThis.sideEffectValue).toBe("stable");
+	expect((await values.always()).value).toBe("always");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/rspack.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/rspack.config.js
@@ -1,0 +1,24 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  output: {
+    filename: 'main.js',
+    chunkFilename: '[name].js',
+  },
+  optimization: {
+    concatenateModules: false,
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    splitChunks: false,
+    usedExports: true,
+  },
+  incremental: {
+    buildChunkGraph: true,
+  },
+  stats: {
+    loggingDebug: /codeSplittingCache/,
+  },
+};

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/test.config.js
@@ -11,24 +11,24 @@ module.exports = {
 	checkStats(step, stats, stringStats) {
 		const hasFeatureChunk = stats.assets.some(asset => asset.name === "feature.js");
 		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
-		const conditionChanged = stringStats.includes(
-			"async dependency condition change detected"
+		const topologyChanged = stringStats.includes(
+			"module topology change detected"
 		);
 
 		if (step === "0") {
 			assert(rebuilt, "the cold build should build the chunk graph");
 			assert(!hasFeatureChunk, "the unused dynamic import should not emit a chunk");
 		} else if (step === "1") {
-			assert(!conditionChanged, "an unchanged condition should keep the cache valid");
+			assert(!topologyChanged, "an unchanged condition should keep the cache valid");
 			assert(!rebuilt, "an unrelated edit should reuse the chunk graph");
 			assert(!hasFeatureChunk, "the unused dynamic import should stay omitted");
 		} else if (step === "2") {
 			assert(rebuilt, "activating the dynamic import should rebuild the chunk graph");
-			assert(conditionChanged, "the active condition change should invalidate the cache");
+			assert(topologyChanged, "the active condition change should invalidate the cache");
 			assert(hasFeatureChunk, "the active dynamic import should emit its chunk");
 		} else if (step === "3") {
 			assert(rebuilt, "deactivating the dynamic import should rebuild the chunk graph");
-			assert(conditionChanged, "the inactive condition change should invalidate the cache");
+			assert(topologyChanged, "the inactive condition change should invalidate the cache");
 			assert(!hasFeatureChunk, "the inactive dynamic import chunk should be removed");
 		} else {
 			throw new Error(`Unexpected watch step: ${step}`);

--- a/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-dynamic-import-inner-graph/test.config.js
@@ -1,0 +1,39 @@
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(`Assertion failed: ${message}`);
+	}
+}
+
+module.exports = {
+	findBundle() {
+		return "main.js";
+	},
+	checkStats(step, stats, stringStats) {
+		const hasFeatureChunk = stats.assets.some(asset => asset.name === "feature.js");
+		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
+		const conditionChanged = stringStats.includes(
+			"async dependency condition change detected"
+		);
+
+		if (step === "0") {
+			assert(rebuilt, "the cold build should build the chunk graph");
+			assert(!hasFeatureChunk, "the unused dynamic import should not emit a chunk");
+		} else if (step === "1") {
+			assert(!conditionChanged, "an unchanged condition should keep the cache valid");
+			assert(!rebuilt, "an unrelated edit should reuse the chunk graph");
+			assert(!hasFeatureChunk, "the unused dynamic import should stay omitted");
+		} else if (step === "2") {
+			assert(rebuilt, "activating the dynamic import should rebuild the chunk graph");
+			assert(conditionChanged, "the active condition change should invalidate the cache");
+			assert(hasFeatureChunk, "the active dynamic import should emit its chunk");
+		} else if (step === "3") {
+			assert(rebuilt, "deactivating the dynamic import should rebuild the chunk graph");
+			assert(conditionChanged, "the inactive condition change should invalidate the cache");
+			assert(!hasFeatureChunk, "the inactive dynamic import chunk should be removed");
+		} else {
+			throw new Error(`Unexpected watch step: ${step}`);
+		}
+
+		return true;
+	}
+};

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/eager-feature.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/eager-feature.js
@@ -1,0 +1,1 @@
+export const value = "WATCH_EAGER_FEATURE_MARKER";

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/index.js
@@ -1,0 +1,7 @@
+import { live } from "./module";
+import { leaf } from "./leaf";
+
+it("should omit an eager dynamic import owned by an unused export", () => {
+	expect(live).toBe("live");
+	expect(leaf).toBe(WATCH_STEP === "0" ? "before" : "after");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/leaf.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/leaf.js
@@ -1,0 +1,2 @@
+eval("");
+export const leaf = "before";

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/module.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/0/module.js
@@ -1,0 +1,4 @@
+export const loadEagerFeature = () =>
+	import(/* webpackMode: "eager" */ "./eager-feature");
+
+export const live = "live";

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/1/leaf.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/1/leaf.js
@@ -1,0 +1,2 @@
+eval("");
+export const leaf = "after";

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/2/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/2/index.js
@@ -1,0 +1,8 @@
+import { live, loadEagerFeature } from "./module";
+import { leaf } from "./leaf";
+
+it("should restore the eager dynamic import when its export becomes used", async () => {
+	expect(live).toBe("live");
+	expect(leaf).toBe("after");
+	expect((await loadEagerFeature()).value).toBe("WATCH_EAGER_FEATURE_MARKER");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/3/index.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/3/index.js
@@ -1,0 +1,7 @@
+import { live } from "./module";
+import { leaf } from "./leaf";
+
+it("should omit the eager dynamic import when its export becomes unused again", () => {
+	expect(live).toBe("live");
+	expect(leaf).toBe("after");
+});

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/rspack.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/rspack.config.js
@@ -1,0 +1,23 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  output: {
+    filename: 'main.js',
+  },
+  optimization: {
+    concatenateModules: false,
+    innerGraph: true,
+    minimize: false,
+    providedExports: true,
+    sideEffects: true,
+    splitChunks: false,
+    usedExports: true,
+  },
+  incremental: {
+    buildChunkGraph: true,
+  },
+  stats: {
+    loggingDebug: /codeSplittingCache/,
+  },
+};

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/test.config.js
@@ -1,0 +1,46 @@
+const fs = require("fs");
+const path = require("path");
+
+let outputPath;
+
+function assert(condition, message) {
+	if (!condition) {
+		throw new Error(`Assertion failed: ${message}`);
+	}
+}
+
+module.exports = {
+	findBundle(_, options) {
+		outputPath = options.output.path;
+		return "main.js";
+	},
+	checkStats(step, _, stringStats) {
+		const source = fs.readFileSync(path.join(outputPath, "main.js"), "utf-8");
+		const hasEagerFeature = source.includes("WATCH_EAGER_FEATURE_MARKER");
+		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
+		const conditionChanged = stringStats.includes(
+			"eager dependency condition change detected"
+		);
+
+		if (step === "0") {
+			assert(rebuilt, "the cold build should build the chunk graph");
+			assert(!hasEagerFeature, "the unused eager import should be omitted");
+		} else if (step === "1") {
+			assert(!conditionChanged, "an unchanged condition should keep the cache valid");
+			assert(!rebuilt, "an unrelated edit should reuse the chunk graph");
+			assert(!hasEagerFeature, "the unused eager import should stay omitted");
+		} else if (step === "2") {
+			assert(conditionChanged, "the active condition change should invalidate the cache");
+			assert(rebuilt, "activating the eager import should rebuild the chunk graph");
+			assert(hasEagerFeature, "the active eager import should be included");
+		} else if (step === "3") {
+			assert(conditionChanged, "the inactive condition change should invalidate the cache");
+			assert(rebuilt, "deactivating the eager import should rebuild the chunk graph");
+			assert(!hasEagerFeature, "the inactive eager import should be removed");
+		} else {
+			throw new Error(`Unexpected watch step: ${step}`);
+		}
+
+		return true;
+	},
+};

--- a/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/test.config.js
+++ b/tests/rspack-test/watchCases/side-effects/unused-eager-dynamic-import-inner-graph/test.config.js
@@ -18,23 +18,23 @@ module.exports = {
 		const source = fs.readFileSync(path.join(outputPath, "main.js"), "utf-8");
 		const hasEagerFeature = source.includes("WATCH_EAGER_FEATURE_MARKER");
 		const rebuilt = stringStats.includes("<t> rebuild chunk graph");
-		const conditionChanged = stringStats.includes(
-			"eager dependency condition change detected"
+		const topologyChanged = stringStats.includes(
+			"module topology change detected"
 		);
 
 		if (step === "0") {
 			assert(rebuilt, "the cold build should build the chunk graph");
 			assert(!hasEagerFeature, "the unused eager import should be omitted");
 		} else if (step === "1") {
-			assert(!conditionChanged, "an unchanged condition should keep the cache valid");
+			assert(!topologyChanged, "an unchanged condition should keep the cache valid");
 			assert(!rebuilt, "an unrelated edit should reuse the chunk graph");
 			assert(!hasEagerFeature, "the unused eager import should stay omitted");
 		} else if (step === "2") {
-			assert(conditionChanged, "the active condition change should invalidate the cache");
+			assert(topologyChanged, "the active condition change should invalidate the cache");
 			assert(rebuilt, "activating the eager import should rebuild the chunk graph");
 			assert(hasEagerFeature, "the active eager import should be included");
 		} else if (step === "3") {
-			assert(conditionChanged, "the inactive condition change should invalidate the cache");
+			assert(topologyChanged, "the inactive condition change should invalidate the cache");
 			assert(rebuilt, "deactivating the eager import should rebuild the chunk graph");
 			assert(!hasEagerFeature, "the inactive eager import should be removed");
 		} else {


### PR DESCRIPTION
## Summary

Propagate InnerGraph export usage into static-string dynamic import dependencies, so a dynamic import directly owned by an unused export can be removed from the active module graph.

This covers both the default lazy mode and `webpackMode: "eager"`:

```js
export const loadFeature = () => import("./feature");
export const loadEagerFeature = () =>
  import(/* webpackMode: "eager" */ "./eager-feature");
```

When an owner export is unused, its target is omitted. When it is used, the condition remains runtime-aware: the import is active only in runtimes that use the owner. An active eager import still follows its existing behavior and places the target in the current chunk.

The default and eager dependency types share the same InnerGraph condition evaluator. Normal imports receive ownership inside their async dependency blocks, while eager imports receive it from ordinary module dependencies.

## Incremental and persistent cache

The chunk-graph snapshot tracks conditional async dependencies as before and also tracks eager dependencies in modules that own them. On rebuild it checks only previously recorded eager owners plus modules affected by the current mutation, avoiding a full scan of all synchronous dependencies.

A watch rebuild therefore:

- reuses the chunk graph while export usage is unchanged;
- rebuilds when an eager or normal dynamic import becomes active or inactive;
- preserves runtime-specific activation;
- restores both dependency types correctly from persistent cache.

## Stack boundary

This is the first and independently reviewable layer of the stack. It covers direct exports and the shared dependency/incremental infrastructure.

Object-property ownership such as `export const feature = { loader: () => import(...) }` is intentionally handled by the follow-up PR #15443.

## Tests

- default and eager imports owned by unused direct exports;
- runtime-specific activation for both modes;
- runtime expansion during incremental builds;
- dedicated eager watch transitions covering reuse, activation, and deactivation;
- `removeEmptyChunks: false`;
- persistent-cache restore;
- watch, native watcher, and incremental watch transitions.

## Related links

- Follow-up: #15443

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
