### PR TITLE
fix(paths): canonicalize Windows path spellings before interning

### DIFF
--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -107,39 +107,47 @@ fn path_from_bytes(bytes: &[u8]) -> &Path {
   Path::new(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) })
 }
 
-/// Returns the spelling `Path::components` rebuilds for `path`, or `None` when `path` already is
-/// spelled that way.
+/// Returns the native spelling of an absolute Windows `path` — separators as `\`, no doubled
+/// separators, no `.` components — or `None` when `path` already is spelled that way.
 ///
-/// On Windows [`PreHashedPath::eq`] compares components, so `D:/a/b`, `D:\a\b\`, `D:\a\\b` and
-/// `D:\a\.\b` all share one allocation and come back with whichever spelling was interned first.
-/// String-keyed consumers such as watchpack only match the native spelling, so it has to be the
-/// one stored. The spellings rewritten here are exactly the ones `eq` merges; on Unix `eq` is
-/// byte-wise, nothing is merged, and nothing needs rewriting.
+/// On Windows [`PreHashedPath::eq`] compares components, so `D:/a/b`, `D:\a\\b` and `D:\a\.\b`
+/// all share one allocation with `D:\a\b` and come back with whichever spelling was interned
+/// first. String-keyed consumers such as watchpack only match the native spelling, so it has to
+/// be the one stored. On Unix `eq` is byte-wise, nothing is merged, and nothing needs rewriting.
 ///
-/// Verbatim paths (`\\?\`), `..` components and the drive letter's case are left as they are.
+/// Left as they are: relative paths, verbatim paths (`\\?\`), `..` components, a trailing
+/// separator (kept, spelled `\`) and the drive letter's case.
 #[cfg(not(unix))]
 fn canonical_spelling(path: &Path) -> Option<PathBuf> {
-  use std::path::Component;
+  use std::path::{Component, MAIN_SEPARATOR_STR};
 
   let bytes = path.as_os_str().as_encoded_bytes();
   if !has_unnormalized_separator_or_dot(bytes) {
     return None;
   }
-  if let Some(Component::Prefix(prefix)) = path.components().next()
-    && prefix.kind().is_verbatim()
-  {
-    return None;
+  // Only absolute paths are compared against strings the file system produced; a verbatim
+  // prefix (`\\?\`) turns `/` into an ordinary character.
+  match path.components().next() {
+    Some(Component::Prefix(prefix)) if !prefix.kind().is_verbatim() => {}
+    _ => return None,
   }
-  let rebuilt: PathBuf = path.components().collect();
+  let mut rebuilt: PathBuf = path.components().collect();
+  // A trailing separator is significant to glob matching (`**/node_modules/**` matches
+  // `node_modules/` but not `node_modules`), so it is kept, just spelled natively. Appended to
+  // the `OsString` because `PathBuf::push` treats a bare separator as a new root.
+  if matches!(bytes.last(), Some(b'\\' | b'/'))
+    && !rebuilt.as_os_str().as_encoded_bytes().ends_with(b"\\")
+  {
+    rebuilt.as_mut_os_string().push(MAIN_SEPARATOR_STR);
+  }
   (rebuilt.as_os_str().as_encoded_bytes() != bytes).then_some(rebuilt)
 }
 
-/// Byte scan for the spellings `Path::components` would rewrite. Returns `true` when `bytes`
+/// Byte scan for the spellings [`canonical_spelling`] rewrites. Returns `true` when `bytes`
 /// contain any of:
 ///
 /// - a `/` separator: `D:/a/b`, `D:\a/b`
 /// - a doubled `\` after the prefix: `D:\a\\b` (the leading `\\` of a UNC path does not count)
-/// - a trailing `\`: `D:\a\b\` (a bare root such as `D:\` does not count)
 /// - a `.` component: `D:\a\.\b`, `D:\a\b\.`
 ///
 /// A false positive only costs the rebuild-and-compare in [`canonical_spelling`].
@@ -159,7 +167,7 @@ fn has_unnormalized_separator_or_dot(bytes: &[u8]) -> bool {
       _ => prev_sep = false,
     }
   }
-  prev_sep && bytes.len() > 3
+  false
 }
 
 /// An interned path: equal paths share one allocation process-wide, so equality is a pointer

--- a/crates/rspack_paths/src/lib.rs
+++ b/crates/rspack_paths/src/lib.rs
@@ -107,6 +107,61 @@ fn path_from_bytes(bytes: &[u8]) -> &Path {
   Path::new(unsafe { OsStr::from_encoded_bytes_unchecked(bytes) })
 }
 
+/// Returns the spelling `Path::components` rebuilds for `path`, or `None` when `path` already is
+/// spelled that way.
+///
+/// On Windows [`PreHashedPath::eq`] compares components, so `D:/a/b`, `D:\a\b\`, `D:\a\\b` and
+/// `D:\a\.\b` all share one allocation and come back with whichever spelling was interned first.
+/// String-keyed consumers such as watchpack only match the native spelling, so it has to be the
+/// one stored. The spellings rewritten here are exactly the ones `eq` merges; on Unix `eq` is
+/// byte-wise, nothing is merged, and nothing needs rewriting.
+///
+/// Verbatim paths (`\\?\`), `..` components and the drive letter's case are left as they are.
+#[cfg(not(unix))]
+fn canonical_spelling(path: &Path) -> Option<PathBuf> {
+  use std::path::Component;
+
+  let bytes = path.as_os_str().as_encoded_bytes();
+  if !has_unnormalized_separator_or_dot(bytes) {
+    return None;
+  }
+  if let Some(Component::Prefix(prefix)) = path.components().next()
+    && prefix.kind().is_verbatim()
+  {
+    return None;
+  }
+  let rebuilt: PathBuf = path.components().collect();
+  (rebuilt.as_os_str().as_encoded_bytes() != bytes).then_some(rebuilt)
+}
+
+/// Byte scan for the spellings `Path::components` would rewrite. Returns `true` when `bytes`
+/// contain any of:
+///
+/// - a `/` separator: `D:/a/b`, `D:\a/b`
+/// - a doubled `\` after the prefix: `D:\a\\b` (the leading `\\` of a UNC path does not count)
+/// - a trailing `\`: `D:\a\b\` (a bare root such as `D:\` does not count)
+/// - a `.` component: `D:\a\.\b`, `D:\a\b\.`
+///
+/// A false positive only costs the rebuild-and-compare in [`canonical_spelling`].
+#[cfg(not(unix))]
+fn has_unnormalized_separator_or_dot(bytes: &[u8]) -> bool {
+  let mut prev_sep = false;
+  for (i, &b) in bytes.iter().enumerate() {
+    match b {
+      b'/' => return true,
+      b'\\' => {
+        if prev_sep && i > 1 {
+          return true;
+        }
+        prev_sep = true;
+      }
+      b'.' if prev_sep && matches!(bytes.get(i + 1), None | Some(b'\\')) => return true,
+      _ => prev_sep = false,
+    }
+  }
+  prev_sep && bytes.len() > 3
+}
+
 /// An interned path: equal paths share one allocation process-wide, so equality is a pointer
 /// comparison and each path is stored once. Hashing still uses the precomputed content hash
 /// (see [`Hash`] below).
@@ -129,8 +184,18 @@ impl InternedPath {
   /// that `hash` equals [`hash_path`] of `path`. Used at boundaries (e.g. consuming
   /// `rspack_resolver::ResolverPath`) where the same `FxHash` has already been computed
   /// upstream.
+  ///
+  /// On Windows a non-canonical spelling is rewritten before it is interned, see
+  /// `canonical_spelling`. This is the only place an [`InternedPath`] is created.
   #[inline]
   pub fn from_parts(hash: u64, path: &Path) -> Self {
+    #[cfg(not(unix))]
+    if let Some(native) = canonical_spelling(path) {
+      return Self(InternedSlice::new(
+        hash_path(&native),
+        native.as_os_str().as_encoded_bytes(),
+      ));
+    }
     Self(InternedSlice::new(
       hash,
       path.as_os_str().as_encoded_bytes(),

--- a/crates/rspack_paths/tests/intern.rs
+++ b/crates/rspack_paths/tests/intern.rs
@@ -86,7 +86,6 @@ fn windows_redundant_separators_and_dot_components_are_canonicalized() {
   // intern to the canonical bytes, whichever arrives first.
   let canonical = InternedPath::from(Path::new(r"D:\intern\win\c.js"));
   for spelling in [
-    r"D:\intern\win\c.js\",
     r"D:\intern\\win\c.js",
     r"D:\intern\.\win\c.js",
     r"D:\intern\win\c.js\.",
@@ -103,15 +102,30 @@ fn windows_redundant_separators_and_dot_components_are_canonicalized() {
 
 #[cfg(windows)]
 #[test]
+fn windows_trailing_separator_is_kept_but_spelled_natively() {
+  // `**/node_modules/**` matches `node_modules/` but not `node_modules`, so the trailing
+  // separator must survive; only its spelling changes.
+  let interned = InternedPath::from(Path::new("D:/intern/win/node_modules/"));
+  assert_eq!(
+    interned.as_ref().as_os_str(),
+    r"D:\intern\win\node_modules\"
+  );
+}
+
+#[cfg(windows)]
+#[test]
 fn windows_already_canonical_paths_keep_their_bytes() {
-  // `..` stays (it is not collapsed by `Path::components` and keeps paths distinct), a bare root
-  // keeps its trailing separator, a UNC prefix keeps its leading `\\`, and the drive letter's
-  // case is not touched.
+  // `..` stays (it is not collapsed by `Path::components` and keeps paths distinct), trailing
+  // separators stay, a UNC prefix keeps its leading `\\`, the drive letter's case is not touched,
+  // and relative paths are never rewritten.
   for spelling in [
     r"D:\intern\win\..\up.js",
+    r"D:\intern\win\dir\",
     r"D:\",
     r"\\server\share\intern\unc.js",
     r"d:\intern\win\lower.js",
+    "src/index.js",
+    "src/",
   ] {
     let interned = InternedPath::from(Path::new(spelling));
     assert_eq!(interned.as_ref().as_os_str(), spelling, "{spelling}");

--- a/crates/rspack_paths/tests/intern.rs
+++ b/crates/rspack_paths/tests/intern.rs
@@ -54,6 +54,89 @@ fn from_parts_interns_into_the_same_object() {
   assert!(same_allocation(&hashed_here, &hashed_upstream));
 }
 
+#[cfg(windows)]
+#[test]
+fn windows_slash_spelling_never_becomes_canonical() {
+  // A `/` spelling interned first (e.g. a JS loader's `addDependency`) must not make the native
+  // spelling of the same file come back with `/`: watchpack keys watchers by the exact string.
+  let slash = InternedPath::from(Path::new("D:/intern/win/a.js"));
+  let native = InternedPath::from(Path::new(r"D:\intern\win\a.js"));
+
+  assert!(same_allocation(&slash, &native));
+  assert_eq!(slash.as_ref().as_os_str(), r"D:\intern\win\a.js");
+  assert_eq!(native.as_ref().as_os_str(), r"D:\intern\win\a.js");
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_mixed_spelling_from_parts_is_normalized() {
+  // The resolver hands over `from_parts` paths; a `/` base directory from JS yields `D:/a\b`.
+  let mixed = Path::new(r"D:/intern/win\mixed.js");
+  let interned = InternedPath::from_parts(hash_path(mixed), mixed);
+  let native = InternedPath::from(Path::new(r"D:\intern\win\mixed.js"));
+
+  assert_eq!(interned.as_ref().as_os_str(), r"D:\intern\win\mixed.js");
+  assert!(same_allocation(&interned, &native));
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_redundant_separators_and_dot_components_are_canonicalized() {
+  // Every spelling `Path::components` collapses is one path to `Path::eq`, so all of them must
+  // intern to the canonical bytes, whichever arrives first.
+  let canonical = InternedPath::from(Path::new(r"D:\intern\win\c.js"));
+  for spelling in [
+    r"D:\intern\win\c.js\",
+    r"D:\intern\\win\c.js",
+    r"D:\intern\.\win\c.js",
+    r"D:\intern\win\c.js\.",
+  ] {
+    let interned = InternedPath::from(Path::new(spelling));
+    assert_eq!(
+      interned.as_ref().as_os_str(),
+      r"D:\intern\win\c.js",
+      "{spelling}"
+    );
+    assert!(same_allocation(&interned, &canonical), "{spelling}");
+  }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_already_canonical_paths_keep_their_bytes() {
+  // `..` stays (it is not collapsed by `Path::components` and keeps paths distinct), a bare root
+  // keeps its trailing separator, a UNC prefix keeps its leading `\\`, and the drive letter's
+  // case is not touched.
+  for spelling in [
+    r"D:\intern\win\..\up.js",
+    r"D:\",
+    r"\\server\share\intern\unc.js",
+    r"d:\intern\win\lower.js",
+  ] {
+    let interned = InternedPath::from(Path::new(spelling));
+    assert_eq!(interned.as_ref().as_os_str(), spelling, "{spelling}");
+  }
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_verbatim_paths_keep_their_bytes() {
+  // Under `\\?\` a `/` is an ordinary character, so nothing is rewritten.
+  let verbatim = Path::new(r"\\?\D:\intern\win\verbatim/file.js");
+  let interned = InternedPath::from(verbatim);
+
+  assert_eq!(interned.as_ref().as_os_str(), verbatim.as_os_str());
+}
+
+#[cfg(unix)]
+#[test]
+fn unix_never_rewrites_bytes() {
+  let path = Path::new("/intern/unix/back\\slash.js");
+  let interned = InternedPath::from(path);
+
+  assert_eq!(interned.as_ref().as_os_str(), path.as_os_str());
+}
+
 #[test]
 fn reinterning_a_freed_path_still_dedupes() {
   let path = Path::new("/intern/freed.js");

--- a/crates/rspack_watcher/src/paths.rs
+++ b/crates/rspack_watcher/src/paths.rs
@@ -387,11 +387,8 @@ mod tests {
     let all = path_tracker.all;
 
     assert_eq!(all.len(), 1);
-    assert!(
-      all
-        .iter()
-        .any(|p| p.to_string_lossy().contains("src/index.js"))
-    )
+    // Compare by components: on Windows the interned spelling is native (`src\index.js`).
+    assert!(all.iter().any(|p| p.ends_with("src/index.js")))
   }
 
   #[tokio::test]
@@ -416,8 +413,9 @@ mod tests {
     let accessor = PathAccessor::new(&path_manager);
     let mut all_paths = vec![];
 
+    // Keep `PathBuf`s so `ends_with` compares components, not separators.
     for path in accessor.all() {
-      all_paths.push(path.to_string_lossy().to_string());
+      all_paths.push(path.to_path_buf());
     }
 
     all_paths.sort();
@@ -461,10 +459,8 @@ mod tests {
       .unwrap();
 
     let accessor = path_manager.access();
-    let mut all_paths = accessor
-      .all()
-      .map(|p| p.to_string_lossy().to_string())
-      .collect::<Vec<_>>();
+    // Keep `PathBuf`s so `ends_with` compares components, not separators.
+    let mut all_paths = accessor.all().map(|p| p.to_path_buf()).collect::<Vec<_>>();
 
     all_paths.sort();
 

--- a/tests/rspack-test/compilerCases/interned-path-native-separators.js
+++ b/tests/rspack-test/compilerCases/interned-path-native-separators.js
@@ -1,0 +1,156 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const CASE_NAME = "interned-path-native-separators";
+const INITIAL_VALUE = "initial value";
+const UPDATED_VALUE = "updated value from watch";
+
+function write(file, content) {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+const toSlash = file => file.replace(/\\/g, "/");
+
+function watchWithSlashDependency(context, compiler, valueFile, outputFile) {
+	return new Promise((resolve, reject) => {
+		let buildCount = 0;
+		let written = false;
+		let changeTimer;
+		let watching;
+		let settled = false;
+
+		const timeout = setTimeout(
+			() => finish(new Error("Timed out waiting for the watcher to rebuild")),
+			process.platform === "win32" ? 15_000 : 10_000
+		);
+
+		const finish = error => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timeout);
+			clearTimeout(changeTimer);
+
+			const done = closeError => {
+				const finalError = error || closeError;
+				if (finalError) {
+					reject(finalError);
+				} else {
+					resolve();
+				}
+			};
+
+			if (watching) {
+				watching.close(done);
+			} else {
+				done();
+			}
+		};
+
+		// A JS plugin or loader handing rspack the `/` spelling of a file before the resolver
+		// interns its native spelling (rspress' page data module does exactly this).
+		compiler.hooks.thisCompilation.tap(CASE_NAME, compilation => {
+			if (buildCount === 0) {
+				compilation.fileDependencies.add(toSlash(valueFile));
+			}
+		});
+
+		watching = compiler.watch(
+			{
+				aggregateTimeout: 50,
+				ignored: []
+			},
+			(error, stats) => {
+				if (settled) return;
+				if (error) return finish(error);
+				if (stats.hasErrors()) {
+					return finish(
+						new Error(
+							stats.toString({ all: false, errors: true, errorDetails: true })
+						)
+					);
+				}
+
+				buildCount += 1;
+				const dependencies = Array.from(stats.compilation.fileDependencies);
+				const valueDependencies = dependencies.filter(
+					dependency =>
+						toSlash(dependency).toLowerCase() ===
+						toSlash(valueFile).toLowerCase()
+				);
+
+				if (buildCount === 1) {
+					context.setValue("initialOutput", fs.readFileSync(outputFile, "utf8"));
+					context.setValue("valueDependencies", valueDependencies);
+					changeTimer = setTimeout(() => {
+						written = true;
+						write(valueFile, `export default ${JSON.stringify(UPDATED_VALUE)};\n`);
+					}, process.platform === "win32" ? 500 : 100);
+					return;
+				}
+
+				// A rebuild may fire for the freshly written sources before the change above;
+				// only the build that picked up the change settles the case.
+				const output = fs.readFileSync(outputFile, "utf8");
+				if (!written || !output.includes(UPDATED_VALUE)) return;
+				context.setValue("buildCount", buildCount);
+				context.setValue("updatedOutput", output);
+				finish();
+			}
+		);
+	});
+}
+
+module.exports = {
+	description:
+		"should keep watching a file whose `/` spelling was interned before its native spelling",
+	options(context) {
+		const root = context.getDist(CASE_NAME);
+		const sourceDirectory = path.join(root, "src");
+		const outputDirectory = path.join(root, "dist");
+		const valueFile = path.join(sourceDirectory, "value.js");
+
+		fs.rmSync(root, { recursive: true, force: true });
+		write(
+			path.join(sourceDirectory, "index.js"),
+			'import value from "./value.js";\nconsole.log(value);\n'
+		);
+		write(valueFile, `export default ${JSON.stringify(INITIAL_VALUE)};\n`);
+
+		context.setValue("valueFile", valueFile);
+		context.setValue("outputFile", path.join(outputDirectory, "main.js"));
+		return {
+			context: sourceDirectory,
+			mode: "development",
+			devtool: false,
+			target: "node",
+			entry: "./index.js",
+			output: {
+				path: outputDirectory,
+				filename: "main.js",
+				clean: true
+			}
+		};
+	},
+	compiler(_context, compiler) {
+		compiler.outputFileSystem = fs;
+	},
+	async build(context, compiler) {
+		await watchWithSlashDependency(
+			context,
+			compiler,
+			context.getValue("valueFile"),
+			context.getValue("outputFile")
+		);
+	},
+	check({ context }) {
+		// Only the native spelling may reach `fileDependencies`: watchpack keys watchers by the
+		// exact string and never matches a `/` spelling on Windows.
+		expect(context.getValue("valueDependencies")).toEqual([
+			context.getValue("valueFile")
+		]);
+		expect(context.getValue("buildCount")).toBeGreaterThanOrEqual(2);
+		expect(context.getValue("initialOutput")).toContain(INITIAL_VALUE);
+		expect(context.getValue("updatedOutput")).toContain(UPDATED_VALUE);
+	}
+};


### PR DESCRIPTION
## Summary

On Windows `InternedPath` deduplicates by `Path::eq`, so `D:/a/b` and `D:\a\b` share one allocation and every lookup returns whichever spelling was interned first. When a `/` spelling arrives from JS before the resolver interns the native one (rspress' page-data virtual module does this through a loader's `addDependency`), the module's own resource comes back spelled with `/` in `compilation.fileDependencies`. watchpack keys its watchers by the exact string and normalizes events with `path.join`, so it reports the file as removed and never delivers its changes: HMR for that file is dead until restart. Before #15205 the same race only affected one `FileCounter` entry and a later rebuild re-inserted the native spelling; with the process-wide interner the first spelling sticks.

`from_parts` is the only constructor, so it now canonicalizes absolute paths on Windows: `/` separators, doubled separators and `.` components are rewritten to the native form `Path::components` rebuilds. A byte scan keeps already-native paths allocation-free. Relative paths, verbatim paths, `..` components, the drive letter's case and trailing separators (significant to `**/node_modules/**`-style ignores) are left as they are. Unix compares bytes, merges nothing, and is unchanged. #15357 fixed the same class for restored caches only; this covers every ingress.

Before / after on rspress' Windows e2e (three HMR fixtures, same probe): Rspack 2.2.2 fails 6 of 6 runs with the page paths spelled `D:/...` in `fileDependencies`; with the paths handed over natively (web-infra-dev/rspress#3656) 0 of 4 fail. Diagnosis with call-site attribution: web-infra-dev/rspress#3654.

## Related links

- #15352, #15357
- web-infra-dev/rspress#3650

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).