### PR TITLE
chore: document Rust Clone requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ Before running tests after code changes:
 ### Modifying code
 
 - **Rust**: Core in `crates/rspack_core/`, plugins in `crates/rspack_plugin_*/`, rebuild with `pnpm run build:binding:dev`, test with `pnpm run test:rs`, avoid linting and formatting for fast local development
+- **Rust `Clone`**: Do not derive or manually implement `Clone` for data structures without a concrete need. When adding an implementation that copies underlying data, explain why it is necessary in both the type's documentation comment and the PR description. Cloning `Arc` handles, including wrappers that only clone those handles, is exempt.
 - **JS/TS**: API in `packages/rspack/src/`, CLI in `packages/rspack-cli/src/`, rebuild with `pnpm run build:js`, test with `pnpm run test:unit`
 
 ### Adding tests

--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -587,7 +587,7 @@ impl<'a, C: Comments> ServerActions<'a, C> {
       private_ctxt: self.private_ctxt,
     });
 
-    let mut new_body: Option<FunctionBody> = function.body.take();
+    let mut new_body: Option<FunctionBody> = function.body.clone();
 
     if !ids_from_closure.is_empty() {
       // Prepend the decryption declaration to the body.
@@ -981,9 +981,11 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
     self.rewrite_fn_decl_to_proxy_decl = None;
     d.visit_mut_children_with(self);
 
-    if let Some(decl) = self.rewrite_fn_decl_to_proxy_decl.take() {
-      *d = decl.into();
+    if let Some(decl) = &self.rewrite_fn_decl_to_proxy_decl {
+      *d = (*decl).clone().into();
     }
+
+    self.rewrite_fn_decl_to_proxy_decl = None;
   }
 
   fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {

--- a/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
+++ b/crates/rspack_loader_swc/src/rsc_transforms/server_actions.rs
@@ -587,7 +587,7 @@ impl<'a, C: Comments> ServerActions<'a, C> {
       private_ctxt: self.private_ctxt,
     });
 
-    let mut new_body: Option<FunctionBody> = function.body.clone();
+    let mut new_body: Option<FunctionBody> = function.body.take();
 
     if !ids_from_closure.is_empty() {
       // Prepend the decryption declaration to the body.
@@ -981,11 +981,9 @@ impl<'a, C: Comments> VisitMut for ServerActions<'a, C> {
     self.rewrite_fn_decl_to_proxy_decl = None;
     d.visit_mut_children_with(self);
 
-    if let Some(decl) = &self.rewrite_fn_decl_to_proxy_decl {
-      *d = (*decl).clone().into();
+    if let Some(decl) = self.rewrite_fn_decl_to_proxy_decl.take() {
+      *d = decl.into();
     }
-
-    self.rewrite_fn_decl_to_proxy_decl = None;
   }
 
   fn visit_mut_fn_decl(&mut self, f: &mut FnDecl) {


### PR DESCRIPTION
## Summary

Require a concrete need for Rust Clone implementations and an explanation in type documentation and PR descriptions when they copy underlying data. Arc handle clones are exempt.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).