### PR TITLE
chore: add Rspack PR review workflow

### DIFF
--- a/.agents/skills/rspack-api-assessment/SKILL.md
+++ b/.agents/skills/rspack-api-assessment/SKILL.md
@@ -1,25 +1,32 @@
 ---
 name: rspack-api-assessment
-description: Strictly evaluate proposed or newly added public APIs, including hooks, specifically in web-infra-dev/rspack from Rspack's architecture, existing extension points, performance, webpack compatibility, and observed usage. Use when deciding whether Rspack should add or keep such a surface; default against addition when a viable Rspack substitute exists unless broad independent plugin compatibility is demonstrated.
+description: Strictly evaluate proposed, newly added, or changed public APIs, including hooks, specifically in web-infra-dev/rspack from Rspack's architecture, existing extension points, compatibility, performance, webpack behavior, and observed usage. Use when deciding whether Rspack should add or keep a new surface or accept a change to an existing contract; default against addition when a viable Rspack substitute exists unless broad independent plugin compatibility is demonstrated.
 ---
 
 # Assess an Rspack API
 
 ## Scope and outcome
 
-Decide whether Rspack should add or keep a proposed API, including a hook, from Rspack's own architecture. Accept a PR, issue, commit, symbol, or design proposal and answer:
+Accept a PR, issue, commit, symbol, or design proposal and first select exactly one assessment mode:
+
+- **New API mode:** the change proposes or newly adds a public surface; decide whether Rspack should add or keep it.
+- **Existing API change mode:** the change modifies an established public contract, such as its types, defaults, diagnostics, output shape, ordering, serialization, or documented behavior; decide whether Rspack should accept that modification, not whether the entire API should continue to exist.
+
+In either mode, answer:
 
 1. What does it do inside Rspack?
 2. Which concrete scenario needs it?
-3. Can existing Rspack capabilities replace it, and how?
+3. Can existing Rspack capabilities or a more compatible design replace the proposed surface or change, and how?
 4. What is its performance impact?
 5. What is its architectural impact?
 6. How is the analogous webpack API used?
-7. Should Rspack add or keep it?
+7. Should Rspack add or keep the API, or accept the proposed change to it?
 
 The final verdict must always include its reasons. State why the user and compatibility value does or does not outweigh the best substitute, performance cost, and long-term architectural commitment; never return only “add” or “do not add”.
 
-Apply a strict public-API budget: the proposal carries the burden of proving that a permanent extension surface is necessary. If an existing Rspack solution can satisfy the required behavior correctly, reject the new API by default even when the substitute is later, less convenient, or requires rewriting one or a few plugins. Make an exception only when verified ecosystem evidence shows compatibility gains for a substantial set of independently maintained and actively used plugins; theoretical webpack parity, one consumer, forks, and copied implementations are insufficient.
+In new API mode, apply a strict public-API budget: the proposal carries the burden of proving that a permanent extension surface is necessary. If an existing Rspack solution can satisfy the required behavior correctly, reject the new API by default even when the substitute is later, less convenient, or requires rewriting one or a few plugins. Make an exception only when verified ecosystem evidence shows compatibility gains for a substantial set of independently maintained and actively used plugins; theoretical webpack parity, one consumer, forks, and copied implementations are insufficient.
+
+In existing API change mode, preserve the established compatibility contract by default. Require evidence that the behavior change is necessary and that its compatibility boundary, migration path, documentation, performance cost, and webpack alignment are acceptable. Reject the proposed change, rather than the API itself, when a compatible design can satisfy the scenario or existing valid usage would break without sufficient justification and migration support.
 
 This is read-only unless the user separately requests implementation or publication. Do not post comments or mutate GitHub state as part of the assessment.
 
@@ -44,9 +51,9 @@ Trace the exact call path and neighboring phases. Identify the owning subsystem,
 
 Find a concrete consumer or reproducible workflow when possible. Explain the user-visible problem first and generalize only as far as the evidence supports.
 
-### Existing Rspack substitutes
+### Alternatives and compatible designs
 
-Construct the smallest credible alternative from the base version, considering module/parser hooks, runtime modules, render hooks, `processAssets`, `updateAsset`, built-in plugins, and small compositions.
+Construct the smallest credible alternative from the base version, considering module/parser hooks, runtime modules, render hooks, `processAssets`, `updateAsset`, built-in plugins, small compositions, and backward-compatible ways to evolve the existing contract.
 
 Judge replacement separately at three levels:
 
@@ -77,7 +84,7 @@ Judge whether the extension belongs in the Rspack subsystem that owns the phase 
 - determinism, hash/cache correctness, incremental behavior, and concurrency boundaries;
 - source maps, ESM/CommonJS syntax, target differences, errors, tests, and documentation.
 
-For a webpack-compatible API, compare current webpack ordering, hook type, complete context shape, version, and behavior. A matching name is not full compatibility: classify missing fields as available through `compilation`, intentionally unsupported, or unavailable, and treat direct shape differences as compatibility debt.
+For a webpack-compatible API, compare current webpack ordering, hook type, complete context shape, version, and behavior. A matching name is not full compatibility: classify missing fields as available through `compilation`, intentionally unsupported, or unavailable, and treat direct shape differences as compatibility debt. In existing API change mode, identify previously valid calls and observable outputs that would change, and judge the migration path, deprecation strategy, and semver impact.
 
 ### webpack and ecosystem usage
 
@@ -87,14 +94,21 @@ Report external repositories, independent patterns, notable downstream reach, se
 
 ## Make and explain the decision
 
-Choose one outcome:
+In new API mode, choose one outcome:
 
 - **Add or keep:** no viable existing Rspack solution can satisfy a necessary scenario, or broad evidence shows that many independent plugins require this exact compatibility surface; the contract must also be narrow and its unused and active costs acceptable.
 - **Add or keep with conditions:** the necessity or broad compatibility threshold is already met, but performance, context shape, hash/cache correctness, tests, or documentation needs a bounded follow-up; conditions cannot compensate for missing necessity.
 - **Defer:** a specific missing fact about necessity, substitute viability, broad plugin usage, or active cost could materially change the decision.
 - **Do not add:** use this as the default when a viable Rspack substitute exists and broad ecosystem compatibility has not been demonstrated, or when hot-path and architectural costs outweigh a genuinely necessary capability.
 
-Determine the strongest reason for and against the API internally, but report only the decisive reason and any uncertainty that changes the verdict. The verdict must explicitly account for substitute viability and whether the broad-plugin compatibility threshold is met.
+In existing API change mode, choose one outcome:
+
+- **Accept:** the change addresses a necessary scenario while preserving compatibility, or its bounded incompatibility is justified with an adequate migration path, documentation, tests, and semver treatment.
+- **Accept with conditions:** the change is justified, but a bounded compatibility, migration, performance, test, or documentation requirement must be completed before acceptance.
+- **Defer:** a specific missing fact about affected usage, compatibility, migration, webpack behavior, or active cost could materially change the decision.
+- **Reject the change:** a compatible design can satisfy the scenario, existing valid usage would break without sufficient justification, or the performance and architectural costs outweigh the benefit.
+
+Determine the strongest reason for and against the proposal internally, but report only the decisive reason and any uncertainty that changes the verdict. In new API mode, the verdict must explicitly account for substitute viability and whether the broad-plugin compatibility threshold is met. In existing API change mode, it must explicitly account for compatibility impact, the best compatible alternative, and migration support, and it must clearly apply to the proposed change rather than to retaining the API itself.
 
 ## Present the result
 
@@ -102,10 +116,10 @@ Return only the following Markdown list, with exactly seven single-sentence item
 
 - **Function:** <what the API does>.
 - **Use case:** <the concrete problem it solves>.
-- **Replaceability:** <whether existing Rspack APIs or hooks can replace it, including the key difference>.
+- **Replaceability:** <whether existing Rspack APIs, hooks, or a compatible design can replace the proposal, including the key difference>.
 - **Performance impact:** <the main unused-path and active-path costs>.
 - **Architectural impact:** <the most important architectural benefit or cost>.
 - **webpack usage:** <the number and breadth of independent real-world usages>.
-- **Verdict:** <add, keep, defer, or reject, with the decisive reason>.
+- **Verdict:** <in new API mode: add, keep, defer, or reject the API; in existing API change mode: accept, accept with conditions, defer, or reject the change; include the decisive reason>.
 
 Only when `Replaceability` is an evidence-backed “yes” and existing Rspack APIs or hooks preserve the required behavior, append an eighth `**Compatibility implementation:**` list item containing one minimal code block. Keep the snippet to the essential calls, normally no more than 12 non-empty lines; for partial, uncertain, or semantically different alternatives, output no code.

--- a/.agents/skills/rspack-api-assessment/agents/openai.yaml
+++ b/.agents/skills/rspack-api-assessment/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: 'Rspack API Assessment'
-  short_description: 'Strictly assess new Rspack public APIs'
-  default_prompt: 'Use $rspack-api-assessment to decide whether the requested Rspack API should be added, with evidence and explicit reasons.'
+  short_description: 'Assess new or changed Rspack public APIs'
+  default_prompt: 'Use $rspack-api-assessment to decide whether a new Rspack API or a change to an existing API should be accepted, with evidence and explicit reasons.'
 
 policy:
   allow_implicit_invocation: false

--- a/.agents/skills/rspack-pr-review/SKILL.md
+++ b/.agents/skills/rspack-pr-review/SKILL.md
@@ -111,7 +111,7 @@ Explain why the fix addresses the root cause, not merely what lines changed.
 
 After the visible report, put the entire translation in a collapsed block without a language-version heading:
 
-```html
+```text
 <details>
 <summary>Translation</summary>
 

--- a/.agents/skills/rspack-pr-review/SKILL.md
+++ b/.agents/skills/rspack-pr-review/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: rspack-pr-review
+description: Review a pull request in web-infra-dev/rspack from a PR number or GitHub PR URL, classify the change, inspect its design, implementation, tests, compatibility, correctness and performance risks, compare relevant behavior with webpack or other bundlers, and publish or update one concise bilingual English/Chinese review report as a PR comment. Use for Rspack PR design reviews, implementation reviews, risk assessments, and requests to produce or publish a structured PR review report.
+---
+
+# Review an Rspack PR
+
+## Input and scope
+
+- Require either a numeric PR ID or a GitHub PR URL.
+- Interpret a numeric ID as `web-infra-dev/rspack#<id>`.
+- Reject URLs for another repository unless the user explicitly asks to review that repository with this workflow.
+- Treat the user's request to use this skill as authorization to create or update the final report as one ordinary PR comment. Do not approve, request changes, merge, close, label, or otherwise mutate the PR.
+- If the PR cannot be read or commented on, provide the complete comment body to the user and state the exact blocker.
+
+## Gather evidence
+
+Use the connected GitHub tools when available; otherwise use authenticated `gh` and local `git`. Inspect evidence rather than relying only on the PR description.
+
+1. Resolve the PR number, repository, base SHA, head SHA, author, title, body, labels, commits, changed files, checks, review threads, issue comments, and review comments.
+2. Read the complete diff. For large PRs, inspect every changed file at least at the structural level, then deeply inspect behavior-bearing code, public types, tests, documentation, benchmarks, fixtures, snapshots, and generated changes.
+3. Inspect the relevant base-branch implementation and history to explain the previous design and why the change is necessary. Follow repository `AGENTS.md` instructions.
+4. Trace important flows across Rust and JavaScript/TypeScript boundaries where applicable. Check error paths, caching, invalidation, ordering, concurrency, determinism, platform differences, and lifecycle behavior.
+5. Inspect whether existing and changed tests cover the trigger or new behavior, meaningful edge cases, regressions, and API compatibility. Use test design and verified remote CI results as evidence, but do not run local builds, tests, benchmarks, linters, formatters, or static checks. Assess correctness from the code paths, state transitions, invariants, and failure modes themselves.
+6. For performance PRs, read PR comments and check results for `ecosystem-benchmark` and CodSpeed evidence. Distinguish measured results from author claims and missing data.
+7. For feature work, search webpack's current source, tests, and documentation for analogous behavior. If none exists, inspect another relevant bundler such as Rollup, esbuild, Parcel, or Vite. Cite stable source links in the report when useful. Do not infer parity from naming alone.
+
+Fetch remote information when it may have changed. Prefer primary evidence: repository code, tests, official documentation, benchmark output, and CI results.
+
+## Classify the PR
+
+Choose one primary type based on the dominant intent and implementation:
+
+- **Feature development**: adds or materially changes user-visible behavior, configuration, hooks, APIs, or capabilities.
+- **Bug fix**: corrects behavior that violates the intended contract in a reproducible scenario.
+- **Performance optimization**: primarily reduces CPU, memory, allocation, I/O, build time, or rebuild time while intending to preserve behavior.
+- **Other**: refactoring, project governance, dependency/build/CI work, documentation, tests, maintenance, or mixed work without a dominant category above.
+
+Mention important secondary aspects in the overview. Do not force a governance or refactor PR into a feature category merely because code changes.
+
+## Evaluate findings
+
+- Separate verified defects from plausible risks, questions, and missing evidence.
+- For every material concern, identify the affected code path and a concrete trigger. Explain impact and why existing tests do or do not cover it.
+- Judge correctness primarily by tracing the implementation logic through concrete inputs and lifecycle transitions. Treat tests as coverage evidence, not as a substitute for understanding why the code is correct or incorrect.
+- Avoid speculative filler. State `No material risk identified from the inspected changes` when appropriate, while noting validation limits.
+- Treat API changes broadly: JavaScript/TypeScript types, Rust-facing contracts, configuration schema, hooks, defaults, diagnostics, output shape, ordering, serialization, and documented behavior.
+- Call a change breaking only when existing valid usage or observable behavior can fail or change incompatibly. Explain the compatibility boundary.
+- Evaluate performance directionally even without benchmarks: hot-path work, algorithmic complexity, allocations, cloning, hashing, locking, I/O, cache hit rate, and parallelism.
+- Keep the report focused on design and risk. Do not turn it into a file-by-file changelog.
+
+## Write the report
+
+Produce a visible English report followed by a semantically equivalent Chinese translation contained entirely inside a collapsed block. Keep each section short but explicit, normally one to three compact paragraphs or a few bullets. Use `Not applicable`, `Not found`, or `Not verified` instead of omitting a required topic.
+
+Do not place any Chinese text before the opening `<details>` tag. The reviewed-commit line, visible disclaimer, headings, prose, and collapsed-block summary must all be English; Chinese may appear only inside the collapsed block's body. Do not add language labels such as `English`, `Chinese`, `英文`, or `中文` anywhere in the comment.
+
+Start the comment with this preamble, replacing `<full head SHA>` with the complete PR head commit SHA that was actually reviewed:
+
+```markdown
+**Reviewed commit:** `<full head SHA>`
+<!-- rspack-pr-review -->
+
+**This comment is only intended to assist code review and does not constitute a direct code review recommendation.**
+```
+
+The reviewed-commit line must be the first visible line, and the hidden marker must remain unchanged so later runs can find and update the comment. Then write the visible report directly, without a language-version heading. Select only the outline matching the primary type.
+
+### Feature development outline
+
+1. `### PR Overview`
+2. `### Previous Design`
+3. `### New or Changed Design`
+4. `### webpack and Other Bundlers`
+   - State whether webpack has an analogous implementation.
+   - If yes, explain concrete differences.
+   - If no, assess a relevant alternative bundler.
+5. `### API and Documentation`
+   - Identify API changes, breaking changes, and documentation coverage.
+6. `### Correctness Risks`
+7. `### Performance Regression Risks`
+
+### Bug-fix outline
+
+1. `### PR Overview`
+2. `### Problem and Trigger`
+3. `### Previous Design and Root Cause`
+4. `### Fix Design`
+5. `### Correctness Risks`
+6. `### Performance Regression Risks`
+
+Explain why the fix addresses the root cause, not merely what lines changed.
+
+### Performance-optimization outline
+
+1. `### PR Overview`
+2. `### Optimized Phase`
+3. `### Previous Design and Bottleneck`
+4. `### New Design and Why It Is Faster`
+5. `### Benchmark Evidence`
+   - Report ecosystem-benchmark and CodSpeed evidence separately, including absence or inconclusive results.
+6. `### Correctness Risks`
+
+### Other outline
+
+1. `### PR Overview`
+2. `### Previous Design` — include only when existing behavior or architecture is changed.
+3. `### Current Design`
+4. `### Correctness Risks`
+5. `### Performance Regression Risks`
+
+After the visible report, put the entire translation in a collapsed block without a language-version heading:
+
+```html
+<details>
+<summary>Translation</summary>
+
+**本评论仅用于辅助代码审查，不构成直接的代码审查建议。**
+
+...translated report with the same type-specific structure...
+
+</details>
+```
+
+Use natural translated headings corresponding to the visible headings, but do not add a heading that names either language. Preserve technical identifiers in their original form. Ensure the two versions make the same claims, risk assessments, and confidence qualifications. Keep every Chinese character, including the translated disclaimer, after `<details>` and before `</details>`.
+
+## Post and verify
+
+1. Draft the complete comment in a temporary file to avoid shell-quoting corruption.
+2. Immediately before publication, resolve the current PR head SHA again. If it differs from the head SHA used for the review, inspect the new changes and regenerate the report; never attach a stale report to the new SHA.
+3. Put the complete reviewed head SHA in the first visible line. Recheck every factual claim against collected evidence, confirm both language versions match, verify that the hidden marker is present, verify that no Chinese character appears before `<details>`, and ensure the comment contains no language-version heading or label.
+4. List the pull request's existing issue comments. Match a workflow comment by the exact `<!-- rspack-pr-review -->` marker; for comments created before this marker existed, also match a comment whose first line is the exact disclaimer. If multiple comments match, select the most recently updated one.
+5. If a workflow comment exists, verify that the authenticated account can edit it and update that comment in place through its issue-comment endpoint. If it cannot be edited, report the blocker and do not create a duplicate. Create exactly one ordinary issue comment only when no workflow comment exists.
+6. Read back the created or updated comment to verify its body, reviewed head SHA, formatting, URL, and successful publication.
+7. Return the PR link, comment link, whether the comment was created or updated, primary classification, remote checks inspected, and any evidence limitations to the user. Do not report local validation because this workflow must not run it.
+
+Do not post partial drafts or multiple correction comments. If a create or update operation has an uncertain result, fetch the matching comment and compare its body before retrying.

--- a/.agents/skills/rspack-pr-review/SKILL.md
+++ b/.agents/skills/rspack-pr-review/SKILL.md
@@ -17,7 +17,7 @@ description: Review a pull request in web-infra-dev/rspack from a PR number or G
 
 Use the connected GitHub tools when available; otherwise use authenticated `gh` and local `git`. Inspect evidence rather than relying only on the PR description.
 
-1. Resolve the PR number, repository, base SHA, head SHA, author, title, body, labels, commits, changed files, checks, review threads, issue comments, and review comments.
+1. Resolve the PR number, repository, base ref, base SHA, head SHA, effective merge base, author, title, body, labels, commits, changed files, checks, review threads, issue comments, and review comments.
 2. Read the complete diff. For large PRs, inspect every changed file at least at the structural level, then deeply inspect behavior-bearing code, public types, tests, documentation, benchmarks, fixtures, snapshots, and generated changes.
 3. Inspect the relevant base-branch implementation and history to explain the previous design and why the change is necessary. Follow repository `AGENTS.md` instructions.
 4. Trace important flows across Rust and JavaScript/TypeScript boundaries where applicable. Check error paths, caching, invalidation, ordering, concurrency, determinism, platform differences, and lifecycle behavior.
@@ -127,7 +127,7 @@ Use natural translated headings corresponding to the visible headings, but do no
 ## Post and verify
 
 1. Draft the complete comment in a temporary file to avoid shell-quoting corruption.
-2. Immediately before publication, resolve the current PR head SHA again. If it differs from the head SHA used for the review, inspect the new changes and regenerate the report; never attach a stale report to the new SHA.
+2. Immediately before publication, re-resolve the current base ref, base SHA, head SHA, and effective merge base. If any differs from the values used for the review, refresh the diff and all affected evidence, then regenerate the report; never publish a report against stale base or head state.
 3. Put the complete reviewed head SHA in the first visible line. Recheck every factual claim against collected evidence, confirm both language versions match, verify that the hidden marker is present, verify that no Chinese character appears before `<details>`, and ensure the comment contains no language-version heading or label.
 4. List the pull request's existing issue comments. Match a workflow comment by the exact `<!-- rspack-pr-review -->` marker; for comments created before this marker existed, also match a comment whose first line is the exact disclaimer. If multiple comments match, select the most recently updated one.
 5. If a workflow comment exists, verify that the authenticated account can edit it and update that comment in place through its issue-comment endpoint. If it cannot be edited, report the blocker and do not create a duplicate. Create exactly one ordinary issue comment only when no workflow comment exists.

--- a/.agents/skills/rspack-pr-review/agents/openai.yaml
+++ b/.agents/skills/rspack-pr-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: 'Rspack PR Review'
+  short_description: 'Review Rspack PR design and implementation risks'
+  default_prompt: 'Use $rspack-pr-review to review the requested web-infra-dev/rspack pull request and publish or update one bilingual GitHub comment.'
+
+policy:
+  allow_implicit_invocation: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,17 @@ Before running tests after code changes:
 - **Docs**: `website/docs/en/` (English), `website/docs/zh/` (Chinese)
 - **API**: `website/docs/en/api/`
 
+## Code Review Rules
+
+- When handling a GitHub Codex review request for a pull request, invoke `$rspack-pr-review` to prepare the overall review report.
+- Maintain one ordinary GitHub issue comment for the review report. Do not submit a GitHub review, approval, or request-changes event.
+- Make the first visible line identify the exact full PR head commit SHA that was reviewed, using the `Reviewed commit` label, and include the stable `<!-- rspack-pr-review -->` marker immediately after it. Recheck the head SHA before publishing; if it changed during the review, review the new head before updating the comment.
+- Before creating a comment, search the pull request's existing issue comments for that marker. For backward compatibility, also recognize a comment whose first line is the `$rspack-pr-review` disclaimer. If one or more matching comments exist, update the most recently updated one in place and do not create another. If the matching comment cannot be edited, report the blocker instead of creating a duplicate.
+- Before publishing, identify every API changed by the pull request using the API-change scope defined by `$rspack-pr-review`. If the pull request changes APIs, invoke `$rspack-api-assessment` separately for each API.
+- For this combined workflow, keep the overall review and all API assessments as drafts until every section is complete; neither skill should publish a partial result independently.
+- Compose the single comment with the complete overall review first, followed by each API assessment. Identify the API immediately before its assessment, and place a Markdown horizontal rule (`---`) between the overall review and the first API assessment and between every pair of API assessments.
+- After creating or updating the comment, read it back to verify its formatting, reviewed commit SHA, and successful publication. If the mutation result is uncertain, check the existing comment before retrying.
+
 ## Pull request guidelines
 
 - **Template**: Use `.github/PULL_REQUEST_TEMPLATE.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,13 +106,13 @@ Before running tests after code changes:
 - **Docs**: `website/docs/en/` (English), `website/docs/zh/` (Chinese)
 - **API**: `website/docs/en/api/`
 
-## Code review rules
+## Code Review Rules
 
 - When handling a GitHub Codex review request for a pull request, invoke `$rspack-pr-review` to prepare the overall review report.
 - Maintain one ordinary GitHub issue comment for the review report. Do not submit a GitHub review, approval, or request-changes event.
-- Make the first visible line identify the exact full PR head commit SHA that was reviewed, using the `Reviewed commit` label, and include the stable `<!-- rspack-pr-review -->` marker immediately after it. Recheck the head SHA before publishing; if it changed during the review, review the new head before updating the comment.
+- Make the first visible line identify the exact full PR head commit SHA that was reviewed, using the `Reviewed commit` label, and include the stable `<!-- rspack-pr-review -->` marker immediately after it. Before publishing, re-resolve the base ref, base SHA, head SHA, and effective merge base; if any changed during the review, refresh the evidence and review before updating the comment.
 - Before creating a comment, search the pull request's existing issue comments for that marker. For backward compatibility, also recognize a comment whose first line is the `$rspack-pr-review` disclaimer. If one or more matching comments exist, update the most recently updated one in place and do not create another. If the matching comment cannot be edited, report the blocker instead of creating a duplicate.
-- Before publishing, identify every API changed by the pull request using the API-change scope defined by `$rspack-pr-review`. If the pull request changes APIs, invoke `$rspack-api-assessment` separately for each API.
+- Before publishing, identify every API changed by the pull request using the API-change scope defined by `$rspack-pr-review`. If the pull request adds a public API or changes an existing public API contract, invoke `$rspack-api-assessment` separately for each API in the applicable assessment mode.
 - For this combined workflow, keep the overall review and all API assessments as drafts until every section is complete; neither skill should publish a partial result independently.
 - Compose the single comment with the complete overall review first, followed by each API assessment. Identify the API immediately before its assessment, and place a Markdown horizontal rule (`---`) between the overall review and the first API assessment and between every pair of API assessments.
 - After creating or updating the comment, read it back to verify its formatting, reviewed commit SHA, and successful publication. If the mutation result is uncertain, check the existing comment before retrying.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ Before running tests after code changes:
 - **Docs**: `website/docs/en/` (English), `website/docs/zh/` (Chinese)
 - **API**: `website/docs/en/api/`
 
-## Code Review Rules
+## Code review rules
 
 - When handling a GitHub Codex review request for a pull request, invoke `$rspack-pr-review` to prepare the overall review report.
 - Maintain one ordinary GitHub issue comment for the review report. Do not submit a GitHub review, approval, or request-changes event.

--- a/rstack.config.mts
+++ b/rstack.config.mts
@@ -28,6 +28,13 @@ define.fmt({
   plugins: ['heading-case'],
   overrides: [
     {
+      // OpenAI recognizes this file's exact `## Code Review Rules` heading.
+      files: 'AGENTS.md',
+      options: {
+        plugins: [],
+      },
+    },
+    {
       files: '*.toml',
       options: {
         plugins: ['prettier-plugin-toml'],


### PR DESCRIPTION
## Summary

- Add repository-local guidance for structured bilingual pull request risk reports.
- Maintain a single reusable review comment and record the reviewed head commit.
- Append per-API assessments to the same comment when public contracts change.

## Related links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).