### PR TITLE
fix: preserve css-import external conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,6 +4876,7 @@ dependencies = [
  "rspack_core",
  "rspack_error",
  "rspack_hook",
+ "rspack_plugin_css",
  "rspack_plugin_javascript",
  "rspack_regex",
  "tracing",

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -14,13 +14,14 @@ use crate::{
   AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
   BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
   CodeGenerationDataChunkInitFragments, CodeGenerationDataUrl, CodeGenerationResultBuilder,
-  Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId, DependencyRef,
-  ExportProvided, ExternalType, FactoryMeta, ImportAttributes, ImportPhase, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
+  Compilation, ConcatenationScope, Context, CssLayer, CssModuleRenderCondition, DependenciesBlock,
+  DependencyId, DependencyRef, ExportProvided, ExternalType, FactoryMeta, ImportAttributes,
+  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module,
+  ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
   NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
-  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
+  css_module_render_conditions_identifier, extract_url_and_global, impl_module_meta_info,
+  module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -480,6 +481,7 @@ pub struct DependencyMeta {
   pub attributes: Option<ImportAttributes>,
   pub phase: ImportPhase,
   pub source_type: Option<SourceType>,
+  pub css_import_conditions: Option<CssModuleRenderCondition>,
 }
 
 impl ExternalModule {
@@ -510,7 +512,12 @@ impl ExternalModule {
         } else {
           format!(" phase={}", dependency_meta.phase.as_str())
         };
-        format!("external {resolved_type} {request_str}{attrs_str}{phase_str}")
+        let css_import_str =
+          css_module_render_conditions_identifier(dependency_meta.css_import_conditions.iter())
+            .map_or(String::new(), |conditions| {
+              format!(" css-import-conditions={}", json_stringify_str(&conditions))
+            });
+        format!("external {resolved_type} {request_str}{attrs_str}{phase_str}{css_import_str}")
       }),
       request,
       external_type,
@@ -1252,14 +1259,38 @@ impl Module for ExternalModule {
       }
       "css-import" if request.is_some() => {
         let request = request.expect("request should be some");
-        cgr.add(
-          SourceType::Css,
-          RawStringSource::from(format!(
-            "@import url({});",
-            rspack_util::json_stringify_str(request.primary())
-          ))
-          .boxed(),
+        let mut source = format!(
+          "@import url({})",
+          rspack_util::json_stringify_str(request.primary())
         );
+        if let Some(conditions) = &self.dependency_meta.css_import_conditions {
+          if let Some(layer) = &conditions.layer {
+            source.push_str(" layer(");
+            if let CssLayer::Named(layer) = layer {
+              source.push_str(layer);
+            }
+            source.push(')');
+          }
+          if let Some(supports) = conditions
+            .supports
+            .as_deref()
+            .filter(|value| !value.is_empty())
+          {
+            source.push_str(" supports(");
+            source.push_str(supports);
+            source.push(')');
+          }
+          if let Some(media) = conditions
+            .media
+            .as_deref()
+            .filter(|value| !value.is_empty())
+          {
+            source.push(' ');
+            source.push_str(media);
+          }
+        }
+        source.push(';');
+        cgr.add(SourceType::Css, RawStringSource::from(source).boxed());
       }
       _ => {
         let (source, chunk_init_fragments) = self.get_source(

--- a/crates/rspack_plugin_css/src/dependency/import.rs
+++ b/crates/rspack_plugin_css/src/dependency/import.rs
@@ -52,6 +52,10 @@ impl CssImportDependency {
     iter_css_module_render_conditions(&self.inherited_render_conditions, &self.render_condition)
   }
 
+  pub fn render_condition(&self) -> &CssModuleRenderCondition {
+    &self.render_condition
+  }
+
   pub fn export_type(&self) -> Option<CssExportType> {
     self.export_type
   }

--- a/crates/rspack_plugin_externals/Cargo.toml
+++ b/crates/rspack_plugin_externals/Cargo.toml
@@ -12,6 +12,7 @@ regex                    = { workspace = true }
 rspack_core              = { workspace = true }
 rspack_error             = { workspace = true }
 rspack_hook              = { workspace = true }
+rspack_plugin_css        = { workspace = true }
 rspack_plugin_javascript = { workspace = true }
 rspack_regex             = { workspace = true }
 tracing                  = { workspace = true }

--- a/crates/rspack_plugin_externals/src/plugin.rs
+++ b/crates/rspack_plugin_externals/src/plugin.rs
@@ -12,6 +12,7 @@ use rspack_core::{
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
+use rspack_plugin_css::dependency::CssImportDependency;
 use rspack_plugin_javascript::dependency::{ESMImportSideEffectDependency, ImportDependency};
 
 static UNSPECIFIED_EXTERNAL_TYPE_REGEXP: LazyLock<Regex> =
@@ -145,6 +146,10 @@ impl ExternalsPlugin {
         }
       },
       source_type: None,
+      css_import_conditions: dependency
+        .as_any()
+        .downcast_ref::<CssImportDependency>()
+        .map(|dependency| dependency.render_condition().clone()),
     };
 
     let external_module_type = r#type.unwrap_or(external_module_type);

--- a/tests/rspack-test/configCases/css/import/__snapshot__/bundle0.css.txt
+++ b/tests/rspack-test/configCases/css/import/__snapshot__/bundle0.css.txt
@@ -1,26 +1,31 @@
 Array [
   @import url("https://test.cases/path/../../../../configCases/css/import/external.css");
+@import url("https://test.cases/path/../../../../configCases/css/import/external.css") screen and (orientation:landscape);
 @import url("//example.com/style.css");
 @import url("https://fonts.googleapis.com/css?family=Roboto");
 @import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC");
 @import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto");
-@import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto?foo=1");
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto?foo=1") layer(super.foo) supports(display: flex) screen and (min-width: 400px);
 @import url("https://test.cases/path/../../../../configCases/css/import/external1.css");
 @import url("https://test.cases/path/../../../../configCases/css/import/external2.css");
 @import url("external-1.css");
-@import url("external-2.css");
-@import url("external-3.css");
-@import url("external-4.css");
-@import url("external-5.css");
-@import url("external-6.css");
-@import url("external-7.css");
-@import url("external-8.css");
-@import url("external-9.css");
-@import url("external-10.css");
-@import url("external-11.css");
-@import url("external-12.css");
-@import url("external-13.css");
-@import url("external-14.css");
+@import url("external-2.css") supports(display: grid) screen and (max-width: 400px);
+@import url("external-3.css") supports(not (display: grid) and (display: flex)) screen and (max-width: 400px);
+@import url("external-4.css") supports((selector(h2 > p)) and
+    (font-tech(color-COLRv1)));
+@import url("external-5.css") layer(default);
+@import url("external-6.css") layer(default);
+@import url("external-7.css") layer();
+@import url("external-8.css") layer();
+@import url("external-9.css") print;
+@import url("external-10.css") print, screen;
+@import url("external-11.css") screen;
+@import url("external-12.css") screen and (orientation: landscape);
+@import url("external-13.css") supports(not (display: flex));
+@import url("external-14.css") layer(default) supports(display: grid) screen and (max-width: 400px);
+@import url("external-1.css") layer(theme);
+@import url("external-1.css") supports(display: grid);
+@import url("external-1.css") print;
 p {
 	color: steelblue;
 }
@@ -1543,6 +1548,9 @@ a {
 @import supports(background: url("./img.png")) screen and (min-width: 400px);
 @import layer(test) supports(background: url("./img.png")) screen and (min-width: 400px);
 @import screen and (min-width: 400px);
+
+
+
 
 
 
@@ -1574,27 +1582,32 @@ body {
 	background: red;
 },
   @import url("https://test.cases/path/../../../../configCases/css/import/external.css");
+@import url("https://test.cases/path/../../../../configCases/css/import/external.css") screen and (orientation:landscape);
 @import url("//example.com/style.css");
 @import url("https://fonts.googleapis.com/css?family=Roboto");
 @import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC");
 @import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto");
-@import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto?foo=1");
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans+TC|Roboto?foo=1") layer(super.foo) supports(display: flex) screen and (min-width: 400px);
 @import url("https://test.cases/path/../../../../configCases/css/import/external1.css");
 @import url("https://test.cases/path/../../../../configCases/css/import/external2.css");
 @import url("external-1.css");
-@import url("external-2.css");
-@import url("external-3.css");
-@import url("external-4.css");
-@import url("external-5.css");
-@import url("external-6.css");
-@import url("external-7.css");
-@import url("external-8.css");
-@import url("external-9.css");
-@import url("external-10.css");
-@import url("external-11.css");
-@import url("external-12.css");
-@import url("external-13.css");
-@import url("external-14.css");
+@import url("external-2.css") supports(display: grid) screen and (max-width: 400px);
+@import url("external-3.css") supports(not (display: grid) and (display: flex)) screen and (max-width: 400px);
+@import url("external-4.css") supports((selector(h2 > p)) and
+    (font-tech(color-COLRv1)));
+@import url("external-5.css") layer(default);
+@import url("external-6.css") layer(default);
+@import url("external-7.css") layer();
+@import url("external-8.css") layer();
+@import url("external-9.css") print;
+@import url("external-10.css") print, screen;
+@import url("external-11.css") screen;
+@import url("external-12.css") screen and (orientation: landscape);
+@import url("external-13.css") supports(not (display: flex));
+@import url("external-14.css") layer(default) supports(display: grid) screen and (max-width: 400px);
+@import url("external-1.css") layer(theme);
+@import url("external-1.css") supports(display: grid);
+@import url("external-1.css") print;
 p {
 	color: steelblue;
 }
@@ -3117,6 +3130,9 @@ a {
 @import supports(background: url("./img.png")) screen and (min-width: 400px);
 @import layer(test) supports(background: url("./img.png")) screen and (min-width: 400px);
 @import screen and (min-width: 400px);
+
+
+
 
 
 

--- a/tests/rspack-test/configCases/css/import/style.css
+++ b/tests/rspack-test/configCases/css/import/style.css
@@ -256,6 +256,9 @@ url(style6.css?foo=14)
 @import url("external-12.css") screen and (orientation: landscape);
 @import url("external-13.css") supports(not (display: flex));
 @import url("external-14.css") layer(default) supports(display: grid) screen and (max-width: 400px);
+@import url("external-1.css") layer(theme);
+@import url("external-1.css") supports(display: grid);
+@import url("external-1.css") print;
 
 @import url("ignore.css");
 @import url("list-of-media-queries.css");


### PR DESCRIPTION
## Summary

CSS imports resolved as `css-import` externals lose their `layer`, `supports`, and media conditions because ExternalModule only emits the URL. Pass the parsed CSS render condition to ExternalModule and reconstruct the import with the same condition syntax as webpack, including `layer()` for anonymous layers.

For example, with `'external.css': 'css-import external.css'`:

```css
/* Input and fixed output */
@import url("external.css") layer(theme) supports(display: grid) screen;

/* Previous output: the stylesheet was imported unconditionally */
@import url("external.css");
```

Include conditions in the external module identifier so imports of the same URL with different conditions remain distinct. Update the existing webpack-derived CSS import snapshots and add same-URL cases with different conditions.

Validation:

- `pnpm run build:binding:dev` passed.
- CSS config cases: 230 passed.
- Externals config cases: 120 passed.
- Rust formatting and `git diff --check` passed.

## Related links

- [webpack CSS import cases](https://github.com/webpack/webpack/blob/main/test/configCases/css/import/style.css)
- [webpack ExternalModule](https://github.com/webpack/webpack/blob/main/lib/ExternalModule.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_