### PR TITLE
perf(javascript): streamline AST range traversal

### DIFF
--- a/crates/rspack_plugin_javascript/src/magic_comment.rs
+++ b/crates/rspack_plugin_javascript/src/magic_comment.rs
@@ -4,7 +4,10 @@ use regex::Regex;
 use rspack_core::{ContextMode, DependencyRange};
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_regex::RspackRegex;
-use rspack_util::{SpanExt, swc::RspackComment as Comment};
+use rspack_util::{
+  SpanExt,
+  swc::{AstSubRangeExt, RspackComment as Comment},
+};
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_next_allocator::Allocator;
 use swc_next_ecma_ast::{
@@ -414,7 +417,7 @@ fn expr_to_str<'a>(ast: &'a Ast<'a>, expr: Expr) -> Option<Cow<'a, str>> {
     ExprData::TemplateLiteral(template)
       if template.expressions(ast).is_empty() && template.quasis(ast).len() == 1 =>
     {
-      let element = template.quasis(ast).get_node(ast, 0)?;
+      let element = ast.first(template.quasis(ast))?;
       Some(Cow::Borrowed(ast.get_utf8(element.raw(ast))))
     }
     _ => None,
@@ -499,8 +502,8 @@ fn expr_to_magic_comment_value_with_offset(
     return None;
   };
   let mut items = Vec::new();
-  for element in array.elements(ast).iter() {
-    let element = ast.get_node_in_sub_range(element)?;
+  for element in ast.nodes(array.elements(ast)) {
+    let element = element?;
     let ArgumentData::Expr(element) = ast.argument_data(element) else {
       return None;
     };
@@ -523,8 +526,8 @@ fn expr_to_exports(ast: &Ast<'_>, expr: Expr) -> Option<MagicCommentValue> {
   };
 
   let mut exports = Vec::new();
-  for element in array.elements(ast).iter() {
-    let element = ast.get_node_in_sub_range(element)?;
+  for element in ast.nodes(array.elements(ast)) {
+    let element = element?;
     let ArgumentData::Expr(element) = ast.argument_data(element) else {
       return None;
     };
@@ -593,8 +596,7 @@ fn analyze_comments(
     let Some(object) = expr.as_object_expression(&ast) else {
       continue;
     };
-    for property in object.properties(&ast).iter() {
-      let property = ast.get_node_in_sub_range(property);
+    for property in ast.nodes(object.properties(&ast)) {
       let ObjectPropertyKindData::ObjectProperty(property) =
         ast.object_property_kind_data(property)
       else {
@@ -758,8 +760,7 @@ mod tests_extract_magic_comment_object {
     let allocator = Allocator::new();
     let (ast, _) = parse_magic_comment_object(&allocator, raw)?;
     let object = ast.root_expression().as_object_expression(&ast)?;
-    for property in object.properties(&ast).iter() {
-      let property = ast.get_node_in_sub_range(property);
+    for property in ast.nodes(object.properties(&ast)) {
       let ObjectPropertyKindData::ObjectProperty(property) =
         ast.object_property_kind_data(property)
       else {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/amd/amd_define_dependency_parser_plugin.rs
@@ -528,12 +528,7 @@ impl AMDDefineDependencyParserPlugin {
           );
         }
 
-        parser.walk_arguments(
-          call_expr
-            .arguments(parser.ast.ast)
-            .iter()
-            .map(|id| parser.ast.ast.get_node_in_sub_range(id)),
-        );
+        parser.walk_arguments(parser.ast.ast.nodes(call_expr.arguments(parser.ast.ast)));
       }
     } else if let Some(expr) = func {
       parser.walk_expression(expr);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/api_plugin.rs
@@ -370,12 +370,7 @@ pub(crate) fn import_meta_runtime_api_call(
     call_expr.callee(ast).span(ast).into(),
     api.runtime_global,
   )));
-  parser.walk_arguments(
-    call_expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id)),
-  );
+  parser.walk_arguments(ast.nodes(call_expr.arguments(ast)));
   Some(true)
 }
 
@@ -821,13 +816,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
       None,
     );
     if handled.is_some() {
-      if preserve_require_receiver
-        && let Some(first_arg) = expr
-          .arguments(ast)
-          .iter()
-          .next()
-          .map(|id| ast.get_node_in_sub_range(id))
-      {
+      if preserve_require_receiver && let Some(first_arg) = ast.first(expr.arguments(ast)) {
         parser.add_presentational_dependency(Arc::new(RuntimeRequirementsDependency::add_only(
           RuntimeGlobals::REQUIRE,
         )));
@@ -842,12 +831,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for APIPlugin {
           format!("{}, ", parser.parser_runtime_requirements.require).into(),
         )));
       }
-      parser.walk_arguments(
-        expr
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id)),
-      );
+      parser.walk_arguments(ast.nodes(expr.arguments(ast)));
     }
     handled
   }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_exports_parse_plugin.rs
@@ -157,7 +157,7 @@ fn parse_require_call<'p: 'a, 'a>(
     && is_require_call_expr(parser, call)
   {
     let ast = parser.ast.ast;
-    let arg = call.arguments(ast).get_node(ast, 0)?.as_expr(ast)?;
+    let arg = ast.first(call.arguments(ast))?.as_expr(ast)?;
     let arg = parser.evaluate_expression(arg);
     ids.reverse();
     return Some((arg, ids));

--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -2324,22 +2324,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
         && preserve_unhandled_created_require(parser)
       {
         let ast = parser.ast.ast;
-        parser.walk_arguments(
-          expr
-            .arguments(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id)),
-        );
+        parser.walk_arguments(ast.nodes(expr.arguments(ast)));
         return Some(true);
       }
       if ids.len() != members.len() {
         let ast = parser.ast.ast;
-        parser.walk_arguments(
-          expr
-            .arguments(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id)),
-        );
+        parser.walk_arguments(ast.nodes(expr.arguments(ast)));
         return Some(true);
       }
       return None;
@@ -2366,12 +2356,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
           && !direct_import,
       );
     let ast = parser.ast.ast;
-    parser.walk_arguments(
-      expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    parser.walk_arguments(ast.nodes(expr.arguments(ast)));
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/const/if_stmt.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use itertools::Itertools;
 use rspack_core::ConstDependency;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use rustc_hash::FxHashSet;
 use swc_next_ecma_ast::{
   Ast, BindingPattern, BindingPatternData, GetSpan, IfStatement, VariableKind,
@@ -24,22 +24,15 @@ fn collect_declaration_from_pattern<'a>(
       BindingPatternData::AssignmentPattern(assignment) => stack.push(assignment.left(ast)),
       BindingPatternData::BindingRestElement(rest) => stack.push(rest.argument(ast)),
       BindingPatternData::ArrayPattern(array) => {
-        stack.extend(
-          array
-            .elements(ast)
-            .iter()
-            .filter_map(|id| ast.get_node_in_sub_range(id)),
-        );
+        stack.extend(ast.nodes(array.elements(ast)).flatten());
         if let Some(rest) = array.rest(ast) {
           stack.push(rest.argument(ast));
         }
       }
       BindingPatternData::ObjectPattern(object) => {
         stack.extend(
-          object
-            .properties(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id))
+          ast
+            .nodes(object.properties(ast))
             .map(|property| property.value(ast)),
         );
         if let Some(rest) = object.rest(ast) {
@@ -57,11 +50,7 @@ fn collect_variable_declaration<'a>(
   declarations: &mut FxHashSet<&'a str>,
 ) {
   if declaration.kind(ast) == VariableKind::Var {
-    for declarator in declaration
-      .declarators(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for declarator in ast.nodes(declaration.declarators(ast)) {
       collect_declaration_from_pattern(ast, declarator.id(ast), declarations);
     }
   }
@@ -80,10 +69,8 @@ pub fn get_hoisted_declarations<'a>(
     match statement {
       Statement::Block(block) => {
         stmt_stack.extend(
-          block
-            .body(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id))
+          ast
+            .nodes(block.body(ast))
             .map(|statement| Statement::from_stmt(ast, statement)),
         );
       }
@@ -124,45 +111,31 @@ pub fn get_hoisted_declarations<'a>(
         stmt_stack.push(Statement::from_stmt(ast, statement.body(ast)));
       }
       Statement::Switch(statement) => {
-        for case in statement
-          .cases(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id))
-        {
+        for case in ast.nodes(statement.cases(ast)) {
           stmt_stack.extend(
-            case
-              .consequent(ast)
-              .iter()
-              .map(|id| ast.get_node_in_sub_range(id))
+            ast
+              .nodes(case.consequent(ast))
               .map(|statement| Statement::from_stmt(ast, statement)),
           );
         }
       }
       Statement::Try(statement) => {
         stmt_stack.extend(
-          statement
-            .block(ast)
-            .body(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id))
+          ast
+            .nodes(statement.block(ast).body(ast))
             .map(|statement| Statement::from_stmt(ast, statement)),
         );
         if let Some(handler) = statement.handler(ast) {
           stmt_stack.extend(
-            handler
-              .body(ast)
-              .body(ast)
-              .iter()
-              .map(|id| ast.get_node_in_sub_range(id))
+            ast
+              .nodes(handler.body(ast).body(ast))
               .map(|statement| Statement::from_stmt(ast, statement)),
           );
         }
         if let Some(finalizer) = statement.finalizer(ast) {
           stmt_stack.extend(
-            finalizer
-              .body(ast)
-              .iter()
-              .map(|id| ast.get_node_in_sub_range(id))
+            ast
+              .nodes(finalizer.body(ast))
               .map(|statement| Statement::from_stmt(ast, statement)),
           );
         }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_detection_parser_plugin.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::{BuildMetaExportsType, ExportsArgument, ModuleArgument, ModuleType};
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   AwaitExpression, CallExpression, ForOfStatement, GetSpan, Program, Span, StmtData,
   UnaryExpression,
@@ -57,9 +57,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMDetectionParserPlugin {
     // as a module. Rspack's legacy parser only enabled ESM semantics when the
     // program contained an actual import/export declaration (or the module
     // type was explicitly `javascript/esm`). Preserve that distinction here.
-    let has_esm_declaration = _program.body(ast).iter().any(|slot| {
+    let has_esm_declaration = ast.nodes(_program.body(ast)).any(|statement| {
       matches!(
-        ast.stmt_data(ast.get_node_in_sub_range(slot)),
+        ast.stmt_data(statement),
         StmtData::ImportDeclaration(_)
           | StmtData::ExportNamedDeclaration(_)
           | StmtData::ExportDefaultDeclaration(_)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use rspack_core::{
   BoxDependency, ConstDependency, Dependency, DependencyRange, DependencyType, ImportPhase,
 };
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{CommentKind, ExprData, GetSpan, Span};
 
 use super::{
@@ -325,7 +325,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       ExportDefaultExpression::FnDecl(f) => {
         let start = f.span(ast).real_lo();
         let params = f.params(ast);
-        let end = if let Some(first_arg) = params.items(ast).get_node(ast, 0) {
+        let end = if let Some(first_arg) = ast.first(params.items(ast)) {
           first_arg.span(ast).real_lo()
         } else if let Some(rest) = params.rest(ast) {
           rest.span(ast).real_lo()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_import_dependency_parser_plugin.rs
@@ -4,7 +4,7 @@ use rspack_core::{
   BoxDependency, ConstDependency, Dependency, DependencyRange, DependencyType, ExportPresenceMode,
   ImportAttributes, ImportPhase,
 };
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   BinaryExpression, BinaryOperator, CallExpression, Expr, GetSpan, ImportDeclaration, Span,
 };
@@ -392,12 +392,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMImportDependencyParserPlugin 
       InnerGraphUsageOperation::ESMImportSpecifier(dep_idx),
     );
 
-    parser.walk_arguments(
-      call_expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    parser.walk_arguments(ast.nodes(call_expr.arguments(ast)));
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/hot_module_replacement_plugin.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use rspack_core::{BoxDependency, DependencyRange, ImportMetaKnownProperties};
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{ArgumentData, CallExpression, GetSpan, Span};
 
 use crate::{
@@ -26,7 +26,7 @@ fn extract_deps(
   let mut dependencies: Vec<BoxDependency> = vec![];
   let ast = parser.ast.ast;
 
-  if let Some(first_arg) = call_expr.arguments(ast).get_node(ast, 0)
+  if let Some(first_arg) = ast.first(call_expr.arguments(ast))
     && let ArgumentData::Expr(first_arg) = ast.argument_data(first_arg)
   {
     let expr = parser.evaluate_expression(first_arg);
@@ -82,7 +82,7 @@ impl JavascriptParser<'_> {
     let dependencies = extract_deps(self, call_expr, create_dependency);
     if !dependencies.is_empty() {
       let dependency_ids = dependencies.iter().map(|dep| *dep.id()).collect::<Vec<_>>();
-      let callback_arg = call_expr.arguments(ast).get_node(ast, 1);
+      let callback_arg = ast.second(call_expr.arguments(ast));
       let range = if let Some(callback) = callback_arg {
         Into::<DependencyRange>::into(callback.span(ast))
       } else {
@@ -97,21 +97,10 @@ impl JavascriptParser<'_> {
         loc,
       )));
       self.add_dependencies(dependencies);
-      self.walk_arguments(
-        call_expr
-          .arguments(ast)
-          .iter()
-          .skip(1)
-          .map(|id| ast.get_node_in_sub_range(id)),
-      );
+      self.walk_arguments(ast.nodes(call_expr.arguments(ast)).skip(1));
       return Some(true);
     }
-    self.walk_arguments(
-      call_expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    self.walk_arguments(ast.nodes(call_expr.arguments(ast)));
     Some(true)
   }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_context_dependency_parser_plugin.rs
@@ -8,7 +8,9 @@ use rspack_error::{Error, Result, Severity};
 use rspack_macros::AstObject;
 use rspack_paths::Utf8Path;
 use rspack_regex::RspackRegex;
-use rspack_util::{SpanExt, identifier::relative_path_to_request, node_path::NodePath};
+use rspack_util::{
+  SpanExt, identifier::relative_path_to_request, node_path::NodePath, swc::AstSubRangeExt,
+};
 use sugar_path::SugarPath;
 use swc_next_ecma_ast::{Ast, CallExpression, Expr, GetSpan, ObjectExpression};
 
@@ -174,11 +176,10 @@ fn static_glob_patterns_from_expr(ast: &Ast<'_>, expr: Expr) -> Option<Vec<Strin
   }
 
   let array = expr.as_array_expression(ast)?;
-  array
-    .elements(ast)
-    .iter()
+  ast
+    .nodes(array.elements(ast))
     .map(|element| {
-      let element = ast.get_node_in_sub_range(element)?;
+      let element = element?;
       static_string_from_expr(ast, element.as_expr(ast)?)
     })
     .collect()
@@ -297,12 +298,11 @@ fn create_import_meta_context_dependency(
   parser: &mut JavascriptParser,
 ) -> Option<ImportMetaContextDependency> {
   let ast = parser.ast.ast;
-  let dyn_imported = node.arguments(ast).get_node(ast, 0)?.as_expr(ast)?;
+  let dyn_imported = ast.first(node.arguments(ast))?.as_expr(ast)?;
   // TODO: should've used expression evaluation to handle cases like `abc${"efg"}`, etc.
   let request = static_string_from_expr(ast, dyn_imported)?;
-  let raw_options = node
-    .arguments(ast)
-    .get_node(ast, 1)
+  let raw_options = ast
+    .second(node.arguments(ast))
     .and_then(|arg| arg.as_expr(ast))
     .and_then(|expr| expr.as_object_expression(ast));
   let options = match raw_options {
@@ -348,12 +348,11 @@ fn create_import_meta_glob_dependency(
   parser: &mut JavascriptParser,
 ) -> Option<ImportMetaContextDependency> {
   let ast = parser.ast.ast;
-  let dyn_imported = node.arguments(ast).get_node(ast, 0)?.as_expr(ast)?;
+  let dyn_imported = ast.first(node.arguments(ast))?.as_expr(ast)?;
   let raw_glob_patterns = static_glob_patterns_from_expr(ast, dyn_imported)?;
   let importer_context = get_context(parser.resource_data);
-  let glob_options = node
-    .arguments(ast)
-    .get_node(ast, 1)
+  let glob_options = ast
+    .second(node.arguments(ast))
     .and_then(|arg| arg.as_expr(ast))
     .and_then(|expr| expr.as_object_expression(ast));
   let options = match glob_options {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -10,7 +10,7 @@ use rspack_core::{
   get_context, property_access, to_normal_comment,
 };
 use rspack_error::{Error, Severity};
-use rspack_util::{SpanExt, json_stringify_str};
+use rspack_util::{SpanExt, json_stringify_str, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   AssignmentExpression, CallExpression, ChainExpression, Expr, GetSpan, PropertyKeyData, Span,
   UnaryExpression,
@@ -388,7 +388,7 @@ impl ImportMetaPlugin {
       return;
     }
 
-    let Some(argument_expr) = arguments.get_node(ast, 0).and_then(|arg| arg.as_expr(ast)) else {
+    let Some(argument_expr) = ast.first(arguments).and_then(|arg| arg.as_expr(ast)) else {
       return;
     };
     let param = parser.evaluate_expression(argument_expr);

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -144,7 +144,7 @@ fn track_dynamic_imports_in_promise_all(
   if arguments.len() != 1 {
     return;
   }
-  let Some(argument) = arguments.get_node(ast, 0) else {
+  let Some(argument) = ast.first(arguments) else {
     return;
   };
   let Some(imports) = argument
@@ -153,23 +153,18 @@ fn track_dynamic_imports_in_promise_all(
   else {
     return;
   };
-  if imports.elements(ast).iter().any(|slot| {
-    ast
-      .get_node_in_sub_range(slot)
-      .is_some_and(|argument| argument.is_spread_element(ast))
-  }) {
+  if ast
+    .nodes(imports.elements(ast))
+    .any(|element| element.is_some_and(|argument| argument.is_spread_element(ast)))
+  {
     return;
   }
 
-  for (pattern_slot, import_slot) in pattern
-    .elements(ast)
-    .iter()
-    .zip(imports.elements(ast).iter())
+  for (pattern, import) in ast
+    .nodes(pattern.elements(ast))
+    .zip(ast.nodes(imports.elements(ast)))
   {
-    let (Some(pattern), Some(import)) = (
-      ast.get_node_in_sub_range(pattern_slot),
-      ast.get_node_in_sub_range(import_slot),
-    ) else {
+    let (Some(pattern), Some(import)) = (pattern, import) else {
       continue;
     };
     let Some(import_call) = import
@@ -389,12 +384,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
           && !direct_import,
       );
     let ast = parser.ast.ast;
-    parser.walk_arguments(
-      expr
-        .arguments(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id)),
-    );
+    parser.walk_arguments(ast.nodes(expr.arguments(ast)));
     Some(true)
   }
 
@@ -673,12 +663,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
         parser.walk_arguments(ast.nodes(arguments).skip(1));
       } else {
         let ast = parser.ast.ast;
-        parser.walk_arguments(
-          import_then
-            .arguments(ast)
-            .iter()
-            .map(|id| ast.get_node_in_sub_range(id)),
-        );
+        parser.walk_arguments(ast.nodes(import_then.arguments(ast)));
       }
     }
 
@@ -761,7 +746,7 @@ fn get_fulfilled_callback_namespace_obj(
   ast: &swc_next_ecma_ast::Ast<'_>,
   import_then: CallExpression,
 ) -> Option<BindingPattern> {
-  let fulfilled_callback = import_then.arguments(ast).get_node(ast, 0)?.as_expr(ast)?;
+  let fulfilled_callback = ast.first(import_then.arguments(ast))?.as_expr(ast)?;
   let params = match ast.expr_data(fulfilled_callback) {
     ExprData::ArrowFunctionExpression(function) => function.params(ast),
     ExprData::Function(function) => function.params(ast),

--- a/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/initialize_evaluating.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use cow_utils::CowUtils;
-use rspack_util::SpanExt;
-use swc_next_ecma_ast::{ArgumentData, CallExpression, GetSpan};
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
+use swc_next_ecma_ast::{CallExpression, GetSpan};
 
 use super::JavascriptParserPlugin;
 use crate::{utils::eval::BasicEvaluatedExpression, visitors::JavascriptParser};
@@ -26,19 +26,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
     expr: CallExpression,
   ) -> Option<BasicEvaluatedExpression<'p>> {
     let ast = parser.ast.ast;
-    let args = expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .map(|argument| match ast.argument_data(argument) {
-        ArgumentData::Expr(expression) => Some(expression),
-        ArgumentData::SpreadElement(_) => None,
-      })
-      .collect::<Option<Vec<_>>>()?;
+    let args = expr.arguments(ast);
     if args.len() != 1 {
       return None;
     }
-    let arg = parser.evaluate_expression(args[0]);
+    let arg = parser.evaluate_expression(ast.first(args)?.as_expr(ast)?);
     let span = expr.span(ast);
     let mut res = BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi());
     match name {
@@ -78,24 +70,22 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
     param: BasicEvaluatedExpression<'p>,
   ) -> Option<BasicEvaluatedExpression<'p>> {
     let ast = parser.ast.ast;
-    let args = expr
-      .arguments(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .map(|argument| match ast.argument_data(argument) {
-        ArgumentData::Expr(expression) => Some(expression),
-        ArgumentData::SpreadElement(_) => None,
-      })
-      .collect::<Option<Vec<_>>>()?;
+    let args = expr.arguments(ast);
+    if ast
+      .nodes(args)
+      .any(|argument| argument.is_spread_element(ast))
+    {
+      return None;
+    }
     let span = expr.span(ast);
     if property == INDEXOF_METHOD_NAME && param.is_string() {
       let arg1 = (!args.is_empty()).then_some(true).and_then(|_| {
-        let arg = parser.evaluate_expression(args[0]);
+        let arg = parser.evaluate_expression(ast.first(args)?.as_expr(ast)?);
         arg.is_string().then_some(arg)
       });
 
       let arg2 = (args.len() >= 2).then_some(true).and_then(|_| {
-        let arg = parser.evaluate_expression(args[1]);
+        let arg = parser.evaluate_expression(ast.second(args)?.as_expr(ast)?);
         arg.is_number().then_some(arg)
       });
 
@@ -118,7 +108,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
       && (args.len() == 1 || args.len() == 2)
     {
       let str = param.string();
-      let arg1 = parser.evaluate_expression(args[0]);
+      let arg1 = parser.evaluate_expression(ast.first(args)?.as_expr(ast)?);
       if !arg1.is_number() || arg1.could_have_side_effects() {
         return None;
       }
@@ -131,7 +121,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
           _ => unreachable!(),
         }
       } else {
-        let arg2 = parser.evaluate_expression(args[1]);
+        let arg2 = parser.evaluate_expression(ast.second(args)?.as_expr(ast)?);
         if !arg2.is_number() || arg2.could_have_side_effects() {
           return None;
         }
@@ -159,11 +149,11 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
       res.set_side_effects(param.could_have_side_effects());
       return Some(res);
     } else if property == REPLACE_METHOD_NAME && param.is_string() && args.len() == 2 {
-      let arg1 = parser.evaluate_expression(args[0]);
+      let arg1 = parser.evaluate_expression(ast.first(args)?.as_expr(ast)?);
       if !arg1.is_string() && !arg1.is_regexp() {
         return None;
       }
-      let arg2 = parser.evaluate_expression(args[1]);
+      let arg2 = parser.evaluate_expression(ast.second(args)?.as_expr(ast)?);
       if !arg2.is_string() {
         return None;
       }
@@ -189,8 +179,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
       let mut string_suffix: Option<BasicEvaluatedExpression<'p>> = None;
       let mut has_unknown_params = false;
       let mut inner_exprs: Vec<BasicEvaluatedExpression<'p>> = Vec::new();
-      for arg in args.iter().rev() {
-        let arg_expr = parser.evaluate_expression(*arg);
+      for arg in ast.nodes(args).rev() {
+        let arg_expr = parser.evaluate_expression(arg.as_expr(ast)?);
         if has_unknown_params || (!arg_expr.is_string() && !arg_expr.is_number()) {
           has_unknown_params = true;
           inner_exprs.push(arg_expr);
@@ -252,7 +242,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InitializeEvaluating {
         return Some(eval);
       }
     } else if property == SPLIT_METHOD_NAME && param.is_string() && args.len() == 1 {
-      let arg = parser.evaluate_expression(args[0]);
+      let arg = parser.evaluate_expression(ast.first(args)?.as_expr(ast)?);
       let array: Vec<String> = if arg.is_string() {
         param
           .string()

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inline_const.rs
@@ -1,6 +1,6 @@
 use rspack_cacheable::cacheable;
 use rspack_core::EvaluatedInlinableValue;
-use rspack_util::ryu_js;
+use rspack_util::{ryu_js, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{BindingPattern, BindingPatternData, VariableDeclarator};
 
 use super::JavascriptParserPlugin;
@@ -141,11 +141,7 @@ fn tag_const_pattern(parser: &mut JavascriptParser, pattern: BindingPattern) {
       );
     }
     BindingPatternData::ArrayPattern(array) => {
-      for elem in array
-        .elements(ast)
-        .iter()
-        .filter_map(|id| ast.get_node_in_sub_range(id))
-      {
+      for elem in ast.nodes(array.elements(ast)).flatten() {
         tag_const_pattern(parser, elem);
       }
       if let Some(rest) = array.rest(ast) {
@@ -156,11 +152,7 @@ fn tag_const_pattern(parser: &mut JavascriptParser, pattern: BindingPattern) {
       tag_const_pattern(parser, assignment.left(ast));
     }
     BindingPatternData::ObjectPattern(object) => {
-      for property in object
-        .properties(ast)
-        .iter()
-        .map(|id| ast.get_node_in_sub_range(id))
-      {
+      for property in ast.nodes(object.properties(ast)) {
         tag_const_pattern(parser, property.value(ast));
       }
       if let Some(rest) = object.rest(ast) {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/provide_plugin/parser.rs
@@ -4,6 +4,7 @@ use cow_utils::CowUtils;
 use itertools::Itertools;
 use rspack_core::{BoxDependency, DependencyRange};
 use rspack_intern::Atom;
+use rspack_util::swc::AstSubRangeExt;
 use rustc_hash::FxHashSet as HashSet;
 use swc_next_ecma_ast::{CallExpression, GetSpan, Span};
 
@@ -77,12 +78,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ProvideParserPlugin {
     let ast = parser.ast.ast;
     if self.add_provide_dep(for_name, expr.callee(ast).span(ast), parser) {
       // FIXME: webpack use `walk_expression` here
-      parser.walk_arguments(
-        expr
-          .arguments(ast)
-          .iter()
-          .map(|id| ast.get_node_in_sub_range(id)),
-      );
+      parser.walk_arguments(ast.nodes(expr.arguments(ast)));
       return Some(true);
     }
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_context_dependency_parser_plugin.rs
@@ -4,7 +4,7 @@ use rspack_core::{
 };
 use rspack_error::Error;
 use rspack_regex::RspackRegex;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{CallExpression, GetSpan};
 
 use super::JavascriptParserPlugin;
@@ -32,7 +32,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireContextDependencyParserPl
     let ast = parser.ast.ast;
     let arguments = expr.arguments(ast);
 
-    let arg = arguments.get_node(ast, 0)?.as_expr(ast)?;
+    let arg = ast.first(arguments)?.as_expr(ast)?;
     let request_expr = parser.evaluate_expression(arg);
     if !request_expr.is_string() {
       return None;
@@ -82,7 +82,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RequireContextDependencyParserPl
     };
 
     let recursive = if arguments.len() >= 2 {
-      let recursive_expr = parser.evaluate_expression(arguments.get_node(ast, 1)?.as_expr(ast)?);
+      let recursive_expr = parser.evaluate_expression(ast.second(arguments)?.as_expr(ast)?);
       if !recursive_expr.is_bool() {
         // FIXME: return `None` in webpack
         true

--- a/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/require_ensure_dependencies_block_parse_plugin.rs
@@ -209,7 +209,7 @@ impl GetFunctionExpression for Expr {
         _need_this: Some(false),
       }),
       ExprData::CallExpression(call) if call.arguments(ast).len() == 1 => {
-        let first_arg = call.arguments(ast).get_node(ast, 0)?.as_expr(ast)?;
+        let first_arg = ast.first(call.arguments(ast))?.as_expr(ast)?;
         let callee = call.callee(ast);
 
         if let Some(member) = callee.as_member_expression(ast)
@@ -228,7 +228,7 @@ impl GetFunctionExpression for Expr {
         if let Some(callee_function) = callee.as_function(ast)
           && first_arg.is_this_expression(ast)
           && callee_function.body(ast).body(ast).len() == 1
-          && let Some(statement) = callee_function.body(ast).body(ast).get_node(ast, 0)
+          && let Some(statement) = ast.first(callee_function.body(ast).body(ast))
           && let StmtData::ReturnStatement(return_statement) = ast.stmt_data(statement)
           && let Some(function) = return_statement
             .argument(ast)

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_analysis.rs
@@ -7,6 +7,7 @@
 //
 // Rspack-specific policies such as `/*#__PURE__*/`, `pureFunctions`, parser hooks, and deferred
 // import checks stay in `side_effects_parser_plugin`.
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{
   ArgumentData, Ast, Class, ClassElementData, DeclData, Expr, ExprData, Function,
   MethodDefinitionKind, ObjectPropertyKindData, PropertyKey, PropertyKeyData, PropertyKind, Stmt,
@@ -115,14 +116,15 @@ pub(super) fn may_have_side_effects(expression: Expr, ctx: SideEffectsContext<'_
     }
     ExprData::Function(_) | ExprData::ArrowFunctionExpression(_) => false,
     ExprData::Class(class) => class_has_side_effects(ctx, class),
-    ExprData::ArrayExpression(array) => array
-      .elements(ast)
-      .iter()
-      .filter_map(|slot| ast.get_node_in_sub_range(slot))
-      .any(|argument| match ast.argument_data(argument) {
-        ArgumentData::Expr(expression) => may_have_side_effects(expression, ctx),
-        ArgumentData::SpreadElement(_) => true,
-      }),
+    ExprData::ArrayExpression(array) => {
+      ast
+        .nodes(array.elements(ast))
+        .flatten()
+        .any(|argument| match ast.argument_data(argument) {
+          ArgumentData::Expr(expression) => may_have_side_effects(expression, ctx),
+          ArgumentData::SpreadElement(_) => true,
+        })
+    }
     ExprData::UnaryExpression(unary) => {
       unary.operator(ast) == UnaryOperator::Delete
         || may_have_side_effects(unary.argument(ast), ctx)
@@ -188,34 +190,34 @@ pub(super) fn may_have_side_effects(expression: Expr, ctx: SideEffectsContext<'_
       arguments_may_have_side_effects(call.arguments(ast), ctx)
     }
     ExprData::CallExpression(_) => true,
-    ExprData::SequenceExpression(sequence) => sequence
-      .expressions(ast)
-      .iter()
-      .any(|slot| may_have_side_effects(ast.get_node_in_sub_range(slot), ctx)),
+    ExprData::SequenceExpression(sequence) => ast
+      .nodes(sequence.expressions(ast))
+      .any(|node| may_have_side_effects(node, ctx)),
     ExprData::ConditionalExpression(conditional) => {
       may_have_side_effects(conditional.test(ast), ctx)
         || may_have_side_effects(conditional.consequent(ast), ctx)
         || may_have_side_effects(conditional.alternate(ast), ctx)
     }
-    ExprData::ObjectExpression(object) => object.properties(ast).iter().any(|slot| {
-      let property = ast.get_node_in_sub_range(slot);
-      match ast.object_property_kind_data(property) {
-        ObjectPropertyKindData::SpreadElement(_) => true,
-        ObjectPropertyKindData::ObjectProperty(property) => {
-          if property.shorthand(ast) {
-            return false;
-          }
+    ExprData::ObjectExpression(object) => {
+      ast.nodes(object.properties(ast)).any(|property| {
+        match ast.object_property_kind_data(property) {
+          ObjectPropertyKindData::SpreadElement(_) => true,
+          ObjectPropertyKindData::ObjectProperty(property) => {
+            if property.shorthand(ast) {
+              return false;
+            }
 
-          let key_has_side_effects =
-            property.computed(ast) && property_key_may_have_side_effects(property.key(ast), ctx);
-          if property.kind(ast) == PropertyKind::Init && !property.method(ast) {
-            key_has_side_effects || may_have_side_effects(property.value(ast), ctx)
-          } else {
-            key_has_side_effects
+            let key_has_side_effects =
+              property.computed(ast) && property_key_may_have_side_effects(property.key(ast), ctx);
+            if property.kind(ast) == PropertyKind::Init && !property.method(ast) {
+              key_has_side_effects || may_have_side_effects(property.value(ast), ctx)
+            } else {
+              key_has_side_effects
+            }
           }
         }
-      }
-    }),
+      })
+    }
     ExprData::JsxElement(_) | ExprData::JsxFragment(_) => true,
   }
 }
@@ -276,22 +278,21 @@ fn arguments_may_have_side_effects(
   arguments: swc_next_ecma_ast::TypedSubRange<swc_next_ecma_ast::Argument>,
   ctx: SideEffectsContext<'_, '_>,
 ) -> bool {
-  arguments.iter().any(|slot| {
-    let argument = ctx.ast.get_node_in_sub_range(slot);
-    match ctx.ast.argument_data(argument) {
+  ctx
+    .ast
+    .nodes(arguments)
+    .any(|argument| match ctx.ast.argument_data(argument) {
       ArgumentData::Expr(expression) => may_have_side_effects(expression, ctx),
       ArgumentData::SpreadElement(_) => true,
-    }
-  })
+    })
 }
 
 fn statement_may_have_side_effects(statement: Stmt, ctx: SideEffectsContext<'_, '_>) -> bool {
   let ast = ctx.ast;
   match ast.stmt_data(statement) {
-    StmtData::BlockStatement(block) => block
-      .body(ast)
-      .iter()
-      .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx)),
+    StmtData::BlockStatement(block) => ast
+      .nodes(block.body(ast))
+      .any(|node| statement_may_have_side_effects(node, ctx)),
     StmtData::EmptyStatement(_) => false,
     StmtData::LabeledStatement(labeled) => statement_may_have_side_effects(labeled.body(ast), ctx),
     StmtData::IfStatement(if_statement) => {
@@ -303,35 +304,28 @@ fn statement_may_have_side_effects(statement: Stmt, ctx: SideEffectsContext<'_, 
     }
     StmtData::SwitchStatement(switch) => {
       may_have_side_effects(switch.discriminant(ast), ctx)
-        || switch.cases(ast).iter().any(|slot| {
-          let case = ast.get_node_in_sub_range(slot);
+        || ast.nodes(switch.cases(ast)).any(|case| {
           case
             .test(ast)
             .is_some_and(|expression| may_have_side_effects(expression, ctx))
-            || case
-              .consequent(ast)
-              .iter()
-              .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx))
+            || ast
+              .nodes(case.consequent(ast))
+              .any(|node| statement_may_have_side_effects(node, ctx))
         })
     }
     StmtData::TryStatement(try_statement) => {
-      try_statement
-        .block(ast)
-        .body(ast)
-        .iter()
-        .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx))
+      ast
+        .nodes(try_statement.block(ast).body(ast))
+        .any(|node| statement_may_have_side_effects(node, ctx))
         || try_statement.handler(ast).is_some_and(|handler| {
-          handler
-            .body(ast)
-            .body(ast)
-            .iter()
-            .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx))
+          ast
+            .nodes(handler.body(ast).body(ast))
+            .any(|node| statement_may_have_side_effects(node, ctx))
         })
         || try_statement.finalizer(ast).is_some_and(|finalizer| {
-          finalizer
-            .body(ast)
-            .iter()
-            .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx))
+          ast
+            .nodes(finalizer.body(ast))
+            .any(|node| statement_may_have_side_effects(node, ctx))
         })
     }
     StmtData::Declaration(declaration) => match ast.decl_data(declaration) {
@@ -356,8 +350,7 @@ fn class_has_side_effects(ctx: SideEffectsContext<'_, '_>, class: Class) -> bool
     return true;
   }
 
-  for slot in class.body(ast).body(ast).iter() {
-    let member = ast.get_node_in_sub_range(slot);
+  for member in ast.nodes(class.body(ast).body(ast)) {
     match ast.class_element_data(member) {
       ClassElementData::MethodDefinition(method) => {
         if method.computed(ast) && property_key_may_have_side_effects(method.key(ast), ctx) {
@@ -381,10 +374,9 @@ fn class_has_side_effects(ctx: SideEffectsContext<'_, '_>, class: Class) -> bool
         }
       }
       ClassElementData::StaticBlock(block)
-        if block
-          .body(ast)
-          .iter()
-          .any(|slot| statement_may_have_side_effects(ast.get_node_in_sub_range(slot), ctx)) =>
+        if ast
+          .nodes(block.body(ast))
+          .any(|node| statement_may_have_side_effects(node, ctx)) =>
       {
         return true;
       }
@@ -400,9 +392,9 @@ fn class_member_access_may_have_side_effects(
   class: Class,
 ) -> bool {
   let ast = ctx.ast;
-  class.body(ast).body(ast).iter().any(|slot| {
-    let member = ast.get_node_in_sub_range(slot);
-    match ast.class_element_data(member) {
+  ast
+    .nodes(class.body(ast).body(ast))
+    .any(|member| match ast.class_element_data(member) {
       ClassElementData::MethodDefinition(method) => {
         method.r#static(ast)
           && matches!(
@@ -418,8 +410,7 @@ fn class_member_access_may_have_side_effects(
           )
       }
       _ => false,
-    }
-  })
+    })
 }
 
 fn object_member_access_may_have_side_effects(
@@ -427,8 +418,7 @@ fn object_member_access_may_have_side_effects(
   object: swc_next_ecma_ast::ObjectExpression,
 ) -> bool {
   let ast = ctx.ast;
-  object.properties(ast).iter().any(|slot| {
-    let property = ast.get_node_in_sub_range(slot);
+  ast.nodes(object.properties(ast)).any(|property| {
     let ObjectPropertyKindData::ObjectProperty(property) = ast.object_property_kind_data(property)
     else {
       return true;
@@ -467,8 +457,7 @@ fn is_pure_new_callee(expression: Expr, ctx: SideEffectsContext<'_, '_>) -> bool
         return false;
       }
 
-      for slot in class.body(ast).body(ast).iter() {
-        let member = ast.get_node_in_sub_range(slot);
+      for member in ast.nodes(class.body(ast).body(ast)) {
         match ast.class_element_data(member) {
           ClassElementData::PropertyDefinition(property) if !property.r#static(ast) => {
             return false;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -4,7 +4,10 @@ use rspack_core::{
   DeferredPureCheck, Dependency, DependencyRange, ModuleDependency, SideEffectsBailoutItemWithSpan,
 };
 use rspack_intern::AtomSet;
-use rspack_util::{SpanExt, swc::RspackComments};
+use rspack_util::{
+  SpanExt,
+  swc::{AstSubRangeExt, RspackComments},
+};
 use rustc_hash::FxHashMap;
 use swc_next_ecma_ast::{
   ArgumentData, ArrowFunctionBodyData, ArrowFunctionExpression, AssignmentExpression,
@@ -60,14 +63,6 @@ fn atom_from_module_export_name(ast: &Ast<'_>, name: ModuleExportName) -> Atom {
   }
 }
 
-fn program_statements(ast: &Ast<'_>, program: Program) -> Vec<Stmt> {
-  program
-    .body(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect()
-}
-
 fn has_no_side_effects_notation(comments: &RspackComments<'_>, span: Span) -> bool {
   comments.has_flag(span.start, "NO_SIDE_EFFECTS")
 }
@@ -91,18 +86,15 @@ fn visit_pattern_binding_names(ast: &Ast<'_>, pattern: BindingPattern, f: &mut i
   match ast.binding_pattern_data(pattern) {
     BindingPatternData::BindingIdentifier(identifier) => f(atom_from_binding(ast, identifier)),
     BindingPatternData::ArrayPattern(array) => {
-      for slot in array.elements(ast).iter() {
-        if let Some(element) = ast.get_node_in_sub_range(slot) {
-          visit_pattern_binding_names(ast, element, f);
-        }
+      for element in ast.nodes(array.elements(ast)).flatten() {
+        visit_pattern_binding_names(ast, element, f);
       }
       if let Some(rest) = array.rest(ast) {
         visit_pattern_binding_names(ast, rest.argument(ast), f);
       }
     }
     BindingPatternData::ObjectPattern(object) => {
-      for slot in object.properties(ast).iter() {
-        let property = ast.get_node_in_sub_range(slot);
+      for property in ast.nodes(object.properties(ast)) {
         visit_pattern_binding_names(ast, property.value(ast), f);
       }
       if let Some(rest) = object.rest(ast) {
@@ -132,8 +124,7 @@ fn visit_decl_binding_names(ast: &Ast<'_>, declaration: Decl, f: &mut impl FnMut
       }
     }
     DeclData::VariableDeclaration(variable) => {
-      for slot in variable.declarators(ast).iter() {
-        let declarator = ast.get_node_in_sub_range(slot);
+      for declarator in ast.nodes(variable.declarators(ast)) {
         visit_pattern_binding_names(ast, declarator.id(ast), f);
       }
     }
@@ -145,8 +136,7 @@ fn visit_stmt_defined_binding_names(ast: &Ast<'_>, statement: Stmt, f: &mut impl
   match ast.stmt_data(statement) {
     StmtData::Declaration(declaration) => visit_decl_binding_names(ast, declaration, f),
     StmtData::ImportDeclaration(import) => {
-      for slot in import.specifiers(ast).iter() {
-        let specifier = ast.get_node_in_sub_range(slot);
+      for specifier in ast.nodes(import.specifiers(ast)) {
         let local = match ast.import_declaration_specifier_data(specifier) {
           ImportDeclarationSpecifierData::ImportSpecifier(specifier) => specifier.local(ast),
           ImportDeclarationSpecifierData::ImportDefaultSpecifier(specifier) => specifier.local(ast),
@@ -195,20 +185,19 @@ fn visit_stmt_defined_binding_names(ast: &Ast<'_>, statement: Stmt, f: &mut impl
 }
 
 fn collect_pure_function_acceptable_names(ast: &Ast<'_>, program: Program) -> AtomSet {
-  let statements = program_statements(ast, program);
+  let statements = program.body(ast);
   let mut names = AtomSet::default();
-  for statement in statements.iter().copied() {
+  for statement in ast.nodes(statements) {
     visit_stmt_defined_binding_names(ast, statement, &mut |name| {
       names.insert(name);
     });
   }
 
   let local_bindings = names.clone();
-  for statement in statements {
+  for statement in ast.nodes(statements) {
     match ast.stmt_data(statement) {
       StmtData::ExportNamedDeclaration(export) if export.source(ast).is_none() => {
-        for slot in export.specifiers(ast).iter() {
-          let specifier = ast.get_node_in_sub_range(slot);
+        for specifier in ast.nodes(export.specifiers(ast)) {
           let local = atom_from_module_export_name(ast, specifier.local(ast));
           if local_bindings.contains(&local) {
             names.insert(atom_from_module_export_name(ast, specifier.exported(ast)));
@@ -251,7 +240,7 @@ fn collect_defined_configured_side_effects_free(
 
 fn collect_duplicate_top_level_names(ast: &Ast<'_>, program: Program) -> AtomSet {
   let mut counts = FxHashMap::<Atom, usize>::default();
-  for statement in program_statements(ast, program) {
+  for statement in ast.nodes(program.body(ast)) {
     visit_stmt_defined_binding_names(ast, statement, &mut |name| {
       *counts.entry(name).or_default() += 1;
     });
@@ -272,7 +261,7 @@ fn collect_annotation_from_variable(
   if variable.kind(ast) != VariableKind::Const || variable.declarators(ast).len() != 1 {
     return;
   }
-  let Some(declarator) = variable.declarators(ast).get_node(ast, 0) else {
+  let Some(declarator) = ast.first(variable.declarators(ast)) else {
     return;
   };
   let BindingPatternData::BindingIdentifier(identifier) =
@@ -303,7 +292,7 @@ fn collect_pure_annotations(
   program: Program,
 ) -> AtomSet {
   let mut side_effects_free = AtomSet::default();
-  for statement in program_statements(ast, program) {
+  for statement in ast.nodes(program.body(ast)) {
     match ast.stmt_data(statement) {
       StmtData::Declaration(declaration) => match ast.decl_data(declaration) {
         DeclData::Function(function) => {
@@ -412,12 +401,7 @@ fn try_mark_auto_side_effects_free_variable(
   if variable.kind(ast) != VariableKind::Const {
     return;
   }
-  let declarators = variable
-    .declarators(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  for declarator in declarators {
+  for declarator in ast.nodes(variable.declarators(ast)) {
     let BindingPatternData::BindingIdentifier(identifier) =
       ast.binding_pattern_data(declarator.id(ast))
     else {
@@ -483,8 +467,7 @@ fn mark_auto_side_effects_free_program(
   duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
-  let statements = program_statements(ast, program);
-  for statement in statements {
+  for statement in ast.nodes(program.body(ast)) {
     match ast.stmt_data(statement) {
       StmtData::Declaration(declaration) => try_mark_auto_side_effects_free_decl(
         parser,
@@ -795,11 +778,7 @@ fn arguments_are_pure(
   mut callees: Option<&mut Vec<(Atom, Span)>>,
 ) -> bool {
   let ast = parser.ast.ast;
-  let arguments = arguments
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  for argument in arguments {
+  for argument in ast.nodes(arguments) {
     let ArgumentData::Expr(expression) = ast.argument_data(argument) else {
       return false;
     };
@@ -933,12 +912,7 @@ pub fn is_pure_expression(
   let ast = parser.ast.ast;
   match ast.expr_data(expression) {
     ExprData::ArrayExpression(array) => {
-      let elements = array
-        .elements(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
-      for element in elements.into_iter().flatten() {
+      for element in ast.nodes(array.elements(ast)).flatten() {
         let ArgumentData::Expr(element) = ast.argument_data(element) else {
           return false;
         };
@@ -983,23 +957,15 @@ pub fn is_pure_expression(
       callees,
     ),
     ExprData::SequenceExpression(sequence) => {
-      let expressions = sequence
-        .expressions(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
-      for expression in expressions {
-        if !is_pure_expression(
+      ast.nodes(sequence.expressions(ast)).all(|expression| {
+        is_pure_expression(
           parser,
           analyze_side_effects_free,
           expression,
           comments,
           callees.as_deref_mut(),
-        ) {
-          return false;
-        }
-      }
-      true
+        )
+      })
     }
     ExprData::TsAsExpression(ts) => is_pure_expression(
       parser,
@@ -1050,17 +1016,10 @@ pub fn is_pure_pat(parser: &mut JavascriptParser, pattern: BindingPattern) -> bo
   let ast = parser.ast.ast;
   match ast.binding_pattern_data(pattern) {
     BindingPatternData::BindingIdentifier(_) | BindingPatternData::BindingRestElement(_) => true,
-    BindingPatternData::ArrayPattern(array) => {
-      let elements = array
-        .elements(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
-      elements
-        .into_iter()
-        .flatten()
-        .all(|element| is_pure_pat(parser, element))
-    }
+    BindingPatternData::ArrayPattern(array) => ast
+      .nodes(array.elements(ast))
+      .flatten()
+      .all(|element| is_pure_pat(parser, element)),
     BindingPatternData::SimpleAssignmentTarget(target) => {
       target.as_identifier_reference(ast).is_some()
     }
@@ -1071,12 +1030,7 @@ pub fn is_pure_pat(parser: &mut JavascriptParser, pattern: BindingPattern) -> bo
 pub fn is_pure_function(parser: &mut JavascriptParser, function: Function) -> bool {
   let ast = parser.ast.ast;
   let parameters = function.params(ast);
-  let items = parameters
-    .items(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  for item in items {
+  for item in ast.nodes(parameters.items(ast)) {
     let FormalParameterItemData::FormalParameter(parameter) = ast.formal_parameter_item_data(item)
     else {
       return false;
@@ -1156,13 +1110,7 @@ pub fn is_pure_class(
     return false;
   }
 
-  let elements = class
-    .body(ast)
-    .body(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  for member in elements {
+  for member in ast.nodes(class.body(ast).body(ast)) {
     let pure = match ast.class_element_data(member) {
       ClassElementData::MethodDefinition(method) => {
         (method.kind(ast) != MethodDefinitionKind::Constructor || class.super_class(ast).is_none())
@@ -1250,12 +1198,7 @@ fn is_pure_var_decl(
     return false;
   }
   let ast = parser.ast.ast;
-  let declarators = variable
-    .declarators(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  declarators.into_iter().all(|declarator| {
+  ast.nodes(variable.declarators(ast)).all(|declarator| {
     declarator.init(ast).is_none_or(|initializer| {
       is_pure_expression(
         parser,
@@ -1358,12 +1301,7 @@ fn is_module_eval_pure_var_decl(
     return false;
   }
   let ast = parser.ast.ast;
-  let declarators = variable
-    .declarators(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  declarators.into_iter().all(|declarator| {
+  ast.nodes(variable.declarators(ast)).all(|declarator| {
     declarator.init(ast).is_none_or(|initializer| {
       is_module_eval_pure_expression(
         parser,
@@ -1389,12 +1327,7 @@ fn is_side_effects_free_var_decl(
     return false;
   }
   let comments = parser.ast.comments;
-  let declarators = variable
-    .declarators(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  for declarator in declarators {
+  for declarator in ast.nodes(variable.declarators(ast)) {
     if !matches!(
       ast.binding_pattern_data(declarator.id(ast)),
       BindingPatternData::BindingIdentifier(_)
@@ -1435,8 +1368,7 @@ fn stmt_may_have_side_effects(parser: &JavascriptParser, statement: Stmt) -> boo
         ) {
           return true;
         }
-        variable.declarators(ast).iter().any(|slot| {
-          let declarator = ast.get_node_in_sub_range(slot);
+        ast.nodes(variable.declarators(ast)).any(|declarator| {
           !matches!(
             ast.binding_pattern_data(declarator.id(ast)),
             BindingPatternData::BindingIdentifier(_)
@@ -1495,14 +1427,8 @@ fn is_side_effects_free_function_body(
   if !formal_parameters_are_simple_identifiers(ast, function.params(ast)) {
     return false;
   }
-  let statements = function
-    .body(ast)
-    .body(ast)
-    .iter()
-    .map(|slot| ast.get_node_in_sub_range(slot))
-    .collect::<Vec<_>>();
-  statements
-    .into_iter()
+  ast
+    .nodes(function.body(ast).body(ast))
     .all(|statement| is_side_effects_free_stmt(parser, analyze_side_effects_free, statement))
 }
 
@@ -1516,16 +1442,9 @@ fn is_side_effects_free_arrow_body(
     return false;
   }
   match ast.arrow_function_body_data(arrow.body(ast)) {
-    ArrowFunctionBodyData::FunctionBody(body) => {
-      let statements = body
-        .body(ast)
-        .iter()
-        .map(|slot| ast.get_node_in_sub_range(slot))
-        .collect::<Vec<_>>();
-      statements
-        .into_iter()
-        .all(|statement| is_side_effects_free_stmt(parser, analyze_side_effects_free, statement))
-    }
+    ArrowFunctionBodyData::FunctionBody(body) => ast
+      .nodes(body.body(ast))
+      .all(|statement| is_side_effects_free_stmt(parser, analyze_side_effects_free, statement)),
     ArrowFunctionBodyData::Expr(expression) => is_pure_expression(
       parser,
       analyze_side_effects_free,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -5,7 +5,7 @@ use rspack_core::{
   JavascriptParserUrl, RuntimeGlobals, RuntimeRequirementsDependency, get_context,
 };
 use rspack_intern::Atom;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   ArgumentData, Ast, Expr, GetSpan, MemberExpression, NewExpression, Visit, VisitWith,
 };
@@ -59,10 +59,10 @@ pub fn get_url_request(
 ) -> Option<(String, u32, u32)> {
   let ast = parser.ast.ast;
   let arguments = expr.arguments(ast);
-  let ArgumentData::Expr(arg1) = ast.argument_data(arguments.get_node(ast, 0)?) else {
+  let ArgumentData::Expr(arg1) = ast.argument_data(ast.first(arguments)?) else {
     return None;
   };
-  let arg2 = arguments.get_node(ast, 1);
+  let arg2 = ast.second(arguments);
 
   if let Some(arg2) = arg2 {
     // new URL(xx, import.meta.url)
@@ -117,14 +117,14 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
     let ast = parser.ast.ast;
     let arguments = expr.arguments(ast);
 
-    let arg = arguments.get_node(ast, 0)?;
+    let arg = ast.first(arguments)?;
     let magic_comment_options = try_extract_magic_comment(parser, expr.span(ast), arg.span(ast));
     match magic_comment_options.get_ignore_value() {
       Some(MagicCommentValue::Bool(true)) => {
         if arguments.len() != 2 || !self.import_meta_url_enabled {
           return None;
         }
-        let arg2 = arguments.get_node(ast, 1)?;
+        let arg2 = ast.second(arguments)?;
         if let ArgumentData::Expr(arg2_expr) = ast.argument_data(arg2)
           && let Some(arg2) = arg2_expr.as_member_expression(ast)
           && !is_meta_url(parser, arg2)
@@ -143,8 +143,8 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
 
     // should not parse new URL(import.meta.url)
     if arguments.len() == 1
-      && arguments
-        .get_node(ast, 0)
+      && ast
+        .first(arguments)
         .and_then(|argument| argument.as_expr(ast))
         .and_then(|expression| expression.as_member_expression(ast))
         .is_some_and(|member| is_meta_url(parser, member))
@@ -155,7 +155,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
     if let Some((request, start, end)) = get_url_request(parser, expr) {
       if request.starts_with("//") {
         if arguments.len() == 2 {
-          parser.walk_arguments(std::iter::once(arguments.get_node(ast, 1)?));
+          parser.walk_arguments(std::iter::once(ast.second(arguments)?));
           return Some(true);
         }
         return None;
@@ -184,7 +184,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
       return None;
     }
 
-    let arg2 = arguments.get_node(ast, 1)?;
+    let arg2 = ast.second(arguments)?;
     if !arg2
       .as_expr(ast)
       .and_then(|expression| expression.as_member_expression(ast))

--- a/crates/rspack_plugin_javascript/src/parser_plugin/use_strict_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/use_strict_plugin.rs
@@ -1,4 +1,5 @@
 use rspack_core::ConstDependency;
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{GetSpan, Program};
 
 use super::JavascriptParserPlugin;
@@ -10,11 +11,7 @@ pub struct UseStrictPlugin;
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for UseStrictPlugin {
   fn program(&self, parser: &mut JavascriptParser<'p>, program: Program) -> Option<bool> {
     let ast = parser.ast.ast;
-    if let Some(first) = program
-      .directives(ast)
-      .iter()
-      .next()
-      .map(|id| ast.get_node_in_sub_range(id))
+    if let Some(first) = ast.first(program.directives(ast))
       && ast.get_utf8(first.value(ast)) == "use strict"
     {
       // Remove "use strict" expression. It will be added later by the renderer again.

--- a/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/worker_plugin.rs
@@ -253,9 +253,9 @@ fn handle_worker(
       && let Some((request, start, end)) = get_url_request(parser, new_url_expr)
     {
       let new_url_arguments = new_url_expr.arguments(ast);
-      let range_request = new_url_arguments.get_node(ast, 1).and_then(|_| {
-        new_url_arguments
-          .get_node(ast, 0)
+      let range_request = ast.second(new_url_arguments).and_then(|_| {
+        ast
+          .first(new_url_arguments)
           .map(|argument| (argument.span(ast).real_lo(), argument.span(ast).real_hi()))
       });
       ParsedNewWorkerPath {
@@ -286,17 +286,10 @@ fn handle_worker(
     let import_options = expression
       .as_new_expression(ast)
       .and_then(|new_url_expr| {
-        new_url_expr
-          .arguments(ast)
-          .get_node(ast, 0)
-          .and_then(|argument| {
-            // new Worker(new URL(/* options */ "worker.js"))
-            parse_new_worker_options_from_comments(
-              parser,
-              argument.span(ast),
-              new_url_expr.span(ast),
-            )
-          })
+        ast.first(new_url_expr.arguments(ast)).and_then(|argument| {
+          // new Worker(new URL(/* options */ "worker.js"))
+          parse_new_worker_options_from_comments(parser, argument.span(ast), new_url_expr.span(ast))
+        })
       })
       .or_else(|| {
         // new Worker(/* options */ new URL("worker.js"))

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_array_expr.rs
@@ -1,4 +1,4 @@
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{ArgumentData, ArrayExpression, GetSpan};
 
 use super::BasicEvaluatedExpression;
@@ -11,11 +11,7 @@ pub fn eval_array_expression<'parser>(
 ) -> Option<BasicEvaluatedExpression<'parser>> {
   let ast = parser.ast.ast;
   let mut items = Vec::new();
-  for element in expression
-    .elements(ast)
-    .iter()
-    .map(|id| ast.get_node_in_sub_range(id))
-  {
+  for element in ast.nodes(expression.elements(ast)) {
     let element = element?;
     let ArgumentData::Expr(element) = ast.argument_data(element) else {
       return None;

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -1,5 +1,5 @@
 use rspack_intern::Atom;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{ArgumentData, GetSpan, NewExpression};
 
 use super::BasicEvaluatedExpression;
@@ -43,7 +43,7 @@ pub fn eval_new_expression<'parser>(
   }
   let arguments = expression.arguments(ast);
   let span = expression.span(ast);
-  let Some(first) = arguments.get_node(ast, 0) else {
+  let Some(first) = ast.first(arguments) else {
     let mut result = BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi());
     result.set_regexp(String::new(), String::new());
     return Some(result);
@@ -52,7 +52,7 @@ pub fn eval_new_expression<'parser>(
     return None;
   };
   let regexp = parser.evaluate_expression(first).as_string()?;
-  let flags = if let Some(second) = arguments.get_node(ast, 1) {
+  let flags = if let Some(second) = ast.second(arguments) {
     let ArgumentData::Expr(second) = ast.argument_data(second) else {
       return None;
     };

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_tpl_expr.rs
@@ -1,4 +1,4 @@
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{GetSpan, TaggedTemplateExpression, TemplateLiteral};
 
 use super::BasicEvaluatedExpression;
@@ -20,14 +20,10 @@ fn get_simplified_template_result<'parser>(
 ) {
   let ast = parser.ast.ast;
   let quasis_nodes = template.quasis(ast);
-  let expressions = template.expressions(ast);
+  let mut expressions = ast.nodes(template.expressions(ast));
   let mut quasis: Vec<BasicEvaluatedExpression<'parser>> = Vec::new();
   let mut parts: Vec<BasicEvaluatedExpression<'parser>> = Vec::new();
-  for (index, quasi_node) in quasis_nodes
-    .iter()
-    .map(|id| ast.get_node_in_sub_range(id))
-    .enumerate()
-  {
+  for (index, quasi_node) in ast.nodes(quasis_nodes).enumerate() {
     let quasi = match kind {
       TemplateStringKind::Cooked if !quasi_node.is_cooked_undefined(ast) => ast
         .get_wtf8(quasi_node.cooked(ast))
@@ -42,7 +38,7 @@ fn get_simplified_template_result<'parser>(
       let previous = parts.last_mut().expect("template has a preceding quasi");
       let expression = parser.evaluate_expression(
         expressions
-          .get_node(ast, index - 1)
+          .next()
           .expect("template has an expression before each non-leading quasi"),
       );
       if !expression.could_have_side_effects()

--- a/crates/rspack_plugin_javascript/src/utils/object_properties.rs
+++ b/crates/rspack_plugin_javascript/src/utils/object_properties.rs
@@ -32,7 +32,7 @@
 use rspack_core::{ContextMode, ImportAttributes, try_convert_str_to_context_mode};
 use rspack_error::{Error, Label, Result};
 use rspack_regex::RspackRegex;
-use rspack_util::SpanExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   Ast, Expr, ExprData, GetSpan, ImportAttribute, ModuleExportNameData, ObjectExpression,
   PropertyKey, PropertyKeyData, TypedSubRange,
@@ -41,20 +41,20 @@ use swc_next_ecma_ast::{
 use crate::visitors::static_string_from_expr;
 
 pub fn get_value_by_obj_prop(ast: &Ast<'_>, object: ObjectExpression, field: &str) -> Option<Expr> {
-  object.properties(ast).iter().rev().find_map(|property| {
-    let property = ast.get_node_in_sub_range(property);
-    let property = property.as_object_property(ast)?;
-    (static_property_name(ast, property.key(ast)).as_deref() == Some(field))
-      .then(|| property.value(ast))
-  })
+  ast
+    .nodes(object.properties(ast))
+    .rev()
+    .find_map(|property| {
+      let property = property.as_object_property(ast)?;
+      (static_property_name(ast, property.key(ast)).as_deref() == Some(field))
+        .then(|| property.value(ast))
+    })
 }
 
 pub fn get_attributes(ast: &Ast<'_>, object: ObjectExpression) -> ImportAttributes {
-  object
-    .properties(ast)
-    .iter()
+  ast
+    .nodes(object.properties(ast))
     .filter_map(|property| {
-      let property = ast.get_node_in_sub_range(property);
       let property = property.as_object_property(ast)?;
       let key = static_property_name(ast, property.key(ast))?;
       let ExprData::StringLiteral(value) = ast.expr_data(property.value(ast)) else {
@@ -79,10 +79,9 @@ pub fn get_import_attributes(
     return None;
   }
   Some(
-    attributes
-      .iter()
-      .map(|id| {
-        let attribute = ast.get_node_in_sub_range(id);
+    ast
+      .nodes(attributes)
+      .map(|attribute| {
         let key = match ast.module_export_name_data(attribute.key(ast)) {
           ModuleExportNameData::IdentifierName(identifier) => {
             ast.get_utf8(identifier.name(ast)).to_string()
@@ -240,11 +239,9 @@ impl<T: FromAstExpr> FromAstExpr for Vec<(String, T)> {
     let Some(object) = expr.as_object_expression(ast) else {
       return Ok(None);
     };
-    object
-      .properties(ast)
-      .iter()
+    ast
+      .nodes(object.properties(ast))
       .map(|prop| -> Result<Option<(String, T)>> {
-        let prop = ast.get_node_in_sub_range(prop);
         let Some(property) = prop.as_object_property(ast) else {
           return Ok(None);
         };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/estree.rs
@@ -31,10 +31,9 @@ pub fn formal_parameter_patterns<'a>(
   params: FormalParameters,
 ) -> impl Iterator<Item = BindingPattern> + 'a {
   let rest = params.rest(ast).map(BindingPattern::BindingRestElement);
-  params
-    .items(ast)
-    .iter()
-    .filter_map(move |id| ast.get_node_in_sub_range(id).as_formal_parameter(ast))
+  ast
+    .nodes(params.items(ast))
+    .filter_map(move |item| item.as_formal_parameter(ast))
     .filter_map(move |parameter| parameter.pattern(ast).as_binding_pattern(ast))
     .chain(rest)
 }
@@ -45,9 +44,8 @@ pub fn formal_parameter_patterns<'a>(
 /// need their parameter initialization semantics to be analyzed separately.
 pub fn formal_parameters_are_simple_identifiers(ast: &Ast<'_>, params: FormalParameters) -> bool {
   params.rest(ast).is_none()
-    && params.items(ast).iter().all(|id| {
-      ast
-        .get_node_in_sub_range(id)
+    && ast.nodes(params.items(ast)).all(|item| {
+      item
         .as_formal_parameter(ast)
         .and_then(|parameter| parameter.pattern(ast).as_binding_pattern(ast))
         .and_then(|pattern| pattern.as_binding_identifier(ast))

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -98,7 +98,7 @@ pub(crate) fn member_property_to_atom(ast: &Ast<'_>, expr: Expr) -> Option<Atom>
     ExprData::TemplateLiteral(node)
       if node.expressions(ast).is_empty() && node.quasis(ast).len() == 1 =>
     {
-      let quasi = node.quasis(ast).get_node(ast, 0)?;
+      let quasi = ast.first(node.quasis(ast))?;
       if quasi.is_cooked_undefined(ast) {
         Atom::from(ast.get_utf8(quasi.raw(ast)))
       } else {
@@ -1323,10 +1323,8 @@ impl<'parser> JavascriptParser<'parser> {
     F: FnOnce(&mut Self, BindingIdentifier) + Copy,
   {
     let ast = self.ast.ast;
-    for slot in array_pat.elements(ast).iter() {
-      if let Some(element) = ast.get_node_in_sub_range(slot) {
-        self.enter_pattern(PatRef::Borrowed(element), on_ident);
-      }
+    for element in ast.nodes(array_pat.elements(ast)).flatten() {
+      self.enter_pattern(PatRef::Borrowed(element), on_ident);
     }
     if let Some(rest) = array_pat.rest(ast) {
       self.enter_rest_pattern(rest, on_ident);
@@ -1345,8 +1343,7 @@ impl<'parser> JavascriptParser<'parser> {
     F: FnOnce(&mut Self, BindingIdentifier) + Copy,
   {
     let ast = self.ast.ast;
-    for slot in object.properties(ast).iter() {
-      let property = ast.get_node_in_sub_range(slot);
+    for property in ast.nodes(object.properties(ast)) {
       let value = property.value(ast);
       let old = self.in_short_hand;
       if property.shorthand(ast) && !value.is_assignment_pattern(ast) {
@@ -1438,8 +1435,7 @@ impl<'parser> JavascriptParser<'parser> {
         }
       }
       DeclData::VariableDeclaration(variable) => {
-        for slot in variable.declarators(ast).iter() {
-          let declarator = ast.get_node_in_sub_range(slot);
+        for declarator in ast.nodes(variable.declarators(ast)) {
           self.enter_pattern(PatRef::Borrowed(declarator.id(ast)), on_ident);
         }
       }
@@ -1540,8 +1536,7 @@ impl<'parser> JavascriptParser<'parser> {
 
   pub fn detect_mode(&mut self, program: Program) {
     let ast = self.ast.ast;
-    for slot in program.directives(ast).iter() {
-      let directive = ast.get_node_in_sub_range(slot);
+    for directive in ast.nodes(program.directives(ast)) {
       if ast.get_utf8(directive.value(ast)) == "use strict" {
         self.set_strict(true);
         return;

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1544,7 +1544,6 @@ impl JavascriptParser<'_> {
       .collect::<Vec<_>>();
 
     let ast = self.ast.ast;
-    let mut params = Vec::new();
     let mut scope_params = Vec::new();
     let formal_params = match ast.expr_data(expr) {
       ExprData::Function(function) => function.params(ast),
@@ -1555,7 +1554,6 @@ impl JavascriptParser<'_> {
       .map(|identifier| identifier.expect("IIFE parameters must be binding identifiers"))
       .enumerate()
     {
-      params.push(identifier);
       if variable_info_for_args
         .get(i)
         .and_then(|info| info.as_ref())
@@ -1589,10 +1587,12 @@ impl JavascriptParser<'_> {
       {
         parser.set_variable("this".into(), this)
       }
-      for (i, var_info) in variable_info_for_args.into_iter().enumerate() {
-        if let Some(var_info) = var_info
-          && let Some(param) = params.get(i)
-        {
+      for (var_info, param) in variable_info_for_args
+        .into_iter()
+        .zip(Self::parameter_identifiers(ast, formal_params))
+      {
+        if let Some(var_info) = var_info {
+          let param = param.expect("IIFE parameters must be binding identifiers");
           parser.set_variable(
             Atom::from(parser.ast.ast.get_utf8(param.name(parser.ast.ast))),
             var_info,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_pre.rs
@@ -289,11 +289,7 @@ impl JavascriptParser<'_> {
       return None;
     }
     let mut keys = DestructuringAssignmentProperties::default();
-    for property in object
-      .properties(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-    {
+    for property in ast.nodes(object.properties(ast)) {
       let key = property.key(ast);
       let value = property.value(ast);
       let (id, shorthand) = if property.shorthand(ast) {
@@ -357,12 +353,7 @@ impl JavascriptParser<'_> {
     }
     let mut keys = DestructuringAssignmentProperties::default();
     let mut buffer = rspack_util::itoa::Buffer::new();
-    for (index, element) in array
-      .elements(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
-      .enumerate()
-    {
+    for (index, element) in ast.nodes(array.elements(ast)).enumerate() {
       let Some(element) = element else {
         continue;
       };

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 use rspack_core::DependencyRange;
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_regex::RspackRegex;
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{Ast, Expr, ExprData, MemberExpression};
 
 use super::JavascriptParser;
@@ -55,7 +56,7 @@ pub fn static_string_from_expr(ast: &Ast<'_>, expr: Expr) -> Option<String> {
     ExprData::TemplateLiteral(template)
       if template.expressions(ast).is_empty() && template.quasis(ast).len() == 1 =>
     {
-      let element = ast.get_node_in_sub_range(template.quasis(ast).iter().next()?);
+      let element = ast.first(template.quasis(ast))?;
       Some(ast.get_utf8(element.raw(ast)).to_string())
     }
     _ => None,

--- a/crates/rspack_plugin_rslib/src/react_directives_parser_plugin.rs
+++ b/crates/rspack_plugin_rslib/src/react_directives_parser_plugin.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use rspack_core::ConstDependency;
 use rspack_plugin_javascript::{JavascriptParserPlugin, visitors::JavascriptParser};
+use rspack_util::swc::AstSubRangeExt;
 use swc_next_ecma_ast::{GetSpan, Program};
 
 pub struct ReactDirectivesParserPlugin;
@@ -10,30 +11,30 @@ pub struct ReactDirectivesParserPlugin;
 impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ReactDirectivesParserPlugin {
   fn program(&self, parser: &mut JavascriptParser<'p>, program: Program) -> Option<bool> {
     let ast = parser.ast.ast;
-    let directives = program
-      .directives(ast)
-      .iter()
-      .map(|id| ast.get_node_in_sub_range(id))
+    let directives = program.directives(ast);
+    let values: Vec<_> = ast
+      .nodes(directives)
       .take_while(|directive| ast.get_utf8(directive.value(ast)).starts_with("use "))
       .map(|directive| {
-        (
-          format!("\"{}\"", ast.get_utf8(directive.value(ast))),
-          directive.span(ast),
-        )
+        serde_json::Value::String(format!("\"{}\"", ast.get_utf8(directive.value(ast))))
       })
-      .collect::<Vec<_>>();
+      .collect();
 
-    if directives.is_empty() {
+    if values.is_empty() {
       return None;
     }
 
+    let directive_count = values.len();
     parser.build_info.extras.insert(
       "react_directives".to_string(),
-      serde_json::json!(directives.iter().map(|(d, _)| d).collect::<Vec<_>>()),
+      serde_json::Value::Array(values),
     );
 
-    for (_, span) in directives {
-      parser.add_presentational_dependency(Arc::new(ConstDependency::new(span.into(), "".into())));
+    for directive in ast.nodes(directives).take(directive_count) {
+      parser.add_presentational_dependency(Arc::new(ConstDependency::new(
+        directive.span(ast).into(),
+        "".into(),
+      )));
     }
 
     None

--- a/crates/rspack_plugin_rstest/src/parser_plugin.rs
+++ b/crates/rspack_plugin_rstest/src/parser_plugin.rs
@@ -19,9 +19,12 @@ use rspack_plugin_javascript::{
     create_traceable_error, expr_name,
   },
 };
-use rspack_util::{SpanExt, json_stringify_str, swc::get_swc_next_comments};
+use rspack_util::{
+  SpanExt, json_stringify_str,
+  swc::{AstSubRangeExt, get_swc_next_comments},
+};
 use swc_next_ecma_ast::{
-  Argument, Ast, CallExpression, ChainExpression, Expr, ExprData, GetSpan, IdentifierName,
+  Ast, CallExpression, ChainExpression, Expr, ExprData, GetSpan, IdentifierName,
   IdentifierReference, ImportDeclaration, ImportExpression, PropertyKeyData, Span, UnaryExpression,
   VariableDeclarator,
 };
@@ -48,14 +51,6 @@ pub(crate) const MOCK_TARGET_REQUEST_PREFIX: &str = "\0rstest_mock_target:\0";
 enum ModulePathType {
   DirName,
   FileName,
-}
-
-fn collect_arguments(ast: &Ast<'_>, call: CallExpression) -> Vec<Argument> {
-  call
-    .arguments(ast)
-    .iter()
-    .map(|id| ast.get_node_in_sub_range(id))
-    .collect()
 }
 
 fn string_literal_value(ast: &Ast<'_>, expr: Expr) -> Option<String> {
@@ -165,26 +160,32 @@ impl RstestParserPlugin {
       return None;
     }
 
-    let args = collect_arguments(ast, call_expr);
+    let args = call_expr.arguments(ast);
     if !(1..=2).contains(&args.len()) {
       return None;
     }
 
-    let first_arg = *args.first()?;
+    let first_arg = ast.first(args)?;
     if first_arg.is_spread_element(ast)
       || self.has_ignore_comment(parser, call_expr.span(ast), first_arg.span(ast))
     {
       return None;
     }
 
-    if args.get(1).is_some_and(|arg| arg.is_spread_element(ast)) {
+    if ast
+      .second(args)
+      .is_some_and(|arg| arg.is_spread_element(ast))
+    {
       return None;
     }
 
     let resource_path = parser.resource_data.path()?;
     let origin_path = resource_path.as_str().to_string();
 
-    let last_arg = args.last().expect("args has at least one element");
+    let last_arg = ast
+      .nodes(args)
+      .next_back()
+      .expect("args has at least one element");
     parser.add_presentational_dependency(Arc::new(RstestRequireResolveOriginDependency::new(
       call_expr.callee(ast).span(ast).into(),
       last_arg.span(ast).real_hi(),
@@ -193,7 +194,7 @@ impl RstestParserPlugin {
 
     // Returning `Some(true)` short-circuits the default walker for this call,
     // so preserve dependency collection for nested expressions in arguments.
-    parser.walk_arguments(args.into_iter());
+    parser.walk_arguments(ast.nodes(args));
     Some(true)
   }
 
@@ -214,10 +215,10 @@ impl RstestParserPlugin {
     call_expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr);
+    let args = call_expr.arguments(ast);
     match args.len() {
       1 => {
-        let first_arg = args[0];
+        let first_arg = ast.first(args).expect("argument count checked");
         if let Some(first_arg_expr) = first_arg.as_expr(ast)
           && let Some(value) = string_literal_value(ast, first_arg_expr)
         {
@@ -269,10 +270,10 @@ impl RstestParserPlugin {
     call_expr: CallExpression,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr);
+    let args = call_expr.arguments(ast);
     match args.len() {
       1 => {
-        let first_arg = args[0];
+        let first_arg = ast.first(args).expect("argument count checked");
         if let Some(first_arg_expr) = first_arg.as_expr(ast)
           && let Some(value) = string_literal_value(ast, first_arg_expr)
         {
@@ -347,7 +348,7 @@ impl RstestParserPlugin {
     mock_call_expr: CallExpression,
   ) -> Option<String> {
     let ast = parser.ast.ast;
-    let first_arg = collect_arguments(ast, mock_call_expr).into_iter().next()?;
+    let first_arg = ast.first(mock_call_expr.arguments(ast))?;
     let first_arg_expr = first_arg.as_expr(ast)?;
 
     if let ExprData::ImportExpression(import_call) = ast.expr_data(first_arg_expr) {
@@ -376,10 +377,10 @@ impl RstestParserPlugin {
     test_api_import_source_order: Option<i32>,
   ) {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr);
+    let args = call_expr.arguments(ast);
     match args.len() {
       1 => {
-        let first_arg = args[0];
+        let first_arg = ast.first(args).expect("argument count checked");
         let first_arg_lit_str = self.handle_mock_first_arg(parser, call_expr);
 
         if let Some(lit_str) = first_arg_lit_str {
@@ -445,8 +446,8 @@ impl RstestParserPlugin {
       }
       // mock a module
       2 => {
-        let first_arg = args[0];
-        let second_arg = args[1];
+        let first_arg = ast.first(args).expect("argument count checked");
+        let second_arg = ast.second(args).expect("argument count checked");
 
         if first_arg.is_spread_element(ast) || second_arg.is_spread_element(ast) {
           return;
@@ -597,10 +598,10 @@ impl RstestParserPlugin {
     is_esm: bool,
   ) -> Option<bool> {
     let ast = parser.ast.ast;
-    let args = collect_arguments(ast, call_expr);
+    let args = call_expr.arguments(ast);
     match args.len() {
       1 => {
-        let first_arg = args[0];
+        let first_arg = ast.first(args).expect("argument count checked");
         if let Some(first_arg_expr) = first_arg.as_expr(ast) {
           if let Some(value) = string_literal_value(ast, first_arg_expr) {
             if let Some(mocked_target) = self.calc_mocked_target(&value).as_std_path().to_str() {
@@ -1011,7 +1012,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for RstestParserPlugin {
         parser.walk_expression(options);
       }
       if let Some(import_then) = import_then {
-        parser.walk_arguments(collect_arguments(ast, import_then).into_iter());
+        parser.walk_arguments(ast.nodes(import_then.arguments(ast)));
       }
 
       return Some(true);

--- a/crates/rspack_util/src/swc.rs
+++ b/crates/rspack_util/src/swc.rs
@@ -17,7 +17,7 @@ pub trait AstSubRangeExt<'ast> {
   where
     T: ExtraDataCompact<'ast>;
 
-  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl Iterator<Item = T> + 'a
+  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl DoubleEndedIterator<Item = T> + 'a
   where
     T: ExtraDataCompact<'ast> + 'a;
 }
@@ -40,7 +40,7 @@ impl<'ast> AstSubRangeExt<'ast> for Ast<'ast> {
   }
 
   #[inline]
-  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl Iterator<Item = T> + 'a
+  fn nodes<'a, T>(&'a self, range: TypedSubRange<T>) -> impl DoubleEndedIterator<Item = T> + 'a
   where
     T: ExtraDataCompact<'ast> + 'a,
   {


### PR DESCRIPTION
## Summary

Traverse side-effects analysis, call evaluation, IIFE parameters, and Rstest arguments directly over AST ranges, removing temporary node vectors. Reuse `AstSubRangeExt::nodes`, `first`, and `second` throughout JavaScript parser plugins, walkers, evaluators, magic comments, and the Rslib/Rstest parser integrations to encapsulate range-slot decoding. Consume template expressions sequentially, and build React directive metadata without intermediate string/span or reference vectors.

Expose the iterator's existing `DoubleEndedIterator` capability so property lookup and string concatenation evaluation retain reverse traversal. Preserve array holes, positional pairing, traversal order, and short-circuit behavior. Member-call evaluation still rejects spread arguments before invoking evaluation hooks.

## Related links

- #15513
- #15515

## Checklist

- [x] Tests updated (not required; behavior is unchanged).
- [x] Documentation updated (not required).
