### PR TITLE
perf(javascript): borrow AST ranges in parser walker

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
@@ -135,22 +135,20 @@ impl ExportNamedDeclaration {
     self.0.attributes(ast)
   }
 
-  pub fn named_export_specifiers(self, ast: &Ast<'_>) -> Vec<(Atom, Atom, Span)> {
-    self
-      .0
-      .specifiers(ast)
-      .iter()
-      .map(|slot| {
-        let specifier = ast.get_node_in_sub_range(slot);
-        let local = specifier.local(ast);
-        let exported = specifier.exported(ast);
-        (
-          module_export_name_to_atom(ast, local),
-          module_export_name_to_atom(ast, exported),
-          exported.span(ast),
-        )
-      })
-      .collect()
+  pub fn named_export_specifiers<'a>(
+    self,
+    ast: &'a Ast<'_>,
+  ) -> impl Iterator<Item = (Atom, Atom, Span)> + 'a {
+    self.0.specifiers(ast).iter().map(move |slot| {
+      let specifier = ast.get_node_in_sub_range(slot);
+      let local = specifier.local(ast);
+      let exported = specifier.exported(ast);
+      (
+        module_export_name_to_atom(ast, local),
+        module_export_name_to_atom(ast, exported),
+        exported.span(ast),
+      )
+    })
   }
 }
 
@@ -408,13 +406,12 @@ impl VariableDeclaration {
     self.0.kind(ast)
   }
 
-  pub fn declarators(self, ast: &Ast<'_>) -> Vec<VariableDeclarator> {
+  pub fn declarators<'a>(self, ast: &'a Ast<'_>) -> impl Iterator<Item = VariableDeclarator> + 'a {
     self
       .0
       .declarators(ast)
       .iter()
-      .map(|slot| ast.get_node_in_sub_range(slot))
-      .collect()
+      .map(move |slot| ast.get_node_in_sub_range(slot))
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1500,18 +1500,15 @@ impl<'parser> JavascriptParser<'parser> {
     let drive = self.plugin_drive.clone();
     if drive.program(self, program).is_none() {
       let ast = self.ast.ast;
-      let body = program
-        .body(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
+      let body = program.body(ast);
       // Match the legacy `Program::Module` traversal without treating an
       // `import.meta`-only unambiguous parse as ESM. Do not set `self.is_esm`
       // early: legacy parsing only flipped that state during pre-walk.
       let is_esm_program = matches!(self.module_type, ModuleType::JsEsm)
-        || body.iter().any(|statement| {
+        || body.iter().any(|slot| {
+          let statement = ast.get_node_in_sub_range(slot);
           matches!(
-            ast.stmt_data(*statement),
+            ast.stmt_data(statement),
             StmtData::ImportDeclaration(_)
               | StmtData::ExportNamedDeclaration(_)
               | StmtData::ExportDefaultDeclaration(_)
@@ -1523,16 +1520,16 @@ impl<'parser> JavascriptParser<'parser> {
       if is_esm_program {
         self.set_strict(true);
         self.prev_statement = None;
-        self.module_pre_walk_module_items(&body);
+        self.module_pre_walk_module_items(body);
       } else {
         self.detect_mode(program);
       }
       self.prev_statement = None;
-      self.pre_walk_module_items(&body);
+      self.pre_walk_module_items(body);
       self.prev_statement = None;
-      self.block_pre_walk_module_items(&body);
+      self.block_pre_walk_module_items(body);
       self.prev_statement = None;
-      self.walk_module_items(&body);
+      self.walk_module_items(body);
     }
     drive.finish(self);
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,6 +1,5 @@
-use std::borrow::Cow;
-
 use rspack_intern::AtomRef;
+use smallvec::SmallVec;
 use swc_next_ecma_ast::*;
 
 use super::{
@@ -9,7 +8,7 @@ use super::{
   TopLevelScope,
   estree::{
     ClassDeclOrExpr, ExportDefaultDeclaration, MaybeNamedClassDecl, MaybeNamedFunctionDecl,
-    Statement, formal_parameter_patterns,
+    Statement, formal_parameter_patterns, formal_parameters_are_simple_identifiers,
   },
   object_and_members_to_name,
 };
@@ -124,8 +123,10 @@ impl JavascriptParser<'_> {
     self.terminated = old_terminated;
   }
 
-  pub fn walk_module_items(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
+  pub fn walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
       self.walk_module_item(statement);
     }
   }
@@ -178,10 +179,12 @@ impl JavascriptParser<'_> {
     }
   }
 
-  pub fn walk_statements(&mut self, statements: &[Stmt]) {
+  pub fn walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
     let mut only_function_declaration = false;
-    for &statement in statements {
-      let stmt = Statement::from_stmt(self.ast.ast, statement);
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
+      let stmt = Statement::from_stmt(ast, statement);
       if only_function_declaration
         && !matches!(stmt, Statement::Fn(_))
         && self
@@ -303,12 +306,7 @@ impl JavascriptParser<'_> {
       }
       let prev = this.prev_statement;
       let body = catch_clause.body(ast);
-      let statements = body
-        .body(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
-      this.block_pre_walk_statements(&statements);
+      this.block_pre_walk_statements(body.body(ast));
       this.prev_statement = prev;
       this.walk_statement(Statement::Block(body));
     })
@@ -317,39 +315,27 @@ impl JavascriptParser<'_> {
   fn walk_switch_statement(&mut self, stmt: SwitchStatement) {
     let ast = self.ast.ast;
     self.walk_expression(stmt.discriminant(ast));
-    let cases = stmt
-      .cases(ast)
-      .iter()
-      .map(|slot| ast.get_node_in_sub_range(slot))
-      .collect::<Vec<_>>();
-    self.walk_switch_cases(&cases);
+    self.walk_switch_cases(stmt.cases(ast));
   }
 
-  fn walk_switch_cases(&mut self, cases: &[SwitchCase]) {
+  fn walk_switch_cases(&mut self, cases: TypedSubRange<SwitchCase>) {
     self.in_block_scope(false, |this| {
       let ast = this.ast.ast;
-      for &case in cases {
-        let consequent = case
-          .consequent(ast)
-          .iter()
-          .map(|slot| ast.get_node_in_sub_range(slot))
-          .collect::<Vec<_>>();
+      for id in cases.iter() {
+        let case = ast.get_node_in_sub_range(id);
+        let consequent = case.consequent(ast);
         if !consequent.is_empty() {
           let prev = this.prev_statement;
-          this.block_pre_walk_statements(&consequent);
+          this.block_pre_walk_statements(consequent);
           this.prev_statement = prev;
         }
       }
-      for &case in cases {
+      for id in cases.iter() {
+        let case = ast.get_node_in_sub_range(id);
         if let Some(test) = case.test(ast) {
           this.walk_expression(test);
         }
-        let consequent = case
-          .consequent(ast)
-          .iter()
-          .map(|slot| ast.get_node_in_sub_range(slot))
-          .collect::<Vec<_>>();
-        this.walk_statements(&consequent);
+        this.walk_statements(case.consequent(ast));
         this.terminated = None;
       }
     })
@@ -456,15 +442,11 @@ impl JavascriptParser<'_> {
       }
       let body = stmt.body(ast);
       if let Some(body) = body.as_block_statement(ast) {
-        let statements = body
-          .body(ast)
-          .iter()
-          .map(|slot| ast.get_node_in_sub_range(slot))
-          .collect::<Vec<_>>();
+        let statements = body.body(ast);
         let prev = this.prev_statement;
-        this.block_pre_walk_statements(&statements);
+        this.block_pre_walk_statements(statements);
         this.prev_statement = prev;
-        this.walk_statements(&statements);
+        this.walk_statements(statements);
       } else {
         this.walk_nested_statement(body);
       }
@@ -482,15 +464,11 @@ impl JavascriptParser<'_> {
       }
       let body = stmt.body(ast);
       if let Some(body) = body.as_block_statement(ast) {
-        let statements = body
-          .body(ast)
-          .iter()
-          .map(|slot| ast.get_node_in_sub_range(slot))
-          .collect::<Vec<_>>();
+        let statements = body.body(ast);
         let prev = this.prev_statement;
-        this.block_pre_walk_statements(&statements);
+        this.block_pre_walk_statements(statements);
         this.prev_statement = prev;
-        this.walk_statements(&statements);
+        this.walk_statements(statements);
       } else {
         this.walk_nested_statement(body);
       }
@@ -508,15 +486,11 @@ impl JavascriptParser<'_> {
       }
       let body = stmt.body(ast);
       if let Some(body) = body.as_block_statement(ast) {
-        let statements = body
-          .body(ast)
-          .iter()
-          .map(|slot| ast.get_node_in_sub_range(slot))
-          .collect::<Vec<_>>();
+        let statements = body.body(ast);
         let prev = this.prev_statement;
-        this.block_pre_walk_statements(&statements);
+        this.block_pre_walk_statements(statements);
         this.prev_statement = prev;
-        this.walk_statements(&statements);
+        this.walk_statements(statements);
       } else {
         this.walk_nested_statement(body);
       }
@@ -784,12 +758,11 @@ impl JavascriptParser<'_> {
         self.clear_created_require_tags_in_pattern(rest.argument(ast));
       }
       BindingPatternData::ArrayPattern(array) => {
-        let elements = array
+        for element in array
           .elements(ast)
           .iter()
           .filter_map(|id| ast.get_node_in_sub_range(id))
-          .collect::<Vec<_>>();
-        for element in elements {
+        {
           self.clear_created_require_tags_in_pattern(element);
         }
         if let Some(rest) = array.rest(ast) {
@@ -797,12 +770,11 @@ impl JavascriptParser<'_> {
         }
       }
       BindingPatternData::ObjectPattern(object) => {
-        let properties = object
+        for property in object
           .properties(ast)
           .iter()
           .map(|id| ast.get_node_in_sub_range(id))
-          .collect::<Vec<_>>();
-        for property in properties {
+        {
           self.clear_created_require_tags_in_pattern(property.value(ast));
         }
         if let Some(rest) = object.rest(ast) {
@@ -962,16 +934,12 @@ impl JavascriptParser<'_> {
 
   fn walk_sequence_expression(&mut self, expr: SequenceExpression) {
     let ast = self.ast.ast;
-    let expressions = expr
-      .expressions(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let expressions = expr.expressions(ast);
     if self.is_statement_level_expression(expr.span(ast))
       && let Some(old) = self.statement_path.pop()
     {
       let prev = self.prev_statement;
-      for expression in expressions {
+      for expression in expressions.iter().map(|id| ast.get_node_in_sub_range(id)) {
         self.statement_path.push(expression.span(ast).into());
         self.walk_expression(expression);
         self.prev_statement = self.statement_path.pop();
@@ -979,7 +947,7 @@ impl JavascriptParser<'_> {
       self.prev_statement = prev;
       self.statement_path.push(old);
     } else {
-      self.walk_expressions(expressions.into_iter());
+      self.walk_expressions(expressions.iter().map(|id| ast.get_node_in_sub_range(id)));
     }
   }
 
@@ -993,20 +961,18 @@ impl JavascriptParser<'_> {
     let ast = self.ast.ast;
     let opening = element.opening_element(ast);
     self.walk_jsx_element_name(opening.name(ast));
-    let attributes = opening
+    for attribute in opening
       .attributes(ast)
       .iter()
       .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for attribute in attributes {
+    {
       self.walk_jsx_attr_or_spread(attribute);
     }
-    let children = element
+    for child in element
       .children(ast)
       .iter()
       .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for child in children {
+    {
       self.walk_jsx_child(child);
     }
     if let Some(closing) = element.closing_element(ast) {
@@ -1015,12 +981,12 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_jsx_fragment(&mut self, fragment: JsxFragment) {
-    let children = fragment
-      .children(self.ast.ast)
+    let ast = self.ast.ast;
+    for child in fragment
+      .children(ast)
       .iter()
-      .map(|id| self.ast.ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for child in children {
+      .map(|id| ast.get_node_in_sub_range(id))
+    {
       self.walk_jsx_child(child);
     }
   }
@@ -1087,7 +1053,7 @@ impl JavascriptParser<'_> {
     let mut members = AtomMembers::new();
     let mut members_optionals = OptionalMembers::new();
     let mut member_ranges = MemberRanges::new();
-    let mut member_nodes = Vec::new();
+    let mut member_nodes = SmallVec::<[JsxMemberExpression; 2]>::new();
     let root = loop {
       let object = current.object(ast);
       members.push(Atom::from(ast.get_utf8(current.property(ast).name(ast))));
@@ -1190,12 +1156,11 @@ impl JavascriptParser<'_> {
 
   fn walk_object_expression(&mut self, expr: ObjectExpression) {
     let ast = self.ast.ast;
-    let properties = expr
+    for property in expr
       .properties(ast)
       .iter()
       .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for property in properties {
+    {
       match ast.object_property_kind_data(property) {
         ObjectPropertyKindData::SpreadElement(spread) => {
           self.walk_expression(spread.argument(ast));
@@ -1513,16 +1478,11 @@ impl JavascriptParser<'_> {
     }
   }
 
-  fn simple_parameter_identifiers(
-    ast: &Ast<'_>,
+  fn parameter_identifiers<'a>(
+    ast: &'a Ast<'_>,
     params: FormalParameters,
-  ) -> Option<Vec<BindingIdentifier>> {
-    if params.rest(ast).is_some() {
-      return None;
-    }
-    formal_parameter_patterns(ast, params)
-      .map(|pattern| pattern.as_binding_identifier(ast))
-      .collect()
+  ) -> impl Iterator<Item = Option<BindingIdentifier>> + 'a {
+    formal_parameter_patterns(ast, params).map(move |pattern| pattern.as_binding_identifier(ast))
   }
 
   pub(crate) fn walk_function_body(&mut self, body: FunctionBody) {
@@ -1537,17 +1497,13 @@ impl JavascriptParser<'_> {
         break;
       }
     }
-    let statements = body
-      .body(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let statements = body.body(ast);
     let prev = self.prev_statement;
-    self.pre_walk_statements(&statements);
+    self.pre_walk_statements(statements);
     self.prev_statement = prev;
-    self.block_pre_walk_statements(&statements);
+    self.block_pre_walk_statements(statements);
     self.prev_statement = prev;
-    self.walk_statements(&statements);
+    self.walk_statements(statements);
   }
 
   fn walk_import_expression(&mut self, expr: ImportExpression) {
@@ -1636,9 +1592,8 @@ impl JavascriptParser<'_> {
       ExprData::ArrowFunctionExpression(arrow) => arrow.params(ast),
       _ => unreachable!("IIFE must be a function or arrow function"),
     };
-    for (i, identifier) in Self::simple_parameter_identifiers(ast, formal_params)
-      .expect("IIFE parameters must be binding identifiers")
-      .into_iter()
+    for (i, identifier) in Self::parameter_identifiers(ast, formal_params)
+      .map(|identifier| identifier.expect("IIFE parameters must be binding identifiers"))
       .enumerate()
     {
       params.push(identifier);
@@ -1707,20 +1662,16 @@ impl JavascriptParser<'_> {
   fn walk_call_expression(&mut self, expr: CallExpression) {
     let ast = self.ast.ast;
     let callee = expr.callee(ast);
-    let arguments = expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let arguments = expr.arguments(ast);
 
     if let Some(member) = callee.as_member_expression(ast)
       && let Some(function) = member.object(ast).as_function(ast)
       && Self::property_key_name(ast, member.property(ast))
         .is_some_and(|name| name == "call" || name == "bind")
       && !arguments.is_empty()
-      && Self::simple_parameter_identifiers(ast, function.params(ast)).is_some()
+      && formal_parameters_are_simple_identifiers(ast, function.params(ast))
     {
-      let mut args = arguments.into_iter();
+      let mut args = arguments.iter().map(|id| ast.get_node_in_sub_range(id));
       let current_this = args.next();
       self._walk_iife(member.object(ast), args, current_this);
       return;
@@ -1731,9 +1682,12 @@ impl JavascriptParser<'_> {
       ExprData::ArrowFunctionExpression(arrow) => Some(arrow.params(ast)),
       _ => None,
     };
-    if direct_params.is_some_and(|params| Self::simple_parameter_identifiers(ast, params).is_some())
-    {
-      self._walk_iife(callee, arguments.into_iter(), None);
+    if direct_params.is_some_and(|params| formal_parameters_are_simple_identifiers(ast, params)) {
+      self._walk_iife(
+        callee,
+        arguments.iter().map(|id| ast.get_node_in_sub_range(id)),
+        None,
+      );
       return;
     }
 
@@ -1785,23 +1739,26 @@ impl JavascriptParser<'_> {
           .import_call(self, call, None, Some((&members, true)))
           .unwrap_or_default()
         {
-          self.walk_arguments(arguments.into_iter());
+          self.walk_arguments(arguments.iter().map(|id| ast.get_node_in_sub_range(id)));
           return;
         }
       }
     }
     let evaluated_callee = self.evaluate_expression(callee);
     if evaluated_callee.is_identifier() {
-      let members = evaluated_callee
-        .members()
-        .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
-      let members_optionals = evaluated_callee.members_optionals().map_or_else(
-        || Cow::Owned(members.iter().map(|_| false).collect::<Vec<_>>()),
-        Cow::Borrowed,
-      );
+      let members = evaluated_callee.members().map_or(&[][..], Vec::as_slice);
+      let owned_members_optionals;
+      let members_optionals = match evaluated_callee.members_optionals() {
+        Some(members_optionals) => members_optionals.as_slice(),
+        None => {
+          owned_members_optionals =
+            std::iter::repeat_n(false, members.len()).collect::<OptionalMembers>();
+          owned_members_optionals.as_slice()
+        }
+      };
       let member_ranges = evaluated_callee
         .member_ranges()
-        .map_or_else(|| Cow::Owned(Vec::new()), Cow::Borrowed);
+        .map_or(&[][..], Vec::as_slice);
       let drive = self.plugin_drive.clone();
       if evaluated_callee
         .root_info()
@@ -1810,9 +1767,9 @@ impl JavascriptParser<'_> {
             parser,
             expr,
             for_name,
-            &members,
-            &members_optionals,
-            &member_ranges,
+            members,
+            members_optionals,
+            member_ranges,
           )
         })
         .unwrap_or_default()
@@ -1840,7 +1797,7 @@ impl JavascriptParser<'_> {
     } else {
       self.walk_expression(callee);
     }
-    self.walk_arguments(arguments.into_iter());
+    self.walk_arguments(arguments.iter().map(|id| ast.get_node_in_sub_range(id)));
   }
 
   fn extract_await_import_member(
@@ -2079,16 +2036,16 @@ impl JavascriptParser<'_> {
 
   fn walk_arrow_function_expression(&mut self, expr: ArrowFunctionExpression) {
     let ast = self.ast.ast;
-    let patterns = formal_parameter_patterns(ast, expr.params(ast)).collect::<Vec<_>>();
+    let params = expr.params(ast);
     let was_top_level_scope = self.top_level_scope;
     if !matches!(was_top_level_scope, TopLevelScope::False) {
       self.top_level_scope = TopLevelScope::ArrowFunction;
     }
     self.in_function_scope(
       false,
-      patterns.iter().copied().map(PatRef::Borrowed),
+      formal_parameter_patterns(ast, params).map(PatRef::Borrowed),
       |this| {
-        for pattern in patterns.iter().copied() {
+        for pattern in formal_parameter_patterns(ast, params) {
           this.walk_pattern(pattern)
         }
         match this
@@ -2136,16 +2093,12 @@ impl JavascriptParser<'_> {
 
   fn walk_block_statement(&mut self, stmt: BlockStatement) {
     let ast = self.ast.ast;
-    let statements = stmt
-      .body(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let statements = stmt.body(ast);
     self.in_block_scope(true, |this| {
       let prev = this.prev_statement;
-      this.block_pre_walk_statements(&statements);
+      this.block_pre_walk_statements(statements);
       this.prev_statement = prev;
-      this.walk_statements(&statements);
+      this.walk_statements(statements);
     })
   }
 
@@ -2154,14 +2107,10 @@ impl JavascriptParser<'_> {
     self.top_level_scope = TopLevelScope::False;
     let ast = self.ast.ast;
     let function = decl.function();
-    let patterns = formal_parameter_patterns(ast, function.params(ast)).collect::<Vec<_>>();
-    self.in_function_scope(
-      true,
-      patterns.iter().copied().map(PatRef::Borrowed),
-      |this| {
-        this.walk_function(function);
-      },
-    );
+    let patterns = formal_parameter_patterns(ast, function.params(ast));
+    self.in_function_scope(true, patterns.map(PatRef::Borrowed), |this| {
+      this.walk_function(function);
+    });
     self.top_level_scope = was_top_level;
   }
 
@@ -2177,15 +2126,16 @@ impl JavascriptParser<'_> {
     let ast = self.ast.ast;
     let was_top_level = self.top_level_scope;
     self.top_level_scope = TopLevelScope::False;
-    let mut scope_params: Vec<PatRef> = formal_parameter_patterns(ast, expr.params(ast))
+    let scope_params = formal_parameter_patterns(ast, expr.params(ast))
       .map(PatRef::Borrowed)
-      .collect();
+      .chain(
+        expr
+          .id(ast)
+          .map(BindingPattern::BindingIdentifier)
+          .map(PatRef::Owned),
+      );
 
-    if let Some(identifier) = expr.id(ast) {
-      scope_params.push(PatRef::Owned(BindingPattern::BindingIdentifier(identifier)));
-    }
-
-    self.in_function_scope(true, scope_params.into_iter(), |this| {
+    self.in_function_scope(true, scope_params, |this| {
       this.walk_function(expr);
     });
     self.top_level_scope = was_top_level;
@@ -2242,12 +2192,11 @@ impl JavascriptParser<'_> {
 
   fn walk_object_pattern(&mut self, object: ObjectPattern) {
     let ast = self.ast.ast;
-    let properties = object
+    for property in object
       .properties(ast)
       .iter()
       .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for property in properties {
+    {
       if property.computed(ast) {
         self.walk_property_key(property.key(ast));
       }
@@ -2266,12 +2215,11 @@ impl JavascriptParser<'_> {
 
   fn walk_array_pattern(&mut self, pattern: ArrayPattern) {
     let ast = self.ast.ast;
-    let elements = pattern
+    for element in pattern
       .elements(ast)
       .iter()
       .filter_map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for element in elements {
+    {
       self.walk_pattern(element);
     }
     if let Some(rest) = pattern.rest(ast) {
@@ -2296,22 +2244,17 @@ impl JavascriptParser<'_> {
     }
 
     // TODO: define variable for class expression in block pre walk
-    let scope_params = if let ClassDeclOrExpr::Expr(class_expr) = class_decl_or_expr
-      && let Some(identifier) = class_expr.id(ast)
-    {
-      vec![PatRef::Owned(BindingPattern::BindingIdentifier(identifier))]
-    } else {
-      vec![]
+    let scope_param = match class_decl_or_expr {
+      ClassDeclOrExpr::Expr(class_expr) => class_expr
+        .id(ast)
+        .map(BindingPattern::BindingIdentifier)
+        .map(PatRef::Owned),
+      ClassDeclOrExpr::Decl(_) => None,
     };
 
-    let elements = classy
-      .body(ast)
-      .body(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    self.in_class_scope(true, scope_params.into_iter(), |this| {
-      for class_element in elements {
+    let elements = classy.body(ast).body(ast);
+    self.in_class_scope(true, scope_param.into_iter(), |this| {
+      for class_element in elements.iter().map(|id| ast.get_node_in_sub_range(id)) {
         if this
           .plugin_drive
           .clone()
@@ -2338,12 +2281,10 @@ impl JavascriptParser<'_> {
             let was_top_level = this.top_level_scope;
             this.top_level_scope = TopLevelScope::False;
             let function = method.value(ast);
-            let patterns = formal_parameter_patterns(ast, function.params(ast)).collect::<Vec<_>>();
-            this.in_function_scope(
-              true,
-              patterns.iter().copied().map(PatRef::Borrowed),
-              |this| this.walk_function(function),
-            );
+            let patterns = formal_parameter_patterns(ast, function.params(ast));
+            this.in_function_scope(true, patterns.map(PatRef::Borrowed), |this| {
+              this.walk_function(function)
+            });
             this.top_level_scope = was_top_level;
           }
           ClassElementData::PropertyDefinition(property) => {
@@ -2367,16 +2308,13 @@ impl JavascriptParser<'_> {
           ClassElementData::StaticBlock(block) => {
             let was_top_level = this.top_level_scope;
             this.top_level_scope = TopLevelScope::False;
-            let statements = block
-              .body(this.ast.ast)
-              .iter()
-              .map(|id| this.ast.ast.get_node_in_sub_range(id))
-              .collect::<Vec<_>>();
+            let ast = this.ast.ast;
+            let statements = block.body(ast);
             this.in_block_scope(true, |this| {
               let prev = this.prev_statement;
-              this.block_pre_walk_statements(&statements);
+              this.block_pre_walk_statements(statements);
               this.prev_statement = prev;
-              this.walk_statements(&statements);
+              this.walk_statements(statements);
             });
             this.top_level_scope = was_top_level;
           }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
@@ -1,4 +1,4 @@
-use swc_next_ecma_ast::{ExprData, GetSpan, Stmt, StmtData};
+use swc_next_ecma_ast::{ExprData, GetSpan, Stmt, StmtData, TypedSubRange};
 
 use super::{
   JavascriptParser,
@@ -14,15 +14,19 @@ use crate::{
 };
 
 impl JavascriptParser<'_> {
-  pub fn block_pre_walk_module_items(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
+  pub fn block_pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
       self.block_pre_walk_module_item(statement);
     }
   }
 
-  pub fn block_pre_walk_statements(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
-      self.block_pre_walk_statement(Statement::from_stmt(self.ast.ast, statement));
+  pub fn block_pre_walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
+      self.block_pre_walk_statement(Statement::from_stmt(ast, statement));
     }
   }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
@@ -1,6 +1,6 @@
 use rspack_intern::Atom;
 use swc_next_ecma_ast::{
-  GetSpan, ImportDeclaration, ImportDeclarationSpecifierData, Stmt, StmtData,
+  GetSpan, ImportDeclaration, ImportDeclarationSpecifierData, Stmt, StmtData, TypedSubRange,
 };
 
 use crate::{
@@ -12,9 +12,10 @@ use crate::{
 };
 
 impl JavascriptParser<'_> {
-  pub fn module_pre_walk_module_items(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
-      let ast = self.ast.ast;
+  pub fn module_pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
       self.statement_path.push(statement.span(ast).into());
       match ast.stmt_data(statement) {
         StmtData::ImportDeclaration(declaration) => {
@@ -41,12 +42,8 @@ impl JavascriptParser<'_> {
       .into_owned();
     drive.import(self, declaration, &source);
     let source_atom = Atom::from(source);
-    let specifiers = declaration
-      .specifiers(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for specifier in specifiers {
+    for id in declaration.specifiers(ast).iter() {
+      let specifier = ast.get_node_in_sub_range(id);
       match ast.import_declaration_specifier_data(specifier) {
         ImportDeclarationSpecifierData::ImportSpecifier(named) => {
           let local = named.local(ast);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -97,15 +97,19 @@ fn skip_js_trivia(source: &str, mut offset: usize, end: usize) -> usize {
 }
 
 impl JavascriptParser<'_> {
-  pub fn pre_walk_module_items(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
+  pub fn pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
       self.pre_walk_module_item(statement);
     }
   }
 
-  pub fn pre_walk_statements(&mut self, statements: &[Stmt]) {
-    for &statement in statements {
-      self.pre_walk_statement(Statement::from_stmt(self.ast.ast, statement));
+  pub fn pre_walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
+    let ast = self.ast.ast;
+    for id in statements.iter() {
+      let statement = ast.get_node_in_sub_range(id);
+      self.pre_walk_statement(Statement::from_stmt(ast, statement));
     }
   }
 
@@ -169,18 +173,9 @@ impl JavascriptParser<'_> {
 
   fn pre_walk_switch_statement(&mut self, stmt: SwitchStatement) {
     let ast = self.ast.ast;
-    let cases = stmt
-      .cases(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for case in cases {
-      let statements = case
-        .consequent(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id))
-        .collect::<Vec<_>>();
-      self.pre_walk_statements(&statements);
+    for id in stmt.cases(ast).iter() {
+      let case = ast.get_node_in_sub_range(id);
+      self.pre_walk_statements(case.consequent(ast));
     }
   }
 
@@ -236,12 +231,8 @@ impl JavascriptParser<'_> {
   }
 
   pub(super) fn pre_walk_block_statement(&mut self, stmt: BlockStatement) {
-    let statements = stmt
-      .body(self.ast.ast)
-      .iter()
-      .map(|id| self.ast.ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    self.pre_walk_statements(&statements);
+    let ast = self.ast.ast;
+    self.pre_walk_statements(stmt.body(ast));
   }
 
   fn pre_walk_do_while_statement(&mut self, stmt: DoWhileStatement) {
@@ -301,12 +292,11 @@ impl JavascriptParser<'_> {
       return None;
     }
     let mut keys = DestructuringAssignmentProperties::default();
-    let properties = object
+    for property in object
       .properties(ast)
       .iter()
       .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    for property in properties {
+    {
       let key = property.key(ast);
       let value = property.value(ast);
       let (id, shorthand) = if property.shorthand(ast) {


### PR DESCRIPTION
## Summary

- Replace temporary AST handle vectors in the parser walker with borrowed `TypedSubRange` iteration.
- Keep traversal order and parser behavior unchanged; this PR only changes walker data structures.
- This is the first Step 3 optimization stacked on #15506. The next layer is #15513.

## Related links

- #15506
- #15513

## Checklist

- [x] Tests updated (not required; behavior is unchanged).
- [x] Documentation updated (not required).