### PR TITLE
chore(deps): upgrade swc-next to 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,7 @@ jobs:
   build-s390x:
     name: Build s390x
     needs: [check-changed]
-    # SWC Next 0.1.3 unconditionally rejects big-endian targets in its AST FFI.
-    # Re-enable after upstream makes the unused FFI serializer portable or optional.
-    if: ${{ false }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
     uses: ./.github/workflows/reusable-build-build.yml
     with:
       target: s390x-unknown-linux-gnu
@@ -253,8 +251,7 @@ jobs:
                 needs.build-wasm.result != 'success' ||
                 needs.build-riscv64.result != 'success' ||
                 needs.build-ppc64.result != 'success' ||
-                (needs.build-s390x.result != 'success' &&
-                  needs.build-s390x.result != 'skipped') ||
+                needs.build-s390x.result != 'success' ||
                 needs.test-wasm.result != 'success' ||
                 needs.check-cache.result != 'skipped'))
           }}

--- a/.github/workflows/preview-commit.yml
+++ b/.github/workflows/preview-commit.yml
@@ -31,7 +31,7 @@ on:
           - aarch64-unknown-linux-musl
           - riscv64gc-unknown-linux-musl
           - powerpc64le-unknown-linux-gnu
-          # SWC Next 0.1.3 rejects big-endian targets, so s390x is unavailable.
+          - s390x-unknown-linux-gnu
           - i686-pc-windows-msvc
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -54,7 +54,8 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: powerpc64le-unknown-linux-gnu
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-          # SWC Next 0.1.3 rejects big-endian targets, so s390x cannot be built.
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-build-all.yml
+++ b/.github/workflows/reusable-build-all.yml
@@ -39,7 +39,8 @@ jobs:
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: powerpc64le-unknown-linux-gnu
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-          # SWC Next 0.1.3 rejects big-endian targets, so s390x cannot be built.
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
           - target: i686-pc-windows-msvc
             runner: ${{ '"windows-latest"' }}
           - target: x86_64-pc-windows-msvc

--- a/.github/workflows/reusable-release-npm.yml
+++ b/.github/workflows/reusable-release-npm.yml
@@ -61,7 +61,9 @@ jobs:
           - target: powerpc64le-unknown-linux-gnu
             runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
             test-runner: '"ubuntu-22.04"'
-          # SWC Next 0.1.3 rejects big-endian targets, so s390x cannot be built.
+          - target: s390x-unknown-linux-gnu
+            runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
+            test-runner: '"ubuntu-22.04"'
           - target: i686-pc-windows-msvc
             runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
             test-runner: '"windows-latest"'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7380,9 +7380,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_allocator"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e7cd2b1d8e0416de91d646162c118c53970dfa5f0ee3bf5f911ec617efe7d"
+checksum = "72965c23b599e53e7dc304d56a8e2d5c971a82738920ba3e303b9799a26c1a75"
 dependencies = [
  "allocator-api2",
  "bumpalo",
@@ -7392,9 +7392,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_ast_macros"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1bab1d6fb73cd5c431785ead29d3f971494f80c7dccd90f9db20642b0b67fb"
+checksum = "2e3570bd93a03c61564002d421ffa93f9ff62a9817a333cd8e340939ef1c8ce3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7403,9 +7403,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_ecma_ast"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f33adc19da19f209cce2b140c19f7a66fd91da1e817bc2f5f2a32ede4f3cb959"
+checksum = "ee81510203d325d7272f4f348b87813258e139e5931ffc1720915ca792b3e6ae"
 dependencies = [
  "oxc_index",
  "swc_next_allocator",
@@ -7415,9 +7415,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_ecma_parser"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b312fc7fa2611536895b3da3703a12982daa3ac654184cad2891ad7827ca890"
+checksum = "f1d1f170e4cb99604e0cfebcc48cc3e10040f1df91921c46f8126e72ae41df61"
 dependencies = [
  "bitflags 2.13.1",
  "memchr",
@@ -7428,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_ecma_semantic"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7615eb63fe495d54d4ba752d896514f4f8b5eee6d794e67c62cd3a406a97533d"
+checksum = "0525b1a36eca433d420faebdf88490cd1242a514a7e35284d3f50957603683db"
 dependencies = [
  "bitflags 2.13.1",
  "hashbrown 0.17.1",
@@ -7443,9 +7443,9 @@ dependencies = [
 
 [[package]]
 name = "swc_next_regular_expression"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3960525459ebbe560e5afb1820097ae4fd0612cb70aded067fc0ee3c26d7c83c"
+checksum = "1dcf071a591caaa222ce6cf39d35c5edf9d8a90523ff52bd13ee32ca49fff370"
 dependencies = [
  "bitflags 2.13.1",
  "phf 0.14.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,10 +157,10 @@ swc_html_minifier   = { version = "61.0.0", default-features = false }
 swc_plugin_runner   = { version = "34.0.0", default-features = false }
 swc_typescript      = { version = "34.0.0", default-features = false }
 
-swc_next_allocator     = { version = "0.1.3", default-features = false }
-swc_next_ecma_ast      = { version = "0.1.3", default-features = false }
-swc_next_ecma_parser   = { version = "0.1.3", default-features = false }
-swc_next_ecma_semantic = { version = "0.1.3", default-features = false }
+swc_next_allocator     = { version = "0.2.0", default-features = false }
+swc_next_ecma_ast      = { version = "0.2.0", default-features = false }
+swc_next_ecma_parser   = { version = "0.2.0", default-features = false }
+swc_next_ecma_semantic = { version = "0.2.0", default-features = false }
 
 tracy-client = { version = "=0.18.4", default-features = false, features = ["enable", "sampling", "demangle", "system-tracing"] }
 wasi-common  = { version = "36.0.13", default-features = false }


### PR DESCRIPTION
## Summary

- Upgrade the swc-next Rust crates from 0.1.3 to 0.2.0 so the SWC Next parser path includes the 0.2.0 parser fixes and semantic-analysis improvements.
- Re-enable s390x across CI, release, canary, full-build, and preview workflows now that swc-next supports big-endian targets, and require the PR build to pass again.

## Related links

- https://github.com/swc-project/swc-next/releases/tag/v0.2.0

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).