### PR TITLE
refactor: move module cache validation off the graph queue

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -1,10 +1,6 @@
 use rspack_error::Result;
 
-use super::{
-  TaskContext,
-  build::{BuildOrigin, BuildResultTask, BuildTask},
-  lazy::process_unlazy_dependencies,
-};
+use super::{TaskContext, build::BuildTask, lazy::process_unlazy_dependencies};
 use crate::{
   BoxModule, DependencyRef, ModuleIdentifier,
   compilation::build_module_graph::ForwardedIdSet,
@@ -109,19 +105,6 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let cached_build_result = if !context.rebuild_modules.contains(&module_identifier)
-      && let Some(module_build_cache) = &context.module_build_cache
-    {
-      module_build_cache
-        .restore(
-          &module,
-          &context.file_system_info,
-          &context.value_cache_versions,
-        )
-        .await?
-    } else {
-      None
-    };
     context
       .artifact
       .module_graph
@@ -144,15 +127,6 @@ impl Task<TaskContext> for AddTask {
       .affected_modules
       .mark_as_add(&module_identifier);
 
-    if let Some(cached_build_result) = cached_build_result {
-      return Ok(vec![Box::new(BuildResultTask {
-        build_result: Box::new(cached_build_result.into_build_result(module)),
-        plugin_driver: context.plugin_driver.clone(),
-        forwarded_ids,
-        origin: BuildOrigin::CacheHit,
-      })]);
-    }
-
     Ok(vec![Box::new(BuildTask {
       compiler_id: context.compiler_id,
       compilation_id: context.compilation_id,
@@ -166,6 +140,8 @@ impl Task<TaskContext> for AddTask {
       fs: context.fs.clone(),
       forwarded_ids,
       module_build_cache: context.module_build_cache.clone(),
+      value_cache_versions: context.value_cache_versions.clone(),
+      use_cache: !context.rebuild_modules.contains(&module_identifier),
     })])
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::{
   BoxModule, BuildContext, BuildResult, CacheFacade, CompilationId, CompilerId, CompilerOptions,
-  FileSystemInfo, ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
+  FileSystemInfo, ModuleCodeTemplate, ResolverFactory, SharedPluginDriver, ValueCacheVersions,
   compilation::build_module_graph::{
     ForwardedIdSet, HasLazyDependencies, module_build_cache::ModuleBuildCache,
   },
@@ -30,6 +30,8 @@ pub struct BuildTask {
   pub fs: Arc<dyn ReadableFileSystem>,
   pub forwarded_ids: ForwardedIdSet,
   pub module_build_cache: Option<ModuleBuildCache>,
+  pub value_cache_versions: Arc<ValueCacheVersions>,
+  pub use_cache: bool,
 }
 
 #[async_trait::async_trait]
@@ -51,9 +53,26 @@ impl Task<TaskContext> for BuildTask {
       fs,
       forwarded_ids,
       module_build_cache,
+      value_cache_versions,
+      use_cache,
     } = *self;
 
     let build_start_time = module_build_cache.as_ref().map(|_| current_time());
+
+    // Cache decoding and snapshot validation run outside the graph's main queue.
+    if use_cache
+      && let Some(cache) = &module_build_cache
+      && let Some(entry) = cache
+        .restore(&module, &file_system_info, &value_cache_versions)
+        .await?
+    {
+      return Ok(vec![Box::new(BuildResultTask {
+        build_result: Box::new(entry.into_build_result(module)),
+        plugin_driver,
+        forwarded_ids,
+        origin: BuildOrigin::CacheHit,
+      })]);
+    }
 
     plugin_driver
       .compilation_hooks

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -36,7 +36,7 @@ pub struct TaskContext {
   pub runtime_template: RuntimeTemplate,
   pub(crate) cache: Cache,
   pub(crate) module_build_cache: Option<ModuleBuildCache>,
-  pub value_cache_versions: ValueCacheVersions,
+  pub value_cache_versions: Arc<ValueCacheVersions>,
   pub(crate) make_session: Arc<MakeSession>,
   pub(crate) rebuild_modules: IdentifierSet,
 
@@ -71,7 +71,7 @@ impl TaskContext {
       make_session,
       rebuild_modules: Default::default(),
       cache: compilation.cache.clone(),
-      value_cache_versions: compilation.value_cache_versions.clone(),
+      value_cache_versions: Arc::new(compilation.value_cache_versions.clone()),
       artifact,
       exports_info_artifact,
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -1,3 +1,6 @@
+use std::sync::Arc;
+
+use rayon::prelude::*;
 use rspack_cacheable::cacheable;
 use rspack_collections::{Identifiable, IdentifierMap};
 use rspack_error::{Result, ToStringResultToRspackResultExt};
@@ -82,7 +85,7 @@ impl ModuleBuildCache {
       return Ok(None);
     }
 
-    Ok(Some(result.as_arc().as_ref().clone()))
+    Ok(Some(Arc::unwrap_or_clone(result.into_arc())))
   }
 
   /// Stores modules built during this phase from the final module graph.
@@ -137,22 +140,15 @@ impl ModuleBuildCache {
       .collect::<Vec<_>>();
 
     let module_graph = artifact.get_module_graph();
-    let cache_entries = rspack_parallel::scope::<_, Result<_>>(|token| {
-      for module_identifier in module_identifiers {
-        // SAFETY: the scope is awaited before the cache entries are published.
-        let task = unsafe { token.used((module_graph, self.persistent_codec.as_ref())) };
-        task.spawn(move |(module_graph, codec)| async move {
-          Ok((
-            module_identifier,
-            create_cache_entry(module_graph, module_identifier, codec),
-          ))
-        });
-      }
-    })
-    .await
-    .into_iter()
-    .map(|result| result.to_rspack_result().and_then(|result| result))
-    .collect::<Result<Vec<_>>>()?;
+    let cache_entries = module_identifiers
+      .into_par_iter()
+      .map(|identifier| {
+        (
+          identifier,
+          create_cache_entry(module_graph, identifier, self.persistent_codec.as_ref()),
+        )
+      })
+      .collect::<Vec<_>>();
 
     for (module_identifier, entry) in cache_entries {
       let entry = match entry {


### PR DESCRIPTION
## Summary

Module-cache decoding and snapshot validation currently await inside the graph's main task queue. Move that work into the background BuildTask after AddTask reserves the module, then install both cache hits and fresh builds through BuildResultTask. Share value-cache versions through Arc, construct cache entries with Rayon for synchronous work, and consume the returned cache value with unwrap_or_clone.

Validation reruns the preceding layers' cache and importModule coverage.

Validation:

- Repository root: `pnpm run build:cli:dev` — passed.

Tests run from `tests/rspack-test`:

- `pnpm run test Compiler.test.js Cache.test.js --project base` — 190 passed.
- `pnpm run test Config.part --project base -t configCases/loader-parallel-import-module` — 12 passed.

## Related links

Part 4 of 4. Base: `codex/make-cache-rebuilds`. Review and merge in this order:

1. #15484 — refactor: retain complete module build data in the module graph
2. #15485 — fix: scope module cache writes to Make sessions
3. #15486 — fix: preserve module cache behavior during rebuilds
4. #15487 — refactor: move module cache validation off the graph queue **(this PR)**

## Checklist

- [x] Tests updated (or not required; existing regressions rerun).
- [x] Documentation updated (or not required; internal change).
