### PR TITLE
test(javascript): distinguish recovered parse diagnostics

### DIFF
--- a/tests/rspack-test/normalCases/parsing/context/errors.js
+++ b/tests/rspack-test/normalCases/parsing/context/errors.js
@@ -1,11 +1,13 @@
 module.exports = [
+	// SWC Next recovers from the first malformed expression statement and then
+	// reports the independent malformed `with` statement on the next code line.
 	[
-		/Module parse failed/,
+		/Expected a semicolon or an implicit semicolon after a statement, but found 'is'/,
 		{ moduleName: /dump-file\.txt/ },
 		{ moduleTrace: /templates|sync/ }
 	],
 	[
-		/Module parse failed/,
+		/Expected '\(' after 'with', but found 'some'/,
 		{ moduleName: /dump-file\.txt/ },
 		{ moduleTrace: /templates|sync/ }
 	]


### PR DESCRIPTION
## Summary

- distinguish the two independent parse errors reported after SWC Next recovers while parsing `dump-file.txt`
- document that diagnostics at different source ranges must be preserved
- keep the existing exact-range duplicate guard unchanged

The source is parsed once. SWC Next reports the malformed expression on line 1, recovers at the next statement, and then reports the malformed `with` statement on line 3. These diagnostics have different messages and ranges, so this change makes the test assert both causes explicitly instead of matching two generic `Module parse failed` errors.

## Related links

Follow-up to #15467.

## Validation

- `pnpm run build:binding:dev`
- `pnpm run test:unit`
- `pnpm run lint:js`
- `pnpm run lint:rs`
- `cargo clippy --workspace --all-targets --tests --locked -- -D warnings`
- `cargo fmt --all -- --check`
- targeted parsing and diagnostic cases

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
