### PR TITLE
fix(javascript): preserve CommonJS exports used through this

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_self_reference_dependency.rs
@@ -168,18 +168,31 @@ impl DependencyTemplate for CommonJsSelfReferenceDependencyTemplate {
     let exports_argument = module.get_exports_argument();
     let module_argument = module.get_module_argument();
 
-    let base = if dep.base.is_exports() {
-      runtime_template.render_exports_argument(exports_argument)
+    let (base, original_base) = if dep.base.is_exports() {
+      (
+        runtime_template.render_exports_argument(exports_argument),
+        "exports",
+      )
     } else if dep.base.is_module_exports() {
-      format!(
-        "{}.exports",
-        runtime_template.render_module_argument(module_argument)
+      (
+        format!(
+          "{}.exports",
+          runtime_template.render_module_argument(module_argument)
+        ),
+        "module.exports",
       )
     } else if dep.base.is_this() {
-      runtime_template.render_this_exports()
+      (runtime_template.render_this_exports(), "this")
     } else {
       unreachable!();
     };
+
+    if let UsedName::Normal(used) = &used
+      && base == original_base
+      && used == &dep.names
+    {
+      return;
+    }
 
     source.replace(
       dep.range.start,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -6,8 +6,9 @@ use rspack_core::{
 };
 use rspack_util::SpanExt;
 use swc_experimental_ecma_ast::{
-  AssignExpr, CallExpr, Expr, ExprOrSpread, GetSpan, Ident, Lit, MemberExpr, Prop, PropName,
-  PropOrSpread, Span, ThisExpr, UnaryExpr, UnaryOp,
+  AssignExpr, AutoAccessor, CallExpr, ClassProp, Constructor, Expr, ExprOrSpread, Function,
+  GetSpan, GetterProp, Ident, Key, Lit, MemberExpr, PrivateProp, Prop, PropName, PropOrSpread,
+  SetterProp, Span, StaticBlock, ThisExpr, UnaryExpr, UnaryOp, Visit, VisitWith,
 };
 
 use super::JavascriptParserPlugin;
@@ -178,6 +179,115 @@ fn parse_require_call<'p: 'a, 'a>(
   None
 }
 
+#[derive(Default)]
+struct OwnThisVisitor {
+  this_span: Option<Span>,
+}
+
+impl OwnThisVisitor {
+  fn visit_computed_key(&mut self, key: &PropName) {
+    if let PropName::Computed(computed) = key {
+      computed.expr.visit_with(self);
+    }
+  }
+}
+
+impl<'a> Visit<'a> for OwnThisVisitor {
+  fn visit_this_expr(&mut self, node: &ThisExpr) {
+    self.this_span.get_or_insert(node.span);
+  }
+
+  // Nested non-arrow functions have their own `this` binding.
+  fn visit_function(&mut self, _node: &Function<'a>) {}
+
+  // Class field initializers, constructors, and static blocks do not use the
+  // surrounding function's `this`. Computed keys still evaluate outside the
+  // class element's own `this` scope and must be inspected.
+  fn visit_class_prop(&mut self, node: &ClassProp<'a>) {
+    self.visit_computed_key(&node.key);
+  }
+
+  fn visit_private_prop(&mut self, _node: &PrivateProp<'a>) {}
+
+  fn visit_constructor(&mut self, _node: &Constructor<'a>) {}
+
+  fn visit_static_block(&mut self, _node: &StaticBlock<'a>) {}
+
+  fn visit_auto_accessor(&mut self, node: &AutoAccessor<'a>) {
+    if let Key::Public(key) = &node.key {
+      self.visit_computed_key(key);
+    }
+  }
+
+  // Object accessors nested in the exported function also introduce their
+  // own `this`; only a computed property key belongs to the outer scope.
+  fn visit_getter_prop(&mut self, node: &GetterProp<'a>) {
+    self.visit_computed_key(&node.key);
+  }
+
+  fn visit_setter_prop(&mut self, node: &SetterProp<'a>) {
+    self.visit_computed_key(&node.key);
+  }
+}
+
+fn find_own_this_in_function(function: &Function) -> Option<Span> {
+  let mut visitor = OwnThisVisitor::default();
+  for param in &function.params {
+    param.visit_with(&mut visitor);
+  }
+  if let Some(body) = &function.body {
+    body.visit_with(&mut visitor);
+  }
+  visitor.this_span
+}
+
+fn get_this_access_in_exported_value(value: &Expr) -> Option<Span> {
+  let Expr::Fn(function) = value else {
+    return None;
+  };
+  find_own_this_in_function(&function.function)
+}
+
+fn get_this_access_in_exported_property(prop: &Prop) -> Option<Span> {
+  match prop {
+    Prop::KeyValue(prop) => get_this_access_in_exported_value(&prop.value),
+    Prop::Method(prop) => find_own_this_in_function(&prop.function),
+    Prop::Getter(prop) => {
+      let mut visitor = OwnThisVisitor::default();
+      if let Some(body) = &prop.body {
+        body.visit_with(&mut visitor);
+      }
+      visitor.this_span
+    }
+    Prop::Setter(prop) => {
+      let mut visitor = OwnThisVisitor::default();
+      prop.param.visit_with(&mut visitor);
+      if let Some(body) = &prop.body {
+        body.visit_with(&mut visitor);
+      }
+      visitor.this_span
+    }
+    Prop::Shorthand(_) | Prop::Assign(_) => None,
+  }
+}
+
+fn keep_all_exports_on_this_access(
+  parser: &mut JavascriptParser,
+  this_span: Option<Span>,
+  base: ExportsBase,
+) {
+  let Some(this_span) = this_span else {
+    return;
+  };
+  parser.add_dependency(BoxDependency::new(CommonJsSelfReferenceDependency::new(
+    this_span.into(),
+    base,
+    vec![],
+    vec![],
+    false,
+  )));
+}
+
 fn get_static_property_name(name: &PropName) -> Option<Atom> {
   let name = match name {
     PropName::Ident(ident) => Atom::from(&ident.sym),
@@ -342,6 +452,7 @@ fn handle_object_literal_export(
       kind,
       pure,
     )));
+    keep_all_exports_on_this_access(parser, get_this_access_in_exported_property(prop), base);
     parser.walk_property(prop);
   }
   Some(true)
@@ -412,6 +523,11 @@ fn handle_assign_export(
     base,
     remaining.to_owned(),
   )));
+  keep_all_exports_on_this_access(
+    parser,
+    get_this_access_in_exported_value(&assign_expr.right),
+    base,
+  );
   parser.walk_expression(&assign_expr.right);
   Some(true)
 }
@@ -552,6 +668,19 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsExportsParserPlugin {
         base,
         vec![property.into()],
       )));
+
+      if let Expr::Object(descriptor) = arg2 {
+        for prop in &descriptor.props {
+          let PropOrSpread::Prop(prop) = prop else {
+            continue;
+          };
+          let this_span = get_this_access_in_exported_property(prop);
+          if this_span.is_some() {
+            keep_all_exports_on_this_access(parser, this_span, base);
+            break;
+          }
+        }
+      }
 
       parser.walk_expression(arg2);
       return Some(true);

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal/index.js
@@ -24,3 +24,9 @@ it("should keep the full object when the namespace is used as a value", () => {
 		unused: "unused-value"
 	});
 });
+
+it("should keep sibling exports when an object method uses this", () => {
+	const m = require("./method-this");
+	expect(m.getValue()).toBe(10);
+	expect(m.usedExports).toBe(true);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal/method-this.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal/method-this.js
@@ -1,0 +1,8 @@
+module.exports = {
+	value: 10,
+	unused: "drop-me",
+	getValue() {
+		return this.value;
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/index.js
@@ -1,0 +1,5 @@
+it("should still tree-shake when this appears in static blocks and class fields", () => {
+	const m = require("./module-inner");
+	expect(m.a()).toBe(2);
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/module-inner.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/module-inner.js
@@ -1,0 +1,21 @@
+exports.a = function () {
+	const results = [];
+	class Inner {
+		static {
+			results.push(this);
+		}
+		[`computed${1}`] = 1;
+		field = this;
+		method() {
+			results.push(this);
+		}
+	}
+	new Inner().method();
+	return results.length;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/test.filter.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function-modern/test.filter.js
@@ -1,0 +1,10 @@
+"use strict";
+
+const [major, minor] = process.versions.node.split(".").map(Number);
+
+module.exports = function filter(config) {
+	return (
+		config.mode !== "development" &&
+		(major > 16 || (major === 16 && minor >= 11))
+	);
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/esm.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/esm.js
@@ -1,0 +1,4 @@
+import * as m from "./module-esm-used";
+
+// Calling a namespace method passes the exports object as `this`.
+export const result = m.sign("/esm");

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/index.js
@@ -1,0 +1,64 @@
+it("should keep all exports when an exported function uses this (#21178)", () => {
+	const signUtils = require("./module");
+	expect(signUtils.buildCanonicalString("/bucket")).toBe("resource:/bucket");
+	expect(signUtils.usedExports).toBe(true);
+});
+
+it("should keep all exports when a module.exports member function uses this", () => {
+	const m = require("./module-module-exports");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when a top-level this member function uses this", () => {
+	const m = require("./module-top-this");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when this is captured by a nested arrow function", () => {
+	const m = require("./module-arrow");
+	expect(m.a()).toBe("b");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when a defineProperty export descriptor uses this", () => {
+	const m = require("./module-define");
+	expect(m.a()).toBe("b");
+	expect(m.c).toBe("b");
+	m.d = "!";
+	expect(m.received).toBe("b!");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should detect this in generator, async, default-param and computed accesses", async () => {
+	const m = require("./module-misc");
+	expect(m.viaGenerator().next().value).toBe("h");
+	expect(await m.viaAsync()).toBe("h");
+	expect(m.viaDefaultParam()).toBe("h");
+	expect(m.viaComputed()).toBe("h");
+	expect(m.usedExports).toBe(true);
+});
+
+it("should keep all exports when the consumer is an ESM module", () => {
+	const { result } = require("./esm");
+	expect(result).toBe("resource:/esm");
+});
+
+it("should still tree-shake when this only appears in nested functions", () => {
+	const m = require("./module-inner");
+	expect(m.a()).toBe(2);
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});
+
+it("should still tree-shake when this is used in an exported class", () => {
+	const m = require("./module-class");
+	expect(new m.Impl().x).toBe("x");
+	expect(m.usedExports).toEqual(["Impl", "usedExports"]);
+});
+
+it("should still tree-shake when the exported values contain no this", () => {
+	const m = require("./module-no-this");
+	expect(m.a()).toBe("function");
+	expect(m.usedExports).toEqual(["a", "usedExports"]);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-arrow.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-arrow.js
@@ -1,0 +1,9 @@
+exports.a = function () {
+	return (() => this.b())();
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-class.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-class.js
@@ -1,0 +1,11 @@
+exports.Impl = class Impl {
+	constructor() {
+		this.x = "x";
+	}
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-define.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-define.js
@@ -1,0 +1,28 @@
+Object.defineProperty(exports, "a", {
+	value: function a() {
+		return this.b();
+	}
+});
+
+Object.defineProperty(exports, "b", {
+	value: function b() {
+		return "b";
+	}
+});
+
+Object.defineProperty(exports, "c", {
+	get() {
+		return this.b();
+	}
+});
+
+const enumerable = { enumerable: true };
+
+Object.defineProperty(exports, "d", {
+	...enumerable,
+	set(value) {
+		this.received = this.b() + value;
+	}
+});
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-esm-used.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-esm-used.js
@@ -1,0 +1,7 @@
+exports.build = function (resourcePath) {
+	return `resource:${resourcePath}`;
+};
+
+exports.sign = function (resourcePath) {
+	return this.build(resourcePath);
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-inner.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-inner.js
@@ -1,0 +1,20 @@
+exports.a = function () {
+	const results = [];
+	function inner() {
+		results.push(this);
+	}
+	class Inner {
+		method() {
+			results.push(this);
+		}
+	}
+	inner.call("inner");
+	new Inner().method();
+	return results.length;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-misc.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-misc.js
@@ -1,0 +1,21 @@
+exports.helper = function () {
+	return "h";
+};
+
+exports.viaGenerator = function* () {
+	yield this.helper();
+};
+
+exports.viaAsync = async function () {
+	return this.helper();
+};
+
+exports.viaDefaultParam = function (x = this.helper()) {
+	return x;
+};
+
+exports.viaComputed = function () {
+	return this["helper"]();
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-module-exports.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-module-exports.js
@@ -1,0 +1,9 @@
+module.exports.a = function () {
+	return this.b();
+};
+
+module.exports.b = function () {
+	return "b";
+};
+
+module.exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-no-this.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-no-this.js
@@ -1,0 +1,13 @@
+function helper() {
+	return this;
+}
+
+exports.a = function () {
+	return typeof helper;
+};
+
+exports.b = function () {
+	return "b";
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-top-this.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module-top-this.js
@@ -1,0 +1,9 @@
+this.a = function () {
+	return this.b();
+};
+
+this.b = function () {
+	return "b";
+};
+
+this.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/module.js
@@ -1,0 +1,9 @@
+exports.buildCanonicalizedResource = function (resourcePath) {
+	return `resource:${resourcePath}`;
+};
+
+exports.buildCanonicalString = function (resourcePath) {
+	return this.buildCanonicalizedResource(resourcePath);
+};
+
+exports.usedExports = __webpack_exports_info__.usedExports;

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/test.filter.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/this-in-exported-function/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function filter(config) {
+	return config.mode !== "development";
+};


### PR DESCRIPTION
## Summary\n\n- Detect own this usage in functions exported from CommonJS modules and conservatively mark the complete exports object as used.\n- Keep lexical this behavior through arrows while excluding unrelated nested function scopes.\n- Avoid rewriting unchanged CommonJS self references, which preserves detached-call semantics.\n- Port webpack coverage for function, object method, class, defineProperty, and nested-scope forms.\n\n## Related links\n\n- Upstream behavior: https://github.com/webpack/webpack/commit/c13cf1ea6\n\n## Checklist\n\n- [x] Tests updated (or not required).\n- [x] Documentation updated (or not required).