### PR TITLE
feat(cache): support all module types in the new module cache

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -29,7 +29,7 @@ impl Task<TaskContext> for AddTask {
   async fn main_run(self: Box<Self>, context: &mut TaskContext) -> TaskResult<TaskContext> {
     let Self {
       original_module_identifier,
-      module,
+      mut module,
       module_graph_module,
       dependencies,
       from_unlazy,
@@ -112,7 +112,7 @@ impl Task<TaskContext> for AddTask {
     let cached_build_result = if let Some(module_build_cache) = &context.module_build_cache {
       module_build_cache
         .restore(
-          &module,
+          &mut module,
           &context.file_system_info,
           &context.value_cache_versions,
         )
@@ -144,7 +144,7 @@ impl Task<TaskContext> for AddTask {
 
     if let Some(cached_build_result) = cached_build_result {
       return Ok(vec![Box::new(BuildResultTask {
-        build_result: Box::new(cached_build_result.into_build_result(module)),
+        build_result: Box::new(cached_build_result.to_build_result(module)),
         plugin_driver: context.plugin_driver.clone(),
         forwarded_ids,
       })]);

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -7,15 +7,15 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 use crate::{
   AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockIdentifier, BoxModule,
   BuildModuleGraphArtifact, BuildResult, CacheOptions, CompilerOptions, DependenciesBlock,
-  DependencyRef, FileSystemInfo, ModuleGraph, ModuleIdentifier, NormalModuleState,
+  DependencyRef, FileSystemInfo, ModuleGraph, ModuleIdentifier, ModuleState, NeedBuildContext,
   OptimizationBailoutItem, ValueCacheVersions,
-  cache::CacheCodec,
+  cache::{CacheCodec, SnapshotStrategyOptions},
   new_cache::{CacheFacade, CacheValue},
 };
 
-/// Cache for completed normal module builds.
+/// Cache for completed module builds.
 ///
-/// Cache entries store only [`NormalModuleState`] plus the graph-owned build
+/// Cache entries store only [`ModuleState`] plus the graph-owned build
 /// output. Factory-owned module data is always supplied by the fresh module.
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCache {
@@ -25,9 +25,10 @@ pub(crate) struct ModuleBuildCache {
 }
 
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct ModuleBuildCacheEntry {
-  module_state: NormalModuleState,
+  module_type: String,
+  module_state: Box<dyn ModuleState>,
   graph_result: ModuleGraphBuildResult,
 }
 
@@ -40,16 +41,12 @@ struct ModuleGraphBuildResult {
 }
 
 impl ModuleBuildCacheEntry {
-  pub(crate) fn into_build_result(self, mut module: BoxModule) -> BuildResult {
-    module
-      .as_normal_module_mut()
-      .expect("module cache entries are only restored for normal modules")
-      .restore_module_state(self.module_state);
+  pub(crate) fn to_build_result(&self, module: BoxModule) -> BuildResult {
     BuildResult {
       module,
-      dependencies: self.graph_result.dependencies,
-      blocks: self.graph_result.blocks,
-      optimization_bailouts: self.graph_result.optimization_bailouts,
+      dependencies: self.graph_result.dependencies.clone(),
+      blocks: self.graph_result.blocks.clone(),
+      optimization_bailouts: self.graph_result.optimization_bailouts.clone(),
     }
   }
 }
@@ -78,11 +75,13 @@ impl ModuleBuildCache {
 
   pub(crate) async fn restore(
     &self,
-    module: &BoxModule,
+    module: &mut BoxModule,
     file_system_info: &FileSystemInfo,
     value_cache_versions: &ValueCacheVersions,
-  ) -> Result<Option<ModuleBuildCacheEntry>> {
-    if module.as_normal_module().is_none() {
+  ) -> Result<Option<CacheValue<ModuleBuildCacheEntry>>> {
+    // Factory data can explicitly disallow reuse, for example an extracted CSS
+    // dependency produced by a non-cacheable loader in the current compilation.
+    if !module.build_info().cacheable {
       return Ok(None);
     }
 
@@ -93,15 +92,34 @@ impl ModuleBuildCache {
     else {
       return Ok(None);
     };
-    if result
-      .module_state
-      .need_build_with_context(file_system_info, value_cache_versions)
-      .await?
+    if result.module_type != module.build_cache_type() {
+      return Ok(None);
+    }
+    let Some(fresh_state) = module.restore_build_state(result.module_state.as_ref()) else {
+      return Ok(None);
+    };
+    if !module.build_info().cacheable
+      || module
+        .diagnostics()
+        .iter()
+        .any(|diagnostic| diagnostic.is_error())
+      || value_cache_versions.has_diff(&module.build_info().value_dependencies)
     {
+      module.restore_build_state(fresh_state.as_ref());
+      return Ok(None);
+    }
+    let need_build = module
+      .need_build(&NeedBuildContext::new(
+        file_system_info,
+        value_cache_versions,
+      ))
+      .await?;
+    if need_build {
+      module.restore_build_state(fresh_state.as_ref());
       return Ok(None);
     }
 
-    Ok(Some(result.as_arc().as_ref().clone()))
+    Ok(Some(result))
   }
 
   /// Stores modules built during this phase from the final module graph.
@@ -129,12 +147,27 @@ impl ModuleBuildCache {
           let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
             return Ok(None);
           };
-          let Some(module) = module.as_normal_module() else {
-            return Ok(None);
+          let build_info = module.build_info();
+          let snapshot = if build_info.cacheable
+            && !module
+              .diagnostics()
+              .iter()
+              .any(|diagnostic| diagnostic.is_error())
+          {
+            Some(
+              file_system_info
+                .create_snapshot(
+                  Some(build_start_time),
+                  &build_info.dependencies.file,
+                  &build_info.dependencies.context,
+                  &build_info.dependencies.missing,
+                  SnapshotStrategyOptions::timestamp(),
+                )
+                .await?,
+            )
+          } else {
+            None
           };
-          let snapshot = module
-            .create_cache_snapshot(file_system_info, build_start_time)
-            .await?;
           Ok(Some((module_identifier, snapshot)))
         });
       }
@@ -205,9 +238,9 @@ fn create_cache_entry(
   let source_module = module_graph
     .module_by_identifier(&module_identifier)
     .expect("pending module should exist in the final module graph");
-  let normal_module = source_module
-    .as_normal_module()
-    .expect("only normal modules are marked pending for the module build cache");
+  let Some(module_state) = source_module.capture_build_state() else {
+    return Ok(None);
+  };
   let Some(dependencies) = clone_dependencies(module_graph, source_module.get_dependencies())
   else {
     return Ok(None);
@@ -225,7 +258,8 @@ fn create_cache_entry(
     .clone();
 
   let entry = ModuleBuildCacheEntry {
-    module_state: normal_module.module_state().clone(),
+    module_type: source_module.build_cache_type().to_owned(),
+    module_state,
     graph_result: ModuleGraphBuildResult {
       dependencies,
       blocks,

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -364,7 +364,7 @@ impl Compilation {
     // Incremental make reuses the previous module graph and owns its own
     // invalidation path. Keep that fast path unchanged.
     let module_build_cache = (options.experiments.new_cache.module
-      && !is_rebuild
+      && !(is_rebuild && incremental.passes_enabled(IncrementalPasses::BUILD_MODULE_GRAPH))
       && !matches!(&options.cache, CacheOptions::Disabled))
     .then(|| ModuleBuildCache::new(cache.facade("Compilation/modules"), &options));
     let snapshot_options = match &options.cache {

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -274,8 +274,7 @@ pub struct ContextModule {
   identifier: Identifier,
   options: ContextModuleOptions,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: crate::BaseModuleState,
   #[debug(skip)]
   #[cacheable(with=Unsupported)]
   resolve_dependencies: ResolveContextModuleDependencies,
@@ -298,10 +297,12 @@ impl ContextModule {
       identifier: create_identifier(&options, None),
       options,
       factory_meta: None,
-      build_info,
-      build_meta: BuildMeta::default()
-        .with_exports_type(BuildMetaExportsType::Default)
-        .with_default_object(BuildMetaDefaultObject::RedirectWarn),
+      state: crate::BaseModuleState {
+        build_info,
+        build_meta: BuildMeta::default()
+          .with_exports_type(BuildMetaExportsType::Default)
+          .with_default_object(BuildMetaDefaultObject::RedirectWarn),
+      },
       source_map_kind: SourceMapKind::empty(),
       resolve_dependencies,
     }
@@ -1324,10 +1325,25 @@ impl DependenciesBlock for ContextModule {
   }
 }
 
+crate::impl_module_state!(ContextModule, crate::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ContextModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, context: &crate::NeedBuildContext<'_>) -> Result<bool> {
+    let Some(snapshot) = &self.state.build_info.snapshot else {
+      return Ok(!self.options.resource.as_str().is_empty());
+    };
+    Ok(matches!(
+      context
+        .file_system_info
+        .check_snapshot_valid(snapshot)
+        .await?,
+      crate::SnapshotValidationResult::Invalid { .. }
+    ))
+  }
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsAuto
@@ -1519,7 +1535,7 @@ impl Module for ContextModule {
     if !self.options.resource.as_str().is_empty() {
       let mut context_dependencies: InternedPathSet = Default::default();
       context_dependencies.insert(self.options.resource.as_std_path().into());
-      self.build_info.dependencies.context = context_dependencies;
+      self.state.build_info.dependencies.context = context_dependencies;
     }
 
     Ok(BuildResult {

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,16 +11,15 @@ use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  CodeGenerationDataChunkInitFragments, CodeGenerationDataUrl, CodeGenerationResultBuilder,
-  Compilation, ConcatenationScope, Context, DependenciesBlock, DependencyId, DependencyRef,
-  ExportProvided, ExternalType, FactoryMeta, ImportAttributes, ImportPhase, InitFragmentExt,
-  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
-  NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
-  StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
-  extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMetaExportsType,
+  BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey, CodeGenerationDataChunkInitFragments,
+  CodeGenerationDataUrl, CodeGenerationResultBuilder, Compilation, ConcatenationScope, Context,
+  DependenciesBlock, DependencyId, DependencyRef, ExportProvided, ExternalType, FactoryMeta,
+  ImportAttributes, ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage,
+  LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate,
+  ModuleGraph, ModuleType, NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals,
+  RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports,
+  UsedNameItem, extract_url_and_global, impl_module_meta_info, module_update_hash, property_access,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   to_identifier,
 };
@@ -457,8 +456,7 @@ pub struct ExternalModule {
   /// Request intended by user (without loaders from config)
   user_request: String,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: crate::BaseModuleState,
   dependency_meta: DependencyMeta,
   place_in_initial: bool,
 }
@@ -516,12 +514,14 @@ impl ExternalModule {
       external_type,
       user_request,
       factory_meta: None,
-      build_info: BuildInfo {
-        top_level_declarations: Some(Default::default()),
-        strict: true,
-        ..Default::default()
+      state: crate::BaseModuleState {
+        build_info: BuildInfo {
+          top_level_declarations: Some(Default::default()),
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
       dependency_meta,
       place_in_initial,
@@ -1083,10 +1083,17 @@ impl DependenciesBlock for ExternalModule {
   }
 }
 
+crate::impl_module_state!(ExternalModule, crate::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ExternalModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &crate::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn get_concatenation_bailout_reason(
     &self,
@@ -1160,7 +1167,7 @@ impl Module for ExternalModule {
     build_context: BuildContext,
     _: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    self.build_info.module = build_context.compiler_options.output.module;
+    self.state.build_info.module = build_context.compiler_options.output.module;
     let resolved_external_type = self.resolve_external_type();
     let request = match &self.request {
       ExternalRequest::Single(request) => Some(request),
@@ -1171,7 +1178,7 @@ impl Module for ExternalModule {
 
     #[allow(clippy::collapsible_match)]
     match resolved_external_type {
-      "this" => self.build_info.strict = false,
+      "this" => self.state.build_info.strict = false,
       "system" => {
         if !request.is_some_and(|r| r.has_rest()) {
           exports_type = BuildMetaExportsType::Namespace;
@@ -1179,22 +1186,22 @@ impl Module for ExternalModule {
         }
       }
       "module" => {
-        if self.build_info.module {
+        if self.state.build_info.module {
           if !request.is_some_and(|r| r.has_rest()) {
             exports_type = BuildMetaExportsType::Namespace;
             can_mangle = true;
           }
         } else {
-          self.build_meta.set_has_top_level_await(true);
+          self.state.build_meta.set_has_top_level_await(true);
           if !request.is_some_and(|r| r.has_rest()) {
             exports_type = BuildMetaExportsType::Namespace;
             can_mangle = false;
           }
         }
       }
-      "script" | "promise" => self.build_meta.set_has_top_level_await(true),
+      "script" | "promise" => self.state.build_meta.set_has_top_level_await(true),
       "import" => {
-        self.build_meta.set_has_top_level_await(true);
+        self.state.build_meta.set_has_top_level_await(true);
         if !request.is_some_and(|r| r.has_rest()) {
           exports_type = BuildMetaExportsType::Namespace;
           can_mangle = false;
@@ -1202,7 +1209,7 @@ impl Module for ExternalModule {
       }
       _ => {}
     }
-    self.build_meta.set_exports_type(exports_type);
+    self.state.build_meta.set_exports_type(exports_type);
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: vec![DependencyRef::new(StaticExportsDependency::new(

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -45,6 +45,8 @@ mod normal_module;
 mod raw_module;
 pub use raw_module::*;
 pub mod module;
+mod module_state;
+pub use module_state::*;
 pub mod parser_and_generator;
 pub use concatenated_module::*;
 pub use module::*;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -853,6 +853,26 @@ pub trait Module:
     ConnectionState::Active(true)
   }
 
+  /// Stable concrete type discriminator for module build cache entries.
+  fn build_cache_type(&self) -> &'static str {
+    std::any::type_name::<Self>()
+  }
+
+  /// Captures build output only. Factory data and graph-owned dependencies are
+  /// supplied separately when restoring a module in a later compilation.
+  fn capture_build_state(&self) -> Option<Box<dyn crate::ModuleState>> {
+    None
+  }
+
+  /// Restores a matching state without replacing factory-owned module data,
+  /// returning the displaced state so a failed validation can be rolled back.
+  fn restore_build_state(
+    &mut self,
+    _state: &dyn crate::ModuleState,
+  ) -> Option<Box<dyn crate::ModuleState>> {
+    None
+  }
+
   /// Determines whether a module needs to be rebuilt using the complete build
   /// context.
   ///
@@ -1110,6 +1130,33 @@ impl dyn Module {
 
 #[macro_export]
 macro_rules! impl_module_meta_info {
+  (state) => {
+    $crate::impl_module_state_access!();
+
+    fn factory_meta(&self) -> Option<&$crate::FactoryMeta> {
+      self.factory_meta.as_ref()
+    }
+
+    fn set_factory_meta(&mut self, v: $crate::FactoryMeta) {
+      self.factory_meta = Some(v);
+    }
+
+    fn build_info(&self) -> &$crate::BuildInfo {
+      &self.state.build_info
+    }
+
+    fn build_info_mut(&mut self) -> &mut $crate::BuildInfo {
+      &mut self.state.build_info
+    }
+
+    fn build_meta(&self) -> &$crate::BuildMeta {
+      &self.state.build_meta
+    }
+
+    fn build_meta_mut(&mut self) -> &mut $crate::BuildMeta {
+      &mut self.state.build_meta
+    }
+  };
   () => {
     fn factory_meta(&self) -> Option<&$crate::FactoryMeta> {
       self.factory_meta.as_ref()

--- a/crates/rspack_core/src/module_state.rs
+++ b/crates/rspack_core/src/module_state.rs
@@ -1,0 +1,86 @@
+use std::fmt::Debug;
+
+use rspack_cacheable::{cacheable, cacheable_dyn};
+use rspack_util::ext::AsAny;
+
+use crate::{BuildInfo, BuildMeta};
+
+/// Type-erased, serializable build output. Factory data stays on the module.
+#[cacheable_dyn]
+pub trait ModuleState: Debug + Send + Sync + AsAny {}
+
+/// Common build output for modules without additional build-owned fields.
+///
+/// Cloning isolates mutable build metadata from later compilation mutations so
+/// a cache entry can be reused independently of the module graph.
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub struct BaseModuleState {
+  pub build_info: BuildInfo,
+  pub build_meta: BuildMeta,
+}
+
+#[cacheable_dyn]
+impl ModuleState for BaseModuleState {}
+
+/// Associates a concrete module with its build state. Copies are needed when
+/// publishing and restoring independent cache entries, not when sharing entries.
+pub trait HasModuleState {
+  type State: ModuleState + Clone + 'static;
+
+  fn module_state(&self) -> &Self::State;
+  /// Returns the displaced state so cache validation can roll back on a miss.
+  fn restore_module_state(&mut self, state: Self::State) -> Self::State;
+}
+
+/// Bridges typed module implementations to the dynamic module cache boundary.
+pub trait ModuleStateAccess {
+  fn capture_state(&self) -> Box<dyn ModuleState>;
+  fn restore_state(&mut self, state: &dyn ModuleState) -> Option<Box<dyn ModuleState>>;
+}
+
+impl<M: HasModuleState> ModuleStateAccess for M {
+  fn capture_state(&self) -> Box<dyn ModuleState> {
+    Box::new(self.module_state().clone())
+  }
+
+  fn restore_state(&mut self, state: &dyn ModuleState) -> Option<Box<dyn ModuleState>> {
+    let state = state.as_any().downcast_ref::<M::State>()?;
+    Some(Box::new(self.restore_module_state(state.clone())))
+  }
+}
+
+/// Implements typed access for modules whose state needs no restoration fixups.
+#[macro_export]
+macro_rules! impl_module_state {
+  ($module:ty, $state:ty) => {
+    impl $crate::HasModuleState for $module {
+      type State = $state;
+
+      fn module_state(&self) -> &Self::State {
+        &self.state
+      }
+
+      fn restore_module_state(&mut self, state: Self::State) -> Self::State {
+        std::mem::replace(&mut self.state, state)
+      }
+    }
+  };
+}
+
+/// Exposes typed state access through the object-safe Module interface.
+#[macro_export]
+macro_rules! impl_module_state_access {
+  () => {
+    fn capture_build_state(&self) -> Option<Box<dyn $crate::ModuleState>> {
+      Some($crate::ModuleStateAccess::capture_state(self))
+    }
+
+    fn restore_build_state(
+      &mut self,
+      state: &dyn $crate::ModuleState,
+    ) -> Option<Box<dyn $crate::ModuleState>> {
+      $crate::ModuleStateAccess::restore_state(self, state)
+    }
+  };
+}

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -36,13 +36,11 @@ use crate::{
   OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
   ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext,
   RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SnapshotValidationResult, SourceType,
-  ValueCacheVersions,
-  cache::SnapshotStrategyOptions,
-  contextify,
+  ValueCacheVersions, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
-  new_cache::{FileSystemInfo, Snapshot},
+  new_cache::FileSystemInfo,
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -102,10 +100,11 @@ pub struct NormalModuleHooks {
 /// This mirrors webpack's serialized module state: cache entries retain build
 /// output, while factory-owned values such as loaders, parser/generator
 /// instances, and their options always come from the fresh module created for
-/// the current compilation.
+/// the current compilation. Cloning gives the cache an independent copy of
+/// mutable build output while shared sources and dependencies retain their handles.
 #[cacheable]
 #[derive(Debug, Clone)]
-pub(crate) struct NormalModuleState {
+pub struct NormalModuleState {
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
   diagnostics: Vec<Diagnostic>,
@@ -318,15 +317,6 @@ impl NormalModule {
     self.parser_and_generator_options.generator_options()
   }
 
-  pub(crate) fn module_state(&self) -> &NormalModuleState {
-    &self.state
-  }
-
-  pub(crate) fn restore_module_state(&mut self, state: NormalModuleState) {
-    self.state = state;
-    self.cached_source_sizes = SourceSizeCache::default();
-  }
-
   pub(crate) async fn need_build_with_context(
     &self,
     file_system_info: &FileSystemInfo,
@@ -335,17 +325,6 @@ impl NormalModule {
     self
       .state
       .need_build_with_context(file_system_info, value_cache_versions)
-      .await
-  }
-
-  pub(crate) async fn create_cache_snapshot(
-    &self,
-    file_system_info: &FileSystemInfo,
-    build_start_time: u64,
-  ) -> Result<Option<Snapshot>> {
-    self
-      .state
-      .create_cache_snapshot(file_system_info, build_start_time)
       .await
   }
 }
@@ -385,33 +364,21 @@ impl NormalModuleState {
       SnapshotValidationResult::Invalid { .. }
     ))
   }
+}
 
-  async fn create_cache_snapshot(
-    &self,
-    file_system_info: &FileSystemInfo,
-    build_start_time: u64,
-  ) -> Result<Option<Snapshot>> {
-    if !self.build_info.cacheable
-      || self
-        .diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.is_error())
-    {
-      return Ok(None);
-    }
+#[cacheable_dyn]
+impl crate::ModuleState for NormalModuleState {}
 
-    Ok(Some(
-      file_system_info
-        .create_snapshot(
-          Some(build_start_time),
-          &self.build_info.dependencies.file,
-          &self.build_info.dependencies.context,
-          &self.build_info.dependencies.missing,
-          // Rspack does not expose webpack's `snapshot.module` strategy yet.
-          SnapshotStrategyOptions::timestamp(),
-        )
-        .await?,
-    ))
+impl crate::HasModuleState for NormalModule {
+  type State = NormalModuleState;
+
+  fn module_state(&self) -> &Self::State {
+    &self.state
+  }
+
+  fn restore_module_state(&mut self, state: Self::State) -> Self::State {
+    self.cached_source_sizes = SourceSizeCache::default();
+    std::mem::replace(&mut self.state, state)
   }
 }
 
@@ -476,6 +443,8 @@ impl Module for NormalModule {
       f64::max(1.0, self.parser_and_generator.size(self, source_type))
     }
   }
+
+  crate::impl_module_state_access!();
 
   async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
     self

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -12,8 +12,8 @@ use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
 use crate::{
-  BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder,
-  Compilation, ConnectionState, Context, DependenciesBlock, DependencyId, FactoryMeta, Module,
+  BoxModule, BuildContext, BuildInfo, BuildResult, CodeGenerationResultBuilder, Compilation,
+  ConnectionState, Context, DependenciesBlock, DependencyId, FactoryMeta, Module,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleType,
   RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
   dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info,
@@ -33,8 +33,7 @@ pub struct RawModule {
   readable_identifier: String,
   runtime_requirements: RuntimeGlobals,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: crate::BaseModuleState,
 }
 
 static RAW_MODULE_SOURCE_TYPES: &[SourceType] = &[SourceType::JavaScript];
@@ -55,12 +54,14 @@ impl RawModule {
       readable_identifier,
       runtime_requirements,
       factory_meta: None,
-      build_info: BuildInfo {
-        cacheable: true,
-        strict: true,
-        ..Default::default()
+      state: crate::BaseModuleState {
+        build_info: BuildInfo {
+          cacheable: true,
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -94,10 +95,17 @@ impl DependenciesBlock for RawModule {
   }
 }
 
+crate::impl_module_state!(RawModule, crate::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for RawModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &crate::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsAuto

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -10,10 +10,10 @@ use rspack_sources::BoxSource;
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkUkey, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier,
-  ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildResult, ChunkUkey,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId, FactoryMeta,
+  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType,
+  RuntimeSpec, SourceType, impl_module_meta_info,
 };
 
 #[impl_source_map_config]
@@ -25,8 +25,7 @@ pub struct SelfModule {
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: crate::BaseModuleState,
 }
 
 impl SelfModule {
@@ -38,11 +37,13 @@ impl SelfModule {
       blocks: Default::default(),
       dependencies: Default::default(),
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        ..Default::default()
+      state: crate::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -76,10 +77,12 @@ impl DependenciesBlock for SelfModule {
   }
 }
 
+crate::impl_module_state!(SelfModule, crate::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for SelfModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     self.identifier.len() as f64

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildResult,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
   EntryDependency, FactoryMeta, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
   ModuleType, NeedBuildContext, RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions,
   impl_module_meta_info, impl_source_map_config, module_update_hash,
@@ -25,9 +25,7 @@ pub struct DllModule {
 
   factory_meta: Option<FactoryMeta>,
 
-  build_info: BuildInfo,
-
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
 
@@ -56,10 +54,12 @@ impl DllModule {
   }
 }
 
+rspack_core::impl_module_state!(DllModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DllModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsDynamic

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -4,10 +4,10 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleDependency, ModuleGraph, ModuleId, ModuleType, NeedBuildContext, RuntimeSpec, SourceType,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildResult,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId, FactoryMeta,
+  LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleDependency,
+  ModuleGraph, ModuleId, ModuleType, NeedBuildContext, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec, ValueCacheVersions, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
@@ -34,8 +34,7 @@ pub struct DelegatedModule {
   dependencies: Vec<DependencyId>,
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 }
 
 impl DelegatedModule {
@@ -58,10 +57,12 @@ impl DelegatedModule {
   }
 }
 
+rspack_core::impl_module_state!(DelegatedModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DelegatedModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
 
   fn module_type(&self) -> &ModuleType {
     &ModuleType::JsDynamic
@@ -109,7 +110,7 @@ impl Module for DelegatedModule {
         false,
       )),
     ];
-    self.build_meta = self.delegate_data.build_meta.clone();
+    self.state.build_meta = self.delegate_data.build_meta.clone();
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -1,7 +1,9 @@
+use std::hash::Hasher;
+
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
+  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildResult,
   CodeGenerationResultBuilder, Compilation, CompilerOptions, DependenciesBlock, DependencyId,
   FactoryMeta, Module, ModuleCodeGenerationContext, ModuleExt, ModuleFactory,
   ModuleFactoryCreateData, ModuleFactoryResult, ModuleGraph, ModuleLayer, RuntimeSpec, SourceType,
@@ -31,14 +33,26 @@ pub(crate) struct CssModule {
   pub(crate) identifier_index: u32,
 
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: CssModuleState,
 
   blocks: Vec<AsyncDependenciesBlockIdentifier>,
   dependencies: Vec<DependencyId>,
 
   identifier__: Identifier,
 }
+
+/// Build metadata and the content fingerprint used to validate a cached CSS build.
+/// Cloning isolates cached metadata from subsequent compilation mutations.
+#[cacheable]
+#[derive(Debug, Clone)]
+pub(crate) struct CssModuleState {
+  build_info: BuildInfo,
+  build_meta: rspack_core::BuildMeta,
+  input_hash: Option<u64>,
+}
+
+#[cacheable_dyn]
+impl rspack_core::ModuleState for CssModuleState {}
 
 impl CssModule {
   pub fn new(dep: &CssDependency) -> Self {
@@ -67,16 +81,29 @@ impl CssModule {
       blocks: vec![],
       dependencies: vec![],
       factory_meta: None,
-      build_info: BuildInfo {
-        cacheable: dep.cacheable,
-        strict: true,
-        dependencies: dep.dependencies.clone(),
-        ..Default::default()
+      state: CssModuleState {
+        build_info: BuildInfo {
+          cacheable: dep.cacheable,
+          strict: true,
+          dependencies: dep.dependencies.clone(),
+          ..Default::default()
+        },
+        build_meta: Default::default(),
+        input_hash: None,
       },
-      build_meta: Default::default(),
       source_map_kind: rspack_util::source_map::SourceMapKind::empty(),
       identifier__,
     }
+  }
+
+  fn input_hash(&self) -> u64 {
+    let mut hasher = rustc_hash::FxHasher::default();
+    std::hash::Hash::hash(&self.content, &mut hasher);
+    std::hash::Hash::hash(&self.css_layer, &mut hasher);
+    std::hash::Hash::hash(&self.supports, &mut hasher);
+    std::hash::Hash::hash(&self.media, &mut hasher);
+    std::hash::Hash::hash(&self.source_map, &mut hasher);
+    hasher.finish()
   }
 
   fn compute_hash(&self, options: &CompilerOptions) -> RspackHashDigest {
@@ -94,10 +121,36 @@ impl CssModule {
   }
 }
 
+impl rspack_core::HasModuleState for CssModule {
+  type State = CssModuleState;
+
+  fn module_state(&self) -> &Self::State {
+    &self.state
+  }
+
+  fn restore_module_state(&mut self, mut state: Self::State) -> Self::State {
+    // The loader supplies current dependency tracking through the factory,
+    // including when its CSS output is unchanged.
+    state
+      .build_info
+      .dependencies
+      .clone_from(&self.state.build_info.dependencies);
+    if !state.build_info.cacheable {
+      state.input_hash = None;
+    }
+    state.build_info.cacheable = self.state.build_info.cacheable;
+    std::mem::replace(&mut self.state, state)
+  }
+}
+
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for CssModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    Ok(self.state.input_hash != Some(self.input_hash()))
+  }
 
   fn readable_identifier(&self, context: &rspack_core::Context) -> std::borrow::Cow<'_, str> {
     let index_suffix = if self.identifier_index > 0 {
@@ -166,7 +219,8 @@ impl Module for CssModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
-    self.build_info.hash = Some(self.compute_hash(&build_context.compiler_options));
+    self.state.build_info.hash = Some(self.compute_hash(&build_context.compiler_options));
+    self.state.input_hash = Some(self.input_hash());
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: vec![],
@@ -190,7 +244,7 @@ impl Module for CssModule {
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHasher::from(&compilation.options.output);
     module_update_hash(self, &mut hasher, compilation, runtime);
-    self.build_info.hash.hash(&mut hasher);
+    self.state.build_info.hash.hash(&mut hasher);
     Ok(hasher.digest(&compilation.options.output.hash_digest))
   }
 

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -47,8 +47,7 @@ fn has_closure_library(output: &OutputOptions) -> bool {
 #[cacheable]
 #[derive(Debug)]
 pub(crate) struct LazyCompilationProxyModule {
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: LazyCompilationProxyModuleState,
   factory_meta: Option<FactoryMeta>,
 
   readable_identifier: String,
@@ -70,8 +69,24 @@ pub(crate) struct LazyCompilationProxyModule {
   // slice so each clones the `Arc`, not the whole list.
   #[cacheable(with=AsVec)]
   reserved_externals: Arc<[String]>,
+}
+
+/// Build output and the factory inputs that determine the proxy dependencies.
+/// Cloning isolates the cached build from later proxy activation and rebuilds.
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LazyCompilationProxyModuleState {
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
+  active: bool,
+  client: String,
   need_build: bool,
 }
+
+#[cacheable_dyn]
+impl rspack_core::ModuleState for LazyCompilationProxyModuleState {}
+
+rspack_core::impl_module_state!(LazyCompilationProxyModule, LazyCompilationProxyModuleState);
 
 impl ModuleSourceMapConfig for LazyCompilationProxyModule {
   fn get_source_map_kind(&self) -> &SourceMapKind {
@@ -106,8 +121,7 @@ impl LazyCompilationProxyModule {
     };
 
     Self {
-      build_info: Default::default(),
-      build_meta: Default::default(),
+      state: Default::default(),
       factory_meta: None,
       readable_identifier,
       lib_ident,
@@ -122,12 +136,11 @@ impl LazyCompilationProxyModule {
       active,
       client,
       reserved_externals,
-      need_build: false,
     }
   }
 
   pub fn invalid(&mut self) {
-    self.need_build = true;
+    self.state.need_build = true;
   }
 }
 
@@ -136,7 +149,7 @@ impl_empty_diagnosable_trait!(LazyCompilationProxyModule);
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for LazyCompilationProxyModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
     &SOURCE_TYPE
@@ -171,7 +184,7 @@ impl Module for LazyCompilationProxyModule {
   }
 
   fn need_build_for_incremental(&self, value_cache_versions: &ValueCacheVersions) -> bool {
-    if self.need_build {
+    if self.state.need_build {
       return true;
     }
     // check client changes
@@ -186,7 +199,11 @@ impl Module for LazyCompilationProxyModule {
   }
 
   async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
-    Ok(self.need_build_for_incremental(context.value_cache_versions))
+    Ok(
+      self.state.active != self.active
+        || self.state.client != self.client
+        || self.need_build_for_incremental(context.value_cache_versions),
+    )
   }
 
   async fn build(
@@ -194,6 +211,9 @@ impl Module for LazyCompilationProxyModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BuildResult> {
+    self.state.need_build = false;
+    self.state.active = self.active;
+    self.state.client.clone_from(&self.client);
     let client_dep = CommonJsRequireDependency::new(
       self.client.clone(),
       DependencyRange::new(0, 0),

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -38,8 +38,7 @@ pub struct ContainerEntryModule {
   exposes: Vec<(String, ExposeOptions)>,
   share_scope: ShareScope,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
   enhanced: bool,
   request: Option<String>,
   version: Option<String>,
@@ -69,12 +68,14 @@ impl ContainerEntryModule {
       exposes,
       share_scope,
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(Default::default()),
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          top_level_declarations: Some(Default::default()),
+          ..Default::default()
+        },
+        build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       enhanced,
       request: None,
       version: None,
@@ -100,12 +101,14 @@ impl ContainerEntryModule {
       exposes: vec![],
       share_scope: ShareScope::Multiple(vec![]),
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(Default::default()),
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          top_level_declarations: Some(Default::default()),
+          ..Default::default()
+        },
+        build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       enhanced: false,
       request: Some(request),
       version: Some(version),
@@ -152,10 +155,17 @@ impl DependenciesBlock for ContainerEntryModule {
   }
 }
 
+rspack_core::impl_module_state!(ContainerEntryModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ContainerEntryModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, ChunkUkey, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildResult,
+  ChunkGraph, ChunkUkey, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
+  DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType,
+  impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
 };
@@ -30,8 +30,7 @@ pub struct FallbackModule {
   lib_ident: String,
   requests: Vec<String>,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 }
 
 impl FallbackModule {
@@ -55,11 +54,13 @@ impl FallbackModule {
       lib_ident,
       requests,
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -93,10 +94,17 @@ impl DependenciesBlock for FallbackModule {
   }
 }
 
+rspack_core::impl_module_state!(FallbackModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for FallbackModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     self.requests.len() as f64 * 5.0 + 42.0

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
-  Dependency, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildResult,
+  ChunkGraph, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, Dependency,
+  DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
 };
@@ -40,8 +40,7 @@ pub struct RemoteModule {
   pub share_scope: ShareScope,
   pub remote_key: String,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 }
 
 impl RemoteModule {
@@ -73,11 +72,13 @@ impl RemoteModule {
       share_scope,
       remote_key,
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -111,10 +112,17 @@ impl DependenciesBlock for RemoteModule {
   }
 }
 
+rspack_core::impl_module_state!(RemoteModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for RemoteModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     6.0

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -5,11 +5,10 @@ use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::BoxSource, runtime_mode::RuntimeMode,
+  BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
+  ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -34,8 +33,7 @@ pub struct ConsumeSharedModule {
   context: Context,
   options: ConsumeOptions,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 }
 
 impl ConsumeSharedModule {
@@ -93,8 +91,10 @@ impl ConsumeSharedModule {
       context,
       options,
       factory_meta: None,
-      build_info: Default::default(),
-      build_meta: Default::default(),
+      state: rspack_core::BaseModuleState {
+        build_info: Default::default(),
+        build_meta: Default::default(),
+      },
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -128,10 +128,17 @@ impl DependenciesBlock for ConsumeSharedModule {
   }
 }
 
+rspack_core::impl_module_state!(ConsumeSharedModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ConsumeSharedModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -5,11 +5,10 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::BoxSource, runtime_mode::RuntimeMode,
+  BuildInfo, BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
+  DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -43,8 +42,7 @@ pub struct ProvideSharedModule {
   strict_version: Option<bool>,
   tree_shaking_mode: Option<String>,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
 }
 
 impl ProvideSharedModule {
@@ -83,11 +81,13 @@ impl ProvideSharedModule {
       strict_version,
       tree_shaking_mode,
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          ..Default::default()
+        },
+        build_meta: Default::default(),
       },
-      build_meta: Default::default(),
       source_map_kind: SourceMapKind::empty(),
     }
   }
@@ -136,10 +136,17 @@ impl DependenciesBlock for ProvideSharedModule {
   }
 }
 
+rspack_core::impl_module_state!(ProvideSharedModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ProvideSharedModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // Called for a previously completed build, as in webpack's needBuild.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -46,8 +46,7 @@ pub struct RscEntryModule {
   /// When true, client modules are loaded eagerly (not as code-split points).
   is_server_side_rendering: bool,
   factory_meta: Option<FactoryMeta>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
+  state: rspack_core::BaseModuleState,
   layer: Option<ModuleLayer>,
 }
 
@@ -87,12 +86,14 @@ impl RscEntryModule {
       name,
       is_server_side_rendering,
       factory_meta: None,
-      build_info: BuildInfo {
-        strict: true,
-        top_level_declarations: Some(Default::default()),
-        ..Default::default()
+      state: rspack_core::BaseModuleState {
+        build_info: BuildInfo {
+          strict: true,
+          top_level_declarations: Some(Default::default()),
+          ..Default::default()
+        },
+        build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       },
-      build_meta: BuildMeta::default().with_exports_type(BuildMetaExportsType::Namespace),
       source_map_kind: SourceMapKind::empty(),
       layer,
     }
@@ -213,10 +214,17 @@ impl DependenciesBlock for RscEntryModule {
   }
 }
 
+rspack_core::impl_module_state!(RscEntryModule, rspack_core::BaseModuleState);
+
 #[cacheable_dyn]
 #[async_trait]
 impl Module for RscEntryModule {
-  impl_module_meta_info!();
+  impl_module_meta_info!(state);
+
+  async fn need_build(&mut self, _context: &rspack_core::NeedBuildContext<'_>) -> Result<bool> {
+    // The identifier includes the client references and server-entry grouping.
+    Ok(false)
+  }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
     42.0

--- a/tests/rspack-test/compilerCases/_module-cache.js
+++ b/tests/rspack-test/compilerCases/_module-cache.js
@@ -1,0 +1,19 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+let timestamp = Date.now() - 60_000;
+
+exports.write = (root, name, content) => {
+	const file = path.join(root, name);
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+	// Keep timestamps distinct and outside the snapshot's filesystem accuracy window.
+	const time = new Date((timestamp += 10));
+	fs.utimesSync(file, time, time);
+	return file;
+};
+
+exports.close = (compiler) =>
+	new Promise((resolve, reject) => {
+		compiler.close((error) => (error ? reject(error) : resolve()));
+	});

--- a/tests/rspack-test/compilerCases/module-cache-lazy-compilation-new-cache.js
+++ b/tests/rspack-test/compilerCases/module-cache-lazy-compilation-new-cache.js
@@ -1,0 +1,136 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+const { close, write } = require("./_module-cache");
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should validate cached proxy activation and client state",
+	options(context) {
+		return { context: context.getSource(), entry: "./a" };
+	},
+	async build(context) {
+		for (const persistent of [false, true]) {
+			const root = context.getDist(persistent ? "persistent" : "memory");
+			fs.rmSync(root, { recursive: true, force: true });
+			fs.mkdirSync(root, { recursive: true });
+			write(root, "index.js", 'module.exports = () => import("./target");');
+			write(root, "target.js", 'module.exports = "target";');
+			for (const name of ["client-a.js", "client-b.js"]) {
+				write(root, name, "module.exports = () => ({ activate() {} });");
+			}
+			const active = new Set();
+			const built = [];
+			const create = (client = "client-a.js") =>
+				rspack({
+					context: root,
+					entry: "./index.js",
+					target: "node",
+					mode: "development",
+					devtool: false,
+					incremental: false,
+					cache: persistent
+						? {
+								type: "persistent",
+								storage: {
+									type: "filesystem",
+									directory: path.join(root, "cache"),
+								},
+							}
+						: { type: "memory" },
+					experiments: {
+						newCache: {
+							module: true,
+							loader: false,
+							codeGeneration: false,
+							devtool: false,
+							minimize: false,
+						},
+					},
+					output: { path: path.join(root, "dist") },
+					plugins: [
+						{
+							apply(compiler) {
+								// Exercise the native backend deterministically without an HTTP server.
+								compiler.__internal__registerBuiltinPlugin({
+									name: "LazyCompilationPlugin",
+									canInherentFromParent: false,
+									options: {
+										currentActiveModules: () => active,
+										entries: false,
+										imports: true,
+										client: path.join(root, client),
+										reservedExternals: [],
+										test: /target\.js$/,
+									},
+								});
+								compiler.hooks.compilation.tap(
+									"LazyModuleCacheTest",
+									(compilation) => {
+										compilation.hooks.buildModule.tap(
+											"LazyModuleCacheTest",
+											(module) => {
+												built.push(module.identifier());
+											},
+										);
+									},
+								);
+							},
+						},
+					],
+				});
+			let compiler = create();
+			const run = () =>
+				new Promise((resolve, reject) => {
+					built.length = 0;
+					compiler.run((error, stats) => {
+						if (error) return reject(error);
+						if (stats.hasErrors())
+							return reject(
+								new Error(stats.toString({ all: false, errors: true })),
+							);
+						resolve(
+							[...stats.compilation.modules].map((module) =>
+								module.identifier(),
+							),
+						);
+					});
+				});
+			try {
+				const first = await run();
+				const proxy = first.find((id) =>
+					id.startsWith("lazy-compilation-proxy|"),
+				);
+				expect(proxy).toBeDefined();
+				expect(first).not.toContain(path.join(root, "target.js"));
+				await run();
+				expect(built).toEqual([]);
+
+				active.add(proxy);
+				expect(await run()).toContain(path.join(root, "target.js"));
+				expect(built).toContain(proxy);
+				await run();
+				expect(built).toEqual([]);
+
+				active.clear();
+				expect(await run()).not.toContain(path.join(root, "target.js"));
+				expect(built).toContain(proxy);
+
+				if (persistent) {
+					await close(compiler);
+					compiler = create();
+					await run();
+					expect(built).toEqual([]);
+					await close(compiler);
+					compiler = create("client-b.js");
+					const modules = await run();
+					expect(built).toContain(proxy);
+					expect(modules).toContain(path.join(root, "client-b.js"));
+					expect(modules).not.toContain(path.join(root, "client-a.js"));
+				}
+			} finally {
+				await close(compiler);
+			}
+		}
+	},
+};

--- a/tests/rspack-test/compilerCases/module-cache-module-types-new-cache.js
+++ b/tests/rspack-test/compilerCases/module-cache-module-types-new-cache.js
@@ -1,0 +1,219 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+const { close, write } = require("./_module-cache");
+
+const PLUGIN = "ModuleStateCacheTest";
+
+function run(compiler, built) {
+	built.length = 0;
+	return new Promise((resolve, reject) => {
+		compiler.run((error, stats) => {
+			if (error) return reject(error);
+			if (stats.hasErrors()) {
+				return reject(new Error(stats.toString({ all: false, errors: true })));
+			}
+			resolve(stats);
+		});
+	});
+}
+
+function options(root, cache, built) {
+	return {
+		context: root,
+		mode: "development",
+		target: "node",
+		entry: "./index.js",
+		devtool: false,
+		incremental: false,
+		cache,
+		experiments: {
+			newCache: {
+				module: true,
+				loader: false,
+				codeGeneration: false,
+				devtool: false,
+				minimize: false,
+			},
+		},
+		resolve: { alias: { ignored: false } },
+		externals: { external: "commonjs node:path" },
+		module: {
+			rules: [
+				{
+					test: /\.css$/,
+					use: [
+						rspack.CssExtractRspackPlugin.loader,
+						require.resolve("css-loader"),
+						"./metadata-loader.js",
+					],
+				},
+			],
+		},
+		optimization: { minimize: false, concatenateModules: false },
+		output: {
+			path: path.join(root, "dist"),
+			filename: "main.js",
+			chunkFilename: "[name].[contenthash].js",
+			library: { type: "commonjs2" },
+		},
+		plugins: [
+			new rspack.CssExtractRspackPlugin({ filename: "main.css" }),
+			{
+				apply(compiler) {
+					compiler.hooks.compilation.tap(PLUGIN, (compilation) => {
+						compilation.hooks.buildModule.tap(PLUGIN, (module) => {
+							built.push(module.identifier());
+						});
+					});
+				},
+			},
+		],
+	};
+}
+
+async function checkOutput(root, values, color) {
+	const bundle = path.join(root, "dist/main.js");
+	delete require.cache[bundle];
+	const result = require(bundle);
+	expect(result.values).toEqual(values);
+	expect(await result.lazy()).toEqual(values);
+	expect(result.external).toBe("file.js");
+	expect(result.ignored).toEqual({});
+	expect(fs.readFileSync(path.join(root, "dist/main.css"), "utf8")).toContain(
+		`color: ${color}`,
+	);
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should cache module states and invalidate context and CSS builds",
+	options(context) {
+		return { context: context.getSource(), entry: "./a" };
+	},
+	async build(context) {
+		for (const persistent of [false, true]) {
+			const root = context.getDist(persistent ? "persistent" : "memory");
+			fs.rmSync(root, { recursive: true, force: true });
+			write(
+				root,
+				"index.js",
+				`
+        require("./style.css");
+        const sync = require.context("./context", false, /\\.js$/, "sync");
+        const lazy = require.context("./context", false, /\\.js$/, "lazy-once");
+        exports.values = sync.keys().sort().map(key => sync(key));
+        exports.lazy = () => Promise.all(lazy.keys().sort().map(key => lazy(key)));
+        exports.external = require("external").basename("/dir/file.js");
+        exports.ignored = require("ignored");
+      `,
+			);
+			write(root, "context/a.js", 'module.exports = "a";');
+			write(root, "style.css", "body { color: red; }");
+			write(
+				root,
+				"metadata-loader.js",
+				`
+        const fs = require("node:fs");
+        const path = require("node:path");
+        module.exports = function(source) {
+          const config = path.join(this.rootContext, "css-deps.json");
+          this.addDependency(config);
+          const metadata = JSON.parse(fs.readFileSync(config, "utf8"));
+          this.addDependency(path.join(this.rootContext, metadata.file));
+          this.cacheable(metadata.cacheable);
+          return source;
+        };
+      `,
+			);
+			const firstDependency = write(root, "first.txt", "first");
+			const secondDependency = write(root, "second.txt", "second");
+			const metadata = (file, cacheable = true) =>
+				write(root, "css-deps.json", JSON.stringify({ file, cacheable }));
+			metadata("first.txt");
+			const built = [];
+			const cache = persistent
+				? {
+						type: "persistent",
+						storage: {
+							type: "filesystem",
+							directory: path.join(root, "cache"),
+						},
+					}
+				: { type: "memory" };
+			const create = () => rspack(options(root, cache, built));
+			let compiler = create();
+			try {
+				await run(compiler, built);
+				const initial = [...built];
+				expect(initial.some((id) => id.startsWith("external "))).toBe(true);
+				expect(initial.some((id) => id.startsWith("ignored|"))).toBe(true);
+				expect(initial.some((id) => id.startsWith("css|"))).toBe(true);
+				expect(
+					initial.filter(
+						(id) => id.includes("|sync") || id.includes("|lazy-once"),
+					),
+				).toHaveLength(2);
+				await checkOutput(root, ["a"], "red");
+
+				if (persistent) {
+					await close(compiler);
+					compiler = create();
+				}
+				await run(compiler, built);
+				expect(built, JSON.stringify({ persistent, built })).toEqual([]);
+				await checkOutput(root, ["a"], "red");
+
+				metadata("second.txt");
+				const stats = await run(compiler, built);
+				expect(built.some((id) => id.startsWith("css|"))).toBe(false);
+				expect([...stats.compilation.fileDependencies]).toContain(
+					secondDependency,
+				);
+				expect([...stats.compilation.fileDependencies]).not.toContain(
+					firstDependency,
+				);
+
+				metadata("second.txt", false);
+				await run(compiler, built);
+				expect(built.some((id) => id.startsWith("css|"))).toBe(true);
+				metadata("second.txt");
+				await run(compiler, built);
+				expect(built.some((id) => id.startsWith("css|"))).toBe(true);
+				await run(compiler, built);
+				expect(built).toEqual([]);
+
+				write(root, "context/b.js", 'module.exports = "b";');
+				await run(compiler, built);
+				expect(
+					built.filter(
+						(id) => id.includes("|sync") || id.includes("|lazy-once"),
+					),
+				).toHaveLength(2);
+				expect(
+					built.some(
+						(id) => id.startsWith("external ") || id.startsWith("ignored|"),
+					),
+				).toBe(false);
+				await checkOutput(root, ["a", "b"], "red");
+
+				fs.unlinkSync(path.join(root, "context/a.js"));
+				write(root, "style.css", "body { color: blue; }");
+				await run(compiler, built);
+				expect(built.some((id) => id.startsWith("css|"))).toBe(true);
+				await checkOutput(root, ["b"], "blue");
+
+				if (persistent) {
+					await close(compiler);
+					compiler = create();
+				}
+				await run(compiler, built);
+				expect(built).toEqual([]);
+				await checkOutput(root, ["b"], "blue");
+			} finally {
+				await close(compiler);
+			}
+		}
+	},
+};

--- a/tests/rspack-test/compilerCases/module-cache-synthetic-modules-new-cache.js
+++ b/tests/rspack-test/compilerCases/module-cache-synthetic-modules-new-cache.js
@@ -1,0 +1,177 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const rspack = require("@rspack/core");
+const { close, write } = require("./_module-cache");
+
+async function checkCache(root, persistent, configure, expectedPrefixes) {
+	fs.mkdirSync(root, { recursive: true });
+	write(root, "value.js", 'module.exports = "value";');
+	write(root, "shared.js", 'module.exports = "shared";');
+	const built = [];
+	const create = () =>
+		rspack({
+			context: root,
+			mode: "development",
+			target: "node",
+			devtool: false,
+			incremental: false,
+			entry: "./index.js",
+			cache: persistent
+				? {
+						type: "persistent",
+						storage: {
+							type: "filesystem",
+							directory: path.join(root, "cache"),
+						},
+					}
+				: { type: "memory" },
+			experiments: {
+				newCache: {
+					module: true,
+					loader: false,
+					codeGeneration: false,
+					devtool: false,
+					minimize: false,
+				},
+			},
+			optimization: { concatenateModules: false, minimize: false },
+			output: {
+				path: path.join(root, "dist"),
+				filename: "main.js",
+				library: { type: "commonjs2" },
+			},
+			plugins: [
+				...configure(root),
+				{
+					apply(compiler) {
+						compiler.hooks.compilation.tap(
+							"SyntheticModuleCacheTest",
+							(compilation) => {
+								compilation.hooks.buildModule.tap(
+									"SyntheticModuleCacheTest",
+									(module) => {
+										built.push(module.identifier());
+									},
+								);
+							},
+						);
+					},
+				},
+			],
+		});
+	let compiler = create();
+	const run = () =>
+		new Promise((resolve, reject) => {
+			built.length = 0;
+			compiler.run((error, stats) => {
+				if (error) return reject(error);
+				if (stats.hasErrors()) {
+					return reject(
+						new Error(stats.toString({ all: false, errors: true })),
+					);
+				}
+				resolve();
+			});
+		});
+	try {
+		await run();
+		for (const prefix of expectedPrefixes) {
+			expect(
+				built.filter((id) => id.startsWith(prefix)).length,
+			).toBeGreaterThan(0);
+		}
+		const first = fs.readFileSync(path.join(root, "dist/main.js"), "utf8");
+		if (persistent) {
+			await close(compiler);
+			compiler = create();
+		}
+		await run();
+		expect(built, JSON.stringify({ root, persistent, built })).toEqual([]);
+		expect(fs.readFileSync(path.join(root, "dist/main.js"), "utf8")).toBe(
+			first,
+		);
+	} finally {
+		await close(compiler);
+	}
+}
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig} */
+module.exports = {
+	description: "should restore DLL and federation module states",
+	options(context) {
+		return { context: context.getSource(), entry: "./a" };
+	},
+	async build(context) {
+		for (const persistent of [false, true]) {
+			const root = context.getDist(persistent ? "persistent" : "memory");
+			fs.rmSync(root, { recursive: true, force: true });
+			await checkCache(
+				path.join(root, "federation"),
+				persistent,
+				(root) => {
+					if (!fs.existsSync(path.join(root, "index.js")))
+						write(
+							root,
+							"index.js",
+							`
+          exports.remote = () => import("remote/value");
+          exports.shared = () => import("shared-value");
+        `,
+						);
+					return [
+						new rspack.container.ModuleFederationPluginV1({
+							name: "container",
+							filename: "container.js",
+							library: { type: "commonjs2" },
+							exposes: { "./value": "./value.js" },
+							remotes: { remote: ["commonjs remote-a", "commonjs remote-b"] },
+							shared: {
+								"shared-value": {
+									import: "./shared.js",
+									requiredVersion: false,
+								},
+							},
+						}),
+					];
+				},
+				[
+					"container entry",
+					"remote ",
+					"fallback ",
+					"consume shared module",
+					"provide shared module",
+				],
+			);
+
+			await checkCache(
+				path.join(root, "dll"),
+				persistent,
+				(root) => {
+					if (!fs.existsSync(path.join(root, "index.js")))
+						write(root, "index.js", 'module.exports = require("./value");');
+					return [
+						new rspack.DllPlugin({ path: path.join(root, "manifest.json") }),
+					];
+				},
+				["dll "],
+			);
+
+			await checkCache(
+				path.join(root, "delegated"),
+				persistent,
+				(root) => {
+					if (!fs.existsSync(path.join(root, "index.js")))
+						write(root, "index.js", 'module.exports = require("dll/value");');
+					return [
+						new rspack.DllReferencePlugin({
+							name: 'function() { return "delegated"; }',
+							scope: "dll",
+							content: { "./value": { id: 1, buildMeta: {}, exports: true } },
+						}),
+					];
+				},
+				["delegated "],
+			);
+		}
+	},
+};


### PR DESCRIPTION
## Summary

Extend `experiments.newCache.module` to all built-in build-stage modules using module-owned state and associated types, with `BaseModuleState` for common metadata.

Keep current factory data, validate reuse through each module's `need_build`, and restore fresh state on cache misses. Clone build state to isolate cached metadata from later module mutations, and allow cache reuse during non-incremental rebuilds.