### PR TITLE
fix: prevent recursive module federation shared compilation

### DIFF
--- a/packages/rspack/src/sharing/IndependentSharedPlugin.ts
+++ b/packages/rspack/src/sharing/IndependentSharedPlugin.ts
@@ -28,10 +28,7 @@ const filterPlugin = (plugin: Plugins[0], excludedPlugins: string[] = []) => {
   if (!plugin) {
     return true;
   }
-  const pluginName = plugin.name || plugin.constructor?.name;
-  if (!pluginName) {
-    return true;
-  }
+  const pluginNames = [plugin.name, plugin.constructor?.name];
   return ![
     'TreeShakingSharedPlugin',
     'IndependentSharedPlugin',
@@ -41,7 +38,7 @@ const filterPlugin = (plugin: Plugins[0], excludedPlugins: string[] = []) => {
     'HtmlRspackPlugin',
     'RsbuildHtmlPlugin',
     ...excludedPlugins,
-  ].includes(pluginName);
+  ].some((excludedPluginName) => pluginNames.includes(excludedPluginName));
 };
 
 export interface IndependentSharePluginOptions {

--- a/tests/rspack-test/configCases/sharing/reshake-share/rspack.config.js
+++ b/tests/rspack-test/configCases/sharing/reshake-share/rspack.config.js
@@ -2,6 +2,22 @@ const { ProvideSharedPlugin, TreeShakingSharedPlugin } =
   require('@rspack/core').sharing;
 const path = require('path');
 
+// Mimic @module-federation/rspack, whose explicit plugin name differs from its
+// constructor name. The plugin must not be inherited by shared child compilers.
+const RspackModuleFederationPlugin = class ModuleFederationPlugin {
+  constructor() {
+    this.name = 'RspackModuleFederationPlugin';
+  }
+
+  apply(compiler) {
+    if (compiler.options.name === 'mf-shared-compiler') {
+      throw new Error(
+        'RspackModuleFederationPlugin should not be applied to shared child compilers',
+      );
+    }
+  }
+};
+
 const shared = {
   'ui-lib': {
     version: '1.0.0',
@@ -37,6 +53,7 @@ module.exports = {
     chunkFilename: '[id].js',
   },
   plugins: [
+    new RspackModuleFederationPlugin(),
     new ProvideSharedPlugin({
       provides: {
         'ui-lib': {


### PR DESCRIPTION
## Summary

- Prevent Module Federation shared child compilers from inheriting excluded plugins whose explicit `name` differs from their constructor name.
- Check both plugin identifiers when filtering inherited plugins, avoiding recursive `RspackModuleFederationPlugin` application and OOMs.
- Add regression coverage matching the `@module-federation/rspack` wrapper shape.

## Related links

Closes #15468

## Testing

- `pnpm run build:js`
- `pnpm run lint:js`
- `cd tests/rspack-test && pnpm run test -t "configCases/sharing"`
- Verified the issue reproduction with the local build; shared fallback compilation completes once.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).