### PR TITLE
chore(ci): remove unused workflow inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,6 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
-    inputs:
-      debug_enabled:
-        type: boolean
-        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
-        required: false
-        default: false
   pull_request:
     types: [opened, synchronize]
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,6 @@ jobs:
     uses: ./.github/workflows/reusable-release-npm.yml
     with:
       tag: ${{ inputs.npm_tag }}
-      tag_confirm: ${{ inputs.npm_tag_confirm }}
       test: ${{ inputs.test }}
       dry_run: ${{ inputs.dry_run }}
       push_tags: ${{ inputs.push_tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
     uses: ./.github/workflows/reusable-release-npm.yml
     with:
       tag: ${{ inputs.npm_tag }}
+      tag_confirm: ${{ inputs.npm_tag_confirm }}
       test: ${{ inputs.test }}
       dry_run: ${{ inputs.dry_run }}
       push_tags: ${{ inputs.push_tags }}

--- a/.github/workflows/reusable-build-all.yml
+++ b/.github/workflows/reusable-build-all.yml
@@ -11,10 +11,6 @@ on:
         type: boolean
         required: false
         default: false
-      bench: # Run benchmarks?
-        type: boolean
-        required: false
-        default: false
       ref: # Git reference to checkout
         required: false
         type: string

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -7,10 +7,6 @@ on:
         type: string
         description: 'Release Npm Tag'
         required: true
-      tag_confirm:
-        type: string
-        description: 'Release Npm Tag Double Check'
-        required: true
       test:
         type: boolean
         description: 'Run JS tests before release'

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -7,6 +7,10 @@ on:
         type: string
         description: 'Release Npm Tag'
         required: true
+      tag_confirm:
+        type: string
+        description: 'Release Npm Tag Double Check'
+        required: true
       test:
         type: boolean
         description: 'Run JS tests before release'
@@ -30,8 +34,23 @@ permissions:
   issues: write
 
 jobs:
+  validate:
+    name: Validate Npm Tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check tag matches tag_confirm
+        run: |
+          if [ "${{ inputs.tag }}" != "${{ inputs.tag_confirm }}" ]; then
+            echo "Error: tag and tag_confirm must match"
+            echo "tag: ${{ inputs.tag }}"
+            echo "tag_confirm: ${{ inputs.tag_confirm }}"
+            exit 1
+          fi
+          echo "npm tag validation passed: ${{ inputs.tag }}"
+
   build:
     name: Build ${{ matrix.array.target }}${{ matrix.array.binding_postfix }}
+    needs: validate
     strategy:
       fail-fast: false # for better utilize ci runners
       matrix:


### PR DESCRIPTION
## Why

A few `workflow_dispatch` / `workflow_call` inputs are declared but never read by the workflow that declares them, so they only add noise to the dispatch form and to callers.

Scanned every workflow under `.github/workflows` for declared inputs vs. `inputs.*` references in the same file, plus the reverse direction (callers passing undeclared keys, dangling `inputs.*` references). After this change both directions are clean.

## What

- `ci.yml`: drop `debug_enabled`. Nothing gates on it (the tmate debugger action it described is not wired into any job).
- `reusable-build-all.yml`: drop `bench`. Never referenced, and no caller passes it.
- `reusable-release-npm.yml`: `tag_confirm` was declared and passed from `release.yml` but never checked by the reusable workflow itself. Instead of dropping it, add a `validate` job that fails when `tag` and `tag_confirm` differ, and make `build` depend on it. The workflow that actually publishes now guards itself, and a mismatch fails before any of the release builds start.

Behavior of every other workflow is unchanged.
