### PR TITLE
fix(javascript): disconnect requires in unused CommonJS methods

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -3,14 +3,15 @@ use rspack_cacheable::{
   with::{AsPreset, AsVec},
 };
 use rspack_core::{
-  AsContextDependency, Dependency, DependencyCategory, DependencyCodeGeneration, DependencyId,
-  DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
-  ExportsInfoArtifact, ExportsType, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
-  ReferencedExport, RuntimeGlobals, RuntimeSpec, TemplateContext, TemplateReplaceSource, UsedName,
-  create_exports_object_referenced, property_access, to_normal_comment,
+  AsContextDependency, ConnectionState, Dependency, DependencyCategory, DependencyCodeGeneration,
+  DependencyCondition, DependencyConditionFn, DependencyId, DependencyLocation, DependencyRange,
+  DependencyTemplate, DependencyTemplateType, DependencyType, ExportsInfoArtifact, ExportsType,
+  ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ReferencedExport,
+  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
+  UsedByExports, UsedName, create_exports_object_referenced, property_access, to_normal_comment,
 };
 
-use crate::Atom;
+use crate::{Atom, connection_active_used_by_exports};
 
 #[cacheable]
 #[derive(Debug)]
@@ -25,6 +26,7 @@ pub struct CommonJsFullRequireDependency {
   optional: bool,
   asi_safe: bool,
   loc: Option<DependencyLocation>,
+  used_by_exports: Option<UsedByExports>,
 }
 
 impl CommonJsFullRequireDependency {
@@ -50,7 +52,12 @@ impl CommonJsFullRequireDependency {
       optional,
       asi_safe,
       loc,
+      used_by_exports: None,
     }
+  }
+
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {
+    self.used_by_exports = used_by_exports;
   }
 }
 
@@ -133,6 +140,39 @@ impl ModuleDependency for CommonJsFullRequireDependency {
 
   fn get_optional(&self) -> bool {
     self.optional
+  }
+
+  fn get_condition(&self) -> Option<DependencyCondition> {
+    self
+      .used_by_exports
+      .is_some()
+      .then(|| DependencyCondition::new(CommonJsFullRequireDependencyCondition))
+  }
+}
+
+struct CommonJsFullRequireDependencyCondition;
+
+impl DependencyConditionFn for CommonJsFullRequireDependencyCondition {
+  fn get_connection_state(
+    &self,
+    connection: &ModuleGraphConnection,
+    runtime: Option<&RuntimeSpec>,
+    module_graph: &ModuleGraph,
+    _module_graph_cache: &ModuleGraphCacheArtifact,
+    _side_effects_state_artifact: &SideEffectsStateArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
+  ) -> ConnectionState {
+    let dependency = module_graph.dependency_by_id(&connection.dependency_id);
+    let dependency = dependency
+      .downcast_ref::<CommonJsFullRequireDependency>()
+      .expect("should be CommonJsFullRequireDependency");
+    ConnectionState::Active(connection_active_used_by_exports(
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+      dependency.used_by_exports.as_ref(),
+    ))
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_object_export_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_object_export_dependency.rs
@@ -25,6 +25,10 @@ pub enum CommonJsObjectExportKind {
 }
 
 impl CommonJsObjectExportKind {
+  pub fn can_drop_nested_requires(self) -> bool {
+    self.unused_prefix().is_some()
+  }
+
   fn unused_prefix(self) -> Option<&'static str> {
     match self {
       Self::Getter | Self::Setter | Self::Method => Some("...void (function "),

--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_require_dependency.rs
@@ -9,13 +9,16 @@ use rspack_core::{
   DependencyLocation, DependencyRange, DependencyTemplate, DependencyTemplateType, DependencyType,
   ExportsInfoArtifact, ModuleDependency, ModuleGraph, ModuleGraphCacheArtifact,
   ModuleGraphConnection, ReferencedExport, ReferencedSpecifier, ResourceIdentifier, RuntimeSpec,
-  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource,
+  SideEffectsStateArtifact, TemplateContext, TemplateReplaceSource, UsedByExports,
   create_exports_object_referenced, create_no_exports_referenced,
   create_referenced_exports_by_referenced_specifiers,
 };
 
 use super::create_resource_identifier_for_contextual_commonjs_dependency;
-use crate::dependency::{DependencyBranchGuard, compose_dependency_condition};
+use crate::{
+  connection_active_used_by_exports,
+  dependency::{DependencyBranchGuard, compose_dependency_condition},
+};
 
 #[cacheable]
 #[derive(Debug)]
@@ -31,6 +34,7 @@ pub struct CommonJsRequireDependency {
   evaluation_only: bool,
   #[cacheable(with=AsOption<AsCacheable>)]
   branch_guard: Option<DependencyBranchGuard>,
+  used_by_exports: Option<UsedByExports>,
   context: Option<Context>,
   resource_identifier: ResourceIdentifier,
 }
@@ -53,6 +57,7 @@ impl CommonJsRequireDependency {
       referenced_specifiers: None,
       evaluation_only: false,
       branch_guard: None,
+      used_by_exports: None,
       context: None,
       resource_identifier: Default::default(),
     }
@@ -98,6 +103,10 @@ impl CommonJsRequireDependency {
       Some(old_guard) => old_guard.and(guard),
       None => guard,
     });
+  }
+
+  pub fn set_used_by_exports(&mut self, used_by_exports: Option<UsedByExports>) {
+    self.used_by_exports = used_by_exports;
   }
 }
 
@@ -184,8 +193,7 @@ impl ModuleDependency for CommonJsRequireDependency {
   }
 
   fn get_condition(&self) -> Option<DependencyCondition> {
-    let condition = self
-      .evaluation_only
+    let condition = (self.evaluation_only || self.used_by_exports.is_some())
       .then(|| DependencyCondition::new(CommonJsRequireDependencyCondition));
     compose_dependency_condition(condition, self.branch_guard.as_ref())
   }
@@ -197,12 +205,29 @@ impl DependencyConditionFn for CommonJsRequireDependencyCondition {
   fn get_connection_state(
     &self,
     connection: &ModuleGraphConnection,
-    _runtime: Option<&RuntimeSpec>,
+    runtime: Option<&RuntimeSpec>,
     module_graph: &ModuleGraph,
     module_graph_cache: &ModuleGraphCacheArtifact,
     side_effects_state_artifact: &SideEffectsStateArtifact,
-    _exports_info_artifact: &ExportsInfoArtifact,
+    exports_info_artifact: &ExportsInfoArtifact,
   ) -> ConnectionState {
+    let dependency = module_graph.dependency_by_id(&connection.dependency_id);
+    let dependency = dependency
+      .downcast_ref::<CommonJsRequireDependency>()
+      .expect("should be CommonJsRequireDependency");
+    if !connection_active_used_by_exports(
+      connection,
+      runtime,
+      module_graph,
+      exports_info_artifact,
+      dependency.used_by_exports.as_ref(),
+    ) {
+      return ConnectionState::Active(false);
+    }
+    if !dependency.evaluation_only {
+      return ConnectionState::Active(true);
+    }
+
     let module_identifier = *connection.module_identifier();
     if let Some(state) =
       side_effects_state_artifact.module_evaluation_side_effects_state(&module_identifier)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use rspack_core::{
   BoxDependency, BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals,
-  RuntimeRequirementsDependency,
+  RuntimeRequirementsDependency, UsedByExports,
 };
 use rspack_util::SpanExt;
 use swc_experimental_ecma_ast::{
@@ -15,9 +15,9 @@ use super::JavascriptParserPlugin;
 use crate::{
   Atom,
   dependency::{
-    CommonJsExportRequireDependency, CommonJsExportsDependency, CommonJsObjectExportDependency,
-    CommonJsObjectExportKind, CommonJsSelfReferenceDependency, ExportsBase,
-    ModuleDecoratorDependency,
+    CommonJsExportRequireDependency, CommonJsExportsDependency, CommonJsFullRequireDependency,
+    CommonJsObjectExportDependency, CommonJsObjectExportKind, CommonJsRequireDependency,
+    CommonJsSelfReferenceDependency, ExportsBase, ModuleDecoratorDependency,
   },
   parser_plugin::{
     common_js_imports_parse_plugin::is_require_call_expr,
@@ -439,6 +439,9 @@ fn handle_object_literal_export(
         None,
       )
     });
+    let used_by_exports = kind
+      .can_drop_nested_requires()
+      .then(|| UsedByExports::set(std::iter::once(name.clone()).collect()));
 
     if name == "__esModule" {
       parser.check_namespace(true, get_object_export_value(prop));
@@ -453,7 +456,21 @@ fn handle_object_literal_export(
       pure,
     )));
     keep_all_exports_on_this_access(parser, get_this_access_in_exported_property(prop), base);
+    let start = parser.next_dependency_idx();
     parser.walk_property(prop);
+    if let Some(used_by_exports) = used_by_exports {
+      for idx in start..parser.next_dependency_idx() {
+        let Some(dependency) = parser.get_dependency_mut(idx) else {
+          continue;
+        };
+        if let Some(dependency) = dependency.downcast_mut::<CommonJsRequireDependency>() {
+          dependency.set_used_by_exports(Some(used_by_exports.clone()));
+        } else if let Some(dependency) = dependency.downcast_mut::<CommonJsFullRequireDependency>()
+        {
+          dependency.set_used_by_exports(Some(used_by_exports.clone()));
+        }
+      }
+    }
   }
   Some(true)
 }

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/heavy.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/heavy.js
@@ -1,0 +1,1 @@
+module.exports = "heavy";

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/index.js
@@ -1,0 +1,7 @@
+it("should keep a module still reached by an active require edge", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.usedExports).toEqual(["used", "usedExports"]);
+	expect(require("./heavy")).toBe("heavy");
+	expect(require.resolveWeak("./heavy")).not.toBe(null);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/lib.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/lib.js
@@ -1,0 +1,7 @@
+module.exports = {
+	used: "used",
+	unusedMethod() {
+		return require("./heavy");
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/test.filter.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require-kept/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function filter(config) {
+	return config.mode !== "development";
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/heavy.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/heavy.js
@@ -1,0 +1,1 @@
+module.exports = "heavy";

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/index.js
@@ -1,0 +1,6 @@
+it("should drop unused methods/getters that contain require without breaking codegen", () => {
+	const m = require("./lib");
+	expect(m.used).toBe("used");
+	expect(m.usedExports).toEqual(["used", "usedExports"]);
+	expect(require.resolveWeak("./heavy")).toBe(null);
+});

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/lib.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/lib.js
@@ -1,0 +1,16 @@
+module.exports = {
+	used: "used",
+	unusedMethod() {
+		return require("./heavy");
+	},
+	unusedFullRequire() {
+		return require("./heavy").toUpperCase();
+	},
+	get unusedGetter() {
+		return require("./heavy");
+	},
+	set unusedSetter(_value) {
+		require("./heavy");
+	},
+	usedExports: __webpack_exports_info__.usedExports
+};

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/test.filter.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/object-literal-nested-require/test.filter.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function filter(config) {
+	return config.mode !== "development";
+};


### PR DESCRIPTION
## Summary\n\n- Associate require dependencies inside analyzed CommonJS object-literal properties with the export that owns them.\n- Disconnect both bare and full member requires when that export is unused.\n- Preserve active connections for requires inside properties that remain used.\n- Port the corresponding webpack nested-require cases.\n\n## Related links\n\n- Upstream behavior: https://github.com/webpack/webpack/commit/ceead5d45\n\n## Checklist\n\n- [x] Tests updated (or not required).\n- [x] Documentation updated (or not required).