### PR TITLE
refactor: retain complete module build data in the module graph

### DIFF
--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -5,11 +5,12 @@ use rspack_error::Diagnostic;
 use rustc_hash::FxHashSet;
 
 use crate::{
-  ArtifactExt, BuildDependency, DependencyId, DependencyRef, FactorizationArtifact, FactorizeInfo,
-  ModuleGraph, ModuleIdentifier, SideEffectsStateArtifact,
-  compilation::build_module_graph::ModuleToLazyMake,
+  ArtifactExt, BuildDependency, BuildResult, DependencyId, DependencyParents, DependencyRef,
+  FactorizationArtifact, FactorizeInfo, ModuleGraph, ModuleIdentifier, SideEffectsStateArtifact,
+  compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
   incremental::IncrementalPasses,
   incremental_info::IncrementalInfo,
+  module_graph::ModuleBuildData,
   utils::{FileCounter, ResourceId},
 };
 
@@ -81,6 +82,86 @@ impl BuildModuleGraphArtifact {
   }
   pub fn get_module_graph_mut(&mut self) -> &mut ModuleGraph {
     &mut self.module_graph
+  }
+
+  /// Installs fresh and cached builds through the same graph and index updates.
+  /// The module record retains the build output after its indices are published.
+  pub(crate) fn apply_build_result(
+    &mut self,
+    result: BuildResult,
+  ) -> (ModuleIdentifier, Vec<DependencyId>, LazyDependencies) {
+    let BuildResult {
+      mut module,
+      dependencies,
+      blocks,
+      optimization_bailouts,
+    } = result;
+    let identifier = module.identifier();
+    let mut data = ModuleBuildData {
+      dependencies,
+      blocks,
+      optimization_bailouts,
+    };
+    data.normalize_blocks();
+
+    if !module.diagnostics().is_empty() {
+      self.make_failed_module.insert(identifier);
+    }
+    let build_info = module.build_info();
+    let resource = ResourceId::from(identifier);
+    self
+      .file_dependencies
+      .add_files(&resource, &build_info.dependencies.file);
+    self
+      .context_dependencies
+      .add_files(&resource, &build_info.dependencies.context);
+    self
+      .missing_dependencies
+      .add_files(&resource, &build_info.dependencies.missing);
+    self
+      .build_dependencies
+      .add_files(&resource, &build_info.dependencies.build);
+
+    let mut all_dependencies = Vec::new();
+    let mut lazy_dependencies = LazyDependencies::default();
+    for (block, dependencies) in std::iter::once((None, data.dependencies.as_slice())).chain(
+      data
+        .blocks
+        .iter()
+        .map(|block| (Some(block.identifier()), block.dependency_refs())),
+    ) {
+      for (index_in_block, dependency) in dependencies.iter().enumerate() {
+        let id = *dependency.id();
+        if let Some(until) = dependency.lazy() {
+          lazy_dependencies.insert(dependency, until);
+        }
+        if block.is_none() {
+          module.add_dependency_id(id);
+        }
+        all_dependencies.push(id);
+        self.module_graph.set_parents(
+          id,
+          DependencyParents {
+            block,
+            module: identifier,
+            index_in_block,
+          },
+        );
+        self.module_graph.add_dependency_ref(dependency.clone());
+      }
+    }
+    for block in &data.blocks {
+      module.add_block_id(block.identifier());
+    }
+    let mgm = self
+      .module_graph
+      .module_graph_module_by_identifier_mut(&identifier);
+    mgm.all_dependencies_mut().clone_from(&all_dependencies);
+    mgm
+      .optimization_bailout_mut()
+      .extend(data.optimization_bailouts.iter().cloned());
+    self.module_graph.add_module_with_build_data(module, data);
+    (identifier, all_dependencies, lazy_dependencies)
   }
 
   /// Add a dependency that has not been factorized in the current build.

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, sync::Arc};
+use std::sync::Arc;
 
 use rspack_fs::ReadableFileSystem;
 use rspack_util::time::current_time;
@@ -8,16 +8,12 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlock, BoxModule, BuildContext, BuildResult, CacheFacade, CompilationId,
-  CompilerId, CompilerOptions, DependencyParents, DependencyRef, FileSystemInfo,
-  ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
+  BoxModule, BuildContext, BuildResult, CacheFacade, CompilationId, CompilerId, CompilerOptions,
+  FileSystemInfo, ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{
-    ForwardedIdSet, HasLazyDependencies, LazyDependencies, module_build_cache::ModuleBuildCache,
+    ForwardedIdSet, HasLazyDependencies, module_build_cache::ModuleBuildCache,
   },
-  utils::{
-    ResourceId,
-    task_loop::{Task, TaskResult, TaskType},
-  },
+  utils::task_loop::{Task, TaskResult, TaskType},
 };
 
 #[derive(Debug)]
@@ -122,89 +118,14 @@ impl Task<TaskContext> for BuildResultTask {
       .call(context.compiler_id, context.compilation_id, &mut module)
       .await?;
 
-    let build_info = module.build_info();
-
-    if !module.diagnostics().is_empty() {
-      context
-        .artifact
-        .make_failed_module
-        .insert(module.identifier());
-    }
-
-    tracing::trace!("Module built: {}", module.identifier());
-    context
-      .artifact
-      .module_graph
-      .get_optimization_bailout_mut(&module.identifier())
-      .extend(build_result.optimization_bailouts);
-    let resource_id = ResourceId::from(module.identifier());
-    context
-      .artifact
-      .file_dependencies
-      .add_files(&resource_id, &build_info.dependencies.file);
-    context
-      .artifact
-      .context_dependencies
-      .add_files(&resource_id, &build_info.dependencies.context);
-    context
-      .artifact
-      .missing_dependencies
-      .add_files(&resource_id, &build_info.dependencies.missing);
-    context
-      .artifact
-      .build_dependencies
-      .add_files(&resource_id, &build_info.dependencies.build);
-
+    let (module_identifier, mut all_dependencies, lazy_dependencies) =
+      context.artifact.apply_build_result(BuildResult {
+        module,
+        dependencies: build_result.dependencies,
+        blocks: build_result.blocks,
+        optimization_bailouts: build_result.optimization_bailouts,
+      });
     let module_graph = &mut context.artifact.module_graph;
-    let mut lazy_dependencies = LazyDependencies::default();
-    let mut queue = VecDeque::new();
-    let mut all_dependencies = vec![];
-    let mut handle_block = |dependencies: Vec<DependencyRef>,
-                            blocks: Vec<Box<AsyncDependenciesBlock>>,
-                            current_block: Option<Box<AsyncDependenciesBlock>>|
-     -> Vec<Box<AsyncDependenciesBlock>> {
-      for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
-        let dependency_id = *dependency.id();
-        if let Some(until) = dependency.lazy() {
-          lazy_dependencies.insert(&dependency, until);
-        }
-        if current_block.is_none() {
-          module.add_dependency_id(dependency_id);
-        }
-        all_dependencies.push(dependency_id);
-        module_graph.set_parents(
-          dependency_id,
-          DependencyParents {
-            block: current_block.as_ref().map(|block| block.identifier()),
-            module: module.identifier(),
-            index_in_block,
-          },
-        );
-        module_graph.add_dependency_ref(dependency);
-      }
-      if let Some(current_block) = current_block {
-        module.add_block_id(current_block.identifier());
-        module_graph.add_block(current_block);
-      }
-      blocks
-    };
-    let blocks = handle_block(build_result.dependencies, build_result.blocks, None);
-    queue.extend(blocks);
-
-    while let Some(mut block) = queue.pop_front() {
-      let dependencies = block.take_dependencies();
-      let blocks = handle_block(dependencies, block.take_blocks(), Some(block));
-      queue.extend(blocks);
-    }
-
-    {
-      let mgm = module_graph.module_graph_module_by_identifier_mut(&module.identifier());
-      mgm.all_dependencies_mut().clone_from(&all_dependencies);
-    }
-
-    let module_identifier = module.identifier();
-
-    module_graph.add_module(module);
 
     let mut tasks: Vec<Box<dyn Task<TaskContext>>> = vec![];
 

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -5,10 +5,10 @@ use rspack_collections::{Identifiable, IdentifierDashMap};
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 
 use crate::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxModule, BuildModuleGraphArtifact,
-  BuildResult, CacheOptions, CompilerOptions, DependenciesBlock, DependencyRef, FileSystemInfo,
-  ModuleGraph, ModuleIdentifier, NormalModuleState, OptimizationBailoutItem, ValueCacheVersions,
+  BoxModule, BuildModuleGraphArtifact, BuildResult, CacheOptions, CompilerOptions, FileSystemInfo,
+  ModuleGraph, ModuleIdentifier, NormalModuleState, ValueCacheVersions,
   cache::CacheCodec,
+  module_graph::ModuleBuildData,
   new_cache::{CacheFacade, CacheValue},
 };
 
@@ -27,17 +27,7 @@ pub(crate) struct ModuleBuildCache {
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCacheEntry {
   module_state: NormalModuleState,
-  graph_result: ModuleGraphBuildResult,
-}
-
-#[cacheable]
-#[derive(Debug, Clone)]
-struct ModuleGraphBuildResult {
-  dependencies: Vec<DependencyRef>,
-  // Preserve BuildResult's ownership shape without reallocating large nested blocks on restore.
-  #[allow(clippy::vec_box)]
-  blocks: Vec<Box<AsyncDependenciesBlock>>,
-  optimization_bailouts: Vec<OptimizationBailoutItem>,
+  build_data: ModuleBuildData,
 }
 
 impl ModuleBuildCacheEntry {
@@ -48,9 +38,9 @@ impl ModuleBuildCacheEntry {
       .restore_module_state(self.module_state);
     BuildResult {
       module,
-      dependencies: self.graph_result.dependencies,
-      blocks: self.graph_result.blocks,
-      optimization_bailouts: self.graph_result.optimization_bailouts,
+      dependencies: self.build_data.dependencies,
+      blocks: self.build_data.blocks,
+      optimization_bailouts: self.build_data.optimization_bailouts,
     }
   }
 }
@@ -109,7 +99,7 @@ impl ModuleBuildCache {
   ///
   /// Snapshot creation and cache-entry construction are parallel. Module state
   /// and graph containers are cloned, while dependencies retain webpack-style
-  /// shared identity through [`DependencyRef`].
+  /// shared identity through [`crate::DependencyRef`].
   pub(crate) async fn store_pending(
     &self,
     artifact: &mut BuildModuleGraphArtifact,
@@ -204,66 +194,22 @@ fn create_cache_entry(
   module_identifier: ModuleIdentifier,
   persistent_codec: Option<&CacheCodec>,
 ) -> Result<Option<ModuleBuildCacheEntry>> {
-  let source_module = module_graph
-    .module_by_identifier(&module_identifier)
-    .expect("pending module should exist in the final module graph");
-  let normal_module = source_module
-    .as_normal_module()
-    .expect("only normal modules are marked pending for the module build cache");
-  let Some(dependencies) = clone_dependencies(module_graph, source_module.get_dependencies())
-  else {
+  let Some(record) = module_graph.module_record(&module_identifier) else {
     return Ok(None);
   };
-  let blocks = source_module
-    .get_blocks()
-    .iter()
-    .map(|block_id| clone_block(module_graph, block_id))
-    .collect::<Option<Vec<_>>>();
-  let Some(blocks) = blocks else {
+  let Some(normal_module) = record.module.as_normal_module() else {
     return Ok(None);
   };
-  let optimization_bailouts = module_graph
-    .get_optimization_bailout(&module_identifier)
-    .clone();
-
+  let mut build_data = record.build_data.clone();
+  build_data
+    .optimization_bailouts
+    .clone_from(module_graph.get_optimization_bailout(&module_identifier));
   let entry = ModuleBuildCacheEntry {
     module_state: normal_module.module_state().clone(),
-    graph_result: ModuleGraphBuildResult {
-      dependencies,
-      blocks,
-      optimization_bailouts,
-    },
+    build_data,
   };
   if let Some(codec) = persistent_codec {
     codec.encode(&entry)?;
   }
   Ok(Some(entry))
-}
-
-fn clone_dependencies(
-  module_graph: &ModuleGraph,
-  dependency_ids: &[crate::DependencyId],
-) -> Option<Vec<DependencyRef>> {
-  dependency_ids
-    .iter()
-    .map(|dependency_id| {
-      crate::module_graph::internal::try_dependency_ref_by_id(module_graph, dependency_id)
-    })
-    .collect()
-}
-
-fn clone_block(
-  module_graph: &ModuleGraph,
-  block_id: &AsyncDependenciesBlockIdentifier,
-) -> Option<Box<AsyncDependenciesBlock>> {
-  let source = module_graph.block_by_id(block_id)?;
-  let mut block = source.clone();
-  let dependencies = clone_dependencies(module_graph, source.get_dependencies())?;
-  let blocks = source
-    .get_blocks()
-    .iter()
-    .map(|block_id| clone_block(module_graph, block_id))
-    .collect::<Option<Vec<_>>>()?;
-  block.restore_build_result(dependencies, blocks);
-  Some(Box::new(block))
 }

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -171,28 +171,22 @@ impl AsyncDependenciesBlock {
     std::mem::take(&mut self.blocks)
   }
 
-  #[allow(clippy::vec_box)]
-  pub(crate) fn restore_build_result(
-    &mut self,
-    dependencies: Vec<DependencyRef>,
-    blocks: Vec<Box<AsyncDependenciesBlock>>,
-  ) {
-    debug_assert_eq!(
-      self.dependency_ids,
-      dependencies
-        .iter()
-        .map(|dependency| *dependency.id())
-        .collect::<Vec<_>>()
-    );
-    debug_assert_eq!(
-      self.block_ids,
-      blocks
-        .iter()
-        .map(|block| block.identifier())
-        .collect::<Vec<_>>()
-    );
+  pub(crate) fn dependency_refs(&self) -> &[DependencyRef] {
+    &self.dependencies
+  }
+
+  pub(crate) fn replace_dependency_ref(&mut self, dependency: &DependencyRef) {
+    if let Some(stored) = self
+      .dependencies
+      .iter_mut()
+      .find(|stored| stored.id() == dependency.id())
+    {
+      *stored = dependency.clone();
+    }
+  }
+
+  pub(crate) fn restore_dependencies(&mut self, dependencies: Vec<DependencyRef>) {
     self.dependencies = dependencies;
-    self.blocks = blocks;
   }
 
   pub fn loc(&self) -> Option<DependencyLocation> {
@@ -250,6 +244,7 @@ impl DependenciesBlock for AsyncDependenciesBlock {
 
   fn remove_dependency_id(&mut self, dependency: DependencyId) {
     self.dependency_ids.retain(|dep| dep != &dependency);
+    self.dependencies.retain(|dep| *dep.id() != dependency);
   }
 
   fn get_dependencies(&self) -> &[DependencyId] {

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/module_graph.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/module_graph.rs
@@ -8,12 +8,14 @@ use rustc_hash::FxHashSet;
 
 use super::alternatives::{TempDependency, TempModule};
 use crate::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, Dependency,
-  DependencyId, DependencyParents, DependencyRef, FactorizationArtifact, FactorizeInfo,
-  ModuleGraph, ModuleGraphConnection, ModuleGraphModule, ModuleIdentifier, RayonConsumer,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule,
+  DependenciesBlock, Dependency, DependencyId, DependencyParents, DependencyRef,
+  FactorizationArtifact, FactorizeInfo, ModuleGraph, ModuleGraphConnection, ModuleGraphModule,
+  ModuleIdentifier, RayonConsumer,
   cache::CacheCodec,
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
   legacy_cache::persistent::storage::Storage,
+  module_graph::ModuleBuildData,
 };
 
 pub const SCOPE: &str = "occasion_make_module_graph";
@@ -178,16 +180,36 @@ pub async fn recovery_module_graph(
         need_check_dep.push((con.dependency_id, *con.module_identifier()));
         mg.cache_recovery_connection(con);
       }
-      for block in node.blocks {
-        let block = block.into_owned();
-        mg.add_block(Box::new(block));
-      }
+      let blocks = node
+        .blocks
+        .into_iter()
+        .map(|block| {
+          let mut block = block.into_owned();
+          block.restore_dependencies(
+            block
+              .get_dependencies()
+              .iter()
+              .map(|id| mg.dependency_ref_by_id(id).clone())
+              .collect(),
+          );
+          Box::new(block)
+        })
+        .collect();
+      let build_data = ModuleBuildData {
+        dependencies: module
+          .get_dependencies()
+          .iter()
+          .map(|id| mg.dependency_ref_by_id(id).clone())
+          .collect(),
+        blocks,
+        optimization_bailouts: mgm.optimization_bailout.clone(),
+      };
       if let Some(lazy_info) = node.lazy_info {
         module_to_lazy_make
           .update_module_lazy_dependencies(module.identifier(), Some(lazy_info.into_owned()));
       }
       mg.add_module_graph_module(mgm);
-      mg.add_module(module);
+      mg.add_module_with_build_data(module, build_data);
     });
   // recovery incoming connections
   for (dep_id, module_identifier) in need_check_dep {

--- a/crates/rspack_core/src/module_graph/build_data.rs
+++ b/crates/rspack_core/src/module_graph/build_data.rs
@@ -1,0 +1,34 @@
+use std::collections::VecDeque;
+
+use rspack_cacheable::cacheable;
+
+use crate::{AsyncDependenciesBlock, BoxModule, DependencyRef, OptimizationBailoutItem};
+
+/// Module-local build output retained after its indices are installed in the graph.
+/// Dependency references keep their shared identity, including mutable dependency state.
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub(crate) struct ModuleBuildData {
+  pub dependencies: Vec<DependencyRef>,
+  #[allow(clippy::vec_box)]
+  pub blocks: Vec<Box<AsyncDependenciesBlock>>,
+  pub optimization_bailouts: Vec<OptimizationBailoutItem>,
+}
+
+impl ModuleBuildData {
+  /// Both fresh builds and restored entries use a flat block table. Blocks keep
+  /// their dependency objects; the graph only installs indices into this data.
+  pub(crate) fn normalize_blocks(&mut self) {
+    let mut queue = VecDeque::from(std::mem::take(&mut self.blocks));
+    while let Some(mut block) = queue.pop_front() {
+      queue.extend(block.take_blocks());
+      self.blocks.push(block);
+    }
+  }
+}
+
+#[derive(Debug)]
+pub(crate) struct ModuleRecord {
+  pub module: BoxModule,
+  pub build_data: ModuleBuildData,
+}

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -1,3 +1,6 @@
+mod build_data;
+pub(crate) use build_data::{ModuleBuildData, ModuleRecord};
+
 pub mod internal;
 pub mod rollback;
 
@@ -95,12 +98,12 @@ pub(crate) struct ModuleGraphData {
   /****** only modified during Make Phase */
   /// Module indexed by `ModuleIdentifier`.
   pub(crate) modules:
-    rollback::RollbackMap<ModuleIdentifier, BoxModule, BuildHasherDefault<IdentifierHasher>>,
+    rollback::RollbackMap<ModuleIdentifier, ModuleRecord, BuildHasherDefault<IdentifierHasher>>,
 
   /// Dependencies indexed by `DependencyId`.
   dependencies: rollback::DenseDependencyIdMap<DependencyRef>,
   /// AsyncDependenciesBlocks indexed by `AsyncDependenciesBlockIdentifier`.
-  blocks: AsyncDependenciesBlockIdentifierMap<Box<AsyncDependenciesBlock>>,
+  blocks: AsyncDependenciesBlockIdentifierMap<(ModuleIdentifier, usize)>,
 
   /// Dependency_id to parent module identifier and parent block
   ///
@@ -177,14 +180,22 @@ impl ModuleGraph {
 
   #[inline]
   pub fn modules(&self) -> impl Iterator<Item = (&ModuleIdentifier, &BoxModule)> {
-    self.inner.modules.iter()
+    self
+      .inner
+      .modules
+      .iter()
+      .map(|(id, record)| (id, &record.module))
   }
 
   #[inline]
   pub fn modules_par(
     &self,
   ) -> impl rayon::prelude::ParallelIterator<Item = (&ModuleIdentifier, &BoxModule)> {
-    self.inner.modules.par_iter()
+    self
+      .inner
+      .modules
+      .par_iter()
+      .map(|(id, record)| (id, &record.module))
   }
 
   #[inline]
@@ -296,10 +307,14 @@ impl ModuleGraph {
       if let Some(m_id) = original_module_identifier
         && let Some(module) = self.inner.modules.get_mut(&m_id)
       {
-        module.remove_dependency_id(*dep_id);
+        module.module.remove_dependency_id(*dep_id);
+        module
+          .build_data
+          .dependencies
+          .retain(|dependency| dependency.id() != dep_id);
       }
       if let Some(b_id) = parent_block
-        && let Some(block) = self.inner.blocks.get_mut(&b_id)
+        && let Some(block) = self.block_by_id_mut(&b_id)
       {
         block.remove_dependency_id(*dep_id);
       }
@@ -493,11 +508,29 @@ impl ModuleGraph {
   }
 
   pub fn add_module(&mut self, module: BoxModule) {
-    self.inner.modules.insert(module.identifier(), module);
+    self.add_module_with_build_data(module, ModuleBuildData::default());
   }
 
-  pub fn add_block(&mut self, block: Box<AsyncDependenciesBlock>) {
-    self.inner.blocks.insert(block.identifier(), block);
+  pub(crate) fn add_module_with_build_data(
+    &mut self,
+    module: BoxModule,
+    build_data: ModuleBuildData,
+  ) {
+    let identifier = module.identifier();
+    for (slot, block) in build_data.blocks.iter().enumerate() {
+      self
+        .inner
+        .blocks
+        .insert(block.identifier(), (identifier, slot));
+    }
+    self
+      .inner
+      .modules
+      .insert(identifier, ModuleRecord { module, build_data });
+  }
+
+  pub(crate) fn module_record(&self, identifier: &ModuleIdentifier) -> Option<&ModuleRecord> {
+    self.inner.modules.get(identifier)
   }
 
   pub fn set_parents(&mut self, dependency_id: DependencyId, parents: DependencyParents) {
@@ -538,7 +571,15 @@ impl ModuleGraph {
     &self,
     block_id: &AsyncDependenciesBlockIdentifier,
   ) -> Option<&AsyncDependenciesBlock> {
-    self.inner.blocks.get(block_id).map(AsRef::as_ref)
+    let (owner, slot) = self.inner.blocks.get(block_id)?;
+    self
+      .inner
+      .modules
+      .get(owner)?
+      .build_data
+      .blocks
+      .get(*slot)
+      .map(AsRef::as_ref)
   }
 
   pub fn block_by_id_expect(
@@ -546,14 +587,33 @@ impl ModuleGraph {
     block_id: &AsyncDependenciesBlockIdentifier,
   ) -> &AsyncDependenciesBlock {
     self
-      .inner
-      .blocks
-      .get(block_id)
+      .block_by_id(block_id)
       .expect("should insert block before get it")
   }
 
-  pub fn blocks(&self) -> &AsyncDependenciesBlockIdentifierMap<Box<AsyncDependenciesBlock>> {
-    &self.inner.blocks
+  fn block_by_id_mut(
+    &mut self,
+    block_id: &AsyncDependenciesBlockIdentifier,
+  ) -> Option<&mut AsyncDependenciesBlock> {
+    let (owner, slot) = self.inner.blocks.get(block_id)?;
+    self
+      .inner
+      .modules
+      .get_mut(owner)?
+      .build_data
+      .blocks
+      .get_mut(*slot)
+      .map(AsMut::as_mut)
+  }
+
+  pub fn blocks(
+    &self,
+  ) -> impl Iterator<Item = (&AsyncDependenciesBlockIdentifier, &AsyncDependenciesBlock)> {
+    self
+      .inner
+      .blocks
+      .keys()
+      .map(|id| (id, self.block_by_id_expect(id)))
   }
 
   pub fn dependencies(&self) -> impl Iterator<Item = (DependencyId, &(dyn Dependency + 'static))> {
@@ -569,7 +629,31 @@ impl ModuleGraph {
   }
 
   pub(crate) fn add_dependency_ref(&mut self, dependency: DependencyRef) {
-    self.inner.dependencies.insert(*dependency.id(), dependency);
+    let id = *dependency.id();
+    if self
+      .inner
+      .dependencies
+      .get(&id)
+      .is_some_and(|stored| std::ptr::eq(stored.as_ref(), dependency.as_ref()))
+    {
+      return;
+    }
+    if let Some(parents) = self.inner.dependency_id_to_parents.get(&id).cloned() {
+      if let Some(block) = parents.block {
+        if let Some(block) = self.block_by_id_mut(&block) {
+          block.replace_dependency_ref(&dependency);
+        }
+      } else if let Some(record) = self.inner.modules.get_mut(&parents.module)
+        && let Some(stored) = record
+          .build_data
+          .dependencies
+          .iter_mut()
+          .find(|stored| *stored.id() == id)
+      {
+        *stored = dependency.clone();
+      }
+    }
+    self.inner.dependencies.insert(id, dependency);
   }
 
   pub(crate) fn dependency_ref_by_id(&self, dependency_id: &DependencyId) -> &DependencyRef {
@@ -623,7 +707,7 @@ impl ModuleGraph {
   pub fn get_module_by_dependency_id(&self, dep_id: &DependencyId) -> Option<&BoxModule> {
     self
       .module_identifier_by_dependency_id(dep_id)
-      .and_then(|module_id| self.inner.modules.get(module_id))
+      .and_then(|module_id| self.module_by_identifier(module_id))
   }
 
   fn add_connection(
@@ -700,14 +784,22 @@ impl ModuleGraph {
 
   /// Uniquely identify a module by its identifier and return the aliased reference
   pub fn module_by_identifier(&self, identifier: &ModuleIdentifier) -> Option<&BoxModule> {
-    self.inner.modules.get(identifier)
+    self
+      .inner
+      .modules
+      .get(identifier)
+      .map(|record| &record.module)
   }
 
   pub fn module_by_identifier_mut(
     &mut self,
     identifier: &ModuleIdentifier,
   ) -> Option<&mut BoxModule> {
-    self.inner.modules.get_mut(identifier)
+    self
+      .inner
+      .modules
+      .get_mut(identifier)
+      .map(|record| &mut record.module)
   }
 
   /// Uniquely identify a module graph module by its module's identifier and return the aliased reference

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -84,7 +84,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       None
     } else {
       let mut global_runtime = RuntimeSpec::default();
-      for block in module_graph.blocks().values() {
+      for (_, block) in module_graph.blocks() {
         if let Some(GroupOptions::Entrypoint(options)) = block.get_group_options()
           && let Some(runtime) = RuntimeSpec::from_entry_options(options)
         {

--- a/tests/rspack-test/compilerCases/module-build-cache.js
+++ b/tests/rspack-test/compilerCases/module-build-cache.js
@@ -1,0 +1,168 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { RawSource } = require("webpack-sources");
+
+const newCache = {
+  codeGeneration: false,
+  devtool: false,
+  loader: false,
+  minimize: false,
+  module: true,
+};
+
+let mtime = Date.now() - 3_600_000;
+
+function write(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+  // Keep fixtures outside the snapshot's filesystem timestamp accuracy window.
+  const timestamp = new Date((mtime += 2_000));
+  fs.utimesSync(file, timestamp, timestamp);
+}
+
+function run(compiler, modifiedFiles = []) {
+  return new Promise((resolve, reject) => {
+    compiler.run(
+      (error, stats) => {
+        if (error) return reject(error);
+        if (stats.hasErrors()) {
+          return reject(
+            new Error(stats.toString({ all: false, errors: true })),
+          );
+        }
+        resolve(stats);
+      },
+      { modifiedFiles: new Set(modifiedFiles) },
+    );
+  });
+}
+
+function readOutput(root) {
+  const output = path.join(root, "dist");
+  for (const filename of Object.keys(require.cache)) {
+    if (filename.startsWith(`${output}${path.sep}`))
+      delete require.cache[filename];
+  }
+  return require(path.join(output, "main.js"));
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [false].flatMap((cache) =>
+  [false, true].map((incremental) => {
+    let root;
+    let built;
+    const entry =
+      'export { value } from "./stable.js"; export const load = () => import("./async.js").then(m => m.default);';
+
+    return {
+      description: `should preserve module build records with cache=${cache}, incremental=${incremental}`,
+      options(context) {
+        root = context.getDist(`cache-${cache}-incremental-${incremental}`);
+        fs.rmSync(root, { recursive: true, force: true });
+        write(path.join(root, "src/index.js"), entry);
+        write(
+          path.join(root, "src/stable.js"),
+          'export const value = "stable";',
+        );
+        write(path.join(root, "src/async.js"), 'export default "async";');
+        return {
+          context: path.join(root, "src"),
+          mode: "development",
+          devtool: false,
+          target: "async-node",
+          entry: "./index.js",
+          cache,
+          incremental,
+          experiments: { newCache },
+          optimization: { concatenateModules: true },
+          output: {
+            path: path.join(root, "dist"),
+            filename: "main.js",
+            library: { type: "commonjs2" },
+          },
+          plugins: [
+            {
+              apply(compiler) {
+                compiler.hooks.compilation.tap(
+                  "ModuleBuildCache",
+                  (compilation) => {
+                    built = [];
+                    compilation.hooks.buildModule.tap(
+                      "ModuleBuildCache",
+                      (module) => {
+                        if (module.resource)
+                          built.push(path.basename(module.resource));
+                      },
+                    );
+                    compilation.hooks.succeedModule.tap(
+                      "ModuleBuildCache",
+                      (module) => {
+                        if (
+                          module.resource === path.join(root, "src/stable.js")
+                        ) {
+                          module.emitFile(
+                            "from-hook.txt",
+                            new RawSource("hook asset"),
+                          );
+                        }
+                      },
+                    );
+                  },
+                );
+              },
+            },
+          ],
+        };
+      },
+      compiler(_, compiler) {
+        compiler.outputFileSystem = fs;
+      },
+      async build(_, compiler) {
+        const index = path.join(root, "src/index.js");
+        const stable = path.join(root, "src/stable.js");
+        await run(compiler);
+        expect(built.sort()).toEqual(["async.js", "index.js", "stable.js"]);
+        expect(readOutput(root).value).toBe("stable");
+        expect(await readOutput(root).load()).toBe("async");
+
+        const warm = await run(compiler);
+        expect(built.sort()).toEqual(
+          cache || incremental ? [] : ["async.js", "index.js", "stable.js"],
+        );
+        expect(warm.compilation.getAsset("from-hook.txt").source.source()).toBe(
+          "hook asset",
+        );
+        expect(await readOutput(root).load()).toBe("async");
+
+        write(index, 'export const value = "detached";');
+        await run(compiler, [index]);
+        expect(built).toEqual(["index.js"]);
+        expect(readOutput(root).value).toBe("detached");
+
+        // These dependencies were removed from the previous incremental artifact.
+        // A warm cache must still supply their build output when they reappear.
+        write(index, entry);
+        const restored = await run(compiler, [index]);
+        expect(built.sort()).toEqual(
+          cache ? ["index.js"] : ["async.js", "index.js", "stable.js"],
+        );
+        expect(
+          restored.compilation.getAsset("from-hook.txt").source.source(),
+        ).toBe("hook asset");
+        expect(readOutput(root).value).toBe("stable");
+        expect(await readOutput(root).load()).toBe("async");
+
+        write(stable, 'export const value = "changed";');
+        await run(compiler, [stable]);
+        expect(built.sort()).toEqual(
+          cache || incremental
+            ? ["stable.js"]
+            : ["async.js", "index.js", "stable.js"],
+        );
+        expect(readOutput(root).value).toBe("changed");
+        expect(await readOutput(root).load()).toBe("async");
+      },
+    };
+  }),
+);
+


### PR DESCRIPTION
## Summary

Installing a module currently consumes its dependency and async-block containers, so module caching reconstructs build output from graph IDs. Retain this output in ModuleRecord/ModuleBuildData and install fresh and cached builds through the same apply_build_result path. Keep dependency and block indices synchronized and adapt legacy persistent recovery.

This layer preserves the existing cache eligibility, write timing, and task scheduling. It adds graph-record regression coverage and exercises both cache backends through the existing suites.

Validation:

- Repository root: `pnpm run build:cli:dev` — passed.

Tests run from `tests/rspack-test`:

- `pnpm run test Compiler.test.js Cache.test.js --project base` — 182 passed.
- `pnpm run test Watch.part --project base -t watchCases/compilation` — 14 passed.
- `pnpm run test Config.part --project base -t configCases/compilation` — 30 passed.

## Related links

Part 1 of 4. Base: `main`. Review and merge in this order:

1. #15484 — refactor: retain complete module build data in the module graph **(this PR)**
2. #15485 — fix: scope module cache writes to Make sessions
3. #15486 — fix: preserve module cache behavior during rebuilds
4. #15487 — refactor: move module cache validation off the graph queue

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; internal change).
