### PR TITLE
Defer source maps with immutable native asset snapshots

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -281,6 +281,7 @@ export declare class JsCompilation {
   getAssets(): Readonly<JsAsset>[]
   getAsset(name: string): JsAsset | null
   getAssetSource(name: string): JsSource | null
+  getAssetSourceSnapshot(name: string): JsSourceSnapshot | null
   get modules(): Array<Module>
   get builtModules(): Array<Module>
   getOptimizationBailout(): Array<JsStatsOptimizationBailout>
@@ -436,6 +437,11 @@ export declare class JsResolver {
 export declare class JsResolverFactory {
   constructor(pnp: boolean, jsResolveOptions: RawResolveOptions, jsLoaderResolveOptions: RawResolveOptions)
   get(type: string, options?: RawResolveOptionsWithDependencyType): JsResolver
+}
+
+export declare class JsSourceSnapshot {
+  source(): string | Buffer
+  sourceAndMap(): JsSource
 }
 
 export declare class JsStats {

--- a/crates/rspack_binding_api/src/compilation/mod.rs
+++ b/crates/rspack_binding_api/src/compilation/mod.rs
@@ -36,7 +36,7 @@ use crate::{
   module_graph::JsModuleGraph,
   options::entry::JsEntryOptions,
   path_data::{JsPathData, PathWithInfo},
-  source::{JsSourceFromJs, JsSourceToJs},
+  source::{JsSourceFromJs, JsSourceSnapshot, JsSourceToJs},
   stats::{JsStats, JsStatsOptimizationBailout, create_stats_warnings},
   utils::callbackify,
   with_compilation,
@@ -217,6 +217,18 @@ impl JsCompilation {
       .get(&name)
       .and_then(|v| v.source.as_ref().map(JsSourceToJs::try_from))
       .transpose()
+  }
+
+  #[napi]
+  pub fn get_asset_source_snapshot(&self, name: String) -> Result<Option<JsSourceSnapshot>> {
+    let compilation = self.as_ref()?;
+    Ok(
+      compilation
+        .assets()
+        .get(&name)
+        .and_then(|asset| asset.source.as_ref())
+        .map(|source| JsSourceSnapshot::new(source.clone())),
+    )
   }
 
   #[napi(getter, ts_return_type = "Array<Module>")]

--- a/crates/rspack_binding_api/src/source.rs
+++ b/crates/rspack_binding_api/src/source.rs
@@ -53,6 +53,33 @@ pub struct JsSourceToJs {
   pub map: Option<String>,
 }
 
+#[napi]
+pub struct JsSourceSnapshot {
+  inner: BoxSource,
+}
+
+impl JsSourceSnapshot {
+  pub fn new(inner: BoxSource) -> Self {
+    Self { inner }
+  }
+}
+
+#[napi]
+impl JsSourceSnapshot {
+  #[napi]
+  pub fn source(&self) -> Either<String, Buffer> {
+    match self.inner.source() {
+      SourceValue::String(source) => Either::A(source.into_owned()),
+      SourceValue::Buffer(source) => Either::B(Buffer::from(source.to_vec())),
+    }
+  }
+
+  #[napi(ts_return_type = "JsSource")]
+  pub fn source_and_map(&self) -> Result<JsSourceToJs> {
+    (&self.inner).try_into()
+  }
+}
+
 impl From<String> for JsSourceToJs {
   fn from(source: String) -> Self {
     Self {

--- a/packages/rspack/src/Compilation.ts
+++ b/packages/rspack/src/Compilation.ts
@@ -739,6 +739,23 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
   }
 
   /**
+   * Read an asset without parsing its serialized source map in JavaScript.
+   * The returned content is a copy, not a live view of the asset.
+   */
+  getAssetSource(filename: string): JsSource | undefined {
+    return this.#inner.getAssetSource(filename) ?? undefined;
+  }
+
+  /**
+   * Set an asset's content and serialized map without changing existing info.
+   * Creates an asset with default info if the filename is not present.
+   * A Buffer represents unmapped binary data. Omit map for unmapped text.
+   */
+  setAssetSource(filename: string, source: JsSource): void {
+    this.#inner.setAssetSource(filename, source);
+  }
+
+  /**
    * Note: This is not a webpack public API, maybe removed in future.
    *
    * @internal
@@ -1079,11 +1096,11 @@ BREAKING CHANGE: Asset processing hooks in Compilation has been merged into a si
    * @internal
    */
   __internal__getAssetSource(filename: string): Source | void {
-    const rawSource = this.#inner.getAssetSource(filename);
-    if (!rawSource) {
+    const snapshot = this.#inner.getAssetSourceSnapshot(filename);
+    if (!snapshot) {
       return;
     }
-    return SourceAdapter.fromBinding(rawSource);
+    return SourceAdapter.fromSnapshot(snapshot);
   }
 
   /**

--- a/packages/rspack/src/util/source.ts
+++ b/packages/rspack/src/util/source.ts
@@ -1,8 +1,73 @@
-import type { JsSource } from '@rspack/binding';
-import { RawSource, type Source, SourceMapSource } from 'webpack-sources';
+import type { JsSource, JsSourceSnapshot } from '@rspack/binding';
+import { RawSource, Source, SourceMapSource } from 'webpack-sources';
+
+class NativeSource extends Source {
+  #state:
+    | { snapshot: JsSourceSnapshot; content?: string | Buffer }
+    | { source: RawSource | SourceMapSource };
+
+  constructor(snapshot: JsSourceSnapshot) {
+    super();
+    this.#state = { snapshot };
+  }
+
+  source(): string | Buffer {
+    const state = this.#state;
+    return 'source' in state
+      ? state.source.source()
+      : (state.content ??= state.snapshot.source());
+  }
+
+  buffer(): Buffer {
+    // The adapter owns the mutable buffer, including its hash semantics.
+    return this.#materialize().buffer();
+  }
+
+  size(): number {
+    if ('source' in this.#state) {
+      return this.#state.source.size();
+    }
+    const source = this.source();
+    return Buffer.isBuffer(source) ? source.length : Buffer.byteLength(source);
+  }
+
+  #materialize(): RawSource | SourceMapSource {
+    const state = this.#state;
+    if ('source' in state) {
+      return state.source;
+    }
+    // A returned Buffer belongs to this wrapper and may have been mutated.
+    const source = Buffer.isBuffer(state.content)
+      ? new RawSource(state.content)
+      : SourceAdapter.fromBinding(state.snapshot.sourceAndMap());
+    // The ordinary adapter now owns the content; release the native snapshot.
+    this.#state = { source };
+    return source;
+  }
+
+  map(options: Parameters<Source['map']>[0]) {
+    return this.#materialize().map(options);
+  }
+
+  sourceAndMap(options: Parameters<Source['sourceAndMap']>[0]) {
+    return this.#materialize().sourceAndMap(options);
+  }
+
+  streamChunks(...args: Parameters<SourceMapSource['streamChunks']>) {
+    return this.#materialize().streamChunks(...args);
+  }
+
+  updateHash(hash: Parameters<Source['updateHash']>[0]): void {
+    this.#materialize().updateHash(hash);
+  }
+}
 
 export class SourceAdapter {
-  static fromBinding(source: JsSource): Source {
+  static fromSnapshot(snapshot: JsSourceSnapshot): Source {
+    return new NativeSource(snapshot);
+  }
+
+  static fromBinding(source: JsSource): RawSource | SourceMapSource {
     if (!source.map) {
       return new RawSource(source.source);
     }

--- a/tests/rspack-test/compilerCases/source-snapshots.js
+++ b/tests/rspack-test/compilerCases/source-snapshots.js
@@ -1,0 +1,191 @@
+const { createHash } = require('node:crypto');
+const { createRequire } = require('node:module');
+const { JsSourceSnapshot } = createRequire(require.resolve('@rspack/core'))(
+  '@rspack/binding',
+);
+
+function digest(source) {
+  const hash = createHash('sha256');
+  source.updateHash(hash);
+  return hash.digest('hex');
+}
+
+function stream(source, options) {
+  const events = [];
+  const result = source.streamChunks(
+    options || {},
+    (...args) => events.push(['chunk', ...args]),
+    (...args) => events.push(['source', ...args]),
+    (...args) => events.push(['name', ...args]),
+  );
+  return { events, result };
+}
+
+module.exports = {
+  description: 'retains source snapshots, maps and mutable buffers after close',
+  options() {
+    const retained = [];
+    this.retained = retained;
+    return {
+      plugins: [
+        {
+          apply(compiler) {
+            const { RawSource, OriginalSource, SourceMapSource } =
+              compiler.rspack.sources;
+            compiler.hooks.compilation.tap('SourceSnapshots', (compilation) => {
+              compilation.hooks.processAssets.tap('SourceSnapshots', () => {
+                expect(compilation.getAssetSource('missing')).toBeUndefined();
+                compilation.emitAsset(
+                  'lazy.js',
+                  new OriginalSource('globalThis.lazy = 1;\n', 'lazy.ts'),
+                );
+                const materialize = rstest.spyOn(
+                  JsSourceSnapshot.prototype,
+                  'sourceAndMap',
+                );
+                try {
+                  const lazy = compilation.getAsset('lazy.js').source;
+                  expect(lazy.source()).toBe('globalThis.lazy = 1;\n');
+                  expect(lazy.size()).toBe(21);
+                  expect(materialize).not.toHaveBeenCalled();
+                  expect(lazy.map().sources).toEqual(['lazy.ts']);
+                  expect(materialize).toHaveBeenCalledTimes(1);
+                  lazy.sourceAndMap();
+                  lazy.updateHash(createHash('sha256'));
+                  expect(materialize).toHaveBeenCalledTimes(1);
+                } finally {
+                  materialize.mockRestore();
+                }
+                compilation.deleteAsset('lazy.js');
+                const variants = [
+                  [
+                    'mapped.js',
+                    () =>
+                      new OriginalSource(
+                        "globalThis.value = '\u{1f680}';\n",
+                        'original.ts',
+                      ),
+                  ],
+                  ['plain.txt', () => new RawSource('plain\u00e9')],
+                  [
+                    'binary.dat',
+                    () => new RawSource(Buffer.from([0, 255, 13])),
+                  ],
+                ];
+                for (const [suffix, makeSource] of variants) {
+                  for (const first of ['source', 'map', 'buffer', 'deferred']) {
+                    const name = `${first}-${suffix}`;
+                    compilation.emitAsset(name, makeSource(), {
+                      development: true,
+                      customField: 'preserved',
+                    });
+                    const raw = compilation.getAssetSource(name);
+                    const original = Buffer.isBuffer(raw.source)
+                      ? Buffer.from(raw.source)
+                      : raw.source;
+                    const expected = raw.map
+                      ? new SourceMapSource(
+                          raw.source,
+                          'inmemory://from rust',
+                          raw.map,
+                        )
+                      : new RawSource(raw.source);
+                    const actual =
+                      first === 'source'
+                        ? compilation.assets[name]
+                        : first === 'map'
+                          ? compilation.getAsset(name).source
+                          : compilation.getAssets().find((a) => a.name === name)
+                              .source;
+                    if (first === 'source') {
+                      expect(actual.source()).toEqual(expected.source());
+                    } else if (first === 'map') {
+                      expect(actual.map({ columns: false })).toEqual(
+                        expected.map({ columns: false }),
+                      );
+                    } else if (first === 'buffer') {
+                      const buffer = actual.buffer();
+                      expect(actual.buffer()).toBe(buffer);
+                      buffer[0] = 42;
+                      expected.buffer()[0] = 42;
+                    }
+                    if (
+                      first === 'source' &&
+                      Buffer.isBuffer(actual.source())
+                    ) {
+                      actual.source()[0] = 43;
+                      expected.source()[0] = 43;
+                    }
+                    expect(compilation.getAssetSource(name).source).toEqual(
+                      original,
+                    );
+                    compilation.setAssetSource(name, { source: 'replacement' });
+                    expect(compilation.getAsset(name).info.customField).toBe(
+                      'preserved',
+                    );
+                    expect(compilation.getAssetSource(name)).toEqual({
+                      source: 'replacement',
+                      map: undefined,
+                    });
+                    compilation.deleteAsset(name);
+                    retained.push({ actual, expected });
+                  }
+                }
+                compilation.setAssetSource('new.txt', { source: 'new' });
+                expect(compilation.assets['new.txt'].source()).toBe('new');
+                expect(() =>
+                  compilation.setAssetSource('bad.js', {
+                    source: 'text',
+                    map: '{',
+                  }),
+                ).toThrow();
+                expect(compilation.getAssetSource('bad.js')).toBeUndefined();
+                const input = Buffer.from([1, 2, 3]);
+                compilation.setAssetSource('copy.dat', {
+                  source: input,
+                  map: '{',
+                });
+                input[0] = 9;
+                const copy = compilation.getAssetSource('copy.dat');
+                expect(copy.map).toBeUndefined();
+                expect(copy.source[0]).toBe(1);
+                copy.source[0] = 8;
+                expect(compilation.getAssetSource('copy.dat').source[0]).toBe(
+                  1,
+                );
+              });
+            });
+          },
+        },
+      ],
+    };
+  },
+  async check({ compiler }) {
+    await new Promise((resolve, reject) => {
+      compiler.close((error) => (error ? reject(error) : resolve()));
+    });
+    expect(this.retained.length).toBe(12);
+    for (const { actual, expected } of this.retained) {
+      expect(actual.source()).toEqual(expected.source());
+      expect(actual.size()).toBe(expected.size());
+      expect(actual.buffer()).toEqual(expected.buffer());
+      for (const options of [
+        undefined,
+        { columns: false },
+        { columns: true },
+      ]) {
+        expect(actual.map(options)).toEqual(expected.map(options));
+        expect(actual.sourceAndMap(options)).toEqual(
+          expected.sourceAndMap(options),
+        );
+        expect(stream(actual, options)).toEqual(stream(expected, options));
+      }
+      expect(digest(actual)).toBe(digest(expected));
+      actual.buffer()[0] = 44;
+      expected.buffer()[0] = 44;
+      expect(actual.source()).toEqual(expected.source());
+      expect(actual.sourceAndMap()).toEqual(expected.sourceAndMap());
+      expect(digest(actual)).toBe(digest(expected));
+    }
+  },
+};

--- a/website/docs/en/api/javascript-api/compilation.mdx
+++ b/website/docs/en/api/javascript-api/compilation.mdx
@@ -143,6 +143,47 @@ compiler.hooks.thisCompilation.tap('MyPlugin', (compilation) => {
   </CollapsePanel>
 </Collapse>
 
+### getAssetSource
+
+Read an asset as text or binary data with an optional serialized source map.
+This Rspack-specific API avoids parsing a map into a JavaScript object when
+passing it to a native processor.
+
+```ts
+getAssetSource(filename: string):
+  | { source: string | Buffer; map?: string }
+  | undefined;
+```
+
+The result is a snapshot, not a live view. Mutating a returned Buffer does not
+change the compilation. Binary sources have no map. A missing asset, or an
+asset without a source, returns `undefined`.
+
+### setAssetSource
+
+Set an asset's content and optional serialized source map without parsing the
+map in JavaScript. This Rspack-specific API preserves existing asset information,
+or creates an asset with default information if the filename is new.
+
+```ts
+setAssetSource(
+  filename: string,
+  source: { source: string | Buffer; map?: string },
+): void;
+```
+
+Omit `map` for unmapped text. A Buffer represents binary data and ignores `map`,
+matching the `Source` adapter. Invalid serialized maps on text sources throw.
+The map is final: this method does not compose it with the previous asset's map.
+Use `updateAsset` when also updating asset information or requiring an existing
+asset.
+
+Sources obtained through `assets`, `getAsset` and `getAssets` retain their
+original content after replacement, deletion or compiler closure. Reading their
+text with `source()` or `size()` defers map materialization. Map, buffer, chunk
+stream and hash operations use the existing source adapter, preserving map
+options and mutable buffer behavior.
+
 ### renameAsset
 
 Rename an existing asset.


### PR DESCRIPTION
## Summary

Avoid materializing source maps when a plugin only reads asset text or size. The native binding now exposes an owned snapshot of the immutable source. The JavaScript Source wrapper defers map conversion until an operation needs the existing adapter, then releases its native snapshot.

Add `Compilation.getAssetSource()` and `Compilation.setAssetSource()` for plugins that consume and produce serialized maps. This avoids parsing and stringifying a map solely to pass it between native tools. The setter preserves existing asset information, creates missing assets with default information, and treats Buffer inputs as unmapped binary content.

The compiler regression covers text-first, map-first, buffer-first and deferred reads; retained sources after replacement, deletion and compiler closure; mutable Buffer identity; map options; chunk streams; and hashes. A native-method spy verifies that text and size reads do not materialize maps.

Validated with a source-built Linux x64 release binding, core and test-tools declaration builds, and the compiler asset/snapshot selection (11 passing cases). Cross-platform builds remain for CI.

## Related links

<!-- Related issues or discussions. -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
