### PR TITLE
fix: keep compilation artifacts available in finishModules

### DIFF
--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -14,8 +14,8 @@ use entries::JsEntries;
 use napi_derive::napi;
 use rspack_collections::IdentifierSet;
 use rspack_core::{
-  BindingCell, Compilation, CompilationId, DependencyRef, EntryOptions, ExportsInfoArtifact,
-  ModuleIdentifier, OptimizationBailoutItem, Reflector, rspack_sources::BoxSource,
+  BindingCell, Compilation, CompilationId, DependencyRef, EntryOptions, ModuleIdentifier,
+  OptimizationBailoutItem, Reflector, rspack_sources::BoxSource,
 };
 use rspack_error::{Diagnostic, Severity, ToStringResultToRspackResultExt};
 use rspack_napi::napi::bindgen_prelude::*;
@@ -87,23 +87,6 @@ impl JsCompilation {
     // SAFETY: The memory address of rspack_core::Compilation will not change,
     // so as long as the Compiler is not dropped, we can safely return a 'static reference.
     Ok(unsafe { self.inner.as_mut() })
-  }
-
-  pub(crate) fn exports_info_artifact_mut(
-    &mut self,
-  ) -> napi::Result<&'static mut ExportsInfoArtifact> {
-    let compilation = self.as_mut()?;
-    if let Some(ptr) = compilation.compiler_context.exports_info_artifact_ptr() {
-      // SAFETY: pointer is injected by binding hook phases and valid in current scope.
-      return Ok(unsafe { &mut *(ptr as *mut ExportsInfoArtifact) });
-    }
-    if let Some(exports_info_artifact) = compilation.exports_info_artifact.try_write() {
-      return Ok(exports_info_artifact);
-    }
-    Err(napi::Error::new(
-      napi::Status::GenericFailure,
-      "Cannot mutate exports info artifact after it was stolen from compilation.".to_string(),
-    ))
   }
 }
 
@@ -651,9 +634,6 @@ impl JsCompilation {
     let compilation = self
       .as_mut()
       .map_err(|err| napi::Error::new(err.status.into(), err.reason))?;
-    let exports_info_artifact = self
-      .exports_info_artifact_mut()
-      .map_err(|err| napi::Error::new(err.status.into(), err.reason))?;
     let compiler_context = compilation.compiler_context.clone();
     callbackify(
       f,
@@ -666,7 +646,6 @@ impl JsCompilation {
               .into_iter()
               .map(ModuleIdentifier::from)
               .collect::<IdentifierSet>(),
-            exports_info_artifact,
             |modules| {
               modules
                 .into_iter()

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -438,10 +438,11 @@ impl JsCompiler {
     f: Function<'static>,
   ) -> Result<(), ErrorCode> {
     unsafe {
-      self.run(reference, |compiler, guard| {
+      self.run(reference, |compiler, state_guard, reference| {
         callbackify(
           f,
           async move {
+            let _state_guard = state_guard;
             let result = compiler.build().await.to_napi_result_with_message(|e| {
               print_error_diagnostic(e, compiler.options.stats.colors)
             });
@@ -450,7 +451,7 @@ impl JsCompiler {
             Ok(())
           },
           Some(move || {
-            drop(guard);
+            drop(reference);
           }),
         )
       })
@@ -469,10 +470,11 @@ impl JsCompiler {
     f: Function<'static>,
   ) -> Result<(), ErrorCode> {
     unsafe {
-      self.run(reference, |compiler, guard| {
+      self.run(reference, |compiler, state_guard, reference| {
         callbackify(
           f,
           async move {
+            let _state_guard = state_guard;
             let result = compiler
               .rebuild(
                 changed_files.into_iter().collect::<FxHashSet<_>>(),
@@ -487,7 +489,7 @@ impl JsCompiler {
             Ok(())
           },
           Some(move || {
-            drop(guard);
+            drop(reference);
           }),
         )
       })
@@ -548,11 +550,6 @@ impl JsCompiler {
   }
 }
 
-struct RunGuard {
-  _compiler_state_guard: CompilerStateGuard,
-  _reference: Reference<JsCompiler>,
-}
-
 impl JsCompiler {
   /// Run the given function with the compiler.
   ///
@@ -563,7 +560,11 @@ impl JsCompiler {
   unsafe fn run<R>(
     &mut self,
     mut reference: Reference<JsCompiler>,
-    f: impl FnOnce(&'static mut Compiler, RunGuard) -> Result<R, ErrorCode>,
+    f: impl FnOnce(
+      &'static mut Compiler,
+      CompilerStateGuard,
+      Reference<JsCompiler>,
+    ) -> Result<R, ErrorCode>,
   ) -> Result<R, ErrorCode> {
     if self.state.running() {
       return Err(concurrent_compiler_error());
@@ -584,13 +585,13 @@ impl JsCompiler {
       references.insert(compiler.id(), weak_reference);
     });
 
-    let guard = RunGuard {
-      _compiler_state_guard: compiler_state_guard,
-      _reference: reference,
-    };
-
     self.cleanup_last_compilation(&compiler.compilation);
-    within_compiler_context_sync(self.compiler_context.clone(), || f(compiler, guard))
+    // Release the running state when native work finishes, including errors.
+    // N-API skips callbackify's argument conversion/finalizer on its error path,
+    // so that finalizer must only retain the JS reference, not the running state.
+    within_compiler_context_sync(self.compiler_context.clone(), || {
+      f(compiler, compiler_state_guard, reference)
+    })
   }
 
   fn cleanup_last_compilation(&self, compilation: &Compilation) {

--- a/crates/rspack_binding_api/src/module_graph_connection.rs
+++ b/crates/rspack_binding_api/src/module_graph_connection.rs
@@ -143,15 +143,7 @@ impl ModuleGraphConnection {
   ) -> napi::Result<JsConnectionState> {
     self.with_ref(|compilation, module_graph| {
       if let Some(connection) = module_graph.connection_by_dependency_id(&self.dependency_id) {
-        // When exports_info_artifact is stolen (e.g. during finishModules hook),
-        // we cannot evaluate conditional connections properly, so we need the
-        // real artifact to get accurate results.
-        let Some(exports_info_artifact) = compilation.exports_info_artifact.try_read() else {
-          // Fallback: without exports info, non-conditional connections return
-          // their raw active state; conditional ones are treated as active since
-          // the optimization phase hasn't run yet.
-          return Ok(JsConnectionState::Bool(true));
-        };
+        let exports_info_artifact = &compilation.exports_info_artifact;
         let runtime_spec = runtime.map(|r| {
           let mut set = ustr::UstrSet::default();
           match r {

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -1,5 +1,4 @@
 use std::{
-  ffi::c_void,
   hash::Hash,
   marker::PhantomData,
   ptr::NonNull,
@@ -14,35 +13,35 @@ use napi::{
 };
 use rspack_collections::{Identifier, IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AfterResolveResult, AssetEmittedInfo, AsyncModulesArtifact, BeforeResolveResult, BindingCell,
-  BoxModule, ChunkGraph, ChunkUkey, CircularModulesInfo, Compilation,
-  CompilationAdditionalTreeRuntimeRequirements, CompilationAdditionalTreeRuntimeRequirementsHook,
-  CompilationAfterOptimizeModules, CompilationAfterOptimizeModulesHook,
-  CompilationAfterProcessAssets, CompilationAfterProcessAssetsHook, CompilationAfterSeal,
-  CompilationAfterSealHook, CompilationBeforeModuleIds, CompilationBeforeModuleIdsHook,
-  CompilationBuildModule, CompilationBuildModuleHook, CompilationChunkAsset,
-  CompilationChunkAssetHook, CompilationChunkHash, CompilationChunkHashHook,
-  CompilationExecuteModule, CompilationExecuteModuleHook, CompilationFinishModules,
-  CompilationFinishModulesHook, CompilationId, CompilationOptimizeChunkModules,
-  CompilationOptimizeChunkModulesHook, CompilationOptimizeModules, CompilationOptimizeModulesHook,
-  CompilationOptimizeTree, CompilationOptimizeTreeHook, CompilationParams,
-  CompilationProcessAssets, CompilationProcessAssetsHook, CompilationRuntimeModule,
-  CompilationRuntimeModuleHook, CompilationRuntimeRequirementInTree,
-  CompilationRuntimeRequirementInTreeHook, CompilationSeal, CompilationSealHook,
-  CompilationStillValidModule, CompilationStillValidModuleHook, CompilationSucceedModule,
-  CompilationSucceedModuleHook, CompilerAfterCompile, CompilerAfterCompileHook, CompilerAfterEmit,
-  CompilerAfterEmitHook, CompilerAssetEmitted, CompilerAssetEmittedHook, CompilerCompilation,
-  CompilerCompilationHook, CompilerEmit, CompilerEmitHook, CompilerFinishMake,
-  CompilerFinishMakeHook, CompilerId, CompilerMake, CompilerMakeHook, CompilerShouldEmit,
-  CompilerShouldEmitHook, CompilerThisCompilation, CompilerThisCompilationHook,
-  ContextModuleFactoryAfterResolve, ContextModuleFactoryAfterResolveHook,
-  ContextModuleFactoryBeforeResolve, ContextModuleFactoryBeforeResolveHook, ExecuteModuleId,
-  ExternalModuleChunkCondition, ExternalModuleChunkConditionHook, Module, ModuleFactoryCreateData,
-  ModuleId, ModuleIdentifier, ModuleIdsArtifact, NormalModuleCreateData,
-  NormalModuleFactoryAfterResolve, NormalModuleFactoryAfterResolveHook,
-  NormalModuleFactoryBeforeResolve, NormalModuleFactoryBeforeResolveHook,
-  NormalModuleFactoryCreateModule, NormalModuleFactoryCreateModuleHook,
-  NormalModuleFactoryFactorize, NormalModuleFactoryFactorizeHook, NormalModuleFactoryResolve,
+  AfterResolveResult, AssetEmittedInfo, BeforeResolveResult, BindingCell, BoxModule, ChunkGraph,
+  ChunkUkey, CircularModulesInfo, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilationAdditionalTreeRuntimeRequirementsHook, CompilationAfterOptimizeModules,
+  CompilationAfterOptimizeModulesHook, CompilationAfterProcessAssets,
+  CompilationAfterProcessAssetsHook, CompilationAfterSeal, CompilationAfterSealHook,
+  CompilationBeforeModuleIds, CompilationBeforeModuleIdsHook, CompilationBuildModule,
+  CompilationBuildModuleHook, CompilationChunkAsset, CompilationChunkAssetHook,
+  CompilationChunkHash, CompilationChunkHashHook, CompilationExecuteModule,
+  CompilationExecuteModuleHook, CompilationFinishModules, CompilationFinishModulesHook,
+  CompilationId, CompilationOptimizeChunkModules, CompilationOptimizeChunkModulesHook,
+  CompilationOptimizeModules, CompilationOptimizeModulesHook, CompilationOptimizeTree,
+  CompilationOptimizeTreeHook, CompilationParams, CompilationProcessAssets,
+  CompilationProcessAssetsHook, CompilationRuntimeModule, CompilationRuntimeModuleHook,
+  CompilationRuntimeRequirementInTree, CompilationRuntimeRequirementInTreeHook, CompilationSeal,
+  CompilationSealHook, CompilationStillValidModule, CompilationStillValidModuleHook,
+  CompilationSucceedModule, CompilationSucceedModuleHook, CompilerAfterCompile,
+  CompilerAfterCompileHook, CompilerAfterEmit, CompilerAfterEmitHook, CompilerAssetEmitted,
+  CompilerAssetEmittedHook, CompilerCompilation, CompilerCompilationHook, CompilerEmit,
+  CompilerEmitHook, CompilerFinishMake, CompilerFinishMakeHook, CompilerId, CompilerMake,
+  CompilerMakeHook, CompilerShouldEmit, CompilerShouldEmitHook, CompilerThisCompilation,
+  CompilerThisCompilationHook, ContextModuleFactoryAfterResolve,
+  ContextModuleFactoryAfterResolveHook, ContextModuleFactoryBeforeResolve,
+  ContextModuleFactoryBeforeResolveHook, ExecuteModuleId, ExternalModuleChunkCondition,
+  ExternalModuleChunkConditionHook, Module, ModuleFactoryCreateData, ModuleId, ModuleIdentifier,
+  ModuleIdsArtifact, NormalModuleCreateData, NormalModuleFactoryAfterResolve,
+  NormalModuleFactoryAfterResolveHook, NormalModuleFactoryBeforeResolve,
+  NormalModuleFactoryBeforeResolveHook, NormalModuleFactoryCreateModule,
+  NormalModuleFactoryCreateModuleHook, NormalModuleFactoryFactorize,
+  NormalModuleFactoryFactorizeHook, NormalModuleFactoryResolve,
   NormalModuleFactoryResolveForScheme, NormalModuleFactoryResolveForSchemeHook,
   NormalModuleFactoryResolveHook, NormalModuleFactoryResolveResult, ResourceData, RuntimeGlobals,
   RuntimeModule, RuntimeModuleGenerateContext, Scheme,
@@ -1359,31 +1358,13 @@ impl CompilationExecuteModule for CompilationExecuteModuleTap {
 
 #[async_trait]
 impl CompilationFinishModules for CompilationFinishModulesTap {
-  async fn run(
-    &self,
-    compilation: &Compilation,
-    _async_modules_artifact: &mut AsyncModulesArtifact,
-    exports_info_artifact: &mut rspack_core::ExportsInfoArtifact,
-    _side_effects_state_artifact: &mut rspack_core::SideEffectsStateArtifact,
-  ) -> rspack_error::Result<()> {
+  async fn run(&self, compilation: &mut Compilation) -> rspack_error::Result<()> {
     let compiler_context = compilation.compiler_context.clone();
-    let previous_ptr_addr = compiler_context
-      .exports_info_artifact_ptr()
-      .map_or(0usize, |ptr| ptr as usize);
-    compiler_context
-      .set_exports_info_artifact_ptr(Some(exports_info_artifact as *mut _ as *mut c_void));
-    let result = within_compiler_context(compiler_context.clone(), async {
+    within_compiler_context(compiler_context, async {
       let compilation = JsCompilationWrapper::new(compilation);
       self.function.call_with_promise(compilation).await
     })
-    .await;
-    let previous_ptr = if previous_ptr_addr == 0 {
-      None
-    } else {
-      Some(previous_ptr_addr as *mut c_void)
-    };
-    compiler_context.set_exports_info_artifact_ptr(previous_ptr);
-    result
+    .await
   }
 
   fn stage(&self) -> i32 {

--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -136,17 +136,6 @@ impl BuildModuleGraphArtifact {
     Some(factorize_info.related_dep_ids().to_vec())
   }
 
-  pub fn steal_side_effects_state_artifact(&mut self) -> SideEffectsStateArtifact {
-    std::mem::take(&mut self.side_effects_state_artifact)
-  }
-
-  pub fn set_side_effects_state_artifact(
-    &mut self,
-    side_effects_state_artifact: SideEffectsStateArtifact,
-  ) {
-    self.side_effects_state_artifact = side_effects_state_artifact;
-  }
-
   /// revoke a module and return multiple parent ModuleIdentifier and DependencyId pair that can generate it.
   ///
   /// This function will update index on MakeArtifact.

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -33,45 +33,8 @@ impl PassExt for FinishModulesPhasePass {
   }
 }
 
+#[tracing::instrument("Compilation:finish_modules", skip_all)]
 pub async fn finish_modules_pass(compilation: &mut Compilation) -> Result<()> {
-  let mut dependencies_diagnostics_artifact = compilation.dependencies_diagnostics_artifact.steal();
-  let mut async_modules_artifact = compilation.async_modules_artifact.steal();
-  let mut exports_info_artifact = compilation.exports_info_artifact.steal();
-  let mut side_effects_state_artifact = compilation
-    .build_module_graph_artifact
-    .steal_side_effects_state_artifact();
-  let diagnostics = finish_modules_inner(
-    compilation,
-    &mut side_effects_state_artifact,
-    &mut dependencies_diagnostics_artifact,
-    &mut async_modules_artifact,
-    &mut exports_info_artifact,
-  )
-  .await;
-  compilation.dependencies_diagnostics_artifact = dependencies_diagnostics_artifact.into();
-  compilation.async_modules_artifact = async_modules_artifact.into();
-  compilation.exports_info_artifact = exports_info_artifact.into();
-  let diagnostics = diagnostics?;
-  apply_side_effects_state_artifact(
-    compilation.get_module_graph_mut(),
-    &side_effects_state_artifact,
-  );
-  compilation
-    .build_module_graph_artifact
-    .set_side_effects_state_artifact(side_effects_state_artifact);
-  compilation.extend_diagnostics(diagnostics);
-
-  Ok(())
-}
-
-#[tracing::instrument("Compilation:finish_modules_inner", skip_all)]
-pub async fn finish_modules_inner(
-  compilation: &Compilation,
-  side_effects_state_artifact: &mut SideEffectsStateArtifact,
-  dependencies_diagnostics_artifact: &mut DependenciesDiagnosticsArtifact,
-  async_modules_artifact: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-) -> Result<Vec<Diagnostic>> {
   if let Some(mut mutations) = compilation.incremental.mutations_write() {
     let build_module_graph_artifact = &compilation.build_module_graph_artifact;
     mutations.extend(
@@ -109,17 +72,14 @@ pub async fn finish_modules_inner(
   // frozen and start to optimize (provided exports, infer async, etc.) based on the
   // module graph, so any kind of change that affect these should be done before the
   // finish_modules
+  // Keep artifacts in Compilation across hook calls. JavaScript taps can access
+  // ModuleGraph and ExportsInfo, including while an asynchronous tap is pending.
   compilation
     .plugin_driver
     .clone()
     .compilation_hooks
     .finish_modules
-    .call(
-      compilation,
-      async_modules_artifact,
-      exports_info_artifact,
-      side_effects_state_artifact,
-    )
+    .call(compilation)
     .await?;
 
   // https://github.com/webpack/webpack/blob/19ca74127f7668aaf60d59f4af8fcaee7924541a/lib/Compilation.js#L2988
@@ -127,26 +87,28 @@ pub async fn finish_modules_inner(
   // Collect dependencies diagnostics at here to make sure:
   // 1. after finish_modules: has provide exports info
   // 2. before optimize dependencies: side effects free module hasn't been skipped
-  let mut all_diagnostics = collect_dependencies_diagnostics(
-    compilation,
-    dependencies_diagnostics_artifact,
-    exports_info_artifact,
-  );
+  let mut all_diagnostics = collect_dependencies_diagnostics(compilation);
   compilation.module_graph_cache_artifact.unfreeze();
 
   // take make diagnostics
   let diagnostics = compilation.build_module_graph_artifact.diagnostics();
   all_diagnostics.extend(diagnostics);
-  Ok(all_diagnostics)
+
+  let build_module_graph_artifact = &mut *compilation.build_module_graph_artifact;
+  apply_side_effects_state_artifact(
+    &mut build_module_graph_artifact.module_graph,
+    &build_module_graph_artifact.side_effects_state_artifact,
+  );
+  compilation.extend_diagnostics(all_diagnostics);
+  Ok(())
 }
 
 #[tracing::instrument("Compilation:collect_dependencies_diagnostics", skip_all)]
-fn collect_dependencies_diagnostics(
-  compilation: &Compilation,
-  dependencies_diagnostics_artifact: &mut DependenciesDiagnosticsArtifact,
-  exports_info_artifact: &ExportsInfoArtifact,
-) -> Vec<Diagnostic> {
+fn collect_dependencies_diagnostics(compilation: &mut Compilation) -> Vec<Diagnostic> {
+  let logger = compilation.get_logger("rspack.incremental.finishModules");
   let build_module_graph_artifact = &compilation.build_module_graph_artifact;
+  let dependencies_diagnostics_artifact = &mut *compilation.dependencies_diagnostics_artifact;
+  let exports_info_artifact = &compilation.exports_info_artifact;
   // Compute modules while holding the lock, then release it
   let (modules, has_mutations) = {
     let mutations = compilation
@@ -165,7 +127,6 @@ fn collect_dependencies_diagnostics(
         }
         let modules = mutations
           .get_affected_modules_with_module_graph(build_module_graph_artifact.get_module_graph());
-        let logger = compilation.get_logger("rspack.incremental.finishModules");
         logger.log(format!(
           "{} modules are affected, {} in total",
           modules.len(),

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -84,8 +84,8 @@ use crate::{
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleIdsArtifact, ModuleStaticCache, PathData,
   ProcessRuntimeRequirementsCacheArtifact, ReferencedExport, ResolverFactory, RuntimeGlobals,
   RuntimeKeyMap, RuntimeMode, RuntimeModule, RuntimeProxyMetadataArtifact, RuntimeSpec,
-  RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact,
-  SideEffectsStateArtifact, SourceType, Stats, StatsContext, StealCell, ValueCacheVersions,
+  RuntimeSpecMap, RuntimeTemplate, SharedPluginDriver, SideEffectsOptimizeArtifact, SourceType,
+  Stats, StatsContext, StealCell, ValueCacheVersions,
   cache::SnapshotOptions,
   compilation::build_module_graph::{
     BuildModuleGraphArtifact, ModuleExecutor, UpdateParam, module_build_cache::ModuleBuildCache,
@@ -109,7 +109,7 @@ define_hook!(CompilationStillValidModule: Series(compiler_id: CompilerId, compil
 define_hook!(CompilationSucceedModule: Series(compiler_id: CompilerId, compilation_id: CompilationId, module: &mut BoxModule),tracing=false);
 define_hook!(CompilationExecuteModule:
   Series(module: &ModuleIdentifier, runtime_modules: &[Identifier], code_generation_results: &BindingCell<CodeGenerationResults>, execute_module_id: &ExecuteModuleId));
-define_hook!(CompilationFinishModules: Series(compilation: &Compilation, async_modules_artifact: &mut AsyncModulesArtifact, exports_info_artifact: &mut ExportsInfoArtifact, side_effects_state_artifact: &mut SideEffectsStateArtifact));
+define_hook!(CompilationFinishModules: Series(compilation: &mut Compilation));
 define_hook!(CompilationSeal: Series(compilation: &Compilation, diagnostics: &mut Vec<Diagnostic>));
 define_hook!(CompilationDependencyReferencedExports: Sync(
   compilation: &Compilation,
@@ -1093,10 +1093,10 @@ impl Compilation {
   pub async fn rebuild_module<T>(
     &mut self,
     module_identifiers: IdentifierSet,
-    exports_info_artifact: &mut ExportsInfoArtifact,
     f: impl Fn(Vec<&BoxModule>) -> T,
   ) -> Result<T> {
     let artifact = self.build_module_graph_artifact.steal();
+    let exports_info_artifact = std::mem::take(&mut *self.exports_info_artifact);
 
     // https://github.com/webpack/webpack/blob/19ca74127f7668aaf60d59f4af8fcaee7924541a/lib/Compilation.js#L2462C21-L2462C25
     self.module_graph_cache_artifact.unfreeze();
@@ -1104,11 +1104,11 @@ impl Compilation {
     let (artifact, updated_exports_info_artifact) = update_module_graph(
       self,
       artifact,
-      std::mem::take(exports_info_artifact),
+      exports_info_artifact,
       vec![UpdateParam::ForceBuildModules(module_identifiers.clone())],
     )
     .await?;
-    *exports_info_artifact = updated_exports_info_artifact;
+    self.exports_info_artifact = updated_exports_info_artifact.into();
     self.build_module_graph_artifact = artifact.into();
 
     let module_graph = self.get_module_graph();

--- a/crates/rspack_core/src/compilation/pass.rs
+++ b/crates/rspack_core/src/compilation/pass.rs
@@ -16,7 +16,10 @@ pub trait PassExt: Send + Sync {
   /// The name of this pass, used for logging and profiling.
   fn name(&self) -> &'static str;
 
-  /// Core pass logic.
+  /// Core pass logic. Keep hook-visible artifacts in Compilation when invoking
+  /// plugins: JavaScript hooks may re-enter Compilation throughout an awaited tap.
+  /// Borrow individual fields locally inside algorithms instead of moving them
+  /// out across a hook call.
   async fn run_pass(&self, compilation: &mut Compilation) -> Result<()>;
 
   /// Override this instead of run_pass if you need cache access mid-pass.

--- a/crates/rspack_plugin_esm_library/src/plugin.rs
+++ b/crates/rspack_plugin_esm_library/src/plugin.rs
@@ -9,18 +9,18 @@ use rspack_collections::{
   Identifiable, Identifier, IdentifierIndexMap, IdentifierMap, IdentifierSet,
 };
 use rspack_core::{
-  ApplyContext, AssetInfo, AsyncModulesArtifact, BoxModule, BuildModuleGraphArtifact, ChunkUkey,
-  Compilation, CompilationAdditionalChunkRuntimeRequirements,
-  CompilationAdditionalModuleRuntimeRequirements, CompilationAdditionalTreeRuntimeRequirements,
-  CompilationAfterCodeGeneration, CompilationConcatenationScope, CompilationFinishModules,
-  CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeDependencies,
-  CompilationParams, CompilationProcessAssets, CompilationRuntimeRequirementInTree,
-  CompilerCompilation, ConcatenatedModuleInfo, ConcatenationScope, DependencyType,
-  ExportsInfoArtifact, ExternalModuleInfo, GetTargetResult, JavascriptParserUrl, Logger,
-  ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType,
-  NormalModuleFactoryAfterFactorize, NormalModuleFactoryParser, ParserAndGenerator, ParserOptions,
-  Plugin, REQUIRE_SCOPE_GLOBALS, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule,
-  SideEffectsOptimizeArtifact, SideEffectsStateArtifact, get_target, is_esm_dep_like,
+  ApplyContext, AssetInfo, BoxModule, BuildModuleGraphArtifact, ChunkUkey, Compilation,
+  CompilationAdditionalChunkRuntimeRequirements, CompilationAdditionalModuleRuntimeRequirements,
+  CompilationAdditionalTreeRuntimeRequirements, CompilationAfterCodeGeneration,
+  CompilationConcatenationScope, CompilationFinishModules, CompilationOptimizeChunkModules,
+  CompilationOptimizeChunks, CompilationOptimizeDependencies, CompilationParams,
+  CompilationProcessAssets, CompilationRuntimeRequirementInTree, CompilerCompilation,
+  ConcatenatedModuleInfo, ConcatenationScope, DependencyType, ExportsInfoArtifact,
+  ExternalModuleInfo, GetTargetResult, JavascriptParserUrl, Logger, ModuleFactoryCreateData,
+  ModuleGraph, ModuleIdentifier, ModuleInfo, ModuleType, NormalModuleFactoryAfterFactorize,
+  NormalModuleFactoryParser, ParserAndGenerator, ParserOptions, Plugin, REQUIRE_SCOPE_GLOBALS,
+  RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, SideEffectsOptimizeArtifact, get_target,
+  is_esm_dep_like,
   rspack_sources::{ReplaceSource, Source},
 };
 use rspack_error::{Diagnostic, Result};
@@ -309,13 +309,7 @@ async fn render_chunk_content(
 }
 
 #[plugin_hook(CompilationFinishModules for EsmLibraryPlugin, stage = 100)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  _async_modules_artifact: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   let module_graph = compilation.get_module_graph();
   // mark all entry exports as used
   let mut entry_modules = IdentifierSet::default();
@@ -329,7 +323,8 @@ async fn finish_modules(
   }
 
   for m in entry_modules {
-    exports_info_artifact
+    compilation
+      .exports_info_artifact
       .get_exports_info_data_mut(&m)
       .set_used_in_unknown_way(None);
   }

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_exports_plugin.rs
@@ -1,11 +1,11 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, BuildMetaExportsType, Compilation, CompilationFinishModules, DependencyId,
+  BuildMetaExportsType, Compilation, CompilationFinishModules, DependencyId,
   EvaluatedInlinableValue, ExportInfo, ExportInfoData, ExportNameOrSpec, ExportProvided,
   ExportsInfo, ExportsInfoArtifact, ExportsInfoData, ExportsOfExportsSpec, ExportsSpec,
   GetTargetResult, Logger, ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection,
-  ModuleIdentifier, Nullable, Plugin, SideEffectsStateArtifact, get_target,
+  ModuleIdentifier, Nullable, Plugin, get_target,
   incremental::{self, IncrementalPasses},
 };
 use rspack_error::Result;
@@ -195,14 +195,8 @@ pub struct FlagDependencyExportsPlugin;
 pub static FLAG_DEPENDENCY_EXPORTS_STAGE: i32 = 0;
 
 #[plugin_hook(CompilationFinishModules for FlagDependencyExportsPlugin, stage = FLAG_DEPENDENCY_EXPORTS_STAGE)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  _async_modules_artifact: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
-  let module_graph = compilation.get_module_graph();
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+  let module_graph = &compilation.build_module_graph_artifact.module_graph;
   let modules: IdentifierSet = if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::FINISH_MODULES)
@@ -221,8 +215,12 @@ async fn finish_modules(
   };
   let module_graph_cache = compilation.module_graph_cache_artifact.clone();
 
-  FlagDependencyExportsState::new(module_graph, &module_graph_cache, exports_info_artifact)
-    .apply(modules);
+  FlagDependencyExportsState::new(
+    module_graph,
+    &module_graph_cache,
+    &mut compilation.exports_info_artifact,
+  )
+  .apply(modules);
 
   Ok(())
 }

--- a/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/infer_async_modules_plugin.rs
@@ -1,8 +1,8 @@
 use rayon::prelude::*;
 use rspack_collections::{IdentifierLinkedSet, IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, Compilation, CompilationFinishModules, DependencyType, ExportsInfoArtifact,
-  Logger, ModuleGraph, Plugin, SideEffectsStateArtifact,
+  AsyncModulesArtifact, Compilation, CompilationFinishModules, DependencyType, Logger, ModuleGraph,
+  Plugin,
   incremental::{IncrementalPasses, Mutation, Mutations},
 };
 use rspack_error::Result;
@@ -13,13 +13,8 @@ use rspack_hook::{plugin, plugin_hook};
 pub struct InferAsyncModulesPlugin;
 
 #[plugin_hook(CompilationFinishModules for InferAsyncModulesPlugin)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  async_modules_artifact: &mut AsyncModulesArtifact,
-  _exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+  let async_modules_artifact = &mut compilation.async_modules_artifact;
   if let Some(mutations) = compilation
     .incremental
     .mutations_read(IncrementalPasses::FINISH_MODULES)
@@ -38,7 +33,7 @@ async fn finish_modules(
       });
   }
 
-  let module_graph = compilation.get_module_graph();
+  let module_graph = &compilation.build_module_graph_artifact.module_graph;
   let mut sync_modules = IdentifierLinkedSet::default();
   let mut async_modules = IdentifierLinkedSet::default();
   for (module_identifier, module) in module_graph.modules() {

--- a/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/side_effects_flag_plugin.rs
@@ -3,13 +3,12 @@ use std::{borrow::Cow, fmt::Debug};
 use rayon::prelude::*;
 use rspack_collections::{IdentifierMap, IdentifierSet};
 use rspack_core::{
-  AsyncModulesArtifact, BoxModule, Compilation, CompilationFinishModules,
-  CompilationOptimizeDependencies, ConnectionState, DependencyExtraMeta, DependencyId,
-  ExportsInfoArtifact, FactoryMeta, GetTargetResult, Logger, ModuleFactoryCreateData, ModuleGraph,
-  ModuleGraphConnection, ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule,
-  OptimizationBailoutItem, Plugin, ResolvedExportInfoTarget, SideEffectsDoOptimize,
-  SideEffectsDoOptimizeMoveTarget, SideEffectsOptimizeArtifact, SideEffectsState,
-  SideEffectsStateArtifact,
+  BoxModule, Compilation, CompilationFinishModules, CompilationOptimizeDependencies,
+  ConnectionState, DependencyExtraMeta, DependencyId, ExportsInfoArtifact, FactoryMeta,
+  GetTargetResult, Logger, ModuleFactoryCreateData, ModuleGraph, ModuleGraphConnection,
+  ModuleIdentifier, NormalModuleCreateData, NormalModuleFactoryModule, OptimizationBailoutItem,
+  Plugin, ResolvedExportInfoTarget, SideEffectsDoOptimize, SideEffectsDoOptimizeMoveTarget,
+  SideEffectsOptimizeArtifact, SideEffectsState,
   build_module_graph::BuildModuleGraphArtifact,
   can_move_target, get_target,
   incremental::{self, IncrementalPasses, Mutation},
@@ -166,13 +165,8 @@ async fn nmf_module(
 
 // run after exports info are set
 #[plugin_hook(CompilationFinishModules for SideEffectsFlagPlugin, stage = SIDE_EFFECTS_FLAG_PLUGIN_STAGE)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  _modules: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-  side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
+  let exports_info_artifact = &compilation.exports_info_artifact;
   let modules: IdentifierSet = compilation
     .get_module_graph()
     .modules()
@@ -214,6 +208,9 @@ async fn finish_modules(
     ));
   }
 
+  let side_effects_state_artifact = &mut compilation
+    .build_module_graph_artifact
+    .side_effects_state_artifact;
   side_effects_state_artifact.clear();
   for (module_id, side_effect_free, has_impure_deferred_check) in deferred_side_effect_states {
     side_effects_state_artifact.insert(

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -3,13 +3,12 @@ use std::sync::LazyLock;
 use futures::future::join_all;
 use regex::Regex;
 use rspack_core::{
-  AsyncModulesArtifact, BoxModule, CanInlineUse, Chunk, ChunkUkey,
-  CodeGenerationDataTopLevelDeclarations, Compilation,
+  BoxModule, CanInlineUse, Chunk, ChunkUkey, CodeGenerationDataTopLevelDeclarations, Compilation,
   CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules, CompilationParams,
-  CompilerCompilation, EntryData, ExportProvided, ExportsInfoArtifact, Filename, LibraryExport,
-  LibraryName, LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin,
-  RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable, SideEffectsStateArtifact,
-  SourceType, UsageState, get_entry_runtime, property_access,
+  CompilerCompilation, EntryData, ExportProvided, Filename, LibraryExport, LibraryName,
+  LibraryNonUmdObject, LibraryOptions, ModuleIdentifier, PathData, Plugin, RuntimeCodeTemplate,
+  RuntimeGlobals, RuntimeModule, RuntimeVariable, SourceType, UsageState, get_entry_runtime,
+  property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -440,13 +439,7 @@ async fn strict_runtime_bailout(
 }
 
 #[plugin_hook(CompilationFinishModules for AssignLibraryPlugin)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  _async_modules_artifact: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   let module_graph = compilation.get_module_graph();
   let mut runtime_info = Vec::with_capacity(compilation.entries.len());
   for (entry_name, entry) in compilation.entries.iter() {
@@ -484,6 +477,7 @@ async fn finish_modules(
     }
   }
 
+  let exports_info_artifact = &mut compilation.exports_info_artifact;
   for (runtime, export, module_identifier) in runtime_info {
     if let Some(export) = export {
       let export_info = exports_info_artifact

--- a/crates/rspack_plugin_library/src/export_property_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/export_property_library_plugin.rs
@@ -1,9 +1,8 @@
 use rspack_core::{
-  AsyncModulesArtifact, CanInlineUse, ChunkUkey, Compilation,
-  CompilationAdditionalChunkRuntimeRequirements, CompilationFinishModules, CompilationParams,
-  CompilerCompilation, EntryData, ExportsInfoArtifact, LibraryExport, LibraryOptions, LibraryType,
-  ModuleIdentifier, Plugin, RuntimeCodeTemplate, RuntimeGlobals, RuntimeModule, RuntimeVariable,
-  SideEffectsStateArtifact, UsageState, get_entry_runtime, property_access,
+  CanInlineUse, ChunkUkey, Compilation, CompilationAdditionalChunkRuntimeRequirements,
+  CompilationFinishModules, CompilationParams, CompilerCompilation, EntryData, LibraryExport,
+  LibraryOptions, LibraryType, ModuleIdentifier, Plugin, RuntimeCodeTemplate, RuntimeGlobals,
+  RuntimeModule, RuntimeVariable, UsageState, get_entry_runtime, property_access,
   rspack_sources::{ConcatSource, RawStringSource, SourceExt},
 };
 use rspack_error::Result;
@@ -111,13 +110,7 @@ async fn js_chunk_hash(
 }
 
 #[plugin_hook(CompilationFinishModules for ExportPropertyLibraryPlugin)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  _async_modules_artifact: &mut AsyncModulesArtifact,
-  exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   let module_graph = compilation.get_module_graph();
   let mut runtime_info = Vec::with_capacity(compilation.entries.len());
   for (entry_name, entry) in compilation.entries.iter() {
@@ -155,6 +148,7 @@ async fn finish_modules(
     }
   }
 
+  let exports_info_artifact = &mut compilation.exports_info_artifact;
   for (runtime, export, module_identifier) in runtime_info {
     if let Some(export) = export {
       let export_info = exports_info_artifact

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -5,10 +5,9 @@
 
 use rspack_cacheable::cacheable;
 use rspack_core::{
-  AsyncModulesArtifact, BoxDependency, ChunkUkey, Compilation,
-  CompilationAdditionalTreeRuntimeRequirements, CompilationFinishModules, CompilationParams,
-  CompilerCompilation, CompilerFinishMake, DependencyType, EntryOptions, ExportsInfoArtifact,
-  Plugin, RuntimeGlobals, RuntimeModule, SideEffectsStateArtifact,
+  BoxDependency, ChunkUkey, Compilation, CompilationAdditionalTreeRuntimeRequirements,
+  CompilationFinishModules, CompilationParams, CompilerCompilation, CompilerFinishMake,
+  DependencyType, EntryOptions, Plugin, RuntimeGlobals, RuntimeModule,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -107,18 +106,13 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
 // renderers (e.g. library wrappers) can safely `await` exports without sprinkling MF-specific
 // RuntimeGlobals checks across generic plugins.
 #[plugin_hook(CompilationFinishModules for ModuleFederationRuntimePlugin, stage = 1000)]
-async fn finish_modules(
-  &self,
-  compilation: &Compilation,
-  async_modules_artifact: &mut AsyncModulesArtifact,
-  _exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, compilation: &mut Compilation) -> Result<()> {
   if !self.options.experiments.async_startup {
     return Ok(());
   }
 
-  let module_graph = compilation.get_module_graph();
+  let module_graph = &compilation.build_module_graph_artifact.module_graph;
+  let async_modules_artifact = &mut compilation.async_modules_artifact;
   for (module_identifier, module) in module_graph.modules() {
     if module
       .as_ref()

--- a/crates/rspack_plugin_progress/src/lib.rs
+++ b/crates/rspack_plugin_progress/src/lib.rs
@@ -12,16 +12,16 @@ use futures::future::BoxFuture;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use rspack_collections::IdentifierMap;
 use rspack_core::{
-  AsyncModulesArtifact, BoxModule, ChunkByUkey, ChunkNamedIdArtifact, CircularModulesInfo,
-  Compilation, CompilationAfterOptimizeModules, CompilationAfterProcessAssets,
-  CompilationBuildModule, CompilationChunkIds, CompilationFinishModules, CompilationId,
-  CompilationModuleIds, CompilationOptimizeChunkModules, CompilationOptimizeChunks,
-  CompilationOptimizeCodeGeneration, CompilationOptimizeDependencies, CompilationOptimizeModules,
-  CompilationOptimizeTree, CompilationParams, CompilationProcessAssets, CompilationSeal,
-  CompilationSucceedModule, CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit,
-  CompilerFinishMake, CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact,
-  ModuleIdentifier, ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
-  SideEffectsStateArtifact, build_module_graph::BuildModuleGraphArtifact,
+  BoxModule, ChunkByUkey, ChunkNamedIdArtifact, CircularModulesInfo, Compilation,
+  CompilationAfterOptimizeModules, CompilationAfterProcessAssets, CompilationBuildModule,
+  CompilationChunkIds, CompilationFinishModules, CompilationId, CompilationModuleIds,
+  CompilationOptimizeChunkModules, CompilationOptimizeChunks, CompilationOptimizeCodeGeneration,
+  CompilationOptimizeDependencies, CompilationOptimizeModules, CompilationOptimizeTree,
+  CompilationParams, CompilationProcessAssets, CompilationSeal, CompilationSucceedModule,
+  CompilerAfterEmit, CompilerClose, CompilerCompilation, CompilerEmit, CompilerFinishMake,
+  CompilerId, CompilerMake, CompilerThisCompilation, ExportsInfoArtifact, ModuleIdentifier,
+  ModuleIdsArtifact, Plugin, SideEffectsOptimizeArtifact,
+  build_module_graph::BuildModuleGraphArtifact,
 };
 use rspack_error::{Diagnostic, Result};
 use rspack_hook::{plugin, plugin_hook};
@@ -437,13 +437,7 @@ async fn finish_make(&self, _compilation: &mut Compilation) -> Result<()> {
 }
 
 #[plugin_hook(CompilationFinishModules for ProgressPlugin)]
-async fn finish_modules(
-  &self,
-  _compilation: &Compilation,
-  _async_modules_artifact: &mut AsyncModulesArtifact,
-  _exports_info_artifact: &mut ExportsInfoArtifact,
-  _side_effects_state_artifact: &mut SideEffectsStateArtifact,
-) -> Result<()> {
+async fn finish_modules(&self, _compilation: &mut Compilation) -> Result<()> {
   self.sealing_hooks_report("finish modules", 0).await
 }
 

--- a/crates/rspack_tasks/src/lib.rs
+++ b/crates/rspack_tasks/src/lib.rs
@@ -1,12 +1,8 @@
 // borrow the ideas from turbo_tasks https://github.com/vercel/next.js/blob/678ef8b5650871a730ca14c480c762ca53716575/turbopack/crates/turbo-tasks/src/manager.rs#L1
 // which creates a implicit compiler context to support isolated parallel compiler state
 use std::{
-  ffi::c_void,
   future::Future,
-  sync::{
-    Arc,
-    atomic::{AtomicPtr, AtomicU32},
-  },
+  sync::{Arc, atomic::AtomicU32},
 };
 
 use tokio::{
@@ -18,7 +14,6 @@ use tokio::{
 #[derive(Debug)]
 pub struct CompilerContext {
   dependenc_id_generator: AtomicU32,
-  exports_info_artifact_ptr: AtomicPtr<c_void>,
 }
 
 task_local! {
@@ -30,7 +25,6 @@ impl CompilerContext {
   pub fn new() -> Self {
     Self {
       dependenc_id_generator: AtomicU32::new(0),
-      exports_info_artifact_ptr: AtomicPtr::new(std::ptr::null_mut()),
     }
   }
   pub fn fetch_new_dependency_id(&self) -> u32 {
@@ -47,20 +41,6 @@ impl CompilerContext {
     self
       .dependenc_id_generator
       .store(id, std::sync::atomic::Ordering::SeqCst);
-  }
-
-  pub fn exports_info_artifact_ptr(&self) -> Option<*mut c_void> {
-    let ptr = self
-      .exports_info_artifact_ptr
-      .load(std::sync::atomic::Ordering::SeqCst);
-    (!ptr.is_null()).then_some(ptr)
-  }
-
-  pub fn set_exports_info_artifact_ptr(&self, ptr: Option<*mut c_void>) {
-    self.exports_info_artifact_ptr.store(
-      ptr.unwrap_or(std::ptr::null_mut()),
-      std::sync::atomic::Ordering::SeqCst,
-    );
   }
 }
 

--- a/tests/rspack-test/compilerCases/finish-modules-artifacts-error.js
+++ b/tests/rspack-test/compilerCases/finish-modules-artifacts-error.js
@@ -1,0 +1,59 @@
+const path = require('path');
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+  description:
+    'should retain compilation artifacts after a rejected finishModules tap',
+  options() {
+    return {
+      entry: './esm/a.js',
+      optimization: { providedExports: true, usedExports: false },
+    };
+  },
+  async build(context, compiler) {
+    let calls = 0;
+    let checkArtifacts;
+    compiler.hooks.compilation.tap('Test', (compilation) => {
+      compilation.hooks.finishModules.tapPromise(
+        { name: 'Test', stage: 100 },
+        async (modules) => {
+          const module = [...modules].find(
+            (module) =>
+              module.resource === path.join(context.getSource(), 'esm/a.js'),
+          );
+          const exportsInfo = compilation.moduleGraph.getExportsInfo(module);
+          checkArtifacts = () => {
+            expect(
+              compilation.moduleGraph.getProvidedExports(module).sort(),
+            ).toEqual(['a', 'default']);
+            expect(compilation.moduleGraph.isAsync(module)).toBe(false);
+            expect(exportsInfo.isUsed('main')).toBe(true);
+          };
+          checkArtifacts();
+          await new Promise((resolve) => setImmediate(resolve));
+          checkArtifacts();
+          if (++calls % 2 === 1) {
+            throw new Error('finishModules failure');
+          }
+        },
+      );
+    });
+
+    const run = () =>
+      new Promise((resolve, reject) => {
+        compiler.run((error, stats) => {
+          if (error) reject(error);
+          else resolve(stats);
+        });
+      });
+
+    // Exercise error cleanup for both the initial build and a later rebuild.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await expect(run()).rejects.toThrow('finishModules failure');
+      checkArtifacts();
+      const stats = await run();
+      expect(stats.hasErrors()).toBe(false);
+    }
+    expect(calls).toBe(4);
+  },
+};

--- a/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/async.js
+++ b/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/async.js
@@ -1,0 +1,1 @@
+export const answer = await Promise.resolve(42);

--- a/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/index.js
+++ b/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/index.js
@@ -1,0 +1,7 @@
+import { value } from './sync';
+import { answer } from './async';
+
+it('keeps module graph artifacts available during finishModules', () => {
+  expect(value).toBe(42);
+  expect(answer).toBe(42);
+});

--- a/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/rspack.config.js
+++ b/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/rspack.config.js
@@ -1,0 +1,81 @@
+const path = require('path');
+
+const PLUGIN_NAME = 'FinishModulesArtifacts';
+const runtime = 'finish-modules-test';
+
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  optimization: {
+    concatenateModules: false,
+    providedExports: true,
+    usedExports: true,
+    sideEffects: true,
+  },
+  plugins: [
+    (compiler) => {
+      compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+        const moduleGraph = compilation.moduleGraph;
+        let syncModule;
+        let exportsInfo;
+
+        const check = () => {
+          const asyncModule = [...compilation.modules].find(
+            (module) => module.resource === path.join(__dirname, 'async.js'),
+          );
+          expect(compilation.moduleGraph).toBe(moduleGraph);
+          expect(moduleGraph.getProvidedExports(syncModule).sort()).toEqual([
+            'unused',
+            'value',
+          ]);
+          expect(moduleGraph.getUsedExports(syncModule, 'main')).toBeNull();
+          expect(moduleGraph.getUsedExports(syncModule, ['main'])).toBeNull();
+          expect(exportsInfo.isUsed('main')).toBe(true);
+          expect(exportsInfo.isModuleUsed('main')).toBe(true);
+          expect(exportsInfo.getUsed('value', 'main')).toBe(2);
+          expect(exportsInfo.getUsed(['value'], new Set(['main']))).toBe(2);
+          expect(moduleGraph.isAsync(syncModule)).toBe(false);
+          expect(moduleGraph.isAsync(asyncModule)).toBe(true);
+
+          // A side-effect-free import is inactive even before usage analysis.
+          const states = moduleGraph
+            .getIncomingConnections(syncModule)
+            .map((connection) => connection.getActiveState('main'));
+          expect(states).toContain(false);
+        };
+
+        compilation.hooks.finishModules.tap(
+          { name: PLUGIN_NAME, stage: 20 },
+          (modules) => {
+            syncModule = [...modules].find(
+              (module) => module.resource === path.join(__dirname, 'sync.js'),
+            );
+            exportsInfo = moduleGraph.getExportsInfo(syncModule);
+            check();
+            expect(exportsInfo.setUsedInUnknownWay(runtime)).toBe(true);
+          },
+        );
+
+        compilation.hooks.finishModules.tapPromise(
+          { name: PLUGIN_NAME, stage: 30 },
+          async () => {
+            check();
+            await new Promise((resolve) => setImmediate(resolve));
+            check();
+            // The mutation must reach the same artifact across taps and await.
+            expect(exportsInfo.setUsedInUnknownWay(runtime)).toBe(false);
+            expect(
+              moduleGraph
+                .getExportsInfo(syncModule)
+                .setUsedInUnknownWay(runtime),
+            ).toBe(false);
+          },
+        );
+
+        compilation.hooks.seal.tap(PLUGIN_NAME, () => {
+          check();
+          expect(exportsInfo.setUsedInUnknownWay(runtime)).toBe(false);
+        });
+      });
+    },
+  ],
+};

--- a/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/sync.js
+++ b/tests/rspack-test/configCases/module-graph/finish-modules-artifacts/sync.js
@@ -1,0 +1,2 @@
+export const value = 42;
+export const unused = 0;

--- a/tests/rspack-test/configCases/module-graph/get-incoming-connections-active/rspack.config.js
+++ b/tests/rspack-test/configCases/module-graph/get-incoming-connections-active/rspack.config.js
@@ -23,31 +23,34 @@ class Plugin {
         const outgoingConnections =
           moduleGraph.getOutgoingConnections(entryModule);
 
-        // Find the connection to "used.js"
-        const usedConnection = outgoingConnections.find(
+        const usedConnections = outgoingConnections.filter(
           (c) => c.module && normalize(c.module.request).includes('used.js'),
         );
-        expect(usedConnection).toBeTruthy();
+        // The value import is active; the pure module's side-effect import is not.
+        const outgoingStates = usedConnections.map((connection) =>
+          connection.getActiveState(undefined),
+        );
+        expect(new Set(outgoingStates)).toEqual(new Set([false, true]));
 
-        // Active connection should return true (boolean)
-        const outgoingState = usedConnection.getActiveState(undefined);
-        expect(outgoingState).toBe(true);
-        expect(typeof outgoingState).toBe('boolean');
-
-        // Incoming connections to "used.js" should all be active
-        const usedModule = usedConnection.module;
+        const usedModule = usedConnections[0].module;
         const incomingConnections =
           moduleGraph.getIncomingConnections(usedModule);
         expect(incomingConnections.length).toBeGreaterThan(0);
         for (const connection of incomingConnections) {
           const state = connection.getActiveState(undefined);
-          expect(state).toBe(true);
+          expect(typeof state).toBe('boolean');
           expect(connection.originModule).toBeTruthy();
         }
+        expect(
+          new Set(
+            incomingConnections.map((connection) =>
+              connection.getActiveState(undefined),
+            ),
+          ),
+        ).toEqual(new Set(outgoingStates));
       });
 
-      // Test TransitiveOnly in processAssets phase where exports info is available
-      compilation.hooks.processAssets.tap(PLUGIN_NAME, () => {
+      const checkTransitiveOnly = () => {
         const moduleGraph = compilation.moduleGraph;
 
         // Walk all modules to find CssDependency connections with TransitiveOnly state
@@ -63,7 +66,12 @@ class Plugin {
           }
         }
         expect(foundTransitiveOnly).toBe(true);
-      });
+      };
+      compilation.hooks.finishModules.tap(
+        { name: PLUGIN_NAME, stage: 20 },
+        checkTransitiveOnly,
+      );
+      compilation.hooks.processAssets.tap(PLUGIN_NAME, checkTransitiveOnly);
     });
   }
 }


### PR DESCRIPTION
## Summary

Pass the full mutable `Compilation` to `finishModules` hooks and keep artifacts available so JavaScript plugins can read and update module graph state across async taps. Remove the exports-info pointer bridge and return actual connection states.

Release the compiler's running state before failure callbacks so builds can be retried immediately.