### PR TITLE
fix(javascript): preserve CommonJS require call context

### DIFF
--- a/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
+++ b/crates/rspack_plugin_javascript/src/dependency/commonjs/common_js_full_require_dependency.rs
@@ -90,7 +90,7 @@ impl Dependency for CommonJsFullRequireDependency {
     exports_info_artifact: &ExportsInfoArtifact,
     _runtime: Option<&RuntimeSpec>,
   ) -> Vec<ReferencedExport> {
-    let mut namespace_object_as_context = self.namespace_object_as_context;
+    let namespace_object_as_context = self.namespace_object_as_context;
 
     let module = module_graph
       .get_module_by_dependency_id(&self.id)
@@ -102,17 +102,12 @@ impl Dependency for CommonJsFullRequireDependency {
       false,
     );
 
-    // Force enable namespace object as context for json module, it's a common case:
-    // import json from "./array.json"; json.map(d => d * 2);
-    if matches!(
-      exports_type,
-      ExportsType::DefaultOnly | ExportsType::DefaultWithNamed
-    ) && module.build_info().json_data.is_some()
+    // CommonJS exports are real objects, so a member call can observe the whole
+    // object through `this`. ESM namespace objects only need this bailout when
+    // strictThisContextOnImports is enabled.
+    if self.is_call
+      && (namespace_object_as_context || !matches!(exports_type, ExportsType::Namespace))
     {
-      namespace_object_as_context = true;
-    }
-
-    if namespace_object_as_context && self.is_call {
       if self.names.is_empty() {
         return create_exports_object_referenced();
       }

--- a/tests/rspack-test/configCases/strict-this-context/statical-require-this/index.js
+++ b/tests/rspack-test/configCases/strict-this-context/statical-require-this/index.js
@@ -10,7 +10,7 @@ it("should respect strictThisContextOnImports for member call", () => {
 
 it("should always correctly handle this for exportsType is DefaultWithNamed and DefaultOnly", () => {
 	const cjs = require("./cjs");
-	expect(cjs.that().value).toBe(STRICT_THIS_CONTEXT_ON_IMPORTS ? 42 : undefined);
+	expect(cjs.that().value).toBe(42);
 	const json = require("./data.json");
 	expect(json.map(d => d * 2)).toEqual([2, 4, 6]);
 })

--- a/tests/rspack-test/normalCases/cjs-tree-shaking/bailouts/index.js
+++ b/tests/rspack-test/normalCases/cjs-tree-shaking/bailouts/index.js
@@ -28,10 +28,9 @@ it("should not mangle or remove nested properties", () => {
 });
 
 it("should be able to access the exports via call context", () => {
-	// We have different design about strictThisContextOnImports, this should covered by tests/rspack-test/configCases/parsing/statical-require-this
-	// expect(require("./accessing-call-context?1").func().abc).toBe("abc");
-	// var cc = require("./accessing-call-context?2");
-	// expect(cc.func().abc).toBe("abc");
+	expect(require("./accessing-call-context?1").func().abc).toBe("abc");
+	var cc = require("./accessing-call-context?2");
+	expect(cc.func().abc).toBe("abc");
 	var func = require("./accessing-call-context?3").func;
 	expect(func()).toBe(undefined);
 });


### PR DESCRIPTION
## Summary\n\n- Preserve the CommonJS exports object as the receiver of require member calls.\n- Match webpack by treating non-namespace exports as call context regardless of strictThisContextOnImports, while retaining the option for ESM namespace objects.\n- Restore the direct and aliased require call-context assertions and keep detached calls unchanged.\n\n## Related links\n\n- Webpack implementation: https://github.com/webpack/webpack/blob/v5.110.3/lib/dependencies/CommonJsFullRequireDependency.js\n\n## Checklist\n\n- [x] Tests updated (or not required).\n- [x] Documentation updated (or not required).