### PR TITLE
fix(css): substitute value references in media queries and selectors

### DIFF
--- a/crates/css-module-lexer/src/dependencies.rs
+++ b/crates/css-module-lexer/src/dependencies.rs
@@ -1707,12 +1707,15 @@ impl<'s, W: HandleWarning<'s>> LexDependencies<'s, W> {
     keep_comments: bool,
     has_mode: bool,
   ) {
+    let mut square_depth = self.selector_square_depth;
     let invalidates_composes = stream.fast_forward_selector_if_buffer_empty(
-      &mut self.selector_square_depth,
+      &mut square_depth,
       keep_comments,
       has_mode,
+      |ident| self.contains_icss_symbol(ident),
       is_css_modules_pure_magic_comment,
     );
+    self.selector_square_depth = square_depth;
     if invalidates_composes
       && self.block_nesting_level == 0
       && let Some(mode_data) = &mut self.mode_data
@@ -3656,9 +3659,35 @@ impl<'s, W: HandleWarning<'s>> LexDependencies<'s, W> {
     end: Pos,
     flags: TokenFlags,
   ) -> Option<()> {
+    let ident = stream.slice_trusted(start, end);
+    // ICSS references can also occur in selectors and at-rule preludes,
+    // where the scope is not necessarily a declaration block.
+    if matches!(self.scope, Scope::TopLevel | Scope::InBlock)
+      && matches!(
+        self.scan_context,
+        ScanContext::Selector
+          | ScanContext::GenericValue
+          | ScanContext::SpecialValue(_)
+          | ScanContext::AtRule
+      )
+      && (self.scan_context != ScanContext::Selector || self.selector_square_depth == 0)
+      && self.contains_icss_symbol(ident)
+    {
+      self
+        .dependency_context
+        .push_dependency(Dependency::ICSSSymbol {
+          name: ident,
+          range: Range::new(start, end),
+        });
+      if matches!(self.scope, Scope::TopLevel)
+        && let Some(mode_data) = &mut self.mode_data
+      {
+        mode_data.composes_local_classes.invalidate();
+      }
+      return Some(());
+    }
     match self.scope {
       Scope::InBlock => {
-        let ident = stream.slice_trusted(start, end);
         let is_declaration_name = self.scan_context == ScanContext::DeclarationName;
         if is_declaration_name {
           let property_local_mode = self
@@ -3672,19 +3701,6 @@ impl<'s, W: HandleWarning<'s>> LexDependencies<'s, W> {
           if self.property_kind != PropertyKind::Composes {
             return Some(());
           }
-        }
-        let can_reference_icss = matches!(
-          self.scan_context,
-          ScanContext::GenericValue | ScanContext::SpecialValue(_) | ScanContext::AtRule
-        );
-        if can_reference_icss && !self.icss_symbols.is_empty() && self.contains_icss_symbol(ident) {
-          self
-            .dependency_context
-            .push_dependency(Dependency::ICSSSymbol {
-              name: ident,
-              range: Range::new(start, end),
-            });
-          return Some(());
         }
         let Some(mode_data) = &mut self.mode_data else {
           return Some(());

--- a/crates/css-module-lexer/src/lexer.rs
+++ b/crates/css-module-lexer/src/lexer.rs
@@ -476,14 +476,16 @@ impl<'s, V: LexerVisitor> Lexer<'s, V> {
   /// Attribute selectors remain opaque across calls through `square_depth`;
   /// the scanner stops before dependency candidates and structural tokens so
   /// the normal token stream remains the sole owner of parser state changes.
-  pub(crate) fn fast_forward_selector<C>(
+  pub(crate) fn fast_forward_selector<F, C>(
     &mut self,
     square_depth: &mut u32,
     keep_comments: bool,
     has_mode: bool,
+    mut is_ident_candidate: F,
     mut is_comment_candidate: C,
   ) -> bool
   where
+    F: FnMut(&str) -> bool,
     C: FnMut(&str) -> bool,
   {
     let mut position = self.scan_pos as usize;
@@ -559,6 +561,9 @@ impl<'s, V: LexerVisitor> Lexer<'s, V> {
         let name = &self.value[position..end];
         // SAFETY: scanned names start and end on UTF-8 boundaries.
         let name = unsafe { str::from_utf8_unchecked(name) };
+        if is_ident_candidate(name) {
+          break;
+        }
         self
           .visitor
           .visit_ident(name, Range::new(position as Pos, end as Pos));
@@ -1870,14 +1875,16 @@ impl<'a, 's, V: LexerVisitor> TokenStream<'a, 's, V> {
   }
 
   #[inline]
-  pub(crate) fn fast_forward_selector_if_buffer_empty<C>(
+  pub(crate) fn fast_forward_selector_if_buffer_empty<F, C>(
     &mut self,
     square_depth: &mut u32,
     keep_comments: bool,
     has_mode: bool,
+    is_ident_candidate: F,
     is_comment_candidate: C,
   ) -> bool
   where
+    F: FnMut(&str) -> bool,
     C: FnMut(&str) -> bool,
   {
     if !self.buffered.is_empty() {
@@ -1919,10 +1926,13 @@ impl<'a, 's, V: LexerVisitor> TokenStream<'a, 's, V> {
         probe += 1;
       }
     }
-    let invalidates_composes =
-      self
-        .lexer
-        .fast_forward_selector(square_depth, keep_comments, has_mode, is_comment_candidate);
+    let invalidates_composes = self.lexer.fast_forward_selector(
+      square_depth,
+      keep_comments,
+      has_mode,
+      is_ident_candidate,
+      is_comment_candidate,
+    );
     self.consumed = self.lexer.scan_pos();
     invalidates_composes
   }

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/css-dev.0.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/css-dev.0.txt
@@ -4,7 +4,7 @@
 
 
 
-@media small {
+@media (max-width: 599px) {
 	abbr:hover {
 		color: limegreen;
 		transition-duration: Xs;
@@ -56,7 +56,7 @@
 }
 
 
-colorValue-v3 {
+.red {
 	color: .red;
 }
 

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/css-prod.1.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/css-prod.1.txt
@@ -4,7 +4,7 @@
 
 
 
-@media small {
+@media (max-width: 599px) {
 	abbr:hover {
 		color: limegreen;
 		transition-duration: Xs;
@@ -56,7 +56,7 @@
 }
 
 
-colorValue-v3 {
+.red {
 	color: .red;
 }
 

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/global-css-dev.4.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/global-css-dev.4.txt
@@ -4,7 +4,7 @@
 
 
 
-@media small {
+@media (max-width: 599px) {
 	abbr:hover {
 		color: limegreen;
 		transition-duration: Xs;
@@ -56,7 +56,7 @@
 }
 
 
-colorValue-v3 {
+.red {
 	color: .red;
 }
 

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/global-css-prod.5.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/global-css-prod.5.txt
@@ -4,7 +4,7 @@
 
 
 
-@media small {
+@media (max-width: 599px) {
 	abbr:hover {
 		color: limegreen;
 		transition-duration: Xs;
@@ -56,7 +56,7 @@
 }
 
 
-colorValue-v3 {
+.red {
 	color: .red;
 }
 

--- a/tests/rspack-test/configCases/css/css-modules/__snapshot__/options-css.6.txt
+++ b/tests/rspack-test/configCases/css/css-modules/__snapshot__/options-css.6.txt
@@ -4,7 +4,7 @@
 
 
 
-@media small {
+@media (max-width: 599px) {
 	abbr:hover {
 		color: limegreen;
 		transition-duration: Xs;
@@ -56,7 +56,7 @@
 }
 
 
-colorValue-v3 {
+.red {
 	color: .red;
 }
 

--- a/tests/rspack-test/configCases/css/icss-value-references/at-rule-value.module.css
+++ b/tests/rspack-test/configCases/css/icss-value-references/at-rule-value.module.css
@@ -1,0 +1,262 @@
+@value my-red blue;
+
+.value-in-class {
+	color: my-red;
+}
+
+@value v-comment-broken:;
+@value v-comment-broken-v1:/* comment */;
+
+@value small: (max-width: 599px);
+
+@media small {
+	abbr:hover {
+		color: limegreen;
+		transition-duration: 1s;
+	}
+}
+
+@value blue-v1: red;
+
+.foo { color: blue-v1; }
+
+@value blue-v3: red;
+
+.foo {
+	&.bar { color: blue-v3; }
+}
+
+@value blue-v3: red;
+
+.foo {
+	@media (min-width: 1024px) {
+		&.bar { color: blue-v3; }
+	}
+}
+
+@value blue-v4: red;
+
+.foo {
+	@media (min-width: 1024px) {
+		&.bar {
+			@media (min-width: 1024px) {
+				color: blue-v4;
+			}
+		}
+	}
+}
+
+@value test-t: 40px;
+@value test_q: 36px;
+
+.foo { height: test-t; height: test_q; }
+
+@value colorValue: red;
+
+.colorValue-cls {
+	color: colorValue;
+}
+
+@value colorValue-v1: red;
+
+#colorValue-v1-id {
+	color: colorValue-v1;
+}
+
+@value colorValue-v2: red;
+
+.colorValue-v2-cls > .colorValue-v2-cls {
+	color: colorValue-v2;
+}
+
+@value colorValue-v3: .red;
+
+colorValue-v3 {
+	color: colorValue-v3;
+}
+
+@value red-v2 from "./colors.module.css";
+
+.export {
+	color: red-v2;
+}
+
+@value blue-v1 as green from "./colors.module.css";
+
+.foo { color: green; }
+
+@value blue-i, green-v2 from "./colors.module.css";
+
+.foo { color: blue-i; }
+.bar { color: green-v2 }
+
+@value colors: "./colors.module.css";
+@value red-v4 from colors;
+
+.foo { color: red-v4; }
+
+@value aaa: red;
+@value bbb: aaa;
+
+.class-a { color: bbb; }
+
+@value base: 10px;
+@value large: calc(base * 2);
+
+.class-a { margin: large; }
+
+@value a from "./colors.module.css";
+@value b from "./colors.module.css";
+
+.class-a { content: a b; }
+
+@value --red from "./colors.module.css";
+
+.foo { color: --red; }
+
+@value named: red;
+@value _3char #0f0;
+@value _6char #00ff00;
+@value rgba rgba(34, 12, 64, 0.3);
+@value hsla hsla(220, 13.0%, 18.0%, 1);
+
+.foo {
+	color: named;
+	background-color: _3char;
+	border-top-color: _6char;
+	border-bottom-color: rgba;
+	outline-color: hsla;
+}
+
+@value (blue-i, red-i) from "./colors.module.css";
+
+.foo { color: red-i; }
+.bar { color: blue-i }
+
+@value coolShadow: 0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14)   ;
+
+.foo { box-shadow: coolShadow; }
+
+@value func: color(red lightness(50%));
+
+.foo { color: func; }
+
+@value v-color: red;
+
+:root { --color: v-color; }
+
+@value v-empty: ;
+
+:root { --color:v-empty; }
+
+@value v-empty-v2:   ;
+
+:root { --color:v-empty-v2; }
+
+@value v-empty-v3: /* comment */;
+
+:root { --color:v-empty-v3; }
+
+@value override: blue;
+@value override: red;
+
+.override-cls {
+	color: override;
+}
+
+@value (blue-v1 as my-name) from "./colors.module.css";
+@value (blue-v1 as my-name-again, red-v1) from "./colors.module.css";
+
+.class {
+	color: my-name;
+	color: my-name-again;
+	color: red-v1;
+}
+
+@value/* test */blue-v5/* test */:/* test */red/* test */;
+
+.color-cls {
+	color: blue-v5;
+}
+
+@value/* test */blue-v6/* test *//* test */red/* test */;
+
+.color-cls {
+	color: blue-v6;
+}
+
+@value coolShadow-v2   :   0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14)   ;
+
+.foo { box-shadow: coolShadow-v2; }
+
+@value   /* test */   coolShadow-v3   /* test */   :   0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14)   ;
+
+.foo { box-shadow: coolShadow-v3; }
+
+@value   /* test */   coolShadow-v4   /* test */   0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14)   ;
+
+.foo { box-shadow: coolShadow-v4; }
+
+@value/* test */coolShadow-v5/* test */0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14);
+
+.foo { box-shadow: coolShadow-v5; }
+
+@value/* test */coolShadow-v6/* test */:0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14);
+
+.foo { box-shadow: coolShadow-v6; }
+
+@value/* test */coolShadow-v7/* test */:/* test */0 11px 15px -7px rgba(0,0,0,.2),0 24px 38px 3px rgba(0,0,0,.14);
+
+.foo { box-shadow: coolShadow-v7; }
+
+@value /* test */ test-v1 /* test */ from /* test */ "./colors.module.css" /* test */;
+
+.foo { color: test-v1; }
+
+@value/* test */test-v2/* test */from/* test */"./colors.module.css"/* test */;
+
+.foo { color: test-v2; }
+
+@value/* test */(/* test */blue-v1/* test */as/* test */my-name-q/* test */)/* test */from/* test */"./colors.module.css"/* test */;
+
+.foo { color: my-name-q; }
+
+@value/*
+	multiline
+	comment
+*/multiline-v1/*
+	multiline
+	comment
+*/:/*
+	multiline
+	comment
+*/red/*
+	multiline
+	comment
+*/;
+
+.color-cls {
+	color: multiline-v1;
+}
+
+@value /*
+	multiline comment
+*/ red-v3 /*
+	multiline comment
+*/ from /*
+	multiline comment
+*/ "./colors.module.css" /*
+	multiline comment
+*/;
+
+.foo { color: red-v3; }
+
+@value multiline-empty: /*
+	multiline
+	comment
+*/;
+
+:root { --color:multiline-empty; }
+
+@value;
+@value test;

--- a/tests/rspack-test/configCases/css/icss-value-references/colors.module.css
+++ b/tests/rspack-test/configCases/css/icss-value-references/colors.module.css
@@ -1,0 +1,13 @@
+@value red-v1 blue;
+@value red-i: blue;
+@value blue-v1 red;
+@value blue-i: red;
+@value a: "test-a";
+@value b: "test-b";
+@value --red: var(--color);
+@value test-v1: blue;
+@value test-v2: blue;
+@value red-v2: blue;
+@value green-v2: yellow;
+@value red-v3: blue;
+@value red-v4: blue;

--- a/tests/rspack-test/configCases/css/icss-value-references/index.js
+++ b/tests/rspack-test/configCases/css/icss-value-references/index.js
@@ -1,0 +1,28 @@
+import * as values from "./at-rule-value.module.css";
+import * as references from "./references.module.css";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+it("should substitute webpack's @value media queries and selectors", () => {
+	const css = readFileSync(join(__dirname, `bundle${__STATS_I__}.css`), "utf-8");
+	expect(values.small).toBe("(max-width: 599px)");
+	expect(values["colorValue-v3"]).toBe(".red");
+	expect(css).toContain("@media (max-width: 599px) {");
+	expect(css).toContain(".red {\n\tcolor: .red;");
+	expect(css).not.toContain("@media small");
+	expect(css).not.toContain("colorValue-v3 {");
+});
+
+it("should substitute references throughout selector and at-rule preludes", () => {
+	const css = readFileSync(join(__dirname, `bundle${__STATS_I__}.css`), "utf-8");
+	expect(references.selector).toBe(".globalThing");
+	expect(css).toContain(".globalThing { color: blue; }");
+	expect(css).toContain("article .globalThing, section > .globalThing {");
+	expect(css).toContain(":is(.globalThing) {");
+	expect(css).toContain("& .globalThing {");
+	expect(css).toContain("@media screen and (max-width: 599px) {");
+	expect(css).toContain("@supports (display: grid) {");
+	expect(css).toContain("article other-selector-value, section > reexport-selector-value {");
+	expect(css).toContain("selector: blue;");
+	expect(css).toContain('content: "selector mq";');
+});

--- a/tests/rspack-test/configCases/css/icss-value-references/references.module.css
+++ b/tests/rspack-test/configCases/css/icss-value-references/references.module.css
@@ -1,0 +1,40 @@
+@value mq: (max-width: 599px);
+@value selector: .globalThing;
+@value supportsCondition: (display: grid);
+@value other-selector, reexport-selector from "./selectors.module.css";
+
+@media mq {
+	.inMedia { color: red; }
+}
+
+selector { color: blue; }
+
+article selector, section > selector {
+	color: blue;
+}
+
+:is(selector) {
+	color: blue;
+}
+
+.container {
+	& selector {
+		color: blue;
+	}
+	@media screen and mq {
+		color: red;
+	}
+}
+
+@supports supportsCondition {
+	.supported { display: grid; }
+}
+
+article other-selector, section > reexport-selector {
+	color: blue;
+}
+
+.unchanged {
+	selector: blue;
+	content: "selector mq";
+}

--- a/tests/rspack-test/configCases/css/icss-value-references/rspack.config.js
+++ b/tests/rspack-test/configCases/css/icss-value-references/rspack.config.js
@@ -1,0 +1,14 @@
+module.exports = ["development", "production"].map(mode => ({
+	mode,
+	target: "web",
+	externals: {
+		fs: "node-commonjs fs",
+		path: "node-commonjs path"
+	},
+	node: { __dirname: false, __filename: false },
+	module: {
+		rules: [{ test: /\.css$/, type: "css/module" }]
+	},
+	optimization: { minimize: false },
+	experiments: { css: true }
+}));

--- a/tests/rspack-test/configCases/css/icss-value-references/rspack.config.js
+++ b/tests/rspack-test/configCases/css/icss-value-references/rspack.config.js
@@ -1,14 +1,14 @@
-module.exports = ["development", "production"].map(mode => ({
-	mode,
-	target: "web",
-	externals: {
-		fs: "node-commonjs fs",
-		path: "node-commonjs path"
-	},
-	node: { __dirname: false, __filename: false },
-	module: {
-		rules: [{ test: /\.css$/, type: "css/module" }]
-	},
-	optimization: { minimize: false },
-	experiments: { css: true }
+module.exports = ['development', 'production'].map((mode) => ({
+  mode,
+  target: 'web',
+  externals: {
+    fs: 'node-commonjs fs',
+    path: 'node-commonjs path',
+  },
+  node: { __dirname: false, __filename: false },
+  module: {
+    rules: [{ test: /\.css$/, type: 'css/module' }],
+  },
+  optimization: { minimize: false },
+  experiments: { css: true },
 }));

--- a/tests/rspack-test/configCases/css/icss-value-references/selectors-more.module.css
+++ b/tests/rspack-test/configCases/css/icss-value-references/selectors-more.module.css
@@ -1,0 +1,1 @@
+@value reexport-selector: reexport-selector-value;

--- a/tests/rspack-test/configCases/css/icss-value-references/selectors.module.css
+++ b/tests/rspack-test/configCases/css/icss-value-references/selectors.module.css
@@ -1,0 +1,2 @@
+@value other-selector: other-selector-value;
+@value reexport-selector from "./selectors-more.module.css";

--- a/tests/rspack-test/configCases/css/icss-value-references/warnings.js
+++ b/tests/rspack-test/configCases/css/icss-value-references/warnings.js
@@ -1,0 +1,1 @@
+module.exports = Array.from({ length: 4 }, () => /Broken '@value' at-rule/);


### PR DESCRIPTION
## Summary

Resolve CSS Modules `@value` references in selector and at-rule preludes. Previously, ICSS symbol detection was restricted to declaration blocks, and selector fast-forwarding skipped matching identifiers. Recognize references in both contexts and stop fast-forwarding before matching symbols, while preserving declaration names and opaque attribute selectors.

For example:

```css
@value mq: (max-width: 599px);
@value selector: .globalThing;

@media mq { .inMedia { color: red; } }
selector { color: blue; }
```

Previously, the output retained `@media mq` and `selector`. It now emits `@media (max-width: 599px)` and `.globalThing`, matching webpack.

Copy webpack's `css-modules/at-rule-value.module.css` and color fixtures, plus its `reexport` selector fixtures, directly into a regression case. Cover compound and nested selectors, imported references, and at-rule conditions in development and production. Correct five existing snapshots that recorded unresolved references.

Validation:
- `pnpm run build:cli:dev` and final `pnpm run build:binding:dev` passed.
- CSS configuration tests: 218 passed.
- `cargo test -p css-module-lexer`: 313 passed.
- `cargo clippy -p css-module-lexer --all-targets -- -D warnings` passed.
- Confirmed media-query and selector output assertions fail with published Rspack 2.2.2 and pass with this fix.

## Related links

Fixes #15520

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_