### PR TITLE
feat(javascript): drop unused side-effect-free CommonJS requires

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -2,12 +2,15 @@ use rspack_cacheable::{
   cacheable, cacheable_dyn,
   with::{AsCacheable, AsOption, AsVec},
 };
+use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsContextDependency, Context, Dependency, DependencyCategory, DependencyCodeGeneration,
-  DependencyCondition, DependencyId, DependencyLocation, DependencyRange, DependencyTemplate,
-  DependencyTemplateType, DependencyType, ExportsInfoArtifact, ModuleDependency, ModuleGraph,
-  ModuleGraphCacheArtifact, ReferencedExport, ReferencedSpecifier, ResourceIdentifier, RuntimeSpec,
-  TemplateContext, TemplateReplaceSource, create_exports_object_referenced,
+  AsContextDependency, ConnectionState, Context, Dependency, DependencyCategory,
+  DependencyCodeGeneration, DependencyCondition, DependencyConditionFn, DependencyId,
+  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
+  ExportsInfoArtifact, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ReferencedExport, ReferencedSpecifier, ResourceIdentifier, RuntimeSpec,
+  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
+  create_exports_object_referenced, create_no_exports_referenced,
   create_referenced_exports_by_referenced_specifiers,
 };
 
@@ -25,6 +28,7 @@ pub struct CommonJsRequireDependency {
   loc: Option<DependencyLocation>,
   #[cacheable(with=AsOption<AsVec<AsCacheable>>)]
   referenced_specifiers: Option<Vec<ReferencedSpecifier>>,
+  evaluation_only: bool,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guard: Option<DependencyBranchGuard>,
   context: Option<Context>,
@@ -47,6 +51,7 @@ impl CommonJsRequireDependency {
       range_expr,
       loc,
       referenced_specifiers: None,
+      evaluation_only: false,
       branch_guard: None,
       context: None,
       resource_identifier: Default::default(),
@@ -75,13 +80,17 @@ impl CommonJsRequireDependency {
   }
 
   pub fn set_referenced_specifiers(&mut self, referenced_specifiers: Vec<ReferencedSpecifier>) {
-    if referenced_specifiers.is_empty() {
-      // If the referenced specifiers are empty, keep it as default (None), since this dependency can't eliminate by side effects optimization,
-      // so if we set it to Some(vec![]), and the dependency still executes, it will cause runtime error because the exports are all tree shaken.
-      // see test case `tests/rspack-test/configCases/cjs-tree-shaking/side-effects-free`
-      return;
-    }
+    self.evaluation_only = referenced_specifiers.is_empty();
     self.referenced_specifiers = Some(referenced_specifiers);
+  }
+
+  pub fn set_evaluation_only(&mut self) {
+    self.evaluation_only = true;
+    self.referenced_specifiers = Some(Vec::new());
+  }
+
+  pub fn is_evaluation_only(&self) -> bool {
+    self.evaluation_only
   }
 
   pub fn set_branch_guard(&mut self, guard: DependencyBranchGuard) {
@@ -132,6 +141,9 @@ impl Dependency for CommonJsRequireDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ReferencedExport> {
+    if self.evaluation_only {
+      return create_no_exports_referenced();
+    }
     if let Some(referenced_specifiers) = &self.referenced_specifiers {
       let module = module_graph
         .get_module_by_dependency_id(&self.id)
@@ -172,7 +184,42 @@ impl ModuleDependency for CommonJsRequireDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    compose_dependency_condition(None, self.branch_guard.as_ref())
+    let condition = self
+      .evaluation_only
+      .then(|| DependencyCondition::new(CommonJsRequireDependencyCondition));
+    compose_dependency_condition(condition, self.branch_guard.as_ref())
+  }
+}
+
+struct CommonJsRequireDependencyCondition;
+
+impl DependencyConditionFn for CommonJsRequireDependencyCondition {
+  fn get_connection_state(
+    &self,
+    connection: &ModuleGraphConnection,
+    _runtime: Option<&RuntimeSpec>,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &ModuleGraphCacheArtifact,
+    side_effects_state_artifact: &SideEffectsStateArtifact,
+    _exports_info_artifact: &ExportsInfoArtifact,
+  ) -> ConnectionState {
+    let module_identifier = *connection.module_identifier();
+    if let Some(state) =
+      side_effects_state_artifact.module_evaluation_side_effects_state(&module_identifier)
+    {
+      return state;
+    }
+    if let Some(module) = module_graph.module_by_identifier(&module_identifier) {
+      module.get_side_effects_connection_state(
+        module_graph,
+        module_graph_cache,
+        side_effects_state_artifact,
+        &mut IdentifierSet::default(),
+        &mut IdentifierMap::default(),
+      )
+    } else {
+      ConnectionState::Active(true)
+    }
   }
 }
 
@@ -208,6 +255,27 @@ impl DependencyTemplate for CommonJsRequireDependencyTemplate {
       .expect(
         "CommonJsRequireDependencyTemplate should only be used for CommonJsRequireDependency",
       );
+
+    if dep.evaluation_only {
+      let compilation = code_generatable_context.compilation;
+      let module_graph = compilation.get_module_graph();
+      if let Some(connection) = module_graph.connection_by_dependency_id(&dep.id)
+        && !connection.is_target_active(
+          module_graph,
+          code_generatable_context.runtime,
+          &compilation.module_graph_cache_artifact,
+          &compilation
+            .build_module_graph_artifact
+            .side_effects_state_artifact,
+          &compilation.exports_info_artifact,
+        )
+      {
+        if let Some(range) = dep.range_expr {
+          source.replace(range.start, range.end, "0".into(), None);
+        }
+        return;
+      }
+    }
 
     source.replace(
       dep.range.start,

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/require_header_dependency.rs
@@ -5,20 +5,32 @@ use rspack_core::{
   TemplateContext, TemplateReplaceSource,
 };
 
+use super::CommonJsRequireDependency;
+
 #[cacheable]
 #[derive(Debug)]
 pub struct RequireHeaderDependency {
   id: DependencyId,
   range: DependencyRange,
   loc: Option<DependencyLocation>,
+  require_dependency_id: Option<DependencyId>,
 }
 
 impl RequireHeaderDependency {
   pub fn new(range: DependencyRange, loc: Option<DependencyLocation>) -> Self {
+    Self::new_with_require_dependency(range, loc, None)
+  }
+
+  pub fn new_with_require_dependency(
+    range: DependencyRange,
+    loc: Option<DependencyLocation>,
+    require_dependency_id: Option<DependencyId>,
+  ) -> Self {
     Self {
       id: DependencyId::new(),
       range,
       loc,
+      require_dependency_id,
     }
   }
 }
@@ -71,8 +83,34 @@ impl DependencyTemplate for RequireHeaderDependencyTemplate {
       .expect("RequireHeaderDependencyTemplate should only be used for RequireHeaderDependency");
 
     let TemplateContext {
-      runtime_template, ..
+      compilation,
+      runtime,
+      runtime_template,
+      ..
     } = code_generatable_context;
+
+    if let Some(require_dependency_id) = &dep.require_dependency_id {
+      let module_graph = compilation.get_module_graph();
+      let require_dependency = module_graph
+        .dependency_by_id(require_dependency_id)
+        .downcast_ref::<CommonJsRequireDependency>()
+        .expect("paired dependency should be CommonJsRequireDependency");
+      if require_dependency.is_evaluation_only()
+        && let Some(connection) = module_graph.connection_by_dependency_id(require_dependency_id)
+        && !connection.is_target_active(
+          module_graph,
+          *runtime,
+          &compilation.module_graph_cache_artifact,
+          &compilation
+            .build_module_graph_artifact
+            .side_effects_state_artifact,
+          &compilation.exports_info_artifact,
+        )
+      {
+        return;
+      }
+    }
+
     source.replace(
       dep.range.start,
       dep.range.end,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 
 use rspack_core::{
   BoxDependency, ConstDependency, Context, ContextDependency, ContextMode, ContextModulePattern,
-  ContextOptions, DependencyCategory, DependencyRange, DependencyType, ImportMetaKnownProperties,
-  ModuleType, ReferencedSpecifier, RuntimeGlobals, RuntimeRequirementsDependency, get_context,
+  ContextOptions, Dependency, DependencyCategory, DependencyRange, DependencyType,
+  ImportMetaKnownProperties, ModuleType, ReferencedSpecifier, RuntimeGlobals,
+  RuntimeRequirementsDependency, get_context,
 };
 use rspack_error::{Diagnostic, Severity};
 use rspack_intern::AtomRef;
@@ -1698,7 +1699,8 @@ impl CommonJsImportsParserPlugin {
     span: Span,
     param: &BasicEvaluatedExpression,
     request_context: Option<Context>,
-  ) -> Option<bool> {
+    allow_evaluation_only: bool,
+  ) -> Option<rspack_core::DependencyId> {
     param.is_string().then(|| {
       let (start, end) = param.range();
       let range_expr = DependencyRange::new(start, end);
@@ -1715,6 +1717,15 @@ impl CommonJsImportsParserPlugin {
             });
             refs
           });
+      let has_require_binding = parser
+        .common_js_require_references
+        .get_require_mut(&span)
+        .is_some();
+      let is_evaluation_only = referenced_specifiers.as_ref().is_some_and(Vec::is_empty)
+        || (allow_evaluation_only
+          && referenced_specifiers.is_none()
+          && !has_require_binding
+          && parser.is_statement_level_expression(span));
       let mut dep = if let Some(context) = request_context {
         CommonJsRequireDependency::new_contextual(
           param.string().clone(),
@@ -1735,7 +1746,10 @@ impl CommonJsImportsParserPlugin {
       };
       if let Some(referenced_specifiers) = referenced_specifiers {
         dep.set_referenced_specifiers(referenced_specifiers);
+      } else if is_evaluation_only {
+        dep.set_evaluation_only();
       }
+      let dependency_id = *dep.id();
       let dep_idx = parser.next_dependency_idx();
       if let Some(require_references) = parser.common_js_require_references.get_require_mut(&span) {
         require_references.dep_locator = Some(RequireDependencyLocator {
@@ -1745,7 +1759,7 @@ impl CommonJsImportsParserPlugin {
         });
       }
       parser.add_dependency(BoxDependency::new(dep));
-      true
+      dependency_id
     })
   }
 
@@ -1831,7 +1845,7 @@ impl CommonJsImportsParserPlugin {
       let mut is_expression = false;
       for p in param.options() {
         if self
-          .process_require_item(parser, expr.span(), p, request_context.clone())
+          .process_require_item(parser, expr.span(), p, request_context.clone(), false)
           .is_none()
         {
           is_expression = true;
@@ -1862,16 +1876,18 @@ impl CommonJsImportsParserPlugin {
       return None;
     }
 
-    if self
-      .process_require_item(parser, expr.span(), &param, request_context.clone())
-      .is_none()
+    let require_dependency_id =
+      self.process_require_item(parser, expr.span(), &param, request_context.clone(), true);
+    if require_dependency_id.is_none()
       && let CallOrNewExpr::Call(call_expr) = expr
     {
       self.process_require_context(parser, call_expr, &param, request_context);
     } else {
       let range: DependencyRange = callee.span().into();
       let loc = parser.to_dependency_location(range);
-      parser.add_presentational_dependency(Arc::new(RequireHeaderDependency::new(range, loc)));
+      parser.add_presentational_dependency(Arc::new(
+        RequireHeaderDependency::new_with_require_dependency(range, loc, require_dependency_id),
+      ));
     }
     Some(true)
   }

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/effect-ternary.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/effect-ternary.js
@@ -1,0 +1,3 @@
+global.__cjs_ternary_effect_ran = true;
+
+exports.unused = "value";

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/effect.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/effect.js
@@ -1,0 +1,3 @@
+global.__cjs_effect_ran = true;
+
+exports.unused = "value";

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/index.js
@@ -1,0 +1,103 @@
+const { keep } = require("./sibling-lib");
+
+// Bare require: result discarded, target side-effect free.
+require("./pure?bare");
+
+// Unused binding to a side-effect-free module.
+const deadBinding = require("./pure?binding");
+
+// Empty destructure: no members read.
+const {} = require("./pure?destructure");
+
+// Conditional bare require with an unknown condition.
+if (global.__unknown_cond) require("./pure?cond");
+
+// Used require must stay (control).
+const { unused: used } = require("./pure?used");
+
+// Side-effectful bare require must stay.
+global.__cjs_effect_ran = false;
+require("./effect");
+
+// Statement-level conditional require: must not rewrite the shared valueRange to "0".
+require(global.__pick_ternary ? "./pure?ternary-a" : "./pure?ternary-b");
+
+global.__cjs_ternary_effect_ran = false;
+require(
+	global.__pick_ternary_effect ? "./effect-ternary" : "./pure?ternary-c"
+);
+
+// Parenthesized / `new` callee: header must stay paired with the require dep.
+(require)("./pure?paren");
+new require("./pure?new");
+
+it("keeps a sibling declarator when an unused require shares its declaration", () => {
+	expect(keep).toBe("kept");
+});
+
+it("keeps a used require binding", () => {
+	expect(used).toBe("unused");
+});
+
+it("keeps a bare require to a side-effectful module", () => {
+	expect(global.__cjs_effect_ran).toBe(true);
+	delete global.__cjs_effect_ran;
+});
+
+it("runs the effect branch of a statement-level conditional require", () => {
+	global.__pick_ternary_effect = true;
+	global.__cjs_ternary_effect_ran = false;
+	require(
+		global.__pick_ternary_effect ? "./effect-ternary" : "./pure?ternary-c"
+	);
+	expect(global.__cjs_ternary_effect_ran).toBe(true);
+	delete global.__pick_ternary_effect;
+	delete global.__cjs_ternary_effect_ran;
+});
+
+if (process.env.NODE_ENV === "production") {
+	const bundledSource = () =>
+		Object.keys(__webpack_modules__)
+			.map(id => String(__webpack_modules__[id]))
+			.join("\n");
+
+	it("drops a bare require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?bare")).toBe(null);
+		expect(bundledSource()).toMatch(/\b0;/);
+	});
+
+	it("drops an unused require binding of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?binding")).toBe(null);
+	});
+
+	it("drops an unused require that shares a declaration with a kept binding", () => {
+		expect(require.resolveWeak("./pure?sibling")).toBe(null);
+	});
+
+	it("drops an empty destructuring require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?destructure")).toBe(null);
+	});
+
+	it("drops a conditional bare require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?cond")).toBe(null);
+	});
+
+	it("keeps a used require of a side-effect-free module", () => {
+		expect(require.resolveWeak("./pure?used")).not.toBe(null);
+	});
+
+	it("keeps a bare require of a side-effectful module in the graph", () => {
+		expect(require.resolveWeak("./effect")).not.toBe(null);
+	});
+
+	it("keeps both sides of a statement-level ternary require", () => {
+		expect(require.resolveWeak("./pure?ternary-a")).not.toBe(null);
+		expect(require.resolveWeak("./pure?ternary-b")).not.toBe(null);
+		expect(bundledSource()).not.toMatch(/\b00;/);
+	});
+
+	it("drops parenthesized and new require of side-effect-free modules", () => {
+		expect(require.resolveWeak("./pure?paren")).toBe(null);
+		expect(require.resolveWeak("./pure?new")).toBe(null);
+	});
+}

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/package.json
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/package.json
@@ -1,0 +1,6 @@
+{
+  "sideEffects": [
+    "./effect.js",
+    "./effect-ternary.js"
+  ]
+}

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/pure.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/pure.js
@@ -1,0 +1,1 @@
+exports.unused = "unused";

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/sibling-lib.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/remove-unused-requires/sibling-lib.js
@@ -1,0 +1,5 @@
+// Unused require shares a declaration with a kept declarator.
+const dead = require("./pure?sibling"),
+	keep = "kept";
+
+exports.keep = keep;


### PR DESCRIPTION
## Summary\n\n- Track CommonJS require dependencies with inner-graph export usage.\n- Disconnect side-effect-free requires that are reachable only from unused exports while preserving effectful arguments and sibling requires.\n- Add the webpack remove-unused-requires coverage.\n\n## Related links\n\n- Upstream behavior: https://github.com/webpack/webpack/commit/2fbbcf59e\n\n## Checklist\n\n- [x] Tests updated (or not required).\n- [x] Documentation updated (or not required).