### PR TITLE
fix(javascript): drop pure CommonJS object properties

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_object_export_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_object_export_dependency.rs
@@ -46,6 +46,7 @@ pub struct CommonJsObjectExportDependency {
   #[cacheable(with=AsPreset)]
   name: Atom,
   kind: CommonJsObjectExportKind,
+  pure: bool,
 }
 
 impl CommonJsObjectExportDependency {
@@ -55,6 +56,7 @@ impl CommonJsObjectExportDependency {
     value_range: DependencyRange,
     name: Atom,
     kind: CommonJsObjectExportKind,
+    pure: bool,
   ) -> Self {
     Self {
       id: DependencyId::new(),
@@ -63,6 +65,7 @@ impl CommonJsObjectExportDependency {
       value_range,
       name,
       kind,
+      pure,
     }
   }
 }
@@ -197,8 +200,19 @@ impl DependencyTemplate for CommonJsObjectExportDependencyTemplate {
           None,
         );
       } else {
-        // Preserve evaluation of an unused data property's value. A later
-        // optimization may omit it when the value is proven pure.
+        if dep.pure {
+          // Spreading null adds nothing. Keep the value text in a dead branch
+          // so nested dependency replacements continue to target valid ranges.
+          source.replace_static(
+            dep.range.start,
+            dep.value_range.start,
+            "...(/* unused pure expression */ null && (",
+            None,
+          );
+          source.replace_static(dep.value_range.end, dep.range.end, "))", None);
+          return;
+        }
+        // Preserve evaluation of an unused data property's impure value.
         source.replace_static(dep.range.start, dep.value_range.start, "...void (", None);
         source.replace_static(dep.value_range.end, dep.range.end, ")", None);
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -18,7 +18,10 @@ use crate::{
     CommonJsObjectExportKind, CommonJsSelfReferenceDependency, ExportsBase,
     ModuleDecoratorDependency,
   },
-  parser_plugin::common_js_imports_parse_plugin::is_require_call_expr,
+  parser_plugin::{
+    common_js_imports_parse_plugin::is_require_call_expr,
+    side_effects_parser_plugin::is_pure_expression,
+  },
   utils::eval::{self, BasicEvaluatedExpression},
   visitors::JavascriptParser,
 };
@@ -317,6 +320,15 @@ fn handle_object_literal_export(
       .expect("unsupported properties were rejected while collecting export names");
     let (range, key_range, value_range) = get_object_export_ranges(prop, parser.source)
       .expect("unsupported properties were rejected while collecting export names");
+    let pure = get_object_export_value(prop).is_some_and(|value| {
+      is_pure_expression(
+        parser,
+        parser.compiler_options.experiments.pure_functions,
+        value,
+        parser.ast.comments,
+        None,
+      )
+    });
 
     if name == "__esModule" {
       parser.check_namespace(true, get_object_export_value(prop));
@@ -328,6 +340,7 @@ fn handle_object_literal_export(
       value_range,
       name,
       kind,
+      pure,
     )));
     parser.walk_property(prop);
   }

--- a/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/index.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/index.js
@@ -1,0 +1,5 @@
+it("should drop unused data properties with a side-effect-free value", () => {
+	const m = require("./pure");
+	expect(m.used).toBe("used");
+	expect(m.getCount()).toBe(0);
+});

--- a/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/pure.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/pure.js
@@ -1,0 +1,22 @@
+let count = 0;
+
+function track(value) {
+	count++;
+	return value;
+}
+
+/*#__NO_SIDE_EFFECTS__*/
+function trackAnnotated(value) {
+	count++;
+	return value;
+}
+
+module.exports = {
+	used: "used",
+	unusedPure: /*#__PURE__*/ track("unused-pure"),
+	unusedAnnotated: trackAnnotated("unused-annotated"),
+	unusedLiteral: track,
+	getCount() {
+		return count;
+	}
+};

--- a/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/rspack.config.js
+++ b/tests/rspack-test/configCases/cjs-tree-shaking/object-literal-pure/rspack.config.js
@@ -1,0 +1,8 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  optimization: {
+    minimize: false,
+    usedExports: true,
+    concatenateModules: false,
+  },
+};


### PR DESCRIPTION
## Summary\n\n- Record whether each analyzed CommonJS object-literal property value is pure.\n- Remove an unused property only when its value can be dropped safely, while preserving side-effectful initializers.\n- Add focused production coverage for pure and effectful properties.\n\n## Related links\n\n- Upstream behavior: https://github.com/webpack/webpack/commit/5b9ba026d\n\n## Checklist\n\n- [x] Tests updated (or not required).\n- [x] Documentation updated (or not required).