### PR TITLE
refactor: remove unused Clone derives in core

### DIFF
--- a/crates/rspack_core/src/artifacts/async_modules_artifact.rs
+++ b/crates/rspack_core/src/artifacts/async_modules_artifact.rs
@@ -4,7 +4,7 @@ use rspack_collections::IdentifierSet;
 
 use crate::{ArtifactExt, incremental::IncrementalPasses};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct AsyncModulesArtifact(IdentifierSet);
 
 impl ArtifactExt for AsyncModulesArtifact {

--- a/crates/rspack_core/src/artifacts/cgc_runtime_requirements_artifact.rs
+++ b/crates/rspack_core/src/artifacts/cgc_runtime_requirements_artifact.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 
 use crate::{ArtifactExt, ChunkUkey, RuntimeGlobals, incremental::IncrementalPasses};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CgcRuntimeRequirementsArtifact(FxHashMap<ChunkUkey, RuntimeGlobals>);
 
 impl ArtifactExt for CgcRuntimeRequirementsArtifact {

--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CodeGenerationDataUrl {
   inner: String,
 }
@@ -36,15 +36,15 @@ impl CodeGenerationDataUrl {
 
 // For performance, mark the js modules containing AUTO_PUBLIC_PATH_PLACEHOLDER
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CodeGenerationPublicPathAutoReplace(pub bool);
 
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct URLStaticMode;
 
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CodeGenerationDataFilename {
   filename: String,
   public_path: String,
@@ -68,7 +68,7 @@ impl CodeGenerationDataFilename {
 }
 
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CodeGenerationDataAssetInfo {
   inner: AssetInfo,
 }
@@ -114,7 +114,7 @@ impl RspackHash for CodeGenerationDataPreservedAssetImport {
 }
 
 #[cacheable]
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct CodeGenerationDataTopLevelDeclarations {
   #[cacheable(with=AsVec<AsPreset>)]
   inner: AtomSet,
@@ -136,7 +136,7 @@ pub trait CodeGenerationDataItem: Debug + AsAny + IntoAny + Send + Sync {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CodeGenerationDataChunkInitFragments {
   inner: ChunkInitFragments,
 }
@@ -380,7 +380,7 @@ impl CodeGenerationResultBuilder {
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CodeGenerationResults {
   map: IdentifierMap<RuntimeSpecMap<BindingCell<CodeGenerationResult>>>,
 }

--- a/crates/rspack_core/src/artifacts/imported_by_defer_modules_artifact.rs
+++ b/crates/rspack_core/src/artifacts/imported_by_defer_modules_artifact.rs
@@ -4,7 +4,7 @@ use rspack_collections::IdentifierSet;
 
 use crate::{ArtifactExt, incremental::IncrementalPasses};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct ImportedByDeferModulesArtifact(IdentifierSet);
 
 impl ArtifactExt for ImportedByDeferModulesArtifact {

--- a/crates/rspack_core/src/artifacts/module_ids_artifact.rs
+++ b/crates/rspack_core/src/artifacts/module_ids_artifact.rs
@@ -4,7 +4,7 @@ use rspack_collections::IdentifierMap;
 
 use crate::{ArtifactExt, ModuleId, incremental::IncrementalPasses};
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct ModuleIdsArtifact(IdentifierMap<ModuleId>);
 
 impl ArtifactExt for ModuleIdsArtifact {

--- a/crates/rspack_core/src/artifacts/runtime_proxy_metadata_artifact.rs
+++ b/crates/rspack_core/src/artifacts/runtime_proxy_metadata_artifact.rs
@@ -93,7 +93,7 @@ impl RuntimeProxyMetadata {
   }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct RuntimeProxyMetadataArtifact(FxHashMap<ChunkUkey, RuntimeProxyMetadata>);
 
 impl ArtifactExt for RuntimeProxyMetadataArtifact {

--- a/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
+++ b/crates/rspack_core/src/artifacts/side_effects_do_optimize_artifact.rs
@@ -21,7 +21,7 @@ pub struct SideEffectsDoOptimizeMoveTarget {
   pub target_export: Option<Vec<Atom>>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct SideEffectsOptimizeArtifact(FxHashMap<DependencyId, SideEffectsDoOptimize>);
 
 impl Deref for SideEffectsOptimizeArtifact {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -325,7 +325,7 @@ pub(crate) type BlockModulesRuntimeMap = HashMap<Option<Arc<RuntimeSpec>>, Block
 //   }
 // }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct CodeSplitter {
   pub(crate) chunk_group_info_map: HashMap<ChunkGroupUkey, CgiUkey>,
   pub(crate) chunk_group_infos: HashMap<CgiUkey, ChunkGroupInfo>,

--- a/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_map.rs
@@ -1,6 +1,6 @@
 use crate::DependencyId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DenseDependencyIdMap<V> {
   values: Vec<Option<V>>,
 }

--- a/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_overlay_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/dense_dependency_id_overlay_map.rs
@@ -1,7 +1,7 @@
 use super::OverlayValue;
 use crate::DependencyId;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct DenseDependencyIdOverlayMap<V> {
   base: Vec<Option<V>>,
   overlay: Option<Vec<Option<OverlayValue<V>>>>,

--- a/crates/rspack_core/src/module_graph/rollback/map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/map.rs
@@ -10,13 +10,13 @@ use rayon::iter::{
 };
 use rustc_hash::FxBuildHasher;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum Action<K, V> {
   Inserted { key: K, previous: Option<V> },
   Removed { key: K, value: V },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct RollbackMap<K, V, S = FxBuildHasher> {
   map: HashMap<K, V, S>,
   undo_stack: Vec<Action<K, V>>,

--- a/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
@@ -6,13 +6,13 @@ use std::{
 
 use rustc_hash::FxBuildHasher;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum OverlayValue<V> {
   Value(V),
   Tombstone,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct OverlayMap<K, V, S = FxBuildHasher> {
   base: HashMap<K, V, S>,
   overlay: Option<HashMap<K, OverlayValue<V>, S>>,

--- a/crates/rspack_core/src/utils/concatenation_scope.rs
+++ b/crates/rspack_core/src/utils/concatenation_scope.rs
@@ -37,7 +37,7 @@ pub struct ModuleReferenceOptions {
 /// [`ConcatenationScope`]. The ESM library plugin opts into collecting this
 /// output because it consumes the mutations after the module codegen pass.
 #[cacheable]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct CodeGenerationDataConcatenationScopeOutput {
   #[cacheable(with=AsOption<AsPreset>)]
   namespace_export_symbol: Option<Atom>,


### PR DESCRIPTION
## Summary

Remove unused `Clone` derives from core artifacts, rollback containers, code splitting state, and code generation data.