### PR TITLE
refactor: remove redundant clones in core

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -20,7 +20,7 @@ use crate::{
   find_graph_roots, merge_runtime,
 };
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ChunkSizeOptions {
   // constant overhead for a chunk
   pub chunk_overhead: Option<f64>,

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -41,7 +41,7 @@ type BlockConnectionMap = DependenciesBlockIdentifierMap<Arc<BlockModules>>;
 
 static EMPTY_BLOCK_MODULES: LazyLock<Arc<BlockModules>> = LazyLock::new(|| Arc::new(Vec::new()));
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PreparedBlockConnection {
   block: DependenciesBlockIdentifier,
   module: ModuleIdentifier,
@@ -157,7 +157,7 @@ fn prepare_module_connection_map(
   ))
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ChunkGroupInfo {
   pub initialized: bool,
   pub ukey: CgiUkey,
@@ -2599,7 +2599,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) enum QueueAction {
   AddAndEnterEntryModule(AddAndEnterEntryModule),
   AddAndEnterModule(AddAndEnterModule),
@@ -2609,28 +2609,28 @@ pub(crate) enum QueueAction {
   LeaveModule(LeaveModule),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct AddAndEnterEntryModule {
   module: ModuleIdentifier,
   chunk_group_info: CgiUkey,
   chunk: ChunkUkey,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct AddAndEnterModule {
   module: ModuleIdentifier,
   chunk_group_info: CgiUkey,
   chunk: ChunkUkey,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct EnterModule {
   module: ModuleIdentifier,
   chunk_group_info: CgiUkey,
   chunk: ChunkUkey,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Hash, PartialEq, Eq)]
 pub(crate) struct ProcessBlock {
   pub(crate) module: ModuleIdentifier,
   pub(crate) block: DependenciesBlockIdentifier,
@@ -2638,7 +2638,7 @@ pub(crate) struct ProcessBlock {
   pub(crate) chunk: ChunkUkey,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ProcessEntryBlock {
   module: ModuleIdentifier,
   block: AsyncDependenciesBlockIdentifier,
@@ -2684,7 +2684,7 @@ impl From<AsyncDependenciesBlockIdentifier> for DependenciesBlockIdentifier {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct LeaveModule {
   module: ModuleIdentifier,
   chunk_group_info: CgiUkey,

--- a/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/incremental.rs
@@ -340,7 +340,7 @@ impl CodeSplitter {
           .build_chunk_graph_artifact
           .chunk_by_ukey
           .expect_get(chunk_ukey);
-        chunk_groups.extend(chunk.groups().clone());
+        chunk_groups.extend(chunk.groups().iter().copied());
       }
     }
     for group in chunk_groups {
@@ -348,11 +348,11 @@ impl CodeSplitter {
         .chunk_group_info_map
         .get(&group)
         .expect("should have chunk group");
-      let Some(blocks) = self.incoming_blocks_by_cgi.get(cgi).cloned() else {
+      let Some(blocks) = self.incoming_blocks_by_cgi.get(cgi) else {
         continue;
       };
 
-      for block in blocks {
+      for &block in blocks {
         if let DependenciesBlockIdentifier::AsyncDependenciesBlock(async_block) = block {
           removed.insert(async_block);
         }

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -69,7 +69,7 @@ impl Compiler {
       removed_files.extend(deleted_files.iter().map(|files| Path::new(files).into()));
 
       let mut all_files = modified_files.clone();
-      all_files.extend(removed_files.clone());
+      all_files.extend(removed_files.iter().cloned());
 
       self.plugin_driver.clear_cache(self.compilation.id());
       let compilation_logging = self.compilation.get_logging().clone();

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -875,10 +875,12 @@ impl Module for ConcatenatedModule {
       }
 
       // populate assets
-      self
-        .build_info
-        .assets
-        .extend(module_build_info.assets.as_ref().clone());
+      self.build_info.assets.extend(
+        module_build_info
+          .assets
+          .iter()
+          .map(|(name, asset)| (name.clone(), asset.clone())),
+      );
     }
     // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
     Ok(BuildResult {

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -183,7 +183,7 @@ impl RuntimeRequirementsDependency {
 }
 
 #[cacheable]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct CodeGenerationRuntimeRequirementsWrite {
   pub runtime_requirements: RuntimeGlobals,
 }

--- a/crates/rspack_core/src/module_factory.rs
+++ b/crates/rspack_core/src/module_factory.rs
@@ -8,7 +8,7 @@ use crate::{
   ModuleLayer, Resolve, ResolverFactory,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ModuleFactoryCreateData {
   pub compiler_id: CompilerId,
   pub compilation_id: CompilationId,

--- a/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/overlay_map.rs
@@ -31,7 +31,7 @@ where
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum OverlayIter<'a, K, V, S = FxBuildHasher> {
   Base(HashMapIter<'a, K, V>),
   Combined {

--- a/crates/rspack_core/src/options/module.rs
+++ b/crates/rspack_core/src/options/module.rs
@@ -462,7 +462,12 @@ impl ImportMetaOptions {
 
 impl MergeFrom for ImportMetaOptions {
   fn merge_from(mut self, other: &Self) -> Self {
-    self.properties.extend(other.properties.clone());
+    self.properties.extend(
+      other
+        .properties
+        .iter()
+        .map(|(name, enabled)| (name.clone(), *enabled)),
+    );
     self.enabled_known_properties = Self::enabled_known_properties(&self.properties);
     self
   }

--- a/crates/rspack_core/src/utils/extract_source_map.rs
+++ b/crates/rspack_core/src/utils/extract_source_map.rs
@@ -24,7 +24,7 @@ pub struct ExtractSourceMapResult {
 }
 
 /// Source mapping URL information
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct SourceMappingURL {
   pub source_mapping_url: String,
   pub replacement_string: String,


### PR DESCRIPTION
## Summary

Avoid temporary collection copies in incremental cache collection, rebuild file tracking, asset merging, and ImportMeta option merging. Remove unused `Clone` derives from core helper types.