### PR TITLE
refactor(core): use DependencyRef in BuildResult

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -7,8 +7,8 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildResult, CacheFacade,
-  CompilationId, CompilerId, CompilerOptions, DependencyParents, FileSystemInfo,
+  AsyncDependenciesBlock, BoxModule, BuildContext, BuildResult, CacheFacade, CompilationId,
+  CompilerId, CompilerOptions, DependencyParents, DependencyRef, FileSystemInfo,
   ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{ForwardedIdSet, HasLazyDependencies, LazyDependencies},
   utils::{
@@ -148,7 +148,7 @@ impl Task<TaskContext> for BuildResultTask {
     let mut lazy_dependencies = LazyDependencies::default();
     let mut queue = VecDeque::new();
     let mut all_dependencies = vec![];
-    let mut handle_block = |dependencies: Vec<BoxDependency>,
+    let mut handle_block = |dependencies: Vec<DependencyRef>,
                             blocks: Vec<Box<AsyncDependenciesBlock>>,
                             current_block: Option<Box<AsyncDependenciesBlock>>|
      -> Vec<Box<AsyncDependenciesBlock>> {
@@ -169,7 +169,7 @@ impl Task<TaskContext> for BuildResultTask {
             index_in_block,
           },
         );
-        module_graph.add_dependency(dependency);
+        module_graph.add_dependency_ref(dependency);
       }
       if let Some(current_block) = current_block {
         module.add_block_id(current_block.identifier());
@@ -181,7 +181,11 @@ impl Task<TaskContext> for BuildResultTask {
     queue.extend(blocks);
 
     while let Some(mut block) = queue.pop_front() {
-      let dependencies = block.take_dependencies();
+      let dependencies = block
+        .take_dependencies()
+        .into_iter()
+        .map(Into::into)
+        .collect();
       let blocks = handle_block(dependencies, block.take_blocks(), Some(block));
       queue.extend(blocks);
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -181,11 +181,7 @@ impl Task<TaskContext> for BuildResultTask {
     queue.extend(blocks);
 
     while let Some(mut block) = queue.pop_front() {
-      let dependencies = block
-        .take_dependencies()
-        .into_iter()
-        .map(Into::into)
-        .collect();
+      let dependencies = block.take_dependencies();
       let blocks = handle_block(dependencies, block.take_blocks(), Some(block));
       queue.extend(blocks);
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/lazy_barrel_artifact.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/lazy_barrel_artifact.rs
@@ -6,7 +6,7 @@ use rspack_collections::IdentifierMap;
 use rspack_intern::Atom;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::{BoxDependency, DependencyId, DependencyRef, ModuleIdentifier};
+use crate::{DependencyId, DependencyRef, ModuleIdentifier};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ForwardId {
@@ -86,7 +86,7 @@ impl LazyDependencies {
     self.request_to_dependencies.is_empty() && self.fallback_dependencies.is_empty()
   }
 
-  pub fn insert(&mut self, dependency: &BoxDependency, until: LazyUntil) {
+  pub fn insert(&mut self, dependency: &DependencyRef, until: LazyUntil) {
     if matches!(&until, LazyUntil::Fallback) {
       self.fallback_dependencies.insert(*dependency.id());
     } else if let LazyUntil::Local(forward_id) = &until {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1524,7 +1524,7 @@ impl Module for ContextModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -5,8 +5,8 @@ use rspack_collections::{Identifier, IdentifierHasher};
 use rspack_hash::{RspackHash, RspackHasher};
 
 use crate::{
-  BoxDependency, Compilation, DependencyId, DependencyLocation, GroupOptions, ModuleIdentifier,
-  RuntimeSpec,
+  BoxDependency, Compilation, Dependency, DependencyId, DependencyLocation, DependencyRef,
+  GroupOptions, ModuleIdentifier, RuntimeSpec,
 };
 
 pub trait DependenciesBlock {
@@ -83,7 +83,7 @@ pub struct AsyncDependenciesBlock {
   blocks: Vec<Box<AsyncDependenciesBlock>>,
   block_ids: Vec<AsyncDependenciesBlockIdentifier>,
   dependency_ids: Vec<DependencyId>,
-  dependencies: Vec<BoxDependency>,
+  dependencies: Vec<DependencyRef>,
   loc: Option<DependencyLocation>,
   parent: ModuleIdentifier,
   request: Option<String>,
@@ -132,7 +132,7 @@ impl AsyncDependenciesBlock {
       blocks: Default::default(),
       block_ids: Default::default(),
       dependency_ids,
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       loc,
       parent,
       request,
@@ -151,16 +151,20 @@ impl AsyncDependenciesBlock {
     self.group_options.as_ref()
   }
 
-  pub fn take_dependencies(&mut self) -> Vec<BoxDependency> {
+  pub fn take_dependencies(&mut self) -> Vec<DependencyRef> {
     std::mem::take(&mut self.dependencies)
   }
 
-  pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut BoxDependency> {
-    self.dependencies.get_mut(idx)
+  pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut (dyn Dependency + 'static)> {
+    self.dependencies.get_mut(idx)?.get_mut()
   }
 
-  pub fn dependencies_mut(&mut self) -> &mut [BoxDependency] {
-    &mut self.dependencies
+  pub fn dependencies_mut(&mut self) -> impl Iterator<Item = &mut (dyn Dependency + 'static)> {
+    self.dependencies.iter_mut().map(|dependency| {
+      dependency
+        .get_mut()
+        .expect("dependency must be uniquely owned before block publication")
+    })
   }
 
   pub fn take_blocks(&mut self) -> Vec<Box<AsyncDependenciesBlock>> {

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -312,6 +312,10 @@ impl DependencyRef {
   pub fn new<D: Dependency + 'static>(dependency: D) -> Self {
     UniqueDependency::new(dependency).shareable()
   }
+
+  pub fn get_mut(&mut self) -> Option<&mut (dyn Dependency + 'static)> {
+    TriompheArc::get_mut(&mut self.0)
+  }
 }
 
 impl From<UniqueDependency> for DependencyRef {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,16 +11,16 @@ use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
   BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
   CodeGenerationDataChunkInitFragments, CodeGenerationDataUrl, CodeGenerationResultBuilder,
-  Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId, ExportProvided,
-  ExternalType, FactoryMeta, ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey,
-  InitFragmentStage, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleCodeTemplate, ModuleGraph, ModuleType, NAMESPACE_OBJECT_EXPORT, NormalInitFragment,
-  RuntimeGlobals, RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, UsageState,
-  UsedExports, UsedNameItem, extract_url_and_global, impl_module_meta_info, module_update_hash,
-  property_access,
+  Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId, DependencyRef,
+  ExportProvided, ExternalType, FactoryMeta, ImportAttributes, ImportPhase, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
+  StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
+  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -1205,7 +1205,7 @@ impl Module for ExternalModule {
     self.build_meta.set_exports_type(exports_type);
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies: vec![BoxDependency::new(StaticExportsDependency::new(
+      dependencies: vec![DependencyRef::new(StaticExportsDependency::new(
         StaticExportsSpec::True,
         can_mangle,
       ))],

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -28,16 +28,17 @@ use smol_str::SmolStr;
 use swc_core::atoms::Wtf8Atom;
 
 use crate::{
-  AsyncDependenciesBlock, BindingCell, BoxDependency, CacheFacade, ChunkGraph, ChunkUkey,
+  AsyncDependenciesBlock, BindingCell, CacheFacade, ChunkGraph, ChunkUkey,
   CodeGenerationResultBuilder, CollectedTypeScriptInfo, Compilation, CompilationAsset,
   CompilationId, CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
   ContextModule, CssExportType, DependenciesBlock, DependencyCodeGenerationRef, DependencyId,
-  ExportProvided, ExportsInfoArtifact, ExternalModule, FileSystemInfo, Filename, GetTargetResult,
-  ImportPhase, ModuleCodeTemplate, ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer, ModuleType,
-  NormalModule, OptimizationBailoutItem, RawModule, Resolve, ResolverFactory, RuntimeSpec,
-  SelfModule, SharedPluginDriver, SideEffectsStateArtifact, Snapshot, SourceType,
-  concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
-  get_target, value_cache_versions::ValueCacheVersions,
+  DependencyRef, ExportProvided, ExportsInfoArtifact, ExternalModule, FileSystemInfo, Filename,
+  GetTargetResult, ImportPhase, ModuleCodeTemplate, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleLayer, ModuleType, NormalModule, OptimizationBailoutItem, RawModule, Resolve,
+  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SideEffectsStateArtifact, Snapshot,
+  SourceType, concatenated_module::ConcatenatedModule,
+  dependencies_block::dependencies_block_update_hash, get_target,
+  value_cache_versions::ValueCacheVersions,
 };
 
 pub struct BuildContext {
@@ -658,8 +659,8 @@ impl RspackHash for ExportsArgument {
 #[derive(Debug)]
 pub struct BuildResult {
   pub module: BoxModule,
-  /// Whether the result is cacheable, i.e shared between builds.
-  pub dependencies: Vec<BoxDependency>,
+  /// Dependencies are shared after the module build finishes.
+  pub dependencies: Vec<DependencyRef>,
   pub blocks: Vec<Box<AsyncDependenciesBlock>>,
   pub optimization_bailouts: Vec<OptimizationBailoutItem>,
 }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -606,7 +606,7 @@ impl Module for NormalModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts,
     })

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -92,7 +92,7 @@ impl Module for DllModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -112,7 +112,7 @@ impl Module for DelegatedModule {
     self.build_meta = self.delegate_data.build_meta.clone();
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -24,8 +24,8 @@ use rspack_cacheable::{
 };
 use rspack_core::{
   ArcComputed, AsyncDependenciesBlock, BoxDependency, BuildInfo, BuildMeta, CompilerOptions,
-  DependencyCodeGeneration, DependencyCodeGenerationRef, DependencyId, DependencyLocation,
-  DependencyRange, FactoryMeta, ImportMeta, ImportMetaKnownProperties,
+  Dependency, DependencyCodeGeneration, DependencyCodeGenerationRef, DependencyId,
+  DependencyLocation, DependencyRange, FactoryMeta, ImportMeta, ImportMetaKnownProperties,
   JavascriptParserCommonjsExportsOption, JavascriptParserOptions, ModuleIdentifier, ModuleLayer,
   ModuleType, ParseMeta, ResolvedModuleOptions, ResourceData, SideEffectsBailoutItemWithSpan,
 };
@@ -698,8 +698,8 @@ impl<'parser> JavascriptParser<'parser> {
     &self.dependencies
   }
 
-  pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut BoxDependency> {
-    self.dependencies.get_mut(idx)
+  pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut (dyn Dependency + 'static)> {
+    self.dependencies.get_mut(idx).map(AsMut::as_mut)
   }
 
   pub fn collect_dependencies_for_block(
@@ -764,7 +764,7 @@ impl<'parser> JavascriptParser<'parser> {
   pub fn add_block(&mut self, mut block: Box<AsyncDependenciesBlock>) {
     if let Some(guard) = &self.current_branch_guard {
       for dep in block.dependencies_mut() {
-        guard.bind_dependency(dep.as_mut());
+        guard.bind_dependency(dep);
       }
     }
     self.blocks.push(block);

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -234,7 +234,7 @@ impl Module for LazyCompilationProxyModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -242,7 +242,7 @@ impl Module for ContainerEntryModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -146,7 +146,7 @@ impl Module for FallbackModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -193,7 +193,7 @@ impl Module for RemoteModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -190,7 +190,7 @@ impl Module for ConsumeSharedModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -182,7 +182,7 @@ impl Module for ProvideSharedModule {
 
     Ok(BuildResult {
       module: BoxModule::new(self),
-      dependencies,
+      dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks,
       optimization_bailouts: vec![],
     })

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -270,7 +270,7 @@ impl Module for RscEntryModule {
       }
       Ok(BuildResult {
         module: BoxModule::new(self),
-        dependencies,
+        dependencies: dependencies.into_iter().map(Into::into).collect(),
         blocks: vec![],
         optimization_bailouts: vec![],
       })
@@ -375,7 +375,7 @@ impl Module for RscEntryModule {
 
       Ok(BuildResult {
         module: BoxModule::new(self),
-        dependencies,
+        dependencies: dependencies.into_iter().map(Into::into).collect(),
         blocks,
         optimization_bailouts: vec![],
       })


### PR DESCRIPTION
## Summary

- Store BuildResult and async block dependencies as shared DependencyRef values.
- Publish build dependencies directly into the module graph while preserving unique mutation before block publication.
- Prepare the build boundary for dependency caching.

## Related links

N/A

## Checklist

- [x] Tests updated (not required).
- [x] Documentation updated (not required).