### PR TITLE
chore(ci): run workflows on release/2.3.0

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     # Ignore md files in push to skip workflow when only documentation changes
     paths-ignore:
@@ -27,7 +28,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' && github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`

--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -103,5 +103,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_path: '../build-tools-performance/**/dist/rsdoctor-data.json'
-          target_branch: ${{ inputs.target_branch || 'main' }}
+          target_branch: ${{ github.event_name == 'push' && github.ref_name || github.event_name == 'pull_request' && github.base_ref || inputs.target_branch || 'main' }}
           ai_model: qwen3.5-plus

--- a/.github/workflows/ci-dylint.yaml
+++ b/.github/workflows/ci-dylint.yaml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths:
       - '.github/workflows/ci-dylint.yaml'

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     tags-ignore:
       - '**'

--- a/.github/workflows/ci-resolver.yml
+++ b/.github/workflows/ci-resolver.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
     paths:
       - 'crates/rspack_resolver/**'
       - '.github/workflows/ci-resolver.yml'
@@ -20,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths:
       - '.github/workflows/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths-ignore:
       - '**/*.md'
@@ -24,7 +25,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' && github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`
@@ -104,7 +105,7 @@ jobs:
   bench-rust-walltime:
     name: Rust Bench Walltime
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0'))) }}
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
## Summary

- Run the standard CI workflows automatically on pushes to release/2.3.0.
- Apply the same concurrency behavior as main.
- Run the walltime benchmark on release/2.3.0 pushes, matching main.

## Related links

N/A

## Checklist

- [x] Tests updated (not required; workflow configuration only).
- [x] Documentation updated (not required).