### PR TITLE
feat: error handling for new cache

### DIFF
--- a/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
+++ b/crates/rspack_binding_api/src/plugins/js_loader/cache.rs
@@ -159,10 +159,7 @@ impl JsLoaderCache {
       &loader.loader_name,
       etag.clone(),
     );
-    let Some(entry) = item_cache
-      .get::<LoaderCacheEntry>()
-      .map_err(|error| napi::Error::from_reason(error.to_string()))?
-    else {
+    let Some(entry) = item_cache.get::<LoaderCacheEntry>() else {
       self.set_pending_etag(loader_index, Some(etag))?;
       return Ok(None);
     };

--- a/crates/rspack_core/src/cache/codec.rs
+++ b/crates/rspack_core/src/cache/codec.rs
@@ -53,7 +53,7 @@ impl CacheCodec {
   where
     T: for<'a> Serialize<Serializer<'a>>,
   {
-    to_bytes(data, &self.context).map_err(|e| rspack_error::error!(e.to_string()))
+    to_bytes(data, &self.context).map_err(rspack_error::Error::from_error)
   }
 
   pub fn decode<T>(&self, bytes: &[u8]) -> Result<T>
@@ -61,6 +61,6 @@ impl CacheCodec {
     T: Archive,
     T::Archived: for<'a> CheckBytes<Validator<'a>> + Deserialize<T, Deserializer>,
   {
-    from_bytes(bytes, &self.context).map_err(|e| rspack_error::error!(e.to_string()))
+    from_bytes(bytes, &self.context).map_err(rspack_error::Error::from_error)
   }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -89,7 +89,7 @@ impl ModuleBuildCache {
     let identifier = module.identifier();
     let Some(result) = self
       .cache
-      .get::<ModuleBuildCacheEntry>(identifier.as_str(), None)?
+      .get::<ModuleBuildCacheEntry>(identifier.as_str(), None)
     else {
       return Ok(None);
     };

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -301,12 +301,9 @@ async fn use_new_cache<F>(
 where
   F: Future<Output = Result<CodeGenerationResult>>,
 {
-  match cache.get::<CodeGenerationResult>() {
-    Some(cached) => {
-      let result = cached.as_arc().as_ref().clone();
-      return (Ok(result), true);
-    }
-    None => {}
+  if let Some(cached) = cache.get::<CodeGenerationResult>() {
+    let result = cached.as_arc().as_ref().clone();
+    return (Ok(result), true);
   }
 
   match generator.await {

--- a/crates/rspack_core/src/compilation/code_generation/mod.rs
+++ b/crates/rspack_core/src/compilation/code_generation/mod.rs
@@ -302,12 +302,11 @@ where
   F: Future<Output = Result<CodeGenerationResult>>,
 {
   match cache.get::<CodeGenerationResult>() {
-    Ok(Some(cached)) => {
+    Some(cached) => {
       let result = cached.as_arc().as_ref().clone();
       return (Ok(result), true);
     }
-    Ok(None) => {}
-    Err(error) => return (Err(error), false),
+    None => {}
   }
 
   match generator.await {

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,7 +1,7 @@
 mod rebuild;
 use std::{
   sync::{Arc, atomic::AtomicU32},
-  time::Instant,
+  time::{Duration, Instant},
 };
 
 use futures::future::join_all;
@@ -236,18 +236,13 @@ impl Compiler {
     self.new_cache.facade(name)
   }
 
-  fn end_idle(&self) -> Result<Instant> {
-    self.new_cache.end_idle()?;
-    Ok(Instant::now())
+  fn end_idle(&self) -> Instant {
+    self.new_cache.end_idle();
+    Instant::now()
   }
 
-  fn begin_idle(&mut self, started_at: Instant, successful: bool) -> Result<()> {
-    let record_build_time = if successful {
-      self.new_cache.record_build_time(started_at.elapsed())
-    } else {
-      Ok(())
-    };
-    if successful && self.new_cache.has_file_cache() {
+  fn begin_idle(&mut self, build_time: Duration) {
+    if self.new_cache.has_file_cache() {
       if let CacheOptions::Persistent(options) = &self.options.cache {
         self.compilation.build_dependencies.extend(
           options
@@ -264,9 +259,7 @@ impl Compiler {
     self.new_cache.store_meta(Meta {
       max_dependency_id: self.compiler_context.dependency_id(),
     });
-    let begin_idle = self.new_cache.begin_idle();
-
-    record_build_time.and(begin_idle)
+    self.new_cache.begin_idle(build_time);
   }
 
   pub async fn run(&mut self) -> Result<()> {
@@ -275,7 +268,7 @@ impl Compiler {
   }
 
   pub async fn build(&mut self) -> Result<()> {
-    let start = self.end_idle()?;
+    let start = self.end_idle();
     let compiler_context = self.compiler_context.clone();
     let result = match within_compiler_context(compiler_context, self.build_inner()).await {
       Ok(_) => {
@@ -296,8 +289,8 @@ impl Compiler {
         failed.and(Err(e))
       }
     };
-    let cache_result = self.begin_idle(start, result.is_ok());
-    result.and(cache_result)
+    self.begin_idle(start.elapsed());
+    result
   }
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
@@ -669,7 +662,8 @@ impl Compiler {
       .await?;
 
     self.cache.close().await;
-    self.new_cache.shutdown().await
+    self.new_cache.shutdown().await;
+    Ok(())
   }
 }
 

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -21,7 +21,7 @@ impl Compiler {
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
   ) -> Result<()> {
-    let start = self.end_idle()?;
+    let start = self.end_idle();
     let result = match within_compiler_context(
       self.compiler_context.clone(),
       self.rebuild_inner(changed_files, deleted_files),
@@ -46,8 +46,8 @@ impl Compiler {
         failed.and(Err(e))
       }
     };
-    let cache_result = self.begin_idle(start, result.is_ok());
-    result.and(cache_result)
+    self.begin_idle(start.elapsed());
+    result
   }
 
   #[tracing::instrument("Compiler:rebuild", skip_all, fields(

--- a/crates/rspack_core/src/loader/loader_cache.rs
+++ b/crates/rspack_core/src/loader/loader_cache.rs
@@ -229,7 +229,7 @@ pub(crate) async fn before_normal_loader(
     etag.clone(),
   );
 
-  if let Some(entry) = item_cache.get::<LoaderCacheEntry>()?
+  if let Some(entry) = item_cache.get::<LoaderCacheEntry>()
     && loader_cache_dependency_snapshot_is_valid(
       &context.context.file_system_info,
       &entry.dependency_snapshot,

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -69,18 +69,14 @@ impl Cache {
     CacheFacade::new(self.clone(), cache_name)
   }
 
-  pub fn get<T: CacheValueData>(
-    &self,
-    key: CacheKey,
-    etag: Option<Etag>,
-  ) -> Result<Option<CacheValue<T>>> {
+  pub fn get<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>) -> Option<CacheValue<T>> {
     let Some(storage) = &self.inner.storage else {
-      return Ok(None);
+      return None;
     };
     if let Some(memory_cache) = &storage.memory_cache {
       match memory_cache.get(&key, etag.as_ref()) {
-        MemoryCacheGetResult::Hit(value) => return Ok(Some(value)),
-        MemoryCacheGetResult::Miss => return Ok(None),
+        MemoryCacheGetResult::Hit(value) => return Some(value),
+        MemoryCacheGetResult::Miss => return None,
         MemoryCacheGetResult::NotCached => {}
       }
     }
@@ -89,21 +85,21 @@ impl Cache {
       if let Some(memory_cache) = &storage.memory_cache {
         memory_cache.store_miss(key);
       }
-      return Ok(None);
+      return None;
     };
 
-    match file_cache.restore::<T>(key.clone(), etag.clone())? {
+    match file_cache.restore::<T>(key.clone(), etag.clone()) {
       Some(value) => {
         if let Some(memory_cache) = &storage.memory_cache {
           memory_cache.store(key, etag, value.clone());
         }
-        Ok(Some(value))
+        Some(value)
       }
       None => {
         if let Some(memory_cache) = &storage.memory_cache {
           memory_cache.store_miss(key);
         }
-        Ok(None)
+        None
       }
     }
   }
@@ -157,51 +153,36 @@ impl Cache {
       .is_some_and(|storage| storage.idle_file_cache.is_some())
   }
 
-  pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
+  pub fn begin_idle(&self, build_time: Duration) {
     let Some(storage) = &self.inner.storage else {
-      return Ok(());
-    };
-    if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.record_build_time(build_time)
-    } else {
-      Ok(())
-    }
-  }
-
-  pub fn begin_idle(&self) -> Result<()> {
-    let Some(storage) = &self.inner.storage else {
-      return Ok(());
+      return;
     };
     if let Some(memory_cache) = &storage.memory_cache {
       memory_cache.start_next_generation();
     }
     if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.begin_idle()
-    } else {
-      Ok(())
+      file_cache.begin_idle(build_time);
     }
   }
 
-  pub fn end_idle(&self) -> Result<()> {
+  pub fn end_idle(&self) {
     let Some(storage) = &self.inner.storage else {
-      return Ok(());
+      return;
     };
     if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.end_idle()
-    } else {
-      Ok(())
+      file_cache.end_idle();
     }
   }
 
-  pub async fn shutdown(&self) -> Result<()> {
-    if let Some(storage) = &self.inner.storage {
-      if let Some(memory_cache) = &storage.memory_cache {
-        memory_cache.clear();
-      }
-      if let Some(file_cache) = &storage.idle_file_cache {
-        file_cache.shutdown().await?;
-      }
+  pub async fn shutdown(&self) {
+    let Some(storage) = &self.inner.storage else {
+      return;
+    };
+    if let Some(memory_cache) = &storage.memory_cache {
+      memory_cache.clear();
     }
-    Ok(())
+    if let Some(file_cache) = &storage.idle_file_cache {
+      file_cache.shutdown().await;
+    }
   }
 }

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 
-use rspack_error::Result;
-
 use super::{Cache, CacheKey, CacheValue, Etag, cache_value::CacheValueData};
 
 /// A namespaced view of the shared cache.
@@ -41,7 +39,7 @@ impl CacheFacade {
     &self,
     identifier: &str,
     etag: Option<Etag>,
-  ) -> Result<Option<CacheValue<T>>> {
+  ) -> Option<CacheValue<T>> {
     self.cache.get(self.key(identifier), etag)
   }
 
@@ -68,7 +66,7 @@ pub struct ItemCacheFacade {
 }
 
 impl ItemCacheFacade {
-  pub fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
+  pub fn get<T: CacheValueData>(&self) -> Option<CacheValue<T>> {
     self.cache.get(self.key.clone(), self.etag.clone())
   }
 
@@ -93,13 +91,13 @@ impl MultiItemCache {
     }
   }
 
-  pub fn get<T: CacheValueData>(&self) -> Result<Option<CacheValue<T>>> {
+  pub fn get<T: CacheValueData>(&self) -> Option<CacheValue<T>> {
     for item in &self.items {
-      if let Some(value) = item.get()? {
-        return Ok(Some(value));
+      if let Some(value) = item.get() {
+        return Some(value);
       }
     }
-    Ok(None)
+    None
   }
 
   pub fn store<T: CacheValueData>(&self, value: CacheValue<T>) {

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -1,8 +1,8 @@
+#[cfg(target_family = "wasm")]
 mod noop;
 #[cfg(not(target_family = "wasm"))]
 mod turbo;
 
-pub use noop::NoopDatabase;
 use rspack_error::Result;
 
 use crate::new_cache::CacheKey;
@@ -44,9 +44,11 @@ pub(crate) trait Database: Send + Sync {
 
   fn compact(&self) -> Result<()>;
 
+  fn has_unrecoverable_write_error(&self) -> bool;
+
   fn reset(&mut self) -> Result<()>;
 
   fn cleanup_stale(&self) -> Result<()>;
 
-  fn shutdown(&self) -> Result<()>;
+  fn shutdown(self: Box<Self>) -> Result<()>;
 }

--- a/crates/rspack_core/src/new_cache/db/noop.rs
+++ b/crates/rspack_core/src/new_cache/db/noop.rs
@@ -8,7 +8,6 @@ use crate::new_cache::{
 pub struct NoopDatabase;
 
 impl NoopDatabase {
-  #[cfg(target_family = "wasm")]
   pub fn open(
     _base_path: rspack_paths::Utf8PathBuf,
     _path: rspack_paths::Utf8PathBuf,
@@ -35,6 +34,10 @@ impl Database for NoopDatabase {
     Ok(())
   }
 
+  fn has_unrecoverable_write_error(&self) -> bool {
+    false
+  }
+
   fn reset(&mut self) -> Result<()> {
     Ok(())
   }
@@ -43,7 +46,7 @@ impl Database for NoopDatabase {
     Ok(())
   }
 
-  fn shutdown(&self) -> Result<()> {
+  fn shutdown(self: Box<Self>) -> Result<()> {
     Ok(())
   }
 }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -34,7 +34,7 @@ const COMPACT_CONFIG: CompactConfig = CompactConfig {
 };
 
 #[derive(Clone, Copy, Default)]
-pub struct RayonParallelScheduler;
+struct RayonParallelScheduler;
 
 impl ParallelScheduler for RayonParallelScheduler {
   fn block_in_place<R>(&self, f: impl FnOnce() -> R + Send) -> R
@@ -241,6 +241,10 @@ impl Database for TurboDatabase {
     Ok(())
   }
 
+  fn has_unrecoverable_write_error(&self) -> bool {
+    self.inner.has_unrecoverable_write_error()
+  }
+
   fn reset(&mut self) -> Result<()> {
     let old_database = std::mem::replace(
       &mut self.inner,
@@ -266,7 +270,7 @@ impl Database for TurboDatabase {
     }
   }
 
-  fn shutdown(&self) -> Result<()> {
+  fn shutdown(self: Box<Self>) -> Result<()> {
     self.inner.clear_cache();
     self.inner.shutdown()?;
     Ok(())

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -3,15 +3,16 @@ use std::{
   sync::{Arc, Mutex, MutexGuard, OnceLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
 
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashMap;
+use tokio::sync::Notify;
 
 use super::{
   CacheKey, Etag, Meta,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
-  db::{Database, DatabaseFamily, NoopDatabase},
+  db::{Database, DatabaseFamily},
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
@@ -48,7 +49,7 @@ impl PendingWrites {
 }
 
 struct State {
-  database: OnceLock<Box<dyn Database>>,
+  database: Box<dyn Database>,
   pending_writes: PendingWrites,
 }
 
@@ -66,7 +67,9 @@ impl std::fmt::Debug for State {
 pub struct FileCacheStrategy {
   validator: CacheValidator,
   codec: Arc<CacheCodec>,
-  state: RwLock<State>,
+  // Unset: initializing; Some: available; None: unavailable.
+  state: OnceLock<RwLock<Option<State>>>,
+  unavailable: Notify,
   readonly: bool,
   logger: Arc<InfrastructureLogger>,
 }
@@ -89,59 +92,51 @@ impl FileCacheStrategy {
         logger.clone(),
       ),
       codec,
-      state: RwLock::new(State {
-        database: OnceLock::new(),
-        pending_writes: PendingWrites::default(),
-      }),
+      state: OnceLock::new(),
+      unavailable: Notify::new(),
       readonly,
       logger,
     }
   }
 
-  pub async fn db_init(&self, database_paths: (Utf8PathBuf, Utf8PathBuf)) -> Result<()> {
-    self
-      .db_init_impl(database_paths)
-      .await
-      .map(|database| {
-        self
-          .read_state()
-          .database
-          .set(Box::new(database) as Box<dyn Database>)
-          .unwrap_or_else(|_| panic!("database should be set only once"));
-      })
-      .inspect_err(|_| {
-        self
-          .read_state()
-          .database
-          .set(Box::new(NoopDatabase) as Box<dyn Database>)
-          .unwrap_or_else(|_| panic!("database should be set only once"));
-      })
-  }
+  pub async fn db_init(&self, (base_path, path): (Utf8PathBuf, Utf8PathBuf)) {
+    fn set_initialized(strategy: &FileCacheStrategy, database: Box<dyn Database>) {
+      strategy
+        .state
+        .set(RwLock::new(Some(State {
+          database,
+          pending_writes: Default::default(),
+        })))
+        .expect("cache state should be initialized only once");
+    }
 
-  async fn db_init_impl(
-    &self,
-    (base_path, path): (Utf8PathBuf, Utf8PathBuf),
-  ) -> Result<TurboDatabase> {
-    let mut database = {
-      let start = self.logger.time("open cache database");
-      let database = TurboDatabase::open(base_path, path, self.readonly);
-      self.logger.time_end(start);
-      database
-    }?;
+    let start = self.logger.time("open cache database");
+    let mut database = match TurboDatabase::open(base_path, path, self.readonly) {
+      Ok(database) => Box::new(database) as Box<dyn Database>,
+      Err(error) => {
+        self.session_unavailable(Some(&error));
+        return;
+      }
+    };
+    self.logger.time_end(start);
 
     if database.is_empty() {
-      return Ok(database);
+      set_initialized(self, database);
+      return;
     }
 
     let start = self.logger.time("validate cache database");
-    let validation = self.db_validate(&mut database).await;
+    if let Err(e) = self.db_validate(&mut *database).await {
+      self.shutdown_database(database);
+      self.session_unavailable(Some(&e));
+      return;
+    }
     self.logger.time_end(start);
-    validation?;
-
-    Ok(database)
+    // Publish only after validation succeeds, so waiting readers cannot use an invalid DB.
+    set_initialized(self, database);
   }
 
-  async fn db_validate(&self, database: &mut TurboDatabase) -> Result<()> {
+  async fn db_validate(&self, database: &mut dyn Database) -> Result<()> {
     let data = database.get(DatabaseFamily::Validator, &CacheKey::new(VALIDATOR_KEY))?;
     let validation = self.validator.validate(data.as_deref()).await?;
     match validation {
@@ -173,18 +168,70 @@ impl FileCacheStrategy {
     Ok(())
   }
 
-  fn read_state(&self) -> RwLockReadGuard<'_, State> {
+  fn read_state(&self) -> RwLockReadGuard<'_, Option<State>> {
     self
       .state
+      .wait()
       .read()
       .expect("cache state lock should not be poisoned")
   }
 
-  fn write_state(&self) -> RwLockWriteGuard<'_, State> {
+  fn write_state(&self) -> RwLockWriteGuard<'_, Option<State>> {
     self
       .state
+      .wait()
       .write()
       .expect("cache state lock should not be poisoned")
+  }
+
+  pub fn is_available(&self) -> bool {
+    // Uninitialized or initialized and not unavailable.
+    self.state.get().is_none() || self.read_state().is_some()
+  }
+
+  pub async fn wait_until_unavailable(&self) {
+    self.unavailable.notified().await;
+  }
+
+  fn session_unavailable(&self, error: Option<&rspack_error::Error>) {
+    let state = if self.state.get().is_none() {
+      self
+        .state
+        .set(RwLock::new(None))
+        .expect("cache state should be initialized only once");
+      None
+    } else {
+      let state = self.write_state().take();
+      if state.is_none() {
+        return;
+      }
+      state
+    };
+
+    if let Some(error) = error {
+      self.logger.warn(format!(
+        "Filesystem cache unavailable for this session: {error}"
+      ));
+    }
+
+    if let Some(State {
+      database,
+      pending_writes,
+    }) = state
+    {
+      drop(pending_writes);
+      self.shutdown_database(database);
+    }
+    // Notify to exit background job
+    self.unavailable.notify_one();
+  }
+
+  fn shutdown_database(&self, database: Box<dyn Database>) {
+    if let Err(error) = database.shutdown() {
+      self
+        .logger
+        .warn(format!("Failed to shutdown cache database: {error}"));
+    }
   }
 
   pub(super) fn store(
@@ -197,7 +244,11 @@ impl FileCacheStrategy {
     if self.readonly {
       return;
     }
-    self.read_state().pending_writes.entries.insert(
+    let state = self.read_state();
+    let Some(state) = state.as_ref() else {
+      return;
+    };
+    state.pending_writes.entries.insert(
       key,
       PendingWrite {
         entry: CacheEntry::new(etag, value),
@@ -210,8 +261,11 @@ impl FileCacheStrategy {
     if self.readonly {
       return;
     }
-    self
-      .read_state()
+    let state = self.read_state();
+    let Some(state) = state.as_ref() else {
+      return;
+    };
+    state
       .pending_writes
       .new_build_dependencies()
       .get_or_insert_default()
@@ -222,22 +276,28 @@ impl FileCacheStrategy {
     if self.readonly {
       return;
     }
-    *self.read_state().pending_writes.meta() = Some(meta);
+    let state = self.read_state();
+    let Some(state) = state.as_ref() else {
+      return;
+    };
+    *state.pending_writes.meta() = Some(meta);
   }
 
   pub fn restore_meta(&self) -> Result<Option<Meta>> {
-    let state = self.read_state();
+    let state_guard = self.read_state();
+    let Some(state) = state_guard.as_ref() else {
+      return Ok(None);
+    };
     if let Some(pending) = state.pending_writes.meta().as_ref() {
       return Ok(Some(pending.clone()));
     }
-    let Some(entry) = state
+
+    let result = state
       .database
-      .wait()
-      .get(DatabaseFamily::Meta, &CacheKey::new(META_KEY))?
-    else {
-      return Ok(None);
-    };
-    Ok(Some(self.codec.decode(&entry)?))
+      .get(DatabaseFamily::Meta, &CacheKey::new(META_KEY))
+      .and_then(|entry| entry.map(|entry| self.codec.decode(&entry)).transpose());
+    drop(state_guard);
+    result.inspect_err(|error| self.session_unavailable(Some(error)))
   }
 
   pub(super) fn restore(
@@ -245,23 +305,53 @@ impl FileCacheStrategy {
     key: &CacheKey,
     etag: Option<&Etag>,
     decoder: CacheValueDecoder,
-  ) -> Result<Option<ErasedCacheValue>> {
-    let state = self.read_state();
+  ) -> Option<ErasedCacheValue> {
+    let state_guard = self.read_state();
+    let state = state_guard.as_ref()?;
     if let Some(pending) = state.pending_writes.entries.get(key) {
-      return Ok(
-        pending
-          .entry
-          .matches(etag)
-          .then(|| pending.entry.value().clone()),
-      );
+      return pending
+        .entry
+        .matches(etag)
+        .then(|| pending.entry.value().clone());
     }
-    let Some(entry) = state.database.wait().get(DatabaseFamily::Cache, key)? else {
-      return Ok(None);
+
+    let result = state.database.get(DatabaseFamily::Cache, key);
+    let entry = match result {
+      Ok(entry) => entry,
+      Err(e) => {
+        drop(state_guard);
+        self.session_unavailable(Some(&e));
+        return None;
+      }
     };
-    decoder(&entry, etag, &self.codec)
+    let Some(entry) = entry else {
+      return None;
+    };
+    match decoder(&entry, etag, &self.codec) {
+      Ok(decoded) => decoded,
+      Err(e) => {
+        self
+          .logger
+          .warn(format!("Failed to decode cache entry for key {key}: {e}"));
+        None
+      }
+    }
   }
 
   pub(super) async fn after_all_stored(
+    &self,
+    max_compaction_passes: usize,
+    check_idle_ended: impl FnMut() -> bool,
+  ) {
+    if let Err(e) = self
+      .after_all_stored_impl(max_compaction_passes, check_idle_ended)
+      .await
+    {
+      self.session_unavailable(Some(&e));
+    }
+  }
+
+  async fn after_all_stored_impl(
     &self,
     max_compaction_passes: usize,
     mut check_idle_ended: impl FnMut() -> bool,
@@ -278,19 +368,25 @@ impl FileCacheStrategy {
       let new_build_dependencies;
       let meta;
       {
-        let state = self.write_state();
+        let mut state = self.write_state();
+        let Some(state) = state.as_mut() else {
+          return Ok(());
+        };
 
-        writes = state
-          .pending_writes
-          .entries
-          .par_iter()
-          .map(|pending| {
-            let key = pending.key().clone();
-            let value = (pending.encoder)(&pending.entry, codec)?;
-            Ok((DatabaseFamily::Cache, key, value))
-          })
-          .collect::<Result<Vec<_>>>()?;
-        state.pending_writes.entries.clear();
+        writes = std::mem::take(&mut state.pending_writes.entries)
+          .into_par_iter()
+          .filter_map(
+            |(key, pending)| match (pending.encoder)(&pending.entry, codec) {
+              Ok(value) => Some((DatabaseFamily::Cache, key, value)),
+              Err(error) => {
+                self.logger.warn(format!(
+                  "Failed to encode cache entry for key {key}: {error}"
+                ));
+                None
+              }
+            },
+          )
+          .collect::<Vec<_>>();
 
         new_build_dependencies = state.pending_writes.new_build_dependencies().take();
         meta = state.pending_writes.meta().take();
@@ -312,7 +408,13 @@ impl FileCacheStrategy {
       }
 
       let writes_len = writes.len();
-      self.read_state().database.wait().write_batch(writes)?;
+      if writes_len > 0 {
+        let state = self.read_state();
+        let Some(state) = state.as_ref() else {
+          return Ok(());
+        };
+        state.database.write_batch(writes)?;
+      }
       self.logger.time_end(start);
 
       self
@@ -321,36 +423,43 @@ impl FileCacheStrategy {
     }
 
     let state = self.read_state();
-    let database = state.database.wait();
+    let Some(state) = state.as_ref() else {
+      return Ok(());
+    };
     for _ in 0..max_compaction_passes {
       if check_idle_ended() {
         return Ok(());
       }
-      database.compact()?;
+      if let Err(error) = state.database.compact() {
+        self
+          .logger
+          .warn(format!("Failed to compact cache database: {error}"));
+        if state.database.has_unrecoverable_write_error() {
+          return Err(error);
+        }
+        break;
+      }
     }
     if check_idle_ended() {
       return Ok(());
     }
-    if let Err(error) = database.cleanup_stale() {
+    if let Err(error) = state.database.cleanup_stale() {
       self
         .logger
-        .warn(format!("Cleaning up stale cache databases failed: {error}"));
+        .warn(format!("Failed to clean up stale cache databases: {error}"));
     }
     Ok(())
   }
 
-  pub async fn shutdown(&self) -> Result<()> {
-    let store_result = self.after_all_stored(1, || false).await;
-    let database = self.write_state().database.take();
-    let shutdown_result = if let Some(database) = database {
-      database.shutdown()
-    } else {
-      Ok(())
-    };
-    store_result.and(shutdown_result)
+  pub async fn shutdown(&self) {
+    self.after_all_stored(1, || false).await;
+    self.session_unavailable(None);
   }
 
   pub fn has_pending_writes(&self) -> bool {
-    !self.read_state().pending_writes.is_empty()
+    self
+      .read_state()
+      .as_ref()
+      .is_some_and(|state| !state.pending_writes.is_empty())
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -324,9 +324,7 @@ impl FileCacheStrategy {
         return None;
       }
     };
-    let Some(entry) = entry else {
-      return None;
-    };
+    let entry = entry?;
     match decoder(&entry, etag, &self.codec) {
       Ok(decoded) => decoded,
       Err(e) => {

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -10,7 +10,7 @@ use std::{
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use tokio::{
-  sync::{mpsc, oneshot},
+  sync::mpsc,
   time::{Instant, sleep_until},
 };
 
@@ -27,10 +27,9 @@ const MAX_IDLE_COMPACTION_PASSES: usize = 10;
 
 #[derive(Debug)]
 enum Command {
-  RecordBuildTime(Duration),
-  BeginIdle { epoch: u64 },
+  BeginIdle { epoch: u64, build_time: Duration },
   EndIdle,
-  Shutdown(oneshot::Sender<Result<()>>),
+  Shutdown,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -54,17 +53,15 @@ struct BackgroundJob {
 
 impl BackgroundJob {
   async fn run(mut self, database_paths: (Utf8PathBuf, Utf8PathBuf)) {
-    if let Err(error) = self.strategy.db_init(database_paths).await {
-      self
-        .logger
-        .warn(format!("Initializing cache database failed: {error}"));
-    }
+    self.strategy.db_init(database_paths).await;
 
     let idle_epoch = Arc::clone(&self.idle_epoch);
+    let strategy = Arc::clone(&self.strategy);
     loop {
       let idle_deadline = self.idle_deadline;
       let command = tokio::select! {
         biased;
+        _ = strategy.wait_until_unavailable() => return,
         command = self.command_receiver.recv() => command,
         epoch = async {
           match idle_deadline {
@@ -76,9 +73,7 @@ impl BackgroundJob {
           }
         } => {
           self.idle_deadline = None;
-          self
-            .process_idle_tasks(|| idle_epoch.load(Ordering::Acquire) != epoch)
-            .await;
+          self.process_idle_tasks(|| idle_epoch.load(Ordering::Acquire) != epoch).await;
           continue;
         }
       };
@@ -91,21 +86,17 @@ impl BackgroundJob {
         }
         return;
       };
-      if self.handle_command(command).await {
-        return;
-      }
+      self.handle_command(command).await;
     }
   }
 
-  async fn handle_command(&mut self, command: Command) -> bool {
+  async fn handle_command(&mut self, command: Command) {
     match command {
-      Command::RecordBuildTime(build_time) => {
+      Command::BeginIdle { epoch, build_time } => {
         self.time_spent_in_build = self
           .time_spent_in_build
           .mul_f64(0.9)
           .saturating_add(build_time);
-      }
-      Command::BeginIdle { epoch } => {
         if self.idle_epoch.load(Ordering::Acquire) == epoch {
           let is_initial_store = self.avg_time_spent_in_store.is_none();
           let is_large_change = self.time_spent_in_build
@@ -129,25 +120,19 @@ impl BackgroundJob {
       Command::EndIdle => {
         self.idle_deadline = None;
       }
-      Command::Shutdown(result) => {
+      Command::Shutdown => {
         self.idle_deadline = None;
-        let _ = result.send(self.strategy.shutdown().await);
-        return true;
+        self.strategy.shutdown().await;
       }
     }
-    false
   }
 
   async fn process_idle_tasks(&mut self, check_idle_ended: impl FnMut() -> bool) {
     let start = Instant::now();
-    if let Err(error) = self
+    self
       .strategy
       .after_all_stored(MAX_IDLE_COMPACTION_PASSES, check_idle_ended)
-      .await
-    {
-      self.logger.warn(format!("Caching failed: {error}"));
-      return;
-    }
+      .await;
     let time_spent_in_store = start.elapsed();
     self.avg_time_spent_in_store = Some(
       self
@@ -165,6 +150,7 @@ impl BackgroundJob {
 #[derive(Debug)]
 pub struct IdleFileCache {
   strategy: Arc<FileCacheStrategy>,
+  logger: Arc<InfrastructureLogger>,
   command_sender: mpsc::UnboundedSender<Command>,
   idle_epoch: Arc<AtomicU64>,
 }
@@ -188,7 +174,7 @@ impl IdleFileCache {
     let strategy = Arc::new(strategy);
     let background_job = BackgroundJob {
       strategy: Arc::clone(&strategy),
-      logger,
+      logger: Arc::clone(&logger),
       command_receiver,
       idle_epoch: Arc::clone(&idle_epoch),
       idle_deadline: None,
@@ -211,16 +197,20 @@ impl IdleFileCache {
 
     Self {
       strategy,
+      logger,
       command_sender,
       idle_epoch,
     }
   }
 
-  fn send(&self, command: Command) -> Result<()> {
-    self
-      .command_sender
-      .send(command)
-      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))
+  fn send(&self, command: Command) {
+    if self.strategy.is_available()
+      && let Err(e) = self.command_sender.send(command)
+    {
+      self.logger.warn(format!(
+        "Failed to send command to idle file cache background job: {e}"
+      ));
+    }
   }
 
   pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
@@ -233,11 +223,11 @@ impl IdleFileCache {
     &self,
     key: CacheKey,
     etag: Option<Etag>,
-  ) -> Result<Option<CacheValue<T>>> {
+  ) -> Option<CacheValue<T>> {
     let restored = self
       .strategy
-      .restore(&key, etag.as_ref(), CacheValue::<T>::decoder())?;
-    Ok(restored.and_then(ErasedCacheValue::downcast))
+      .restore(&key, etag.as_ref(), CacheValue::<T>::decoder());
+    restored.and_then(ErasedCacheValue::downcast)
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {
@@ -252,26 +242,20 @@ impl IdleFileCache {
     self.strategy.restore_meta()
   }
 
-  pub fn record_build_time(&self, build_time: Duration) -> Result<()> {
-    self.send(Command::RecordBuildTime(build_time))
-  }
-
-  pub fn begin_idle(&self) -> Result<()> {
+  pub fn begin_idle(&self, build_time: Duration) {
     self.send(Command::BeginIdle {
       epoch: self.idle_epoch.load(Ordering::Acquire),
-    })
+      build_time,
+    });
   }
 
-  pub fn end_idle(&self) -> Result<()> {
+  pub fn end_idle(&self) {
     self.idle_epoch.fetch_add(1, Ordering::Release);
-    self.send(Command::EndIdle)
+    self.send(Command::EndIdle);
   }
 
-  pub async fn shutdown(&self) -> Result<()> {
-    let (result, result_receiver) = oneshot::channel();
-    self.send(Command::Shutdown(result))?;
-    result_receiver
-      .await
-      .map_err(|_| rspack_error::error!("Idle file cache background job has stopped"))?
+  pub async fn shutdown(&self) {
+    self.send(Command::Shutdown);
+    self.command_sender.closed().await;
   }
 }

--- a/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
+++ b/crates/rspack_core/src/new_cache/snapshot/file_system_info.rs
@@ -646,10 +646,9 @@ impl FileSystemInfo {
       return Ok(Some(value));
     }
 
-    let metadata = self
-      .metadata(path)
-      .await?
-      .expect("symlink metadata proved that the path exists");
+    let Some(metadata) = self.metadata(path).await? else {
+      return Ok(None);
+    };
     if !metadata.is_directory {
       return self.file_context_value(path, mode).await;
     }

--- a/crates/rspack_fs/src/error.rs
+++ b/crates/rspack_fs/src/error.rs
@@ -18,7 +18,11 @@ impl From<std::io::Error> for Error {
 
 impl From<rspack_error::Error> for Error {
   fn from(e: rspack_error::Error) -> Self {
-    Error::Io(std::io::Error::other(e.to_string()))
+    let kind = match e.code.as_deref() {
+      Some("ENOENT") => std::io::ErrorKind::NotFound,
+      _ => std::io::ErrorKind::Other,
+    };
+    Error::Io(std::io::Error::new(kind, e.to_string()))
   }
 }
 
@@ -43,12 +47,9 @@ pub trait RspackResultToFsResultExt<T> {
   fn to_fs_result(self) -> Result<T>;
 }
 
-impl<T, E: ToString> RspackResultToFsResultExt<T> for std::result::Result<T, E> {
+impl<T> RspackResultToFsResultExt<T> for rspack_error::Result<T> {
   fn to_fs_result(self) -> Result<T> {
-    match self {
-      Ok(t) => Ok(t),
-      Err(e) => Err(Error::Io(std::io::Error::other(e.to_string()))),
-    }
+    self.map_err(Error::from)
   }
 }
 

--- a/crates/rspack_napi/src/errors.rs
+++ b/crates/rspack_napi/src/errors.rs
@@ -9,11 +9,12 @@ pub trait NapiErrorToRspackErrorExt {
 
 impl NapiErrorToRspackErrorExt for Error {
   fn to_rspack_error(self, env: &Env) -> RspackError {
-    let (reason, stack, backtrace, hide_stack) =
+    let (reason, stack, backtrace, hide_stack, code) =
       extract_stack_or_message_from_napi_error(env, self);
     let mut err = RspackError::error(format!("{reason}\n{}", backtrace.unwrap_or_default()));
     err.stack = stack;
     err.hide_stack = hide_stack;
+    err.code = code;
     err
   }
 }
@@ -28,7 +29,13 @@ const fn get_backtrace() -> Option<String> {
 fn extract_stack_or_message_from_napi_error(
   env: &Env,
   err: Error,
-) -> (String, Option<String>, Option<String>, Option<bool>) {
+) -> (
+  String,
+  Option<String>,
+  Option<String>,
+  Option<bool>,
+  Option<String>,
+) {
   let maybe_reason = err.reason.clone();
   match unsafe { ToNapiValue::to_napi_value(env.raw(), err) } {
     Ok(napi_error) => {
@@ -40,6 +47,7 @@ fn extract_stack_or_message_from_napi_error(
         Ok(message) => message,
       };
       let stack = try_extract_string_value_from_property(env, napi_error, "stack").ok();
+      let code = try_extract_string_value_from_property(env, napi_error, "code").ok();
       (
         if hide_stack.unwrap_or_default() {
           message
@@ -49,6 +57,7 @@ fn extract_stack_or_message_from_napi_error(
         stack,
         get_backtrace(),
         hide_stack,
+        code,
       )
     }
     Err(e) if maybe_reason.is_empty() => (
@@ -56,8 +65,9 @@ fn extract_stack_or_message_from_napi_error(
       None,
       get_backtrace(),
       None,
+      None,
     ),
-    Err(_) => (maybe_reason, None, None, None),
+    Err(_) => (maybe_reason, None, None, None, None),
   }
 }
 

--- a/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
+++ b/crates/rspack_plugin_devtool/src/source_map_dev_tool_plugin.rs
@@ -456,7 +456,7 @@ impl SourceMapDevToolPlugin {
         cache.get::<CachedSourceMapDevToolPluginEntry>(
           &filename,
           Some(Etag::from(asset.info.version.clone())),
-        )?
+        )
       } else {
         None
       };

--- a/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
+++ b/crates/rspack_plugin_swc_js_minimizer/src/lib.rs
@@ -277,7 +277,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
             "{:016x}",
             minimize_cache_hash(original_source, self.options_hash, filename, is_module)
           ));
-          let value = cache.get::<CachedMinimizeEntry>(asset_filename, Some(etag.clone()))?;
+          let value = cache.get::<CachedMinimizeEntry>(asset_filename, Some(etag.clone()));
           Some((cache, etag, value))
         } else {
           None

--- a/tests/rspack-test/compilerCases/infrastructure-logging.js
+++ b/tests/rspack-test/compilerCases/infrastructure-logging.js
@@ -216,19 +216,16 @@ module.exports = [
 				}
 			);
 		},
-		async check() {
-			const findDatabaseWarning = () =>
-				nativeInfrastructureLogs.find(
-					log =>
-						log.name === "rspack.cache.IdleFileCache" &&
-						log.type === "warn" &&
-						log.args[0].includes("Failed to open database")
-				);
-			for (let i = 0; i < 50; i++) {
-				if (findDatabaseWarning()) break;
-				await new Promise(resolve => setTimeout(resolve, 20));
-			}
-			const warning = findDatabaseWarning();
+		async check({ context }) {
+			// Closing flushes all pending native infrastructure logs.
+			await context.closeCompiler();
+			const warning = nativeInfrastructureLogs.find(
+				log =>
+					log.name === "rspack.cache.IdleFileCache" &&
+					log.type === "warn" &&
+					log.args[0].includes("Filesystem cache unavailable for this session") &&
+					log.args[0].includes("Open cache database from")
+			);
 			expect(warning).toBeTruthy();
 		}
 	}

--- a/tests/rspack-test/compilerCases/persistent-cache-unavailable.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-unavailable.js
@@ -1,0 +1,81 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { createFsFromVolume, Volume } = require("memfs");
+
+const CACHE_LOGGER = "rspack.cache.IdleFileCache";
+
+async function run(compiler) {
+	const stats = await new Promise((resolve, reject) => {
+		compiler.run((error, stats) => (error ? reject(error) : resolve(stats)));
+	});
+	expect(stats.hasErrors()).toBe(false);
+	expect(stats.hasWarnings()).toBe(false);
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should disable the file cache after a commit fails and keep rebuilding",
+	options(context) {
+		const cacheLocation = context.getDist("cache");
+		context.setValue("cacheLocation", cacheLocation);
+		return {
+			context: context.getSource(),
+			entry: "./a",
+			mode: "production",
+			optimization: { minimize: false },
+			output: { path: context.getDist("output"), pathinfo: true },
+			experiments: { newCache: true },
+			cache: {
+				type: "persistent",
+				storage: { type: "filesystem", location: cacheLocation }
+			},
+			infrastructureLogging: { level: "none" }
+		};
+	},
+	compiler(context, compiler) {
+		compiler.outputFileSystem = createFsFromVolume(new Volume());
+		const warnings = [];
+		context.setValue("cacheWarnings", warnings);
+		context.setValue(
+			"unavailable",
+			new Promise(resolve => {
+				compiler.hooks.infrastructureLog.tap(
+					"UnavailableCacheTest",
+					(name, type, args) => {
+						if (name === CACHE_LOGGER && type === "warn") {
+							warnings.push(args[0]);
+							if (args[0].includes("Filesystem cache unavailable for this session")) {
+								resolve();
+							}
+						}
+					}
+				);
+			})
+		);
+		compiler.hooks.afterCompile.tap("UnavailableCacheTest", () => {
+			if (context.getValue("blocker")) return;
+			const cacheLocation = context.getValue("cacheLocation");
+			context.setValue("current", fs.readFileSync(path.join(cacheLocation, "CURRENT")));
+			// A directory in place of CURRENT.next makes the first idle commit fail.
+			const blocker = path.join(cacheLocation, "CURRENT.next");
+			fs.mkdirSync(blocker);
+			context.setValue("blocker", blocker);
+		});
+	},
+	async build(context, compiler) {
+		await run(compiler);
+		await context.getValue("unavailable");
+		// Removing the fault must not re-enable persistence in the same session.
+		fs.rmdirSync(context.getValue("blocker"));
+		await run(compiler);
+		await run(compiler);
+		await context.closeCompiler();
+		await context.closeCompiler();
+		const warnings = context.getValue("cacheWarnings");
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("Committing CURRENT file failed");
+		expect(
+			fs.readFileSync(path.join(context.getValue("cacheLocation"), "CURRENT"))
+		).toEqual(context.getValue("current"));
+	}
+};


### PR DESCRIPTION
## Summary

Make `newCache` fail open for ordinary cache operations: cache failures should not fail builds or become compilation diagnostics.

The policy separates entry-local failures from failures that require disabling the filesystem cache for the current compiler session. Restoring compiler metadata remains an explicit correctness-critical exception.

**Error-handling policy**:

1. Entry-local failures: log and continue

    - Ordinary cache `get`/`restore` APIs return `Option` instead of `Result`.
    - A decode error logs a warning and becomes a cache miss.
    - An encode error logs a warning and skips only the affected entry; other entries can still be persisted.
    - These failures do not disable the filesystem cache. Loaders, code generation, source maps, and minification fall back to normal computation.

2. Infrastructure failures: disable the filesystem cache for the session

    Database open/read/reset errors, validator validation/update errors, and batch creation/write/commit errors transition the filesystem cache to `Unavailable`. Errors while preparing shared persistence metadata also use this path.

    The transition:

    - Logs an unavailable warning once.
    - Discards pending filesystem-cache writes.
    - Shuts down and releases the database.
    - Notifies the background job to exit.
    - Makes subsequent filesystem-cache reads return misses and writes become no-ops.

    Builds can continue, and any configured memory cache remains usable. The filesystem cache is not reopened or retried within the same compiler session.

    The database is published to readers only after startup validation succeeds. Normal invalidation, such as a version mismatch or changed build dependencies, still resets the database rather than disabling the session.

## Testing

- Added compiler cases covering infrastructure logging and unavailable persistent-cache behavior.