### PR TITLE
fix(binding): guard module graph accessors against stale and mid-pass reads

### DIFF
--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -39,11 +39,11 @@ use crate::{
   source::{JsSourceFromJs, JsSourceToJs},
   stats::{JsStats, JsStatsOptimizationBailout, create_stats_warnings},
   utils::callbackify,
+  with_compilation,
 };
 
 #[napi]
 pub struct JsCompilation {
-  #[allow(dead_code)]
   pub(crate) id: CompilationId,
   pub(crate) inner: NonNull<Compilation>,
 }
@@ -52,6 +52,29 @@ impl JsCompilation {
   pub(crate) fn new(id: CompilationId, inner: NonNull<Compilation>) -> Self {
     #[allow(clippy::unwrap_used)]
     Self { id, inner }
+  }
+
+  // `inner` points at the `Compilation` inlined in `Compiler`, and `Compiler::rebuild`
+  // replaces the value in that slot, so a handle from an earlier build aliases whichever
+  // compilation occupies the slot now. Reading the module graph through such a handle is
+  // the case that aborts the process: these accessors reach into
+  // `build_module_graph_artifact`, which the running build steals for the whole make phase.
+  //
+  // Resolve the compilation by id the way `ChunkGraph` and `JsModuleGraph` already do,
+  // which drops the handle when it is no longer current, and then check that the artifact
+  // is still in its cell.
+  fn with_module_graph<R>(
+    &self,
+    f: impl FnOnce(&Compilation) -> napi::Result<R>,
+  ) -> napi::Result<R> {
+    with_compilation(self.id, |compilation| {
+      if compilation.build_module_graph_artifact.is_stolen() {
+        return Err(napi::Error::from_reason(
+          "ModuleGraph is not available while a compilation pass is holding the module graph artifact".to_string(),
+        ));
+      }
+      f(compilation)
+    })
   }
 
   pub(crate) fn as_ref(&self) -> napi::Result<&'static Compilation> {
@@ -198,55 +221,56 @@ impl JsCompilation {
 
   #[napi(getter, ts_return_type = "Array<Module>")]
   pub fn modules<'a>(&self, env: &'a Env) -> Result<Array<'a>> {
-    let compilation = self.as_ref()?;
-    let module_graph = compilation.get_module_graph();
-    let mut arr = env.create_array(module_graph.modules_len() as u32)?;
-    for (i, identifier) in module_graph.modules_keys().enumerate() {
-      arr.set(
-        i as u32,
-        compilation
-          .module_by_identifier(identifier)
-          .map(|module| ModuleObject::with_ref(module.as_ref(), compilation.compiler_id())),
-      )?;
-    }
-    Ok(arr)
+    self.with_module_graph(|compilation| {
+      let module_graph = compilation.get_module_graph();
+      let mut arr = env.create_array(module_graph.modules_len() as u32)?;
+      for (i, identifier) in module_graph.modules_keys().enumerate() {
+        arr.set(
+          i as u32,
+          compilation
+            .module_by_identifier(identifier)
+            .map(|module| ModuleObject::with_ref(module.as_ref(), compilation.compiler_id())),
+        )?;
+      }
+      Ok(arr)
+    })
   }
 
   #[napi(getter, ts_return_type = "Array<Module>")]
   pub fn built_modules(&self) -> Result<Vec<ModuleObject>> {
-    let compilation = self.as_ref()?;
-
-    Ok(
-      compilation
-        .build_module_graph_artifact
-        .built_modules()
-        .filter_map(|module_id| {
-          compilation
-            .module_by_identifier(module_id)
-            .map(|module| ModuleObject::with_ref(module.as_ref(), compilation.compiler_id()))
-        })
-        .collect::<Vec<_>>(),
-    )
+    self.with_module_graph(|compilation| {
+      Ok(
+        compilation
+          .build_module_graph_artifact
+          .built_modules()
+          .filter_map(|module_id| {
+            compilation
+              .module_by_identifier(module_id)
+              .map(|module| ModuleObject::with_ref(module.as_ref(), compilation.compiler_id()))
+          })
+          .collect::<Vec<_>>(),
+      )
+    })
   }
 
   #[napi]
   pub fn get_optimization_bailout(&self) -> Result<Vec<JsStatsOptimizationBailout>> {
-    let compilation = self.as_ref()?;
-
-    Ok(
-      compilation
-        .get_module_graph()
-        .module_graph_modules()
-        .map(|(_, mgm)| mgm)
-        .flat_map(|item| {
-          item.optimization_bailout.iter().map(|b| match b {
-            OptimizationBailoutItem::Message(msg) => msg.as_str().to_owned(),
-            b => b.to_string(),
+    self.with_module_graph(|compilation| {
+      Ok(
+        compilation
+          .get_module_graph()
+          .module_graph_modules()
+          .map(|(_, mgm)| mgm)
+          .flat_map(|item| {
+            item.optimization_bailout.iter().map(|b| match b {
+              OptimizationBailoutItem::Message(msg) => msg.as_str().to_owned(),
+              b => b.to_string(),
+            })
           })
-        })
-        .map(|item| JsStatsOptimizationBailout { inner: item })
-        .collect::<Vec<_>>(),
-    )
+          .map(|item| JsStatsOptimizationBailout { inner: item })
+          .collect::<Vec<_>>(),
+      )
+    })
   }
 
   #[napi(getter, ts_return_type = "Chunks")]

--- a/tests/rspack-test/watchCases/compilation/access-stale-compilation/0/dep.js
+++ b/tests/rspack-test/watchCases/compilation/access-stale-compilation/0/dep.js
@@ -1,0 +1,1 @@
+export const value = 'zero';

--- a/tests/rspack-test/watchCases/compilation/access-stale-compilation/0/index.js
+++ b/tests/rspack-test/watchCases/compilation/access-stale-compilation/0/index.js
@@ -1,0 +1,5 @@
+import { value } from './dep';
+
+value;
+
+it('should run', function () {});

--- a/tests/rspack-test/watchCases/compilation/access-stale-compilation/1/dep.js
+++ b/tests/rspack-test/watchCases/compilation/access-stale-compilation/1/dep.js
@@ -1,0 +1,1 @@
+export const value = 'one';

--- a/tests/rspack-test/watchCases/compilation/access-stale-compilation/2/dep.js
+++ b/tests/rspack-test/watchCases/compilation/access-stale-compilation/2/dep.js
@@ -1,0 +1,1 @@
+export const value = 'two';

--- a/tests/rspack-test/watchCases/compilation/access-stale-compilation/rspack.config.js
+++ b/tests/rspack-test/watchCases/compilation/access-stale-compilation/rspack.config.js
@@ -1,0 +1,80 @@
+const TOTAL_BUILDS = 3;
+
+let build = 0;
+let staleCompilation = null;
+let staleRead = null;
+let midMakeReads = null;
+
+function capture(read) {
+  try {
+    return { ok: true, value: read() };
+  } catch (err) {
+    return { ok: false, message: String(err && err.message) };
+  }
+}
+
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  plugins: [
+    {
+      apply(compiler) {
+        compiler.hooks.normalModuleFactory.tap('PLUGIN', (nmf) => {
+          nmf.hooks.afterResolve.tap('PLUGIN', () => {
+            // The module graph artifact is stolen for the duration of the make phase, so
+            // accessors that reach into it have to report that rather than dereference the
+            // stolen cell and abort the process.
+            if (!midMakeReads) {
+              midMakeReads = {
+                modules: capture(() => compiler._lastCompilation.modules.size),
+                builtModules: capture(
+                  () => compiler._lastCompilation.builtModules.size,
+                ),
+              };
+            }
+          });
+        });
+
+        compiler.hooks.make.tap('PLUGIN', () => {
+          if (!staleCompilation || staleRead) return;
+          // Read a Compilation the compiler has already replaced, from a timer, i.e. from
+          // the JS thread with no Rust -> JS tap on the stack. That is what a dev server
+          // does when it answers a request while a rebuild is running.
+          setTimeout(() => {
+            staleRead = capture(() => staleCompilation.modules.size);
+          });
+        });
+
+        compiler.hooks.compilation.tap('PLUGIN', (compilation) => {
+          build++;
+          compilation.hooks.seal.tap('PLUGIN', () => {
+            // The live Compilation stays fully readable once the artifact is back in its
+            // cell, so a guard that simply rejected everything would not pass here.
+            expect(compilation.modules.size).toBeGreaterThan(0);
+
+            expect(midMakeReads.modules.ok).toBe(false);
+            expect(midMakeReads.modules.message).toContain(
+              'ModuleGraph is not available',
+            );
+            expect(midMakeReads.builtModules.ok).toBe(false);
+
+            if (build < TOTAL_BUILDS) return;
+
+            // Asserted unconditionally on the last build: if the timer never ran, this
+            // fails instead of letting the case pass without checking anything.
+            expect(staleRead).not.toBe(null);
+            expect(staleRead.ok).toBe(false);
+            expect(staleRead.message).toContain(
+              'Unable to access compilation with id',
+            );
+          });
+        });
+
+        compiler.hooks.done.tap('PLUGIN', (stats) => {
+          if (!staleCompilation) {
+            staleCompilation = stats.compilation;
+          }
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

Fixes the `panic = "abort"` in #15451: a `Compilation` JS object kept from an earlier build takes down `next dev`, reported by @Dwlad90 against `next-rspack` (Next.js 16.3.3) with a repro at [Dwlad90/next-rspack-stale-compilation-repro](https://github.com/Dwlad90/next-rspack-stale-compilation-repro).

`JsCompilation` stores a raw `NonNull<Compilation>` pointing at the `Compilation` inlined in `Compiler`, and `Compiler::rebuild` replaces the value in that slot (`crates/rspack_core/src/compiler/rebuild.rs:113`). A handle handed to JS in an earlier build therefore aliases whichever compilation occupies the slot now. Reading the module graph through it dereferences `build_module_graph_artifact`, which the running build steals for the whole make phase, and the process aborts.

I reproduced it inside the repo's own harness rather than through Next — the new watch case captures `stats.compilation` in `done` and reads it from a timer scheduled in the next build's `make`, which is the same shape as the existing `watchCases/compilation/access-stale-stats`. On `main` (e6fa681) that gives:

| read on a stale `Compilation` | behaviour on `main` |
| --- | --- |
| `hash` | silently answers for the **running** build (`null` mid-make; the captured build's hash was `077161406efae2d1`) |
| `entrypoints` | same — `0` instead of the captured build's `1` |
| `modules` | `panicked at steal_cell.rs:60: attempted to read from stolen value: ...BuildModuleGraphArtifact` |
| `chunkGraph.getModuleId` | **already fails closed** — `Unable to access compilation with id = CompilationId(1) now...` |

The last row corrects one claim in the issue: `getModuleId` is safe because `ChunkGraph` stores a `CompilationId` and goes through `with_compilation` (`crates/rspack_binding_api/src/lib.rs:160`), which looks the id up among live compilers and errors when it no longer matches. `JsModuleGraph` is the same. Only `JsCompilation` keeps a raw pointer, and its `id` field was `#[allow(dead_code)]`.

The probe also turned up something the issue does not mention: `compilation.modules` panics the same way on a **current, non-stale** compilation when it is read during the make phase — from a plugin's timer, or from any `normalModuleFactory` tap — because the artifact is stolen for that whole phase.

## Implementation

One helper, used by the three read-only accessors that actually reach into the module graph (`modules`, `builtModules`, `getOptimizationBailout`):

```rust
fn with_module_graph<R>(&self, f: impl FnOnce(&Compilation) -> napi::Result<R>) -> napi::Result<R> {
  with_compilation(self.id, |compilation| {
    if compilation.build_module_graph_artifact.is_stolen() {
      return Err(napi::Error::from_reason(
        "ModuleGraph is not available while a compilation pass is holding the module graph artifact".to_string(),
      ));
    }
    f(compilation)
  })
}
```

Two decisions worth calling out:

- **Resolving by id through `with_compilation` rather than validating the raw pointer.** My first version compared `self.id` against the id read *through the very pointer it was validating*, which races `mem::replace` and cannot detect a GC'd compiler at all. Going through `with_compilation` needs no pointer deref and makes `modules` and `chunkGraph.getModuleId` fail with the same error when the handle is stale, which is the consistency the issue asks for.
- **Not reusing `JsModuleGraph`'s message verbatim.** Its "during module graph building phase" wording is inaccurate for most windows this guard now covers — the cell is also stolen around `optimizeDependencies`, `optimizeCodeGeneration` and `finish_build_module_graph`. Aligning `JsModuleGraph`'s own message is a separate cosmetic change I left alone.

With this, the reported abort is gone: `modules` becomes a `napi::Error` that Next's `getSourceMapFromCompilation` already catches, degrading to "frame not mapped" instead of killing the dev server.

## Notes for review

- **The silent-aliasing half is deliberately not fixed here, and I have evidence that the obvious fix does not land as-is.** I first implemented the issue's "Expected" — compare `self.id` in `as_ref`/`as_mut` so *every* accessor fails closed. It breaks the repo's own suite in 4 places, because the JS `Stats` model assumes it can read a stale compilation: the `_lastCompilation` comparison in `Stats.ts`/`DefaultStatsFactoryPlugin.ts` only covers `getStatsCompilation` and `cachedGetErrors`, while the default stats preset reaches `publicPath` → `Compilation.getPath()` → `this.hash`:

  ```
  uncaughtException: Unable to access compilation with id = CompilationId(140) now...
      at Compilation.get hash → Compilation.getPath → publicPath → StatsFactory._create
  Error: Unable to access compilation with id = CompilationId(203) now...
      at Stats.hasErrors
  ```

  (`compilerCases/run-again`, `watchCases/entries/dynamic-entries-add-same-entry` and their NativeWatcher/Incremental twins.) So `hash` and `entrypoints` still answer for the wrong build through a stale handle. Closing that needs the JS stats layer to tolerate the error first — happy to do it in a follow-up if you want it, but it did not belong in a crash fix.
- **`JsStats` is not covered either.** `get_stats()` borrows `&Compilation` through `reference.share_with(...)` when the stats object is created, so a `JsStats` that was current at creation keeps its own reference regardless of this guard. That path is currently held by the JS-side `_lastCompilation` comparison (#12839, reaffirmed in #13214).
- `addEntry` / `addInclude` also dereference the module graph, but they are writes running inside `within_compiler_context`, so I left them out rather than widen the change.

## Test

`tests/rspack-test/watchCases/compilation/access-stale-compilation`, three builds:

- build 1's `done` captures the handle; build 2's `make` reads it from a `setTimeout` (JS thread, no Rust→JS tap on the stack); build 3's `compilation.hooks.seal` asserts — a sync hook, so a throw fails the build, the same pattern `watchCases/compilation/built-modules` uses.
- A `normalModuleFactory.afterResolve` tap covers the current-but-mid-make case.
- It also asserts the live compilation is still fully readable (`modules.size > 0`), so an implementation that simply rejected everything would not pass.
- Assertions on the last build are unconditional (`expect(staleRead).not.toBe(null)`), so the case cannot pass without the timer having run.

**Why it distinguishes a correct implementation from a wrong one** — verified by breaking each half and re-running:

| broken | failure |
| --- | --- |
| identity check removed | `AssertionError: expected { name: 'hash', ok: true } to deeply equal { name: 'hash', ok: false }` |
| `is_stolen` check removed | `panicked at steal_cell.rs:60: attempted to read from stolen value: ...BuildModuleGraphArtifact` |

Local: `pnpm run test:unit` 9214 passed / 3 failed — 2 are `configCases/url/self`, which fails on this machine regardless of any change because the checkout path contains non-ASCII characters, and 1 is `defer-import/defer-runtime-dynamic-import` timing out at 30s under parallel load (190ms and green when run alone). `cargo clippy -p rspack_binding_api --all-targets` and `cargo fmt --check` clean; `rs check` clean; `crates/node_binding/napi-binding.d.ts` unchanged.

## Related links

- Closes #15451
- vercel/next.js#98213 — the host-side half
- #12839 / #13214 — the existing JS-side stale-stats handling

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
