### PR TITLE
perf(javascript): reduce atom materialization in parser walkers

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1371,7 +1371,8 @@ impl<'parser> JavascriptParser<'parser> {
   where
     F: FnOnce(&mut Self, BindingIdentifier),
   {
-    let name = Atom::from(self.ast.ast.get_utf8(ident.name(self.ast.ast)));
+    let ast = self.ast.ast;
+    let name = ast.get_utf8(ident.name(ast));
     let drive = self.plugin_drive.clone();
     if !name
       .call_hooks_name(self, |parser, for_name| {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -115,7 +115,11 @@ pub(crate) fn member_property_to_atom(ast: &Ast<'_>, expr: Expr) -> Option<Atom>
 /// `obj["key"]` are exposed directly as `StringLiteral`, without an outer
 /// `PropertyKeyData::Expr` variant.
 pub(crate) fn member_property_key_to_atom(ast: &Ast<'_>, key: PropertyKey) -> Option<Atom> {
-  match ast.property_key_data(key) {
+  member_property_key_data_to_atom(ast, ast.property_key_data(key))
+}
+
+fn member_property_key_data_to_atom(ast: &Ast<'_>, key: PropertyKeyData) -> Option<Atom> {
+  match key {
     PropertyKeyData::StringLiteral(node) => Some(atom_from_wtf8(ast.get_wtf8(node.value(ast)))),
     PropertyKeyData::NumericLiteral(node) => Some(Atom::from(
       rspack_util::ryu_js::Buffer::new().format(node.value(ast)),
@@ -125,6 +129,27 @@ pub(crate) fn member_property_key_to_atom(ast: &Ast<'_>, key: PropertyKey) -> Op
     )),
     PropertyKeyData::Expr(expr) => member_property_to_atom(ast, expr),
     PropertyKeyData::IdentifierName(_) | PropertyKeyData::PrivateIdentifier(_) => None,
+  }
+}
+
+fn member_property_key_data_can_be_atom(ast: &Ast<'_>, key: PropertyKeyData) -> bool {
+  match key {
+    PropertyKeyData::StringLiteral(_)
+    | PropertyKeyData::NumericLiteral(_)
+    | PropertyKeyData::BigIntLiteral(_) => true,
+    PropertyKeyData::Expr(expr) => match ast.expr_data(expr) {
+      ExprData::StringLiteral(_)
+      | ExprData::BooleanLiteral(_)
+      | ExprData::NullLiteral(_)
+      | ExprData::NumericLiteral(_)
+      | ExprData::BigIntLiteral(_)
+      | ExprData::RegExpLiteral(_) => true,
+      ExprData::TemplateLiteral(template) => {
+        template.expressions(ast).is_empty() && template.quasis(ast).len() == 1
+      }
+      _ => false,
+    },
+    PropertyKeyData::IdentifierName(_) | PropertyKeyData::PrivateIdentifier(_) => false,
   }
 }
 
@@ -161,6 +186,26 @@ where
 pub type AtomMembers = SmallVec<[Atom; 2]>;
 pub type OptionalMembers = SmallVec<[bool; 2]>;
 pub type MemberRanges = SmallVec<[Span; 2]>;
+type RawAtomMembers = SmallVec<[PropertyKeyData; 2]>;
+
+struct RawExtractedMemberExpressionChainData {
+  object: ExprRef,
+  members: RawAtomMembers,
+  members_optionals: OptionalMembers,
+  member_ranges: MemberRanges,
+}
+
+fn materialize_member_atoms(ast: &Ast<'_>, members: RawAtomMembers) -> AtomMembers {
+  let mut atoms = AtomMembers::with_capacity(members.len());
+  for property in members {
+    atoms.push(match property {
+      PropertyKeyData::IdentifierName(identifier) => Atom::from(ast.get_utf8(identifier.name(ast))),
+      property => member_property_key_data_to_atom(ast, property)
+        .expect("validated computed member property should convert to an atom"),
+    });
+  }
+  atoms
+}
 
 #[derive(Debug)]
 pub struct ExtractedMemberExpressionChainData {
@@ -1139,7 +1184,7 @@ impl<'parser> JavascriptParser<'parser> {
   fn _get_member_expression_info(
     &mut self,
     object: ExprRef,
-    mut members: AtomMembers,
+    members: RawAtomMembers,
     mut members_optionals: OptionalMembers,
     mut member_ranges: MemberRanges,
     allowed_types: AllowedMemberTypes,
@@ -1151,17 +1196,19 @@ impl<'parser> JavascriptParser<'parser> {
           return None;
         }
         let callee = expr.callee(ast);
-        let (root_name, mut root_members) = if let Some(member) = callee.as_member_expression(ast) {
-          let extracted = self.extract_member_expression_chain(ExprRef::Member(member));
+        let (root_name, root_members) = if let Some(member) = callee.as_member_expression(ast) {
+          let extracted = self.extract_member_expression_chain_raw(ExprRef::Member(member));
           let root_name = extracted.object.get_root_name(ast)?;
           (root_name, extracted.members)
         } else {
-          (callee.get_root_name(ast)?, AtomMembers::new())
+          (callee.get_root_name(ast)?, RawAtomMembers::new())
         };
         let NameInfo {
           info: root_info, ..
         } = self.get_name_info_from_variable(&root_name)?;
 
+        let mut root_members = materialize_member_atoms(ast, root_members);
+        let mut members = materialize_member_atoms(ast, members);
         root_members.reverse();
         members.reverse();
         members_optionals.reverse();
@@ -1190,6 +1237,7 @@ impl<'parser> JavascriptParser<'parser> {
           info: root_info,
         } = self.get_name_info_from_variable(&root_name)?;
 
+        let mut members = materialize_member_atoms(ast, members);
         let name = object_and_members_to_name(resolved_root, &members);
         members.reverse();
         members_optionals.reverse();
@@ -1222,7 +1270,7 @@ impl<'parser> JavascriptParser<'parser> {
       }
       _ => self._get_member_expression_info(
         expr_ref,
-        AtomMembers::new(),
+        RawAtomMembers::new(),
         OptionalMembers::new(),
         MemberRanges::new(),
         allowed_types,
@@ -1235,12 +1283,12 @@ impl<'parser> JavascriptParser<'parser> {
     expr: ExprRef,
     allowed_types: AllowedMemberTypes,
   ) -> Option<MemberExpressionInfo> {
-    let ExtractedMemberExpressionChainData {
+    let RawExtractedMemberExpressionChainData {
       object,
       members,
       members_optionals,
       member_ranges,
-    } = self.extract_member_expression_chain(expr);
+    } = self.extract_member_expression_chain_raw(expr);
     self._get_member_expression_info(
       object,
       members,
@@ -1254,9 +1302,27 @@ impl<'parser> JavascriptParser<'parser> {
     &self,
     expr: ExprRef,
   ) -> ExtractedMemberExpressionChainData {
+    let RawExtractedMemberExpressionChainData {
+      object,
+      members,
+      members_optionals,
+      member_ranges,
+    } = self.extract_member_expression_chain_raw(expr);
+    ExtractedMemberExpressionChainData {
+      object,
+      members: materialize_member_atoms(self.ast.ast, members),
+      members_optionals,
+      member_ranges,
+    }
+  }
+
+  fn extract_member_expression_chain_raw(
+    &self,
+    expr: ExprRef,
+  ) -> RawExtractedMemberExpressionChainData {
     let ast = self.ast.ast;
     let mut object = expr;
-    let mut members = AtomMembers::new();
+    let mut members = RawAtomMembers::new();
     let mut members_optionals = OptionalMembers::new();
     let mut member_ranges = MemberRanges::new();
     let mut in_optional_chain = self.member_expr_in_optional_chain;
@@ -1264,22 +1330,21 @@ impl<'parser> JavascriptParser<'parser> {
       match object {
         ExprRef::Member(expr) => {
           let property = expr.property(ast);
+          let property_data = ast.property_key_data(property);
+          let member_object = expr.object(ast);
           if expr.computed(ast) {
-            let Some(value) = member_property_key_to_atom(ast, property) else {
+            if !member_property_key_data_can_be_atom(ast, property_data) {
               break;
-            };
-            // Since members are not used across rspack javascript parser plugin,
-            // we directly makes it atom here
-            members.push(value);
-            member_ranges.push(expr.object(ast).span(ast));
-          } else if let PropertyKeyData::IdentifierName(ident) = ast.property_key_data(property) {
-            members.push(Atom::from(ast.get_utf8(ident.name(ast))));
-            member_ranges.push(expr.object(ast).span(ast));
+            }
+            members.push(property_data);
+          } else if matches!(property_data, PropertyKeyData::IdentifierName(_)) {
+            members.push(property_data);
           } else {
             break;
           }
+          member_ranges.push(member_object.span(ast));
           members_optionals.push(in_optional_chain || expr.optional(ast));
-          object = ExprRef::from_expr(ast, expr.object(ast));
+          object = ExprRef::from_expr(ast, member_object);
           in_optional_chain = false;
         }
         ExprRef::OptChain(expr) => {
@@ -1294,7 +1359,7 @@ impl<'parser> JavascriptParser<'parser> {
         _ => break,
       }
     }
-    ExtractedMemberExpressionChainData {
+    RawExtractedMemberExpressionChainData {
       object,
       members,
       members_optionals,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -517,7 +517,7 @@ impl JavascriptParser<'_> {
         if let SimpleAssignmentTargetData::IdentifierReference(identifier) =
           ast.simple_assignment_target_data(target)
         {
-          self.clear_create_require_tag(&Atom::from(ast.get_utf8(identifier.name(ast))));
+          self.clear_create_require_tag(ast.get_utf8(identifier.name(ast)));
         }
       }
       AssignmentTargetData::ArrayAssignmentTarget(array) => {
@@ -549,8 +549,8 @@ impl JavascriptParser<'_> {
           .unwrap_or_default()
       {
         self.copy_create_require_assignment_result(
-          &Atom::from(ast.get_utf8(binding.name(ast))),
-          &Atom::from(ast.get_utf8(target.name(ast))),
+          ast.get_utf8(binding.name(ast)),
+          ast.get_utf8(target.name(ast)),
         );
         continue;
       }
@@ -661,12 +661,12 @@ impl JavascriptParser<'_> {
     }
     let updated_ident = argument
       .as_identifier_reference(ast)
-      .map(|ident| Atom::from(ast.get_utf8(ident.name(ast))));
-    if let Some(name) = &updated_ident {
+      .map(|ident| ast.get_utf8(ident.name(ast)));
+    if let Some(name) = updated_ident {
       self.clear_create_require_tag(name);
     }
     self.walk_simple_assign_target(argument);
-    if let Some(name) = &updated_ident {
+    if let Some(name) = updated_ident {
       self.clear_create_require_tag(name);
     }
   }
@@ -738,13 +738,13 @@ impl JavascriptParser<'_> {
     let ast = self.ast.ast;
     match ast.binding_pattern_data(pattern) {
       BindingPatternData::BindingIdentifier(identifier) => {
-        self.clear_create_require_tag(&Atom::from(ast.get_utf8(identifier.name(ast))))
+        self.clear_create_require_tag(ast.get_utf8(identifier.name(ast)))
       }
       BindingPatternData::SimpleAssignmentTarget(target) => {
         if let SimpleAssignmentTargetData::IdentifierReference(identifier) =
           ast.simple_assignment_target_data(target)
         {
-          self.clear_create_require_tag(&Atom::from(ast.get_utf8(identifier.name(ast))));
+          self.clear_create_require_tag(ast.get_utf8(identifier.name(ast)));
         }
       }
       BindingPatternData::AssignmentPattern(pattern) => {
@@ -780,11 +780,11 @@ impl JavascriptParser<'_> {
     ident: IdentifierReference,
   ) -> Option<bool> {
     let ast = self.ast.ast;
-    let ident_name = Atom::from(ast.get_utf8(ident.name(ast)));
+    let ident_name = ast.get_utf8(ident.name(ast));
     if matches!(
       expr.operator(ast),
       AssignmentOperator::LogicalOrAssign | AssignmentOperator::NullishAssign
-    ) && self.has_create_require_tag(&ident_name, true)
+    ) && self.has_create_require_tag(ident_name, true)
     {
       return Some(true);
     }
@@ -793,14 +793,14 @@ impl JavascriptParser<'_> {
     }
     let right = expr.right(ast);
     if let Some(variable) = right.as_identifier_reference(ast).and_then(|rhs| {
-      let rhs_name = Atom::from(ast.get_utf8(rhs.name(ast)));
+      let rhs_name = ast.get_utf8(rhs.name(ast));
       self
-        .has_create_require_tag(&rhs_name, false)
-        .then(|| self.get_variable_info(&rhs_name).map(|info| info.id()))
+        .has_create_require_tag(rhs_name, false)
+        .then(|| self.get_variable_info(rhs_name).map(|info| info.id()))
         .flatten()
     }) {
       self.set_variable(
-        ident_name.clone(),
+        ident_name.into(),
         ExportedVariableInfo::VariableInfo(variable),
       );
       return Some(true);
@@ -811,7 +811,7 @@ impl JavascriptParser<'_> {
         .cloned()
     {
       self.tag_variable(
-        ident_name.clone(),
+        ident_name.into(),
         CREATED_REQUIRE_IDENTIFIER_TAG,
         Some(CreatedRequireTagData {
           side_effects: String::new(),
@@ -824,14 +824,17 @@ impl JavascriptParser<'_> {
       return Some(true);
     }
     if is_create_require_namespace_member(self, right) {
-      self.tag_variable_without_data(ident_name.clone(), CREATE_REQUIRE_SPECIFIER_TAG);
+      self.tag_variable_without_data(ident_name.into(), CREATE_REQUIRE_SPECIFIER_TAG);
       self.walk_expression(right);
       return Some(true);
     }
     if let Some(rename_identifier) = self.get_rename_identifier(right)
       && rename_identifier == CREATE_REQUIRE_EVALUATED_TAG
     {
-      self.set_variable(ident_name, ExportedVariableInfo::Name(rename_identifier));
+      self.set_variable(
+        ident_name.into(),
+        ExportedVariableInfo::Name(rename_identifier),
+      );
       self.walk_expression(right);
       return Some(true);
     }
@@ -1021,13 +1024,11 @@ impl JavascriptParser<'_> {
   fn walk_jsx_member_expr(&mut self, member: JsxMemberExpression) {
     let ast = self.ast.ast;
     let mut current = member;
-    let mut members = AtomMembers::new();
     let mut members_optionals = OptionalMembers::new();
     let mut member_ranges = MemberRanges::new();
     let mut member_nodes = SmallVec::<[JsxMemberExpression; 2]>::new();
     let root = loop {
       let object = current.object(ast);
-      members.push(Atom::from(ast.get_utf8(current.property(ast).name(ast))));
       members_optionals.push(false);
       member_ranges.push(object.span(ast));
       member_nodes.push(current);
@@ -1037,16 +1038,20 @@ impl JavascriptParser<'_> {
       }
     };
 
-    let root_name = Atom::from(ast.get_utf8(root.name(ast)));
-    let Some(name_info) = self.get_name_info_from_variable(&root_name) else {
+    let root_name = ast.get_utf8(root.name(ast));
+    let Some(name_info) = self.get_name_info_from_variable(root_name) else {
       self.walk_identifier_name(root_name, root.span(ast));
       return;
     };
     let resolved_root = name_info.name;
     let root_info = name_info.info.map_or_else(
-      || ExportedVariableInfo::Name(root_name.clone()),
+      || ExportedVariableInfo::Name(root_name.into()),
       |info| ExportedVariableInfo::VariableInfo(info.id()),
     );
+    let mut members: AtomMembers = member_nodes
+      .iter()
+      .map(|member| Atom::from(ast.get_utf8(member.property(ast).name(ast))))
+      .collect();
     let name = object_and_members_to_name(resolved_root, &members);
     members.reverse();
     members_optionals.reverse();
@@ -1122,7 +1127,7 @@ impl JavascriptParser<'_> {
     if name.as_bytes().first().is_some_and(u8::is_ascii_lowercase) {
       return;
     }
-    self.walk_identifier_name(Atom::from(name), identifier.span(ast));
+    self.walk_identifier_name(name, identifier.span(ast));
   }
 
   fn walk_object_expression(&mut self, expr: ObjectExpression) {
@@ -1428,14 +1433,10 @@ impl JavascriptParser<'_> {
     }
   }
 
-  fn property_key_name(ast: &Ast<'_>, key: PropertyKey) -> Option<Atom> {
+  fn property_key_name<'a>(ast: &'a Ast<'_>, key: PropertyKey) -> Option<&'a str> {
     match ast.property_key_data(key) {
-      PropertyKeyData::IdentifierName(identifier) => {
-        Some(Atom::from(ast.get_utf8(identifier.name(ast))))
-      }
-      PropertyKeyData::StringLiteral(literal) => Some(Atom::from(
-        ast.get_wtf8(literal.value(ast)).to_string_lossy().as_ref(),
-      )),
+      PropertyKeyData::IdentifierName(identifier) => Some(ast.get_utf8(identifier.name(ast))),
+      PropertyKeyData::StringLiteral(literal) => ast.get_wtf8(literal.value(ast)).as_str(),
       _ => None,
     }
   }
@@ -1670,7 +1671,7 @@ impl JavascriptParser<'_> {
       }
       // import(...).then(...)
       if let Some(import) = member.object(ast).as_import_expression(ast)
-        && Self::property_key_name(ast, member.property(ast)).as_deref() == Some("then")
+        && Self::property_key_name(ast, member.property(ast)) == Some("then")
         && self
           .plugin_drive
           .clone()
@@ -1830,13 +1831,10 @@ impl JavascriptParser<'_> {
 
   fn walk_identifier(&mut self, identifier: IdentifierReference) {
     let ast = self.ast.ast;
-    self.walk_identifier_name(
-      Atom::from(ast.get_utf8(identifier.name(ast))),
-      identifier.span(ast),
-    );
+    self.walk_identifier_name(ast.get_utf8(identifier.name(ast)), identifier.span(ast));
   }
 
-  fn walk_identifier_name(&mut self, name: Atom, span: Span) {
+  fn walk_identifier_name(&mut self, name: &str, span: Span) {
     let drive = self.plugin_drive.clone();
     name.call_hooks_name(self, |this, for_name| {
       drive.identifier(this, &Identifier { span }, for_name)
@@ -1882,18 +1880,18 @@ impl JavascriptParser<'_> {
         return;
       }
       if !self.javascript_options.is_create_require_enabled()
-        || !right.as_identifier_reference(ast).is_some_and(|rhs| {
-          self.has_create_require_tag(&Atom::from(ast.get_utf8(rhs.name(ast))), false)
-        })
+        || !right
+          .as_identifier_reference(ast)
+          .is_some_and(|rhs| self.has_create_require_tag(ast.get_utf8(rhs.name(ast)), false))
       {
         self.walk_expression(right);
       }
-      let name = Atom::from(ast.get_utf8(ident.name(ast)));
+      let name = ast.get_utf8(ident.name(ast));
       if self.javascript_options.is_create_require_enabled() {
         // The assignment target already gives us the canonical identifier
         // name. Clear any createRequire-derived tag here instead of trying to
         // reconstruct the name from a hook-facing span.
-        self.clear_create_require_tag(&name);
+        self.clear_create_require_tag(name);
       }
       if !name
         .call_hooks_name(self, |this, for_name| {
@@ -1908,7 +1906,7 @@ impl JavascriptParser<'_> {
         })
         .unwrap_or_default()
       {
-        self.walk_identifier(ident);
+        self.walk_identifier_name(name, ident.span(ast));
       }
     } else if let Some(array) = left.as_array_assignment_target(ast) {
       self.walk_expression(right);
@@ -1917,7 +1915,7 @@ impl JavascriptParser<'_> {
       }
       self.enter_array_pattern(array, |this, ident| {
         let ast = this.ast.ast;
-        let name = Atom::from(ast.get_utf8(ident.name(ast)));
+        let name = ast.get_utf8(ident.name(ast));
         if !name
           .call_hooks_name(this, |this, for_name| {
             drive.assign(
@@ -1931,7 +1929,7 @@ impl JavascriptParser<'_> {
           })
           .unwrap_or_default()
         {
-          this.define_variable(name);
+          this.define_variable(name.into());
         }
       });
       self.walk_array_pattern(array);
@@ -1942,7 +1940,7 @@ impl JavascriptParser<'_> {
       }
       self.enter_object_pattern(object, |this, ident| {
         let ast = this.ast.ast;
-        let name = Atom::from(ast.get_utf8(ident.name(ast)));
+        let name = ast.get_utf8(ident.name(ast));
         if !name
           .call_hooks_name(this, |this, for_name| {
             drive.assign(
@@ -1956,7 +1954,7 @@ impl JavascriptParser<'_> {
           })
           .unwrap_or_default()
         {
-          this.define_variable(name);
+          this.define_variable(name.into());
         }
       });
       self.walk_object_pattern(object);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -22,8 +22,7 @@ use crate::{
   },
   visitors::{
     AtomMembers, ExportedVariableInfo, ExprRef, Identifier, VariableDeclaration, VariableInfo,
-    VariableInfoFlags, dependency::parser::ExtractedMemberExpressionChainData,
-    get_non_optional_part,
+    VariableInfoFlags, get_non_optional_part,
   },
 };
 
@@ -1760,16 +1759,17 @@ impl JavascriptParser<'_> {
     expr: MemberExpression,
   ) -> Option<(ImportExpression, AtomMembers, AwaitExpression)> {
     let ast = self.ast.ast;
-    let ExtractedMemberExpressionChainData {
+    let super::RawExtractedMemberExpressionChainData {
       object,
-      mut members,
+      members,
       mut members_optionals,
       ..
-    } = self.extract_member_expression_chain(ExprRef::Member(expr));
+    } = self.extract_member_expression_chain_raw(ExprRef::Member(expr));
     let ExprRef::Await(await_expr) = object else {
       return None;
     };
     let call = await_expr.argument(ast).as_import_expression(ast)?;
+    let mut members = super::materialize_member_atoms(ast, members);
     members.reverse();
     members_optionals.reverse();
     let members = get_non_optional_part(&members, &members_optionals);

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk_module_pre.rs
@@ -5,7 +5,7 @@ use swc_next_ecma_ast::{
 };
 
 use crate::{
-  JavascriptParserPlugin,
+  JS_DEFAULT_KEYWORD, JavascriptParserPlugin,
   visitors::{
     ExportAllDeclaration, ExportImport, ExportNamedDeclaration, JavascriptParser,
     module_export_name_to_atom,
@@ -38,11 +38,14 @@ impl JavascriptParser<'_> {
     let drive = self.plugin_drive.clone();
     let source = ast
       .get_wtf8(declaration.source(ast).value(ast))
-      .to_string_lossy()
-      .into_owned();
+      .to_string_lossy();
     drive.import(self, declaration, &source);
-    let source_atom = Atom::from(source);
-    for specifier in ast.nodes(declaration.specifiers(ast)) {
+    let specifiers = declaration.specifiers(ast);
+    if specifiers.is_empty() {
+      return;
+    }
+    let source_atom = Atom::from(source.as_ref());
+    for specifier in ast.nodes(specifiers) {
       match ast.import_declaration_specifier_data(specifier) {
         ImportDeclarationSpecifierData::ImportSpecifier(named) => {
           let local = named.local(ast);
@@ -68,7 +71,7 @@ impl JavascriptParser<'_> {
               self,
               declaration,
               &source_atom,
-              Some(&"default".into()),
+              Some(&JS_DEFAULT_KEYWORD),
               &identifier_name,
             )
             .unwrap_or_default()


### PR DESCRIPTION
## Summary

Reduce unnecessary atom materialization in the SWC Next JavaScript parser walkers by borrowing AST strings and deferring owned-name construction until it is needed.

- **Defer member-chain atoms.** Keep typed property handles while extracting and classifying a chain. Convert them to atoms only after the root is accepted, including the `(await import(...)).member` path. Defer JSX member-name conversion until the root check succeeds as well.
- **Borrow names for transient operations.** Use `&str` for ordinary and JSX identifier hooks, pattern and assignment hooks, createRequire tag queries, and `call` / `bind` / `then` property-name comparisons.
- **Avoid unnecessary import-source ownership.** Keep the source borrowed when possible, skip source-atom construction for side-effect-only imports, and reuse the existing default-export keyword atom.

Names stored in scope bindings, tags, import/export records, and accepted member chains remain owned atoms. Member ordering, optional-chain handling, hook behavior, and parser output are intended to remain unchanged. No test logic or snapshots are modified.

This is the fourth Step 3 optimization layer, following #15514, targeting `release/2.3.0`.

## Validation

- `pnpm run build:binding:dev`
- `cargo clippy -p rspack_plugin_javascript --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo test -p rspack_plugin_javascript --lib`: 48 passed
- `pnpm run test:unit`: 9,221 passed, 4 skipped

## Related links

- #15514

## Checklist

- [x] Tests updated (not required; behavior is unchanged and existing tests pass).
- [x] Documentation updated (not required; internal performance change).
