### PR TITLE
fix: preserve module cache behavior during rebuilds

### DIFF
--- a/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
+++ b/crates/rspack_core/src/artifacts/build_module_graph_artifact.rs
@@ -8,7 +8,7 @@ use crate::{
   ArtifactExt, BuildDependency, BuildResult, DependencyId, DependencyParents, DependencyRef,
   FactorizationArtifact, FactorizeInfo, ModuleGraph, ModuleIdentifier, SideEffectsStateArtifact,
   compilation::build_module_graph::{LazyDependencies, ModuleToLazyMake},
-  incremental::IncrementalPasses,
+  incremental::{IncrementalPasses, Mutation},
   incremental_info::IncrementalInfo,
   module_graph::ModuleBuildData,
   utils::{FileCounter, ResourceId},
@@ -82,6 +82,35 @@ impl BuildModuleGraphArtifact {
   }
   pub fn get_module_graph_mut(&mut self) -> &mut ModuleGraph {
     &mut self.module_graph
+  }
+
+  pub(crate) fn module_graph_mutations(&self) -> impl Iterator<Item = Mutation> + '_ {
+    self
+      .affected_dependencies
+      .updated()
+      .iter()
+      .map(|&dependency| Mutation::DependencyUpdate { dependency })
+      .chain(
+        self
+          .affected_modules
+          .removed()
+          .iter()
+          .map(|&module| Mutation::ModuleRemove { module }),
+      )
+      .chain(
+        self
+          .affected_modules
+          .updated()
+          .iter()
+          .map(|&module| Mutation::ModuleUpdate { module }),
+      )
+      .chain(
+        self
+          .affected_modules
+          .added()
+          .iter()
+          .map(|&module| Mutation::ModuleAdd { module }),
+      )
   }
 
   /// Installs fresh and cached builds through the same graph and index updates.

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/cutout/mod.rs
@@ -14,6 +14,7 @@ use crate::{BuildDependency, Compilation, internal};
 /// do some post-processing on module graph like clean up isolated module.
 #[derive(Debug, Default)]
 pub struct Cutout {
+  pub(super) rebuild_modules: IdentifierSet,
   fix_issuers: FixIssuers,
   fix_build_meta: FixBuildMeta,
 }
@@ -117,6 +118,8 @@ impl Cutout {
       build_deps.extend(artifact.revoke_dependency(&dep_id, false));
     }
 
+    self.rebuild_modules.clone_from(&force_build_modules);
+
     // do revoke module and collect deps
     for id in force_build_modules {
       build_deps.extend(artifact.revoke_module(&id));
@@ -170,6 +173,7 @@ impl Cutout {
     let Self {
       fix_issuers,
       fix_build_meta,
+      ..
     } = self;
     fix_issuers.fix_artifact(artifact);
     fix_build_meta.fix_artifact(artifact);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/mod.rs
@@ -72,6 +72,7 @@ pub(crate) async fn update_module_graph_with_session(
     artifact,
     exports_info_artifact,
     build_dependencies,
+    std::mem::take(&mut cutout.rebuild_modules),
     session,
   )
   .await?;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -109,7 +109,9 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let cached_build_result = if let Some(module_build_cache) = &context.module_build_cache {
+    let cached_build_result = if !context.rebuild_modules.contains(&module_identifier)
+      && let Some(module_build_cache) = &context.module_build_cache
+    {
       module_build_cache
         .restore(
           &module,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use rspack_collections::IdentifierSet;
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_tasks::CURRENT_COMPILER_CONTEXT;
 use rustc_hash::FxHashMap as HashMap;
@@ -37,6 +38,7 @@ pub struct TaskContext {
   pub(crate) module_build_cache: Option<ModuleBuildCache>,
   pub value_cache_versions: ValueCacheVersions,
   pub(crate) make_session: Arc<MakeSession>,
+  pub(crate) rebuild_modules: IdentifierSet,
 
   pub artifact: BuildModuleGraphArtifact,
   pub exports_info_artifact: ExportsInfoArtifact,
@@ -67,6 +69,7 @@ impl TaskContext {
       runtime_template: RuntimeTemplate::new(compilation.options.clone()),
       module_build_cache: compilation.module_build_cache.clone(),
       make_session,
+      rebuild_modules: Default::default(),
       cache: compilation.cache.clone(),
       value_cache_versions: compilation.value_cache_versions.clone(),
       artifact,

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/mod.rs
@@ -7,6 +7,7 @@ pub mod process_dependencies;
 
 use std::sync::Arc;
 
+use rspack_collections::IdentifierSet;
 use rspack_error::Result;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
@@ -23,6 +24,7 @@ pub async fn repair(
   mut artifact: BuildModuleGraphArtifact,
   exports_info_artifact: ExportsInfoArtifact,
   build_dependencies: HashSet<BuildDependency>,
+  rebuild_modules: IdentifierSet,
   session: Arc<MakeSession>,
 ) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
   let module_graph = artifact.get_module_graph_mut();
@@ -71,6 +73,7 @@ pub async fn repair(
     .collect::<Vec<_>>();
 
   let mut ctx = TaskContext::new(compilation, artifact, exports_info_artifact, session);
+  ctx.rebuild_modules = rebuild_modules;
   run_task_loop(&mut ctx, init_tasks).await?;
   Ok((ctx.artifact, ctx.exports_info_artifact))
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod module_build_cache;
 mod module_executor;
 pub mod pass;
 mod session;
-
 use std::sync::atomic::Ordering;
 
 use rspack_error::Result;
@@ -56,7 +55,7 @@ pub async fn do_build_module_graph(compilation: &mut Compilation) -> Result<()> 
 /// it will use entries, modified_files, removed_files to update the module graph.
 pub async fn build_module_graph(
   compilation: &Compilation,
-  mut artifact: BuildModuleGraphArtifact,
+  artifact: BuildModuleGraphArtifact,
   exports_info_artifact: ExportsInfoArtifact,
 ) -> Result<(BuildModuleGraphArtifact, ExportsInfoArtifact)> {
   let mut params = Vec::with_capacity(6);
@@ -82,8 +81,6 @@ pub async fn build_module_graph(
     params.push(UpdateParam::RemovedFiles(compilation.removed_files.clone()));
   }
 
-  // reset temporary data
-  artifact.reset_temporary_data();
   let artifacts = update_module_graph(compilation, artifact, exports_info_artifact, params).await?;
   Ok(artifacts)
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -36,6 +36,9 @@ impl PassExt for BuildModuleGraphPhasePass {
   }
 
   async fn run_pass(&self, compilation: &mut Compilation) -> Result<()> {
+    compilation
+      .build_module_graph_artifact
+      .reset_temporary_data();
     let plugin_driver = compilation.plugin_driver.clone();
     let logger = compilation.get_logger("rspack.Compiler");
     // align with webpack, make hook include build_module_graph phase in webpack
@@ -47,29 +50,10 @@ impl PassExt for BuildModuleGraphPhasePass {
     finish_make_pass(compilation, plugin_driver).await?;
     finish_module_graph_pass(compilation).await?;
 
-    use crate::incremental::IncrementalPasses;
-    if compilation
-      .incremental
-      .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
-    {
-      compilation
-        .build_module_graph_artifact
-        .module_graph
-        .checkpoint();
-    }
     Ok(())
   }
 
   async fn after_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) -> Result<()> {
-    if let Some(module_build_cache) = compilation.module_build_cache.clone() {
-      module_build_cache
-        .store_pending(
-          &mut compilation.build_module_graph_artifact,
-          &compilation.file_system_info,
-          compilation.make_session.take_cache_writes(),
-        )
-        .await?;
-    }
     cache.after_build_module_graph(compilation).await;
     Ok(())
   }

--- a/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_module_graph/mod.rs
@@ -35,6 +35,6 @@ pub async fn finish_build_module_graph_pass(compilation: &mut Compilation) -> Re
       .await?;
     compilation.module_executor = Some(module_executor);
   }
-  // make finished, make artifact should be readonly thereafter.
+  // finishModules hooks may still rebuild modules before the graph is checkpointed.
   Ok(())
 }

--- a/crates/rspack_core/src/compilation/finish_modules/mod.rs
+++ b/crates/rspack_core/src/compilation/finish_modules/mod.rs
@@ -22,11 +22,27 @@ impl PassExt for FinishModulesPhasePass {
   async fn run_pass(&self, compilation: &mut Compilation) -> Result<()> {
     finish_modules_pass(compilation).await?;
 
+    // finishModules hooks can call rebuildModule. Publish the final build output
+    // only after those graph updates, before Seal starts modifying the graph.
+    if let Some(module_build_cache) = compilation.module_build_cache.clone() {
+      module_build_cache
+        .store_pending(
+          &mut compilation.build_module_graph_artifact,
+          &compilation.file_system_info,
+          compilation.make_session.take_cache_writes(),
+        )
+        .await?;
+    }
+
     use crate::incremental::IncrementalPasses;
     if compilation
       .incremental
       .passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH)
     {
+      compilation
+        .build_module_graph_artifact
+        .module_graph
+        .checkpoint();
       compilation.exports_info_artifact.checkpoint();
     }
     Ok(())
@@ -73,34 +89,10 @@ pub async fn finish_modules_inner(
   exports_info_artifact: &mut ExportsInfoArtifact,
 ) -> Result<Vec<Diagnostic>> {
   if let Some(mut mutations) = compilation.incremental.mutations_write() {
-    let build_module_graph_artifact = &compilation.build_module_graph_artifact;
-    mutations.extend(
-      build_module_graph_artifact
-        .affected_dependencies
-        .updated()
-        .iter()
-        .map(|&dependency| Mutation::DependencyUpdate { dependency }),
-    );
-    mutations.extend(
-      build_module_graph_artifact
-        .affected_modules
-        .removed()
-        .iter()
-        .map(|&module| Mutation::ModuleRemove { module }),
-    );
-    mutations.extend(
-      build_module_graph_artifact
-        .affected_modules
-        .updated()
-        .iter()
-        .map(|&module| Mutation::ModuleUpdate { module }),
-    );
-    mutations.extend(
-      build_module_graph_artifact
-        .affected_modules
-        .added()
-        .iter()
-        .map(|&module| Mutation::ModuleAdd { module }),
+    mutations.replace_module_graph_mutations(
+      compilation
+        .build_module_graph_artifact
+        .module_graph_mutations(),
     );
     tracing::debug!(target: incremental::TRACING_TARGET, passes = %IncrementalPasses::BUILD_MODULE_GRAPH, %mutations);
   }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -362,10 +362,8 @@ impl Compilation {
     is_rebuild: bool,
     compiler_context: Arc<CompilerContext>,
   ) -> Self {
-    // Incremental make reuses the previous module graph and owns its own
-    // invalidation path. Keep that fast path unchanged.
+    // Cache lookup is selected per build request, independently of artifact recovery.
     let module_build_cache = (options.experiments.new_cache.module
-      && !is_rebuild
       && !matches!(&options.cache, CacheOptions::Disabled))
     .then(|| ModuleBuildCache::new(cache.facade("Compilation/modules"), &options));
     let snapshot_options = match &options.cache {
@@ -1112,6 +1110,11 @@ impl Compilation {
     .await?;
     *exports_info_artifact = updated_exports_info_artifact;
     self.build_module_graph_artifact = artifact.into();
+
+    if let Some(mut mutations) = self.incremental.mutations_write() {
+      mutations
+        .replace_module_graph_mutations(self.build_module_graph_artifact.module_graph_mutations());
+    }
 
     let module_graph = self.get_module_graph();
     Ok(f(module_identifiers

--- a/crates/rspack_core/src/incremental/mutations.rs
+++ b/crates/rspack_core/src/incremental/mutations.rs
@@ -71,6 +71,27 @@ impl fmt::Display for Mutation {
 }
 
 impl Mutations {
+  /// Refresh Make's accumulated changes after a hook updates the module graph.
+  /// Derived affected sets may already have been read by earlier finishModules hooks.
+  pub(crate) fn replace_module_graph_mutations(
+    &mut self,
+    mutations: impl IntoIterator<Item = Mutation>,
+  ) {
+    self.inner.retain(|mutation| {
+      !matches!(
+        mutation,
+        Mutation::ModuleAdd { .. }
+          | Mutation::ModuleUpdate { .. }
+          | Mutation::ModuleRemove { .. }
+          | Mutation::DependencyUpdate { .. }
+      )
+    });
+    self.inner.extend(mutations);
+    self.affected_modules_with_module_graph.take();
+    self.affected_modules_with_chunk_graph.take();
+    self.affected_chunks_with_chunk_graph.take();
+  }
+
   pub fn add(&mut self, mutation: Mutation) {
     self.inner.push(mutation);
   }

--- a/tests/rspack-test/compilerCases/module-build-cache.js
+++ b/tests/rspack-test/compilerCases/module-build-cache.js
@@ -47,7 +47,7 @@ function readOutput(root) {
 }
 
 /** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
-module.exports = [false].flatMap((cache) =>
+module.exports = [false, true].flatMap((cache) =>
   [false, true].map((incremental) => {
     let root;
     let built;
@@ -166,12 +166,104 @@ module.exports = [false].flatMap((cache) =>
   }),
 );
 
+module.exports.push(
+  ...[false, true].map((incremental) => ({
+    description: `should cache the final explicit rebuild after finishModules with incremental=${incremental}`,
+    options(context) {
+      const root = context.getDist(`explicit-rebuild-${incremental}`);
+      context.setValue("root", root);
+      context.setValue("builds", []);
+      fs.rmSync(root, { recursive: true, force: true });
+      write(path.join(root, "src/index.js"), 'module.exports = "original";');
+      write(
+        path.join(root, "loader.js"),
+        "module.exports = function(source) { return this.replacement || source; };",
+      );
+      return {
+        context: path.join(root, "src"),
+        mode: "development",
+        devtool: false,
+        target: "node",
+        entry: "./index.js",
+        cache: true,
+        incremental,
+        experiments: { newCache },
+        module: {
+          rules: [{ test: /index\.js$/, loader: path.join(root, "loader.js") }],
+        },
+        output: {
+          path: path.join(root, "dist"),
+          filename: "main.js",
+          library: { type: "commonjs2" },
+        },
+        plugins: [
+          {
+            apply(compiler) {
+              let replacement;
+              compiler.hooks.compilation.tap(
+                "ExplicitRebuild",
+                (compilation) => {
+                  compiler.rspack.NormalModule.getCompilationHooks(
+                    compilation,
+                  ).loader.tap("ExplicitRebuild", (loaderContext) => {
+                    loaderContext.replacement = replacement;
+                  });
+                  compilation.hooks.buildModule.tap(
+                    "ExplicitRebuild",
+                    (module) => {
+                      if (module.resource)
+                        context
+                          .getValue("builds")
+                          .push(path.basename(module.resource));
+                    },
+                  );
+                  compilation.hooks.finishModules.tapPromise(
+                    "ExplicitRebuild",
+                    async (modules) => {
+                      if (!context.getValue("rebuild")) return;
+                      context.setValue("rebuild", false);
+                      replacement = 'module.exports = "rebuilt";';
+                      const module = [...modules].find(
+                        (module) =>
+                          module.resource === path.join(root, "src/index.js"),
+                      );
+                      await new Promise((resolve, reject) =>
+                        compilation.rebuildModule(module, (error) =>
+                          error ? reject(error) : resolve(),
+                        ),
+                      );
+                    },
+                  );
+                },
+              );
+            },
+          },
+        ],
+      };
+    },
+    compiler(_, compiler) {
+      compiler.outputFileSystem = fs;
+    },
+    async build(context, compiler) {
+      const root = context.getValue("root");
+      await run(compiler);
+      expect(readOutput(root)).toBe("original");
+      context.setValue("rebuild", true);
+      await run(compiler);
+      expect(readOutput(root)).toBe("rebuilt");
+      expect(context.getValue("builds")).toEqual(["index.js", "index.js"]);
+      await run(compiler);
+      expect(readOutput(root)).toBe("rebuilt");
+      expect(context.getValue("builds")).toEqual(["index.js", "index.js"]);
+    },
+  })),
+);
 
 const mainEntry = 'export { default } from "./shared.js";';
 const executorEntry = 'export { default } from "./macro.txt";';
 
 module.exports.push(
-  ...["persistent"].flatMap((cacheType) =>
+  ...["memory", "persistent"].flatMap((cacheType) =>
     [false, true].map((executionFirst) => ({
       description: `should share ${cacheType} module builds from ${executionFirst ? "importModule" : "the main graph"} to ${executionFirst ? "the main graph" : "importModule"}`,
       options(context) {
@@ -260,6 +352,24 @@ module.exports.push(
         expect(readOutput(root).default).toBe("initial");
         expect(builds()).toBe(2);
 
+        // Both graphs can install the same cached dependency tree in one compilation.
+        write(
+          index,
+          'import generated from "./macro.txt"; import value from "./shared.js"; export default [generated, value];',
+        );
+        await run(activeCompiler, [index]);
+        expect(readOutput(root).default).toEqual(["initial", "initial"]);
+        expect(builds()).toBe(2);
+
+        const leaf = path.join(root, "src/leaf.js");
+        write(leaf, 'export default "updated";');
+        await run(activeCompiler, [leaf]);
+        expect(readOutput(root).default).toEqual(["updated", "updated"]);
+        expect(builds()).toBe(4);
+
+        await run(activeCompiler);
+        expect(readOutput(root).default).toEqual(["updated", "updated"]);
+        expect(builds()).toBe(4);
       },
     })),
   ),


### PR DESCRIPTION
## Summary

Rebuilds currently disable the module cache globally, while finishModules hooks can rebuild modules after their cache entries and graph checkpoint have been published. Keep cache eligibility independent from incremental artifact recovery, bypass cache for modules selected for rebuilding, and publish the final cache entries and checkpoint after finishModules. Reset temporary Make state before make hooks and refresh Make mutations and derived affected sets after explicit rebuilds.

Extend coverage across cache/incremental combinations, explicit finishModules rebuilds without a source edit, and memory/persistent cache sharing between importModule and the main graph, including invalidation after source changes.

Validation:

- Repository root: `pnpm run build:cli:dev` — passed.

Tests run from `tests/rspack-test`:

- `pnpm run test Compiler.test.js Cache.test.js --project base` — 190 passed.
- `pnpm run test Watch.part --project base -t watchCases/compilation` — 14 passed.
- `pnpm run test Config.part --project base -t configCases/compilation` — 30 passed.
- `pnpm run test Config.part --project base -t configCases/rebuild` — 4 passed.

## Related links

Part 3 of 4. Base: `codex/make-cache-sessions`. Review and merge in this order:

1. #15484 — refactor: retain complete module build data in the module graph
2. #15485 — fix: scope module cache writes to Make sessions
3. #15486 — fix: preserve module cache behavior during rebuilds **(this PR)**
4. #15487 — refactor: move module cache validation off the graph queue

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required; internal change).
