### PR TITLE
perf(resolver): skip tsconfig paths for relative specifiers

### DIFF
--- a/crates/rspack_resolver/src/lib.rs
+++ b/crates/rspack_resolver/src/lib.rs
@@ -99,7 +99,7 @@ use crate::{
   package_json::JSONMap,
   path::{PathUtil, SLASH_START},
   specifier::Specifier,
-  tsconfig::{ExtendsField, ProjectReference, TsConfig},
+  tsconfig::{ExtendsField, ProjectReference, TsConfig, is_relative_specifier},
 };
 pub use crate::{
   builtins::NODEJS_BUILTINS,
@@ -364,11 +364,15 @@ impl<Fs: FileSystem + Send + Sync> ResolverGeneric<Fs> {
     ctx: &mut Ctx,
   ) -> Result<CachedPath, ResolveError> {
     // tsconfig-paths
-    if let Some(path) = self
-      .load_tsconfig_paths(cached_path, specifier, ctx)
-      .await?
-    {
-      return Ok(path);
+    // `paths` never applies to a relative specifier, so the tsconfig is
+    // neither loaded nor a file dependency for one.
+    if !is_relative_specifier(specifier) {
+      if let Some(path) = self
+        .load_tsconfig_paths(cached_path, specifier, ctx)
+        .await?
+      {
+        return Ok(path);
+      }
     }
 
     // enhanced-resolve: try alias

--- a/crates/rspack_resolver/src/tests/tsconfig_project_references.rs
+++ b/crates/rspack_resolver/src/tests/tsconfig_project_references.rs
@@ -84,6 +84,42 @@ async fn tsconfig_file_as_file_dependencies() {
   }
 }
 
+// A relative specifier never goes through `paths`, so the tsconfig is not
+// loaded for it and none of the reference tree is a file dependency.
+#[tokio::test]
+async fn relative_specifier_skips_tsconfig() {
+  let f = super::fixture_root().join("tsconfig/cases/project_references");
+
+  let resolver = Resolver::new(ResolveOptions {
+    tsconfig: Some(TsconfigOptions {
+      config_file: f.join("app"),
+      references: TsconfigReferences::Auto,
+    }),
+    ..ResolveOptions::default()
+  });
+  let mut ctx = ResolveContext::default();
+
+  let resolved_path = resolver
+    .resolve_with_context(&f.join("project_a"), "./index.ts", &mut ctx)
+    .await
+    .map(|f| f.full_path());
+  assert_eq!(resolved_path, Ok(f.join("project_a/index.ts")));
+
+  // The nearest `package.json` sits above `cases`; every `.json` below it is a tsconfig.
+  let cases = super::fixture_root().join("tsconfig/cases");
+  let tsconfig_dependencies = ctx
+    .file_dependencies
+    .iter()
+    .filter(|dependency| {
+      dependency.starts_with(&cases) && dependency.extension().is_some_and(|ext| ext == "json")
+    })
+    .collect::<Vec<_>>();
+  assert!(
+    tsconfig_dependencies.is_empty(),
+    "{tsconfig_dependencies:?}"
+  );
+}
+
 #[tokio::test]
 async fn disabled() {
   let f = super::fixture_root().join("tsconfig/cases/project_references");

--- a/crates/rspack_resolver/src/tsconfig.rs
+++ b/crates/rspack_resolver/src/tsconfig.rs
@@ -80,6 +80,15 @@ pub struct ProjectReference {
   pub tsconfig: Option<Arc<TsConfig>>,
 }
 
+/// tsc's `PathIsRelative`: `.`, `..`, or a `./`, `../` (also `.\`, `..\`)
+/// prefix. `paths` never applies to these; an absolute specifier is not relative.
+pub(crate) fn is_relative_specifier(specifier: &str) -> bool {
+  matches!(
+    specifier.as_bytes(),
+    [b'.'] | [b'.', b'.'] | [b'.', b'/' | b'\\', ..] | [b'.', b'.', b'/' | b'\\', ..]
+  )
+}
+
 impl TsConfig {
   #[cfg_attr(feature="enable_instrument", tracing::instrument(level=tracing::Level::DEBUG, skip_all, fields(path = path.as_str())))]
   pub fn parse(root: bool, path: &Utf8Path, json: &mut str) -> Result<Self, serde_json::Error> {


### PR DESCRIPTION
## Summary

Align with tsc: `compilerOptions.paths` is only consulted for a specifier that is not relative, see [`tryLoadModuleUsingPathsIfEligible`](https://github.com/microsoft/TypeScript/blob/1f70213d4922b434345f639b441681e470c7cfc1/tsc/internal/module/resolver.go#L1241-L1247), where relative means `.`, `..`, or a `./` / `../` prefix (`PathIsRelative`).

The resolver loaded the tsconfig for every request, so a relative specifier still read the tsconfig and attached it, along with its whole project-reference tree, to the importing module's file dependencies. Now the tsconfig is skipped for a relative specifier: it is neither loaded nor a file dependency. Bare and absolute specifiers behave as before.

**Before**: resolving `./index.ts` from a project inside a reference tree reports every tsconfig of the tree as a file dependency.

**After**: no tsconfig is reported for it. Brings some memory and walltime improvement large TS project with lots of references.
<img width="2292" height="1331" alt="rss-internal-large-app" src="https://github.com/user-attachments/assets/ce515353-ec05-41cc-b7fa-19355e1f66fd" />


## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
