### PR TITLE
refactor: remove redundant clones and unused Clone derives

### DIFF
--- a/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
+++ b/crates/rspack_core/src/chunk_graph/chunk_graph_chunk.rs
@@ -894,8 +894,8 @@ impl ChunkGraph {
     let is_available_chunk = |a: &Chunk, b: &Chunk| {
       let mut queue = b
         .groups()
-        .clone()
-        .into_iter()
+        .iter()
+        .copied()
         .collect::<FxIndexSet<ChunkGroupUkey>>();
       let mut index: usize = 0;
       while index < queue.len() {

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -219,7 +219,7 @@ impl CompilationRecords {
           .chunk_by_ukey
           .get(&entry_ukey)
       })
-      .flat_map(|entry_chunk| entry_chunk.runtime().clone())
+      .flat_map(|entry_chunk| entry_chunk.runtime().iter().copied())
       .collect()
   }
 

--- a/crates/rspack_core/src/context_module_factory.rs
+++ b/crates/rspack_core/src/context_module_factory.rs
@@ -46,7 +46,6 @@ pub struct BeforeResolveData {
   pub pattern: ContextModulePattern,
 }
 
-#[derive(Clone)]
 pub enum AfterResolveResult {
   Ignored,
   Data(Box<AfterResolveData>),

--- a/crates/rspack_core/src/dependency/cached_const_dependency.rs
+++ b/crates/rspack_core/src/dependency/cached_const_dependency.rs
@@ -104,7 +104,7 @@ impl DependencyCodeGeneration for CachedConstDependency {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct CachedConstDependencyTemplate;
 
 impl CachedConstDependencyTemplate {

--- a/crates/rspack_core/src/dependency/const_dependency.rs
+++ b/crates/rspack_core/src/dependency/const_dependency.rs
@@ -46,7 +46,7 @@ impl DependencyCodeGeneration for ConstDependency {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct ConstDependencyTemplate;
 
 impl ConstDependencyTemplate {

--- a/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
+++ b/crates/rspack_core/src/dependency/runtime_requirements_dependency.rs
@@ -198,7 +198,7 @@ impl CodeGenerationRuntimeRequirementsWrite {
 }
 
 #[cacheable]
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub struct RuntimeRequirementsDependencyTemplate;
 
 impl RuntimeRequirementsDependencyTemplate {

--- a/crates/rspack_core/src/diagnostics.rs
+++ b/crates/rspack_core/src/diagnostics.rs
@@ -31,7 +31,7 @@ impl From<EmptyDependency> for Error {
 
 ///////////////////// Module /////////////////////
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ModuleBuildError {
   error: Error,
   from: Option<String>,

--- a/crates/rspack_core/src/exports/export_info.rs
+++ b/crates/rspack_core/src/exports/export_info.rs
@@ -86,14 +86,13 @@ impl ExportInfoData {
           Some(
             item
               .target
-              .clone()
-              .into_iter()
+              .iter()
               .map(|(k, v)| {
                 (
-                  k,
+                  *k,
                   ExportInfoTargetValue {
                     dependency: v.dependency,
-                    export: match v.export {
+                    export: match v.export.clone() {
                       Some(vec) => Some(vec),
                       None => Some(vec![
                         name

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -236,7 +236,7 @@ fn module_external_import_statement(
   import_statement
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 struct ModuleExternalRemapping {
   exposed_name: String,
   raw_export_name: String,

--- a/crates/rspack_core/src/glob_utils.rs
+++ b/crates/rspack_core/src/glob_utils.rs
@@ -8,7 +8,7 @@ use rspack_error::Result;
 use rspack_fs::ReadableFileSystem;
 use rspack_paths::{Utf8Path, Utf8PathBuf};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct GlobMatchOptions {
   pub case_sensitive: bool,
   pub require_literal_leading_dot: bool,

--- a/crates/rspack_core/src/init_fragment.rs
+++ b/crates/rspack_core/src/init_fragment.rs
@@ -787,7 +787,7 @@ impl ExternalModuleInitFragment {
     let key = InitFragmentKey::ExternalModule(format!(
       "external module imports|{}|{}",
       imported_module,
-      default_import.clone().unwrap_or_else(|| "null".to_string()),
+      default_import.as_deref().unwrap_or("null"),
     ));
     let top_level_decl_symbols =
       Self::collect_top_level_decl_symbols(&self_import_specifiers, default_import.as_deref());

--- a/crates/rspack_core/src/options/filename.rs
+++ b/crates/rspack_core/src/options/filename.rs
@@ -69,7 +69,7 @@ enum PlaceholderParameters {
   },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct PlaceholderData {
   kind: PlaceholderKind,
   parameters: PlaceholderParameters,
@@ -81,7 +81,7 @@ pub struct StringTemplatePlaceholder {
   parameters: PlaceholderParameters,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum FilenameRenderValue<'value> {
   Value(Cow<'value, str>),
   Rendered(Cow<'value, str>),
@@ -123,7 +123,7 @@ impl StringTemplatePlaceholder {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum StringTemplateSegment {
   Plain(Range<u16>),
   Placeholder {

--- a/crates/rspack_core/src/options/node.rs
+++ b/crates/rspack_core/src/options/node.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct NodeOption {
   pub dirname: NodeDirnameOption,
   pub global: NodeGlobalOption,

--- a/crates/rspack_core/src/options/resolve/clever_merge.rs
+++ b/crates/rspack_core/src/options/resolve/clever_merge.rs
@@ -469,7 +469,7 @@ fn _merge_resolve(first: Resolve, second: Resolve) -> Resolve {
 fn normalize_string_array(a: Vec<String>, b: Vec<String>) -> Vec<String> {
   b.into_iter().fold(vec![], |mut acc, item| {
     if item.eq("...") {
-      acc.append(&mut a.clone());
+      acc.extend(a.iter().cloned());
     } else {
       acc.push(item);
     }

--- a/crates/rspack_core/src/resolver/resolver_impl.rs
+++ b/crates/rspack_core/src/resolver/resolver_impl.rs
@@ -15,7 +15,7 @@ use crate::{
   Alias, AliasMap, DependencyCategory, Resolve, ResolveArgs, ResolveOptionsWithDependencyType,
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct ResolveDependencies {
   /// Files that were found on file system; entries carry the precomputed
   /// `FxHash` from `rspack_resolver`.

--- a/crates/rspack_core/src/stats/struct.rs
+++ b/crates/rspack_core/src/stats/struct.rs
@@ -273,7 +273,7 @@ pub struct StatsModuleIssuer<'s> {
   pub id: Option<ModuleId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct StatsModuleReason<'s> {
   pub module_identifier: Option<ModuleIdentifier>,
   pub module_name: Option<Cow<'s, str>>,

--- a/crates/rspack_core/src/utils/compile_boolean_matcher.rs
+++ b/crates/rspack_core/src/utils/compile_boolean_matcher.rs
@@ -295,19 +295,19 @@ where
 
   let mut result = Vec::new();
 
-  for list in map.values() {
-    if condition(list) {
-      for item in list {
+  for list in map.into_values() {
+    if condition(&list) {
+      for item in &list {
         items_set.remove(item);
       }
-      result.push(list.clone());
+      result.push(list);
     }
   }
 
   result
 }
 
-fn get_common_prefix<'a>(mut items: impl Iterator<Item = &'a str> + Clone) -> &'a str {
+fn get_common_prefix<'a>(mut items: impl Iterator<Item = &'a str>) -> &'a str {
   let mut prefix = if let Some(prefix) = items.next() {
     prefix
   } else {

--- a/crates/rspack_core/src/utils/runtime.rs
+++ b/crates/rspack_core/src/utils/runtime.rs
@@ -11,7 +11,7 @@ pub fn get_entry_runtime(
   if let Some(depend_on) = &options.depend_on {
     let mut result: RuntimeSpec = Default::default();
     let mut queue = vec![];
-    queue.extend(depend_on.clone());
+    queue.extend(depend_on.iter().cloned());
 
     let mut visited = HashSet::<String>::default();
 

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -410,7 +410,7 @@ pub(crate) async fn split(groups: &[CacheGroup], compilation: &mut Compilation) 
       );
     }
 
-    splitted_modules.extend(match_group.modules.clone());
+    splitted_modules.extend(match_group.modules);
   }
 
   Ok(())

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1529,7 +1529,7 @@ impl ModuleConcatenationPlugin {
         set_mid_tasks.push((*connection, new_module_id));
       }
       let mut all_outgoings = outgoings;
-      all_outgoings.extend(root_outgoings.clone());
+      all_outgoings.extend(root_outgoings.iter().copied());
       add_connection_tasks.push((new_module_id, all_outgoings, root_incomings.clone()));
       remove_connection_tasks.push((root_module_id, root_outgoings, root_incomings));
     }

--- a/crates/rspack_plugin_lazy_compilation/src/factory.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/factory.rs
@@ -31,14 +31,14 @@ impl ModuleFactory for LazyCompilationDependencyFactory {
 
     data
       .file_dependencies
-      .extend(options.file_dependencies.clone());
+      .extend(options.file_dependencies.iter().cloned());
     data
       .context_dependencies
-      .extend(options.context_dependencies.clone());
+      .extend(options.context_dependencies.iter().cloned());
     data
       .missing_dependencies
-      .extend(options.missing_dependencies.clone());
-    data.diagnostics.extend(options.diagnostics.clone());
+      .extend(options.missing_dependencies.iter().cloned());
+    data.diagnostics.extend(options.diagnostics.iter().cloned());
 
     self.normal_module_factory.create(data).await
   }


### PR DESCRIPTION
## Summary

Avoid unnecessary collection and string copies in core and related plugins. Remove unused `Clone` derives and an unused iterator bound.