### PR TITLE
perf(javascript): borrow parser plugin arguments

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -6,7 +6,7 @@ use rspack_core::{
   RuntimeRequirementsDependency, get_context,
 };
 use rspack_intern::Atom;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use rustc_hash::FxHashMap;
 use swc_next_ecma_ast::{
   ArrowFunctionBodyData, Ast, CallExpression, Expr, ExprData, GetSpan, PropertyKeyData,
@@ -272,11 +272,7 @@ impl AMDDefineDependencyParserPlugin {
     call_expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let args = call_expr.arguments(ast);
     let mut array: Option<Expr> = None;
     let mut func: Option<Expr> = None;
     let mut obj: Option<Expr> = None;
@@ -285,7 +281,7 @@ impl AMDDefineDependencyParserPlugin {
     match args.len() {
       1 => {
         // We don't support spread syntax in `define()`.
-        let first_arg = args[0].as_expr(ast)?;
+        let first_arg = ast.first(args)?.as_expr(ast)?;
 
         if is_callable(ast, first_arg) {
           // define(f() {…})
@@ -301,8 +297,8 @@ impl AMDDefineDependencyParserPlugin {
         }
       }
       2 => {
-        let first_arg = args[0].as_expr(ast)?;
-        let second_arg = args[1].as_expr(ast)?;
+        let first_arg = ast.first(args)?.as_expr(ast)?;
+        let second_arg = ast.second(args)?.as_expr(ast)?;
 
         if is_literal(ast, first_arg) {
           // define("…", …)
@@ -341,9 +337,9 @@ impl AMDDefineDependencyParserPlugin {
       3 => {
         // define("…", […], …)
 
-        let first_arg = args[0].as_expr(ast)?;
-        let second_arg = args[1].as_expr(ast)?;
-        let third_arg = args[2].as_expr(ast)?;
+        let first_arg = ast.first(args)?.as_expr(ast)?;
+        let second_arg = ast.second(args)?.as_expr(ast)?;
+        let third_arg = args.get_node(ast, 2)?.as_expr(ast)?;
 
         if !is_literal(ast, first_arg) {
           return None;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_require_dependencies_block_parser_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
 };
 use rspack_error::{Error, Severity};
 use rspack_intern::Atom;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   Argument, ArrowFunctionBodyData, Ast, BindingPattern, CallExpression, GetSpan,
 };
@@ -280,11 +280,7 @@ impl AMDRequireDependenciesBlockParserPlugin {
     call_expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let args = call_expr.arguments(ast);
     if args.is_empty() {
       return None;
     }
@@ -292,9 +288,9 @@ impl AMDRequireDependenciesBlockParserPlugin {
 
     // require(['dep1', 'dep2'], callback, errorCallback);
 
-    let first_arg = *args.first().expect("first arg cannot be None");
-    let callback_arg = args.get(1).copied();
-    let error_callback_arg = args.get(2).copied();
+    let first_arg = ast.first(args).expect("first arg cannot be None");
+    let callback_arg = ast.second(args);
+    let error_callback_arg = args.get_node(ast, 2);
     let first_arg_expr = first_arg.as_expr(ast)?;
 
     let param = parser.evaluate_expression(first_arg_expr);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   runtime_mode::RuntimeMode as ExperimentRuntimeMode,
 };
 use rspack_error::{Error, Severity};
-use rspack_util::{SpanExt, json_stringify_str};
+use rspack_util::{SpanExt, json_stringify_str, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   ArgumentData, AssignmentExpression, AssignmentOperator, BindingPatternData, CallExpression,
   GetSpan, Span, UnaryExpression, VariableDeclarator,
@@ -958,14 +958,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
     for_name: &str,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let arguments = call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let arguments = call_expr.arguments(ast);
     if for_name == API_IS_INCLUDED
       && arguments.len() == 1
-      && let ArgumentData::Expr(argument) = ast.argument_data(arguments[0])
+      && let Some(argument) = ast.first(arguments)
+      && let ArgumentData::Expr(argument) = ast.argument_data(argument)
     {
       let request = parser.evaluate_expression(argument);
       if request.is_string() {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -1,10 +1,10 @@
 use rspack_core::{
   BoxDependency, BuildMetaDefaultObject, BuildMetaExportsType, DependencyRange, RuntimeGlobals,
 };
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   Argument, AssignmentExpression, Ast, CallExpression, Expr, ExprData, GetSpan, PropertyKeyData,
-  Span, ThisExpression, UnaryExpression, UnaryOperator,
+  Span, ThisExpression, TypedSubRange, UnaryExpression, UnaryOperator,
 };
 
 use super::JavascriptParserPlugin;
@@ -241,7 +241,7 @@ fn handle_access_export(
   remaining: &[Atom],
   remaining_optionals: &[bool],
   base: ExportsBase,
-  call_args: Option<Vec<Argument>>,
+  call_args: Option<TypedSubRange<Argument>>,
 ) -> Option<bool> {
   if parser.is_esm {
     return None;
@@ -257,7 +257,8 @@ fn handle_access_export(
     call_args.is_some(),
   )));
   if let Some(call_args) = call_args {
-    parser.walk_arguments(call_args.into_iter());
+    let ast = parser.ast.ast;
+    parser.walk_arguments(ast.nodes(call_args));
   }
   Some(true)
 }
@@ -324,17 +325,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsExportsParserPlugin {
     }
     let ast = parser.ast.ast;
     let call_span = call_expr.span(ast);
-    let args = call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let args = call_expr.arguments(ast);
     if for_name == "Object.defineProperty"
       && parser.is_statement_level_expression(call_span)
       && args.len() == 3
-      && let Some(arg0) = args[0].as_expr(ast)
-      && let Some(arg1) = args[1].as_expr(ast)
-      && let Some(arg2) = args[2].as_expr(ast)
+      && let Some(arg0) = ast.first(args).and_then(|argument| argument.as_expr(ast))
+      && let Some(arg1) = ast.second(args).and_then(|argument| argument.as_expr(ast))
+      && let Some(arg2) = args
+        .get_node(ast, 2)
+        .and_then(|argument| argument.as_expr(ast))
     {
       let exports_arg = parser.evaluate_expression(arg0);
       if !exports_arg.is_identifier() {
@@ -517,13 +516,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsExportsParserPlugin {
     }
     let ast = parser.ast.ast;
     let callee_span = expr.callee(ast).span(ast);
-    let arguments = || {
-      expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id))
-        .collect::<Vec<_>>()
-    };
+    let arguments = || expr.arguments(ast);
 
     if for_name == "exports" {
       // exports.a.b.c()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -9,7 +9,7 @@ use rspack_core::{
 };
 use rspack_error::{Diagnostic, Severity};
 use rspack_intern::AtomRef;
-use rspack_util::{SpanExt, json_stringify_str};
+use rspack_util::{SpanExt, json_stringify_str, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   Argument, ArgumentData, AssignmentExpression, AssignmentOperator, Ast, CallExpression, Expr,
   ExprData, GetSpan, MemberExpression, NewExpression, PropertyKeyData, Span, TypedSubRange,
@@ -357,13 +357,6 @@ fn static_member_name(ast: &Ast<'_>, member_expr: MemberExpression) -> Option<At
   }
 }
 
-fn collect_arguments(ast: &Ast<'_>, arguments: TypedSubRange<Argument>) -> Vec<Argument> {
-  arguments
-    .iter()
-    .map(|id| ast.get_node_in_sub_range(id))
-    .collect()
-}
-
 fn argument_expression(ast: &Ast<'_>, argument: Argument) -> Expr {
   match ast.argument_data(argument) {
     ArgumentData::Expr(expression) => expression,
@@ -496,13 +489,13 @@ fn evaluate_create_require_argument(parser: &mut JavascriptParser, arg: Expr) ->
   {
     return None;
   }
-  let args = collect_arguments(ast, new_expr.arguments(ast));
-  if let Some(first_arg) = args.first().and_then(|arg| arg.as_expr(ast))
+  let args = new_expr.arguments(ast);
+  if let Some(first_arg) = ast.first(args).and_then(|arg| arg.as_expr(ast))
     && let Some(value) = parser.evaluate_expression(first_arg).as_string()
     && value.starts_with("file:/")
   {
-    if let Some(base) = args.get(1)
-      && !is_valid_ignored_url_base_arg(parser, *base)
+    if let Some(base) = ast.second(args)
+      && !is_valid_ignored_url_base_arg(parser, base)
     {
       return None;
     }
@@ -543,11 +536,11 @@ fn evaluate_create_require_argument(parser: &mut JavascriptParser, arg: Expr) ->
 #[inline(never)]
 fn ignored_url_args_are_side_effect_free_from(
   parser: &mut JavascriptParser,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   start: usize,
 ) -> bool {
   let ast = parser.ast.ast;
-  args.iter().skip(start).all(|arg| {
+  ast.nodes(args).skip(start).all(|arg| {
     arg
       .as_expr(ast)
       .is_some_and(|expr| is_side_effect_free_ignored_url_arg(parser, expr))
@@ -584,15 +577,15 @@ fn parse_create_require_argument(
   emit_warning: bool,
 ) -> Option<CreateRequireArgument> {
   let ast = parser.ast.ast;
-  let args = collect_arguments(ast, call_expr.arguments(ast));
-  parse_create_require_argument_from_args(parser, &args, call_expr.span(ast), emit_warning)
+  let args = call_expr.arguments(ast);
+  parse_create_require_argument_from_args(parser, args, call_expr.span(ast), emit_warning)
 }
 
 #[cold]
 #[inline(never)]
 fn parse_create_require_argument_from_args(
   parser: &mut JavascriptParser,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   span: Span,
   emit_warning: bool,
 ) -> Option<CreateRequireArgument> {
@@ -604,12 +597,15 @@ fn parse_create_require_argument_from_args(
   }
 
   let ast = parser.ast.ast;
-  let Some(arg) = args[0].as_expr(ast) else {
+  let first_arg = ast
+    .first(args)
+    .expect("argument index should be within range");
+  let Some(arg) = first_arg.as_expr(ast) else {
     if emit_warning {
       add_create_require_warning(
         parser,
         "module.createRequire does not support spread arguments.",
-        args[0].span(ast),
+        first_arg.span(ast),
       );
     }
     return None;
@@ -648,8 +644,8 @@ fn parse_create_require_new_argument(
   emit_warning: bool,
 ) -> Option<CreateRequireArgument> {
   let ast = parser.ast.ast;
-  let args = collect_arguments(ast, new_expr.arguments(ast));
-  parse_create_require_argument_from_args(parser, &args, new_expr.span(ast), emit_warning)
+  let args = new_expr.arguments(ast);
+  parse_create_require_argument_from_args(parser, args, new_expr.span(ast), emit_warning)
 }
 
 #[inline(never)]
@@ -674,31 +670,39 @@ fn should_replace_create_require_argument(parser: &mut JavascriptParser, arg: Ex
   {
     let is_absolute_file_url = is_absolute_file_url_constructor_arg(parser, arg);
     let start = if is_absolute_file_url { 1 } else { 2 };
-    let args = collect_arguments(ast, new_expr.arguments(ast));
+    let args = new_expr.arguments(ast);
     if is_absolute_file_url
-      && let Some(base) = args.get(1)
-      && !is_valid_ignored_url_base_arg(parser, *base)
+      && let Some(base) = ast.second(args)
+      && !is_valid_ignored_url_base_arg(parser, base)
     {
       return false;
     }
-    ignored_url_args_are_side_effect_free_from(parser, &args, start)
+    ignored_url_args_are_side_effect_free_from(parser, args, start)
   } else {
     true
   }
 }
 
 #[inline(never)]
-fn can_defer_create_require_call(parser: &mut JavascriptParser, args: &[Argument]) -> bool {
+fn can_defer_create_require_call(
+  parser: &mut JavascriptParser,
+  args: TypedSubRange<Argument>,
+) -> bool {
   let ast = parser.ast.ast;
   args.len() == 1
-    && args[0]
+    && ast
+      .first(args)
+      .expect("argument index should be within range")
       .as_expr(ast)
       .and_then(|expr| expr.as_member_expression(ast))
       .is_some_and(|member| is_meta_url(parser, member))
 }
 
 #[inline(never)]
-fn should_clear_create_require_call(parser: &mut JavascriptParser, args: &[Argument]) -> bool {
+fn should_clear_create_require_call(
+  parser: &mut JavascriptParser,
+  args: TypedSubRange<Argument>,
+) -> bool {
   !matches!(parser.javascript_options.require_resolve, Some(false))
     && can_defer_create_require_call(parser, args)
 }
@@ -749,9 +753,9 @@ fn is_absolute_file_url_constructor_arg(parser: &mut JavascriptParser, arg: Expr
   {
     return false;
   };
-  let args = collect_arguments(ast, new_expr.arguments(ast));
-  args
-    .first()
+  let args = new_expr.arguments(ast);
+  ast
+    .first(args)
     .and_then(|arg| arg.as_expr(ast))
     .and_then(|arg| parser.evaluate_expression(arg).as_string())
     .is_some_and(|value| value.starts_with("file:/"))
@@ -764,9 +768,9 @@ fn walk_create_require_callee(parser: &mut JavascriptParser, call_expr: CallExpr
 
 fn walk_create_require_ignored_args(parser: &mut JavascriptParser, call_expr: CallExpression) {
   let ast = parser.ast.ast;
-  let args = collect_arguments(ast, call_expr.arguments(ast));
+  let args = call_expr.arguments(ast);
   if args.len() > 1 {
-    parser.walk_arguments(args.into_iter().skip(1));
+    parser.walk_arguments(ast.nodes(args).skip(1));
   }
 }
 
@@ -787,9 +791,9 @@ fn walk_create_require_argument_side_effects(parser: &mut JavascriptParser, arg:
   if !is_unbound_url_constructor(parser, new_expr.callee(ast)) {
     return;
   };
-  let args = collect_arguments(ast, new_expr.arguments(ast));
+  let args = new_expr.arguments(ast);
   if args.len() > 1 {
-    parser.walk_arguments(args.into_iter().skip(1));
+    parser.walk_arguments(ast.nodes(args).skip(1));
   }
 }
 
@@ -838,14 +842,14 @@ fn create_require_url_arg_side_effects(parser: &mut JavascriptParser, arg: Expr)
   if !is_unbound_url_constructor(parser, new_expr.callee(ast)) {
     return String::new();
   };
-  let args = collect_arguments(ast, new_expr.arguments(ast));
+  let args = new_expr.arguments(ast);
   let start = if is_absolute_file_url_constructor_arg(parser, arg) {
     1
   } else {
     2
   };
   let mut side_effects = String::new();
-  for argument in args.iter().skip(start).copied() {
+  for argument in ast.nodes(args).skip(start) {
     let expression = argument_expression(ast, argument);
     let Some(source) = source_for_span(parser, expression.span(ast)) else {
       continue;
@@ -888,10 +892,13 @@ fn wrap_span_with_side_effects(parser: &mut JavascriptParser, span: Span, side_e
 }
 
 #[inline(never)]
-fn create_require_extra_arg_side_effects(parser: &JavascriptParser, args: &[Argument]) -> String {
+fn create_require_extra_arg_side_effects(
+  parser: &JavascriptParser,
+  args: TypedSubRange<Argument>,
+) -> String {
   let ast = parser.ast.ast;
   let mut side_effects = String::new();
-  for argument in args.iter().skip(1).copied() {
+  for argument in ast.nodes(args).skip(1) {
     let expression = argument_expression(ast, argument);
     let Some(source) = source_for_span(parser, expression.span(ast)) else {
       continue;
@@ -908,13 +915,22 @@ fn create_require_extra_arg_side_effects(parser: &JavascriptParser, args: &[Argu
 #[inline(never)]
 fn create_require_args_side_effects(
   parser: &mut JavascriptParser,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   argument: &CreateRequireArgument,
 ) -> String {
   let mut side_effects = if argument.replace_argument {
     String::new()
   } else {
-    create_require_url_arg_side_effects(parser, argument_expression(parser.ast.ast, args[0]))
+    let ast = parser.ast.ast;
+    create_require_url_arg_side_effects(
+      parser,
+      argument_expression(
+        ast,
+        ast
+          .first(args)
+          .expect("argument index should be within range"),
+      ),
+    )
   };
   let extra_side_effects = create_require_extra_arg_side_effects(parser, args);
   if !extra_side_effects.is_empty() {
@@ -927,7 +943,7 @@ fn create_require_args_side_effects(
 fn evaluate_created_require<'p>(
   parser: &mut JavascriptParser<'p>,
   range: Span,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   argument: CreateRequireArgument,
 ) -> BasicEvaluatedExpression<'p> {
   let side_effects = create_require_args_side_effects(parser, args, &argument);
@@ -968,11 +984,11 @@ pub(crate) fn evaluate_create_require_new_expression<'p>(
   }
   let argument = parse_create_require_new_argument(parser, expr, false)?;
   let ast = parser.ast.ast;
-  let args = collect_arguments(ast, expr.arguments(ast));
+  let args = expr.arguments(ast);
   Some(evaluate_created_require(
     parser,
     expr.span(ast),
-    &args,
+    args,
     argument,
   ))
 }
@@ -984,11 +1000,11 @@ fn evaluate_create_require_call_expression<'p>(
 ) -> Option<BasicEvaluatedExpression<'p>> {
   let argument = parse_create_require_argument(parser, expr, false)?;
   let ast = parser.ast.ast;
-  let args = collect_arguments(ast, expr.arguments(ast));
+  let args = expr.arguments(ast);
   Some(evaluate_created_require(
     parser,
     expr.span(ast),
-    &args,
+    args,
     argument,
   ))
 }
@@ -1162,8 +1178,8 @@ fn pre_tag_created_require_declarator(
   let is_create_require_callee = callee.as_identifier_reference(ast).is_some_and(|ident| {
     is_create_require_specifier(parser, &Atom::from(ast.get_utf8(ident.name(ast))))
   }) || is_create_require_namespace_member(parser, callee);
-  let args = collect_arguments(ast, call.arguments(ast));
-  if !is_create_require_callee || !can_defer_create_require_call(parser, &args) {
+  let args = call.arguments(ast);
+  if !is_create_require_callee || !can_defer_create_require_call(parser, args) {
     return;
   }
   let Some(argument) = parse_create_require_argument(parser, call, false) else {
@@ -1195,7 +1211,12 @@ fn pre_tag_created_require_declarator(
   parser.created_require_references.add_pending(
     call_span,
     deferred_callee,
-    argument_expression(parser.ast.ast, args[0]),
+    argument_expression(
+      ast,
+      ast
+        .first(args)
+        .expect("argument index should be within range"),
+    ),
     statement_path,
     prev_statement,
   );
@@ -1208,10 +1229,11 @@ fn tag_created_require_declarator(
   binding: swc_next_ecma_ast::BindingIdentifier,
   call_span: Span,
   clear_call: bool,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   deferred_callee: Option<DeferredCreateRequireCallee>,
   argument: CreateRequireArgument,
 ) {
+  let ast = parser.ast.ast;
   let CreateRequireArgument {
     value,
     context,
@@ -1236,23 +1258,32 @@ fn tag_created_require_declarator(
     parser.created_require_references.add_pending(
       call_span,
       callee,
-      argument_expression(parser.ast.ast, args[0]),
+      argument_expression(
+        ast,
+        ast
+          .first(args)
+          .expect("argument index should be within range"),
+      ),
       statement_path,
       prev_statement,
     );
   } else if clear_call {
     clear_create_require_call(parser, call_span);
   } else if replace_argument {
+    let first_arg = ast
+      .first(args)
+      .expect("argument index should be within range");
     parser.add_presentational_dependency(Arc::new(ConstDependency::new(
-      argument_expression(parser.ast.ast, args[0])
-        .span(parser.ast.ast)
-        .into(),
+      argument_expression(ast, first_arg).span(ast).into(),
       json_stringify_str(&value).into(),
     )));
   } else {
-    walk_create_require_argument_side_effects(parser, argument_expression(parser.ast.ast, args[0]));
+    let first_arg = ast
+      .first(args)
+      .expect("argument index should be within range");
+    walk_create_require_argument_side_effects(parser, argument_expression(ast, first_arg));
   }
-  parser.walk_arguments(args.iter().skip(1).copied());
+  parser.walk_arguments(ast.nodes(args).skip(1));
 }
 
 fn clear_create_require_tag<'key>(parser: &mut JavascriptParser, name: impl Into<AtomRef<'key>>) {
@@ -1362,9 +1393,11 @@ fn walk_unsupported_create_require_resolve(
 ) {
   walk_create_require_callee(parser, inner_call_expr);
   let ast = parser.ast.ast;
-  let inner_args = collect_arguments(ast, inner_call_expr.arguments(ast));
+  let inner_args = inner_call_expr.arguments(ast);
   if inner_args.len() == 1
-    && let Some(arg) = inner_args[0].as_expr(ast)
+    && let Some(arg) = ast
+      .first(inner_args)
+      .and_then(|argument| argument.as_expr(ast))
   {
     if let Some(value) = evaluate_create_require_argument(parser, arg) {
       if should_replace_create_require_argument(parser, arg) {
@@ -1377,27 +1410,23 @@ fn walk_unsupported_create_require_resolve(
       }
     } else if let Some(new_expr) = arg.as_new_expression(parser.ast.ast)
       && is_unbound_url_constructor(parser, new_expr.callee(parser.ast.ast))
-      && let args = collect_arguments(parser.ast.ast, new_expr.arguments(parser.ast.ast))
+      && let args = new_expr.arguments(parser.ast.ast)
       && args.len() > 2
     {
+      let ast = parser.ast.ast;
       if get_url_request(parser, new_expr).is_some() {
-        parser.walk_arguments(args.into_iter().skip(2));
+        parser.walk_arguments(ast.nodes(args).skip(2));
       } else {
-        parser.walk_arguments(args.into_iter());
+        parser.walk_arguments(ast.nodes(args));
       }
     } else {
       parser.walk_expression(arg);
     }
   } else {
-    parser.walk_arguments(inner_args.into_iter());
+    parser.walk_arguments(ast.nodes(inner_args));
   }
   let ast = parser.ast.ast;
-  parser.walk_arguments(
-    call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id)),
-  );
+  parser.walk_arguments(ast.nodes(call_expr.arguments(ast)));
 }
 
 fn tag_commonjs_require_referenced(
@@ -1548,10 +1577,10 @@ impl CallOrNewExpression {
     }
   }
 
-  pub fn args(self, ast: &Ast<'_>) -> Vec<Argument> {
+  pub fn args(self, ast: &Ast<'_>) -> TypedSubRange<Argument> {
     match self {
-      CallOrNewExpression::Call(call_expr) => collect_arguments(ast, call_expr.arguments(ast)),
-      CallOrNewExpression::New(new_expr) => collect_arguments(ast, new_expr.arguments(ast)),
+      CallOrNewExpression::Call(call_expr) => call_expr.arguments(ast),
+      CallOrNewExpression::New(new_expr) => new_expr.arguments(ast),
     }
   }
 
@@ -1607,18 +1636,21 @@ impl CommonJsImportsParserPlugin {
     request_context: Option<Context>,
   ) {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr.arguments(ast));
+    let args = call_expr.arguments(ast);
     if args.len() != 1 {
       return;
     }
 
-    if let Some(argument_expr) = args[0].as_expr(ast)
+    let argument = ast
+      .first(args)
+      .expect("argument index should be within range");
+    if let Some(argument_expr) = argument.as_expr(ast)
       && Self::has_ignore_comment(parser, call_expr.span(ast), argument_expr.span(ast))
     {
       return;
     }
 
-    let argument_expr = argument_expression(ast, args[0]);
+    let argument_expr = argument_expression(ast, argument);
     let param = parser.evaluate_expression(argument_expr);
     let range = call_expr.callee(parser.ast.ast).span(parser.ast.ast).into();
     let loc = parser.to_dependency_location(range);
@@ -1646,15 +1678,21 @@ impl CommonJsImportsParserPlugin {
     expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, expr.arguments(ast));
-    if args.len() != 1 || args[0].as_expr(ast).is_none() {
+    let args = expr.arguments(ast);
+    if args.len() != 1
+      || ast
+        .first(args)
+        .expect("argument index should be within range")
+        .as_expr(ast)
+        .is_none()
+    {
       preserve_unhandled_created_require(parser);
-      parser.walk_arguments(args.into_iter());
+      parser.walk_arguments(ast.nodes(args));
       return Some(true);
     }
     if matches!(parser.javascript_options.require_resolve, Some(false)) {
       preserve_unhandled_created_require(parser);
-      parser.walk_arguments(args.into_iter());
+      parser.walk_arguments(ast.nodes(args));
       return Some(true);
     }
     self.process_resolve(parser, expr, false, current_created_require_context(parser));
@@ -1721,11 +1759,13 @@ impl CommonJsImportsParserPlugin {
     is_call: bool,
   ) -> Option<CommonJsFullRequireDependency> {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr.arguments(ast));
+    let args = call_expr.arguments(ast);
     if args.len() != 1 {
       return None;
     }
-    let arg = args[0];
+    let arg = ast
+      .first(args)
+      .expect("argument index should be within range");
     if let Some(argument_expr) = arg.as_expr(ast)
       && Self::has_ignore_comment(parser, call_expr.span(ast), argument_expr.span(ast))
     {
@@ -1818,7 +1858,7 @@ impl CommonJsImportsParserPlugin {
     request_context: Option<Context>,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let Some(argument_expr) = call_expr.arguments(ast).get_node(ast, 0) else {
+    let Some(argument_expr) = ast.first(call_expr.arguments(ast)) else {
       unreachable!("ensure require includes arguments")
     };
     let argument_expr = argument_expression(ast, argument_expr);
@@ -1871,7 +1911,10 @@ impl CommonJsImportsParserPlugin {
     if args.len() != 1 {
       return None;
     }
-    let argument_expr = args[0].as_expr(ast)?;
+    let argument_expr = ast
+      .first(args)
+      .expect("argument index should be within range")
+      .as_expr(ast)?;
 
     // Skip adding require() as a dependency when in unreachable code after
     // return/throw (e.g. require("fail") in dead code should not be resolved).
@@ -2107,11 +2150,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         || is_create_require_namespace_member(parser, callee))
       && let Some(argument) = parse_create_require_argument(parser, call, false)
     {
-      let args = collect_arguments(parser.ast.ast, call.arguments(parser.ast.ast));
+      let args = call.arguments(parser.ast.ast);
       let call_span = call.span(parser.ast.ast);
-      let clear_call = should_clear_create_require_call(parser, &args);
+      let clear_call = should_clear_create_require_call(parser, args);
       let deferred_callee = (declaration.kind(parser.ast.ast) == VariableDeclarationKind::Const
-        && can_defer_create_require_call(parser, &args))
+        && can_defer_create_require_call(parser, args))
       .then(|| deferred_create_require_callee(parser, callee, call_span))
       .flatten();
       let walk_callee = !clear_call && deferred_callee.is_none();
@@ -2120,7 +2163,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         binding,
         call_span,
         clear_call,
-        &args,
+        args,
         deferred_callee,
         argument,
       );
@@ -2136,16 +2179,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_new_argument(parser, init, false)
     {
       let ast = parser.ast.ast;
-      let args = collect_arguments(ast, init.arguments(ast));
-      tag_created_require_declarator(
-        parser,
-        binding,
-        init.span(ast),
-        false,
-        &args,
-        None,
-        argument,
-      );
+      let args = init.arguments(ast);
+      tag_created_require_declarator(parser, binding, init.span(ast), false, args, None, argument);
       parser.walk_expression(init.callee(parser.ast.ast));
       return Some(true);
     }
@@ -2523,22 +2558,25 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     ) {
       if let Some(argument) = parse_create_require_argument(parser, call_expr, true) {
         let ast = parser.ast.ast;
-        let args = collect_arguments(ast, call_expr.arguments(ast));
+        let args = call_expr.arguments(ast);
         let call_span = call_expr.span(ast);
-        let clear_call = should_clear_create_require_call(parser, &args);
+        let clear_call = should_clear_create_require_call(parser, args);
         if clear_call {
           clear_create_require_call(parser, call_span);
         } else if argument.replace_argument {
-          let argument_expr = argument_expression(parser.ast.ast, args[0]);
+          let first_arg = ast
+            .first(args)
+            .expect("argument index should be within range");
+          let argument_expr = argument_expression(ast, first_arg);
           parser.add_presentational_dependency(Arc::new(ConstDependency::new(
             argument_expr.span(parser.ast.ast).into(),
             json_stringify_str(&argument.value).into(),
           )));
         } else {
-          walk_create_require_argument_side_effects(
-            parser,
-            argument_expression(parser.ast.ast, args[0]),
-          );
+          let first_arg = ast
+            .first(args)
+            .expect("argument index should be within range");
+          walk_create_require_argument_side_effects(parser, argument_expression(ast, first_arg));
         }
         if !clear_call {
           walk_create_require_callee(parser, call_expr);
@@ -2613,9 +2651,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_argument(parser, call_expr, false)
     {
       let ast = parser.ast.ast;
-      let args = collect_arguments(ast, call_expr.arguments(ast));
+      let args = call_expr.arguments(ast);
       let member_span = member_expr.span(ast);
-      let side_effects = create_require_args_side_effects(parser, &args, &argument);
+      let side_effects = create_require_args_side_effects(parser, args, &argument);
       let unsupported_replacement = create_require_unsupported_member_replacement(&side_effects);
       handle_created_require_member(
         parser,
@@ -2661,18 +2699,22 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && members[0].as_ref() == "resolve"
     {
       let ast = parser.ast.ast;
-      let call_args = collect_arguments(ast, call_expr.arguments(ast));
+      let call_args = call_expr.arguments(ast);
       if matches!(parser.javascript_options.require_resolve, Some(false))
         || call_args.len() != 1
-        || call_args[0].as_expr(ast).is_none()
+        || ast
+          .first(call_args)
+          .expect("argument index should be within range")
+          .as_expr(ast)
+          .is_none()
       {
         walk_unsupported_create_require_resolve(parser, inner_call_expr, call_expr);
         return Some(true);
       }
       let argument = parse_create_require_argument(parser, inner_call_expr, false)?;
       let ast = parser.ast.ast;
-      let inner_args = collect_arguments(ast, inner_call_expr.arguments(ast));
-      let side_effects = create_require_args_side_effects(parser, &inner_args, &argument);
+      let inner_args = inner_call_expr.arguments(ast);
+      let side_effects = create_require_args_side_effects(parser, inner_args, &argument);
       wrap_span_with_side_effects(parser, call_expr.span(parser.ast.ast), &side_effects);
       let context = argument.context;
       walk_create_require_ignored_args(parser, inner_call_expr);
@@ -2685,8 +2727,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       && let Some(argument) = parse_create_require_argument(parser, inner_call_expr, false)
     {
       let ast = parser.ast.ast;
-      let inner_args = collect_arguments(ast, inner_call_expr.arguments(ast));
-      let side_effects = create_require_args_side_effects(parser, &inner_args, &argument);
+      let inner_args = inner_call_expr.arguments(ast);
+      let side_effects = create_require_args_side_effects(parser, inner_args, &argument);
       let unsupported_replacement = create_require_unsupported_member_replacement(&side_effects);
       let callee = call_expr.callee(ast);
       let member_span = callee.span(ast);
@@ -2710,12 +2752,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       }
       walk_create_require_ignored_args(parser, inner_call_expr);
       let ast = parser.ast.ast;
-      parser.walk_arguments(
-        call_expr
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id)),
-      );
+      parser.walk_arguments(ast.nodes(call_expr.arguments(ast)));
       return Some(true);
     }
 
@@ -2729,12 +2766,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     {
       parser.add_dependency(BoxDependency::new(dep));
       let ast = parser.ast.ast;
-      parser.walk_arguments(
-        call_expr
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id)),
-      );
+      parser.walk_arguments(ast.nodes(call_expr.arguments(ast)));
       return Some(true);
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use rspack_core::{
   ConstDependency, ContextDependency, DependencyCodeGenerationRef, DependencyRange,
 };
-use rspack_util::{SpanExt, itoa};
+use rspack_util::{SpanExt, itoa, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   ArgumentData, BindingIdentifier, BindingPatternData, CallExpression, GetSpan, Program,
   VariableDeclarator,
@@ -44,15 +44,11 @@ impl CompatibilityPlugin {
     expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let arguments = expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let arguments = expr.arguments(ast);
     if arguments.len() != 2 {
       return None;
     }
-    let ArgumentData::Expr(second) = ast.argument_data(arguments[1]) else {
+    let ArgumentData::Expr(second) = ast.argument_data(ast.second(arguments)?) else {
       return None;
     };
     let second = parser.evaluate_expression(second);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -5,7 +5,10 @@ use rspack_core::{
   ReferencedSpecifier, get_context,
 };
 use rspack_error::{Error, Severity};
-use rspack_util::{SpanExt, swc::get_swc_next_comments};
+use rspack_util::{
+  SpanExt,
+  swc::{AstSubRangeExt, get_swc_next_comments},
+};
 use rustc_hash::FxHashMap;
 use swc_next_ecma_ast::{
   ArrowFunctionBodyData, BindingPattern, BindingPatternData, CallExpression, Expr, ExprData,
@@ -661,17 +664,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
     if let Some(import_then) = import_then {
       if let Some(ns_obj) = referenced_fulfilled_ns_obj {
         let ast = parser.ast.ast;
-        let arguments = import_then
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id))
-          .collect::<Vec<_>>();
-        let fulfilled_callback = arguments
-          .first()
+        let arguments = import_then.arguments(ast);
+        let fulfilled_callback = ast
+          .first(arguments)
           .and_then(|argument| argument.as_expr(ast))
           .expect("fulfilled callback should be an expression");
         walk_import_then_fulfilled_callback(parser, node, fulfilled_callback, ns_obj);
-        parser.walk_arguments(arguments.into_iter().skip(1));
+        parser.walk_arguments(ast.nodes(arguments).skip(1));
       } else {
         let ast = parser.ast.ast;
         parser.walk_arguments(

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   AsyncDependenciesBlock, BoxDependency, ChunkGroupOptions, ConstDependency, DependencyRange,
   GroupOptions,
 };
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   ArrowFunctionBodyData, ArrowFunctionExpression, Ast, CallExpression, Expr, ExprData, Function,
   GetSpan, PropertyKeyData, StmtData, UnaryExpression,
@@ -60,12 +60,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireEnsureDependenciesBlockPa
     }
 
     let ast = parser.ast.ast;
-    let arguments = expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    let dependencies_arg = arguments.first()?.as_expr(ast)?;
+    let arguments = expr.arguments(ast);
+    let dependencies_arg = ast.first(arguments)?.as_expr(ast)?;
     let dependencies_expr = parser.evaluate_expression(dependencies_arg);
     let dependencies_items = if dependencies_expr.is_array() {
       Either::Left(dependencies_expr.items().iter())
@@ -73,10 +69,10 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireEnsureDependenciesBlockPa
       Either::Right(std::iter::once(&dependencies_expr))
     };
 
-    let success_argument = *arguments.get(1)?;
+    let success_argument = ast.second(arguments)?;
     let success_arg = success_argument.as_expr(ast)?;
     let success_expr = success_arg.get_function_expr(ast);
-    let error_arg = arguments.get(2).copied();
+    let error_arg = arguments.get_node(ast, 2);
     let error_expr = error_arg
       .and_then(|arg| arg.as_expr(ast))
       .and_then(|expr| expr.get_function_expr(ast));
@@ -84,7 +80,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireEnsureDependenciesBlockPa
     let chunk_name = match expr
       .arguments(ast)
       .get_node(ast, 3)
-      .or_else(|| if error_expr.is_some() { None } else { arguments.get(2).copied() }) // !errorExpression
+      .or_else(|| if error_expr.is_some() { None } else { arguments.get_node(ast, 2) }) // !errorExpression
     {
       Some(arg) => match arg
         .as_expr(ast)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -8,11 +8,11 @@ use rspack_core::{
 use rspack_error::Severity;
 use rspack_hash::{RspackHash, RspackHasher};
 use rspack_macros::AstObject;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_next_ecma_ast::{
   Argument, ArgumentData, BindingIdentifier, CallExpression, GetSpan, NewExpression, Span,
-  VariableDeclarator,
+  TypedSubRange, VariableDeclarator,
 };
 use url::Url;
 
@@ -235,7 +235,7 @@ fn add_dependencies(
 
 fn handle_worker(
   parser: &mut JavascriptParser,
-  args: &[Argument],
+  args: TypedSubRange<Argument>,
   span: Span,
   is_shared_worker: bool,
 ) -> Option<(
@@ -245,7 +245,7 @@ fn handle_worker(
   bool,
 )> {
   let ast = parser.ast.ast;
-  if let Some(&argument) = args.first()
+  if let Some(argument) = ast.first(args)
     && let ArgumentData::Expr(expression) = ast.argument_data(argument)
   {
     let mut need_new_url = false;
@@ -278,9 +278,8 @@ fn handle_worker(
     } else {
       return None;
     };
-    let mut options = args
-      .get(1)
-      .copied()
+    let mut options = ast
+      .second(args)
       // new Worker(new URL("worker.js"), options)
       .map(|arg| parse_new_worker_options(parser, arg, is_shared_worker));
 
@@ -519,12 +518,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     {
       let ast = parser.ast.ast;
       let span = call_expr.span(ast);
-      let arguments = call_expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id))
-        .collect::<Vec<_>>();
-      return handle_worker(parser, &arguments, span, false).map(
+      let arguments = call_expr.arguments(ast);
+      return handle_worker(parser, arguments, span, false).map(
         |(parsed_path, parsed_options, first_arg, need_new_url)| {
           add_dependencies(
             parser,
@@ -536,7 +531,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
             self.url_mode,
           );
           parser.walk_expression(call_expr.callee(ast));
-          if let Some(&argument) = arguments.get(1) {
+          if let Some(argument) = ast.second(arguments) {
             parser.walk_arguments(std::iter::once(argument));
           }
           true
@@ -565,12 +560,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
       {
         let ast = parser.ast.ast;
         let span = call_expr.span(ast);
-        let arguments = call_expr
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id))
-          .collect::<Vec<_>>();
-        return handle_worker(parser, &arguments, span, false).map(
+        let arguments = call_expr.arguments(ast);
+        return handle_worker(parser, arguments, span, false).map(
           |(parsed_path, parsed_options, first_arg, need_new_url)| {
             add_dependencies(
               parser,
@@ -582,7 +573,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               self.url_mode,
             );
             parser.walk_expression(call_expr.callee(ast));
-            if let Some(&argument) = arguments.get(1) {
+            if let Some(argument) = ast.second(arguments) {
               parser.walk_arguments(std::iter::once(argument));
             }
             true
@@ -596,12 +587,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     }
     let ast = parser.ast.ast;
     let span = call_expr.span(ast);
-    let arguments = call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
-    handle_worker(parser, &arguments, span, false).map(
+    let arguments = call_expr.arguments(ast);
+    handle_worker(parser, arguments, span, false).map(
       |(parsed_path, parsed_options, first_arg, need_new_url)| {
         add_dependencies(
           parser,
@@ -613,7 +600,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           self.url_mode,
         );
         parser.walk_expression(call_expr.callee(ast));
-        if let Some(&argument) = arguments.get(1) {
+        if let Some(argument) = ast.second(arguments) {
           parser.walk_arguments(std::iter::once(argument));
         }
         true
@@ -629,11 +616,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
   ) -> Option<bool> {
     let ast = parser.ast.ast;
     let span = new_expr.span(ast);
-    let arguments = new_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .collect::<Vec<_>>();
+    let arguments = new_expr.arguments(ast);
     if for_name == ESM_SPECIFIER_TAG {
       let tag_info = parser
         .definitions_db
@@ -645,7 +628,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
         .from_new_syntax
         .contains(&(ids, settings.source.to_string()))
       {
-        return handle_worker(parser, &arguments, span, false).map(
+        return handle_worker(parser, arguments, span, false).map(
           |(parsed_path, parsed_options, first_arg, need_new_url)| {
             add_dependencies(
               parser,
@@ -657,7 +640,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
               self.url_mode,
             );
             parser.walk_expression(new_expr.callee(ast));
-            if let Some(&argument) = arguments.get(1) {
+            if let Some(argument) = ast.second(arguments) {
               parser.walk_arguments(std::iter::once(argument));
             }
             true
@@ -669,7 +652,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
     if !self.inner.new_syntax.contains(for_name) {
       return None;
     }
-    handle_worker(parser, &arguments, span, for_name == "SharedWorker").map(
+    handle_worker(parser, arguments, span, for_name == "SharedWorker").map(
       |(parsed_path, parsed_options, first_arg, need_new_url)| {
         add_dependencies(
           parser,
@@ -681,7 +664,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for WorkerPlugin {
           self.url_mode,
         );
         parser.walk_expression(new_expr.callee(ast));
-        if let Some(&argument) = arguments.get(1) {
+        if let Some(argument) = ast.second(arguments) {
           parser.walk_arguments(std::iter::once(argument));
         }
         true

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
@@ -4,6 +4,7 @@
 //! [`Ast`] passed alongside the handle to read fields.
 
 use rspack_intern::Atom;
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{
   Ast, BindingIdentifier, BindingPattern, BlockStatement, BreakStatement, Class, ContinueStatement,
   DebuggerStatement, DeclData, DoWhileStatement, EmptyStatement,
@@ -139,8 +140,7 @@ impl ExportNamedDeclaration {
     self,
     ast: &'a Ast<'_>,
   ) -> impl Iterator<Item = (Atom, Atom, Span)> + 'a {
-    self.0.specifiers(ast).iter().map(move |slot| {
-      let specifier = ast.get_node_in_sub_range(slot);
+    ast.nodes(self.0.specifiers(ast)).map(move |specifier| {
       let local = specifier.local(ast);
       let exported = specifier.exported(ast);
       (
@@ -407,11 +407,7 @@ impl VariableDeclaration {
   }
 
   pub fn declarators<'a>(self, ast: &'a Ast<'_>) -> impl Iterator<Item = VariableDeclarator> + 'a {
-    self
-      .0
-      .declarators(ast)
-      .iter()
-      .map(move |slot| ast.get_node_in_sub_range(slot))
+    ast.nodes(self.0.declarators(ast))
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1,5 +1,5 @@
 use rspack_intern::AtomRef;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 pub mod ast;
 mod call_hooks_name;
 pub mod estree;
@@ -1505,8 +1505,7 @@ impl<'parser> JavascriptParser<'parser> {
       // `import.meta`-only unambiguous parse as ESM. Do not set `self.is_esm`
       // early: legacy parsing only flipped that state during pre-walk.
       let is_esm_program = matches!(self.module_type, ModuleType::JsEsm)
-        || body.iter().any(|slot| {
-          let statement = ast.get_node_in_sub_range(slot);
+        || ast.nodes(body).any(|statement| {
           matches!(
             ast.stmt_data(statement),
             StmtData::ImportDeclaration(_)

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,4 +1,5 @@
 use rspack_intern::AtomRef;
+use rspack_util::swc::AstSubRangeExt;
 use smallvec::SmallVec;
 use swc_next_ecma_ast::*;
 
@@ -125,8 +126,7 @@ impl JavascriptParser<'_> {
 
   pub fn walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.walk_module_item(statement);
     }
   }
@@ -182,8 +182,7 @@ impl JavascriptParser<'_> {
   pub fn walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
     let mut only_function_declaration = false;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       let stmt = Statement::from_stmt(ast, statement);
       if only_function_declaration
         && !matches!(stmt, Statement::Fn(_))
@@ -321,8 +320,7 @@ impl JavascriptParser<'_> {
   fn walk_switch_cases(&mut self, cases: TypedSubRange<SwitchCase>) {
     self.in_block_scope(false, |this| {
       let ast = this.ast.ast;
-      for id in cases.iter() {
-        let case = ast.get_node_in_sub_range(id);
+      for case in ast.nodes(cases) {
         let consequent = case.consequent(ast);
         if !consequent.is_empty() {
           let prev = this.prev_statement;
@@ -330,8 +328,7 @@ impl JavascriptParser<'_> {
           this.prev_statement = prev;
         }
       }
-      for id in cases.iter() {
-        let case = ast.get_node_in_sub_range(id);
+      for case in ast.nodes(cases) {
         if let Some(test) = case.test(ast) {
           this.walk_expression(test);
         }
@@ -758,11 +755,7 @@ impl JavascriptParser<'_> {
         self.clear_created_require_tags_in_pattern(rest.argument(ast));
       }
       BindingPatternData::ArrayPattern(array) => {
-        for element in array
-          .elements(ast)
-          .iter()
-          .filter_map(|id| ast.get_node_in_sub_range(id))
-        {
+        for element in ast.nodes(array.elements(ast)).flatten() {
           self.clear_created_require_tags_in_pattern(element);
         }
         if let Some(rest) = array.rest(ast) {
@@ -770,11 +763,7 @@ impl JavascriptParser<'_> {
         }
       }
       BindingPatternData::ObjectPattern(object) => {
-        for property in object
-          .properties(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id))
-        {
+        for property in ast.nodes(object.properties(ast)) {
           self.clear_created_require_tags_in_pattern(property.value(ast));
         }
         if let Some(rest) = object.rest(ast) {
@@ -915,12 +904,7 @@ impl JavascriptParser<'_> {
 
   pub(crate) fn walk_template_expression(&mut self, expr: TemplateLiteral) {
     let ast = self.ast.ast;
-    self.walk_expressions(
-      expr
-        .expressions(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    self.walk_expressions(ast.nodes(expr.expressions(ast)));
   }
 
   fn walk_tagged_template_expression(&mut self, expr: TaggedTemplateExpression) {
@@ -939,7 +923,7 @@ impl JavascriptParser<'_> {
       && let Some(old) = self.statement_path.pop()
     {
       let prev = self.prev_statement;
-      for expression in expressions.iter().map(|id| ast.get_node_in_sub_range(id)) {
+      for expression in ast.nodes(expressions) {
         self.statement_path.push(expression.span(ast).into());
         self.walk_expression(expression);
         self.prev_statement = self.statement_path.pop();
@@ -947,7 +931,7 @@ impl JavascriptParser<'_> {
       self.prev_statement = prev;
       self.statement_path.push(old);
     } else {
-      self.walk_expressions(expressions.iter().map(|id| ast.get_node_in_sub_range(id)));
+      self.walk_expressions(ast.nodes(expressions));
     }
   }
 
@@ -961,18 +945,10 @@ impl JavascriptParser<'_> {
     let ast = self.ast.ast;
     let opening = element.opening_element(ast);
     self.walk_jsx_element_name(opening.name(ast));
-    for attribute in opening
-      .attributes(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for attribute in ast.nodes(opening.attributes(ast)) {
       self.walk_jsx_attr_or_spread(attribute);
     }
-    for child in element
-      .children(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for child in ast.nodes(element.children(ast)) {
       self.walk_jsx_child(child);
     }
     if let Some(closing) = element.closing_element(ast) {
@@ -982,11 +958,7 @@ impl JavascriptParser<'_> {
 
   fn walk_jsx_fragment(&mut self, fragment: JsxFragment) {
     let ast = self.ast.ast;
-    for child in fragment
-      .children(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for child in ast.nodes(fragment.children(ast)) {
       self.walk_jsx_child(child);
     }
   }
@@ -1156,11 +1128,7 @@ impl JavascriptParser<'_> {
 
   fn walk_object_expression(&mut self, expr: ObjectExpression) {
     let ast = self.ast.ast;
-    for property in expr
-      .properties(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for property in ast.nodes(expr.properties(ast)) {
       match ast.object_property_kind_data(property) {
         ObjectPropertyKindData::SpreadElement(spread) => {
           self.walk_expression(spread.argument(ast));
@@ -1218,12 +1186,7 @@ impl JavascriptParser<'_> {
       }
     }
     self.walk_expression(callee);
-    self.walk_arguments(
-      expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    self.walk_arguments(ast.nodes(expr.arguments(ast)));
   }
 
   fn walk_meta_property(&mut self, expr: MetaProperty) {
@@ -1487,11 +1450,7 @@ impl JavascriptParser<'_> {
 
   pub(crate) fn walk_function_body(&mut self, body: FunctionBody) {
     let ast = self.ast.ast;
-    for directive in body
-      .directives(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for directive in ast.nodes(body.directives(ast)) {
       if ast.get_utf8(directive.value(ast)) == "use strict" {
         self.set_strict(true);
         break;
@@ -1671,7 +1630,7 @@ impl JavascriptParser<'_> {
       && !arguments.is_empty()
       && formal_parameters_are_simple_identifiers(ast, function.params(ast))
     {
-      let mut args = arguments.iter().map(|id| ast.get_node_in_sub_range(id));
+      let mut args = ast.nodes(arguments);
       let current_this = args.next();
       self._walk_iife(member.object(ast), args, current_this);
       return;
@@ -1683,11 +1642,7 @@ impl JavascriptParser<'_> {
       _ => None,
     };
     if direct_params.is_some_and(|params| formal_parameters_are_simple_identifiers(ast, params)) {
-      self._walk_iife(
-        callee,
-        arguments.iter().map(|id| ast.get_node_in_sub_range(id)),
-        None,
-      );
+      self._walk_iife(callee, ast.nodes(arguments), None);
       return;
     }
 
@@ -1739,7 +1694,7 @@ impl JavascriptParser<'_> {
           .import_call(self, call, None, Some((&members, true)))
           .unwrap_or_default()
         {
-          self.walk_arguments(arguments.iter().map(|id| ast.get_node_in_sub_range(id)));
+          self.walk_arguments(ast.nodes(arguments));
           return;
         }
       }
@@ -1797,7 +1752,7 @@ impl JavascriptParser<'_> {
     } else {
       self.walk_expression(callee);
     }
-    self.walk_arguments(arguments.iter().map(|id| ast.get_node_in_sub_range(id)));
+    self.walk_arguments(ast.nodes(arguments));
   }
 
   fn extract_await_import_member(
@@ -2072,12 +2027,7 @@ impl JavascriptParser<'_> {
 
   fn walk_array_expression(&mut self, expr: ArrayExpression) {
     let ast = self.ast.ast;
-    self.walk_arguments(
-      expr
-        .elements(ast)
-        .iter()
-        .filter_map(|id| ast.get_node_in_sub_range(id)),
-    );
+    self.walk_arguments(ast.nodes(expr.elements(ast)).flatten());
   }
 
   fn walk_nested_statement(&mut self, stmt: Stmt) {
@@ -2192,11 +2142,7 @@ impl JavascriptParser<'_> {
 
   fn walk_object_pattern(&mut self, object: ObjectPattern) {
     let ast = self.ast.ast;
-    for property in object
-      .properties(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for property in ast.nodes(object.properties(ast)) {
       if property.computed(ast) {
         self.walk_property_key(property.key(ast));
       }
@@ -2215,11 +2161,7 @@ impl JavascriptParser<'_> {
 
   fn walk_array_pattern(&mut self, pattern: ArrayPattern) {
     let ast = self.ast.ast;
-    for element in pattern
-      .elements(ast)
-      .iter()
-      .filter_map(|id| ast.get_node_in_sub_range(id))
-    {
+    for element in ast.nodes(pattern.elements(ast)).flatten() {
       self.walk_pattern(element);
     }
     if let Some(rest) = pattern.rest(ast) {
@@ -2254,7 +2196,7 @@ impl JavascriptParser<'_> {
 
     let elements = classy.body(ast).body(ast);
     self.in_class_scope(true, scope_param.into_iter(), |this| {
-      for class_element in elements.iter().map(|id| ast.get_node_in_sub_range(id)) {
+      for class_element in ast.nodes(elements) {
         if this
           .plugin_drive
           .clone()

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_block_pre.rs
@@ -1,3 +1,4 @@
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{ExprData, GetSpan, Stmt, StmtData, TypedSubRange};
 
 use super::{
@@ -16,16 +17,14 @@ use crate::{
 impl JavascriptParser<'_> {
   pub fn block_pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.block_pre_walk_module_item(statement);
     }
   }
 
   pub fn block_pre_walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.block_pre_walk_statement(Statement::from_stmt(ast, statement));
     }
   }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
@@ -1,4 +1,5 @@
 use rspack_intern::Atom;
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{
   GetSpan, ImportDeclaration, ImportDeclarationSpecifierData, Stmt, StmtData, TypedSubRange,
 };
@@ -14,8 +15,7 @@ use crate::{
 impl JavascriptParser<'_> {
   pub fn module_pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.statement_path.push(statement.span(ast).into());
       match ast.stmt_data(statement) {
         StmtData::ImportDeclaration(declaration) => {
@@ -42,8 +42,7 @@ impl JavascriptParser<'_> {
       .into_owned();
     drive.import(self, declaration, &source);
     let source_atom = Atom::from(source);
-    for id in declaration.specifiers(ast).iter() {
-      let specifier = ast.get_node_in_sub_range(id);
+    for specifier in ast.nodes(declaration.specifiers(ast)) {
       match ast.import_declaration_specifier_data(specifier) {
         ImportDeclarationSpecifierData::ImportSpecifier(named) => {
           let local = named.local(ast);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -1,4 +1,4 @@
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::*;
 
 use super::{
@@ -99,16 +99,14 @@ fn skip_js_trivia(source: &str, mut offset: usize, end: usize) -> usize {
 impl JavascriptParser<'_> {
   pub fn pre_walk_module_items(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.pre_walk_module_item(statement);
     }
   }
 
   pub fn pre_walk_statements(&mut self, statements: TypedSubRange<Stmt>) {
     let ast = self.ast.ast;
-    for id in statements.iter() {
-      let statement = ast.get_node_in_sub_range(id);
+    for statement in ast.nodes(statements) {
       self.pre_walk_statement(Statement::from_stmt(ast, statement));
     }
   }
@@ -173,8 +171,7 @@ impl JavascriptParser<'_> {
 
   fn pre_walk_switch_statement(&mut self, stmt: SwitchStatement) {
     let ast = self.ast.ast;
-    for id in stmt.cases(ast).iter() {
-      let case = ast.get_node_in_sub_range(id);
+    for case in ast.nodes(stmt.cases(ast)) {
       self.pre_walk_statements(case.consequent(ast));
     }
   }

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -4,8 +4,49 @@ pub mod runtime;
 use rspack_intern::Atom;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_next_ecma_ast::{
-  Ast, CommentKind as NextCommentKind, CommentPosition, Span as NextAstSpan,
+  Ast, CommentKind as NextCommentKind, CommentPosition, ExtraDataCompact, Span as NextAstSpan,
+  TypedSubRange,
 };
+
+pub trait AstSubRangeExt<'ast> {
+  fn first<T>(&self, range: TypedSubRange<T>) -> Option<T>
+  where
+    T: ExtraDataCompact<'ast>;
+
+  fn second<T>(&self, range: TypedSubRange<T>) -> Option<T>
+  where
+    T: ExtraDataCompact<'ast>;
+
+  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl Iterator<Item = T> + 'a
+  where
+    T: ExtraDataCompact<'ast> + 'a;
+}
+
+impl<'ast> AstSubRangeExt<'ast> for Ast<'ast> {
+  #[inline]
+  fn first<T>(&self, range: TypedSubRange<T>) -> Option<T>
+  where
+    T: ExtraDataCompact<'ast>,
+  {
+    range.get_node(self, 0)
+  }
+
+  #[inline]
+  fn second<T>(&self, range: TypedSubRange<T>) -> Option<T>
+  where
+    T: ExtraDataCompact<'ast>,
+  {
+    range.get_node(self, 1)
+  }
+
+  #[inline]
+  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl Iterator<Item = T> + 'a
+  where
+    T: ExtraDataCompact<'ast> + 'a,
+  {
+    range.iter().map(move |id| self.get_node_in_sub_range(id))
+  }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RspackComment<'a> {


### PR DESCRIPTION
## Summary

- Pass call and constructor arguments to parser plugins through borrowed AST ranges.
- Add a small borrowed argument view where CommonJS parsing needs indexed access.
- Keep plugin matching behavior unchanged; this PR only changes argument data structures.
- This is the second Step 3 layer, stacked on #15512. The next layer is #15514.

## Related links

- #15512
- #15514

## Checklist

- [x] Tests updated (not required; behavior is unchanged).
- [x] Documentation updated (not required).