### PR TITLE
ci: probe self-hosted tool cache volume (diagnostic, do not merge)

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -40,6 +40,7 @@ permissions:
 jobs:
   build:
     name: Build Bindings
+    if: ${{ false }}
     uses: ./.github/workflows/reusable-build.yml
     with:
       target: x86_64-unknown-linux-gnu

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -21,6 +21,7 @@ on:
 jobs:
   rust_tests:
     name: Run Rust Tests
+    if: ${{ false }}
     uses: ./.github/workflows/reusable-rust-test.yml
 
   test_required_check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,54 +39,68 @@ jobs:
         with:
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Env, load, cgroup, pressure
+      - name: Env, fs type, reflink support, dirty pages
         run: |
           set +e +o pipefail
-          echo "runner=$RUNNER_NAME RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE RUNNER_TEMP=$RUNNER_TEMP"
-          echo "== cpu"; nproc; uptime; cat /proc/pressure/cpu /proc/pressure/io /proc/pressure/memory
-          echo "== cgroup"; cat /proc/self/cgroup; ls /sys/fs/cgroup | tr '\n' ' '; echo
-          for f in cpu.stat cpu.max cpu.pressure cpu.weight memory.max cgroup.controllers; do echo "-- $f"; cat /sys/fs/cgroup/$f 2>&1 | head -12; done
-          echo "== mem"; free -m | head -2; grep -E 'Dirty|Writeback:' /proc/meminfo
+          echo "runner=$RUNNER_NAME"; nproc; uptime; grep -E 'Dirty|Writeback:' /proc/meminfo; cat /proc/pressure/io
+          echo "== filesystems"; grep -E 'xfs|ext4|btrfs|overlay' /proc/filesystems | tr '\n' ' '; echo; ls /proc/fs; head -2 /proc/fs/xfs/stat 2>&1
+          echo "== reflink test on RUNNER_TEMP"; echo x > "$RUNNER_TEMP/rl.src"; cp --reflink=always "$RUNNER_TEMP/rl.src" "$RUNNER_TEMP/rl.dst" && echo "reflink: SUPPORTED" || echo "reflink: not supported"; rm -f "$RUNNER_TEMP/rl.src" "$RUNNER_TEMP/rl.dst"
+          echo "== python"; command -v python3; python3 -c 'import os; print("copy_file_range" in dir(os))'
+
+      - name: copy_file_range vs read/write vs sendfile on fresh (dirty) source, then after sync
+        run: |
+          set +e +o pipefail
+          D="$RUNNER_TEMP/cfr"; mkdir -p "$D/src" "$D/dst"
+          python3 - "$D" <<'PY'
+          import os, sys, time
+          D = sys.argv[1]; N = 100; SZ = 1 << 20
+          def dirty(): return next(int(l.split()[1]) // 1024 for l in open('/proc/meminfo') if l.startswith('Dirty:'))
+          def mk():
+              for i in range(N):
+                  with open(f"{D}/src/f{i}", "wb") as f: f.write(os.urandom(SZ))
+          def cfr(tag):
+              t = time.time()
+              for i in range(N):
+                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-cfr{i}", "wb") as b:
+                      n = SZ
+                      while n > 0:
+                          r = os.copy_file_range(a.fileno(), b.fileno(), n)
+                          if r == 0: break
+                          n -= r
+              return (time.time() - t) * 1000
+          def rw(tag):
+              t = time.time()
+              for i in range(N):
+                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-rw{i}", "wb") as b:
+                      while True:
+                          buf = a.read(1 << 17)
+                          if not buf: break
+                          b.write(buf)
+              return (time.time() - t) * 1000
+          def sf(tag):
+              t = time.time()
+              for i in range(N):
+                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-sf{i}", "wb") as b:
+                      off = 0
+                      while off < SZ:
+                          r = os.sendfile(b.fileno(), a.fileno(), off, SZ - off)
+                          if r == 0: break
+                          off += r
+              return (time.time() - t) * 1000
+          mk(); print(f"host dirty after writing 100MB src: {dirty()}MB")
+          print(f"DIRTY src : read/write {rw('d'):.0f}ms | sendfile {sf('d'):.0f}ms | copy_file_range {cfr('d'):.0f}ms   (dirty now {dirty()}MB)")
+          t = time.time(); os.sync(); print(f"sync() took {(time.time()-t)*1000:.0f}ms, dirty now {dirty()}MB")
+          print(f"CLEAN src : read/write {rw('s'):.0f}ms | sendfile {sf('s'):.0f}ms | copy_file_range {cfr('s'):.0f}ms")
+          mk(); print(f"re-dirtied src, dirty {dirty()}MB")
+          print(f"DIRTY src2: copy_file_range FIRST {cfr('e'):.0f}ms | then read/write {rw('e'):.0f}ms")
+          PY
+          rm -rf "$D"; cat /proc/pressure/io
 
       - name: Real pnpm setup (timed by setup-node log lines)
         uses: ./.github/actions/pnpm/setup
         with:
           node-version: 24
 
-      - name: Node sync vs async fs micro-benchmark on the real node tree
+      - name: After setup-node
         run: |
-          set +e +o pipefail
-          cat /proc/pressure/cpu
-          cat > "$RUNNER_TEMP/bench.mjs" <<'JS'
-          import fs from 'node:fs'; import fsp from 'node:fs/promises'; import path from 'node:path';
-          const src = process.argv[2], dst = process.argv[3];
-          const t = () => process.hrtime.bigint(); const ms = (a) => (Number(t() - a) / 1e6).toFixed(0) + 'ms';
-          const walk = (d, out) => { for (const e of fs.readdirSync(d, { withFileTypes: true })) { const p = path.join(d, e.name); e.isDirectory() ? walk(p, out) : out.push(p); } return out; };
-          const files = walk(src, []); const n = files.length;
-          const sched = () => fs.readFileSync('/proc/self/schedstat', 'utf8').trim();
-          const s0 = sched();
-          let a = t(); for (let i = 0; i < 5000; i++) await new Promise(r => setImmediate(r)); console.log('setImmediate x5000 (event loop only):', ms(a));
-          a = t(); for (let i = 0; i < 5000; i++) await fsp.stat('/'); console.log("await fsp.stat('/') x5000 (threadpool round trip, no disk):", ms(a));
-          a = t(); for (const f of files) fs.lstatSync(f); console.log(`lstatSync x${n}:`, ms(a));
-          a = t(); for (const f of files) await fsp.lstat(f); console.log(`await fsp.lstat x${n}:`, ms(a));
-          const mk = (d) => { for (const f of files) fs.mkdirSync(path.dirname(path.join(d, path.relative(src, f))), { recursive: true }); };
-          mk(dst + '/sync'); a = t(); for (const f of files) fs.copyFileSync(f, path.join(dst + '/sync', path.relative(src, f))); console.log(`copyFileSync x${n}:`, ms(a));
-          mk(dst + '/async'); a = t(); for (const f of files) await fsp.copyFile(f, path.join(dst + '/async', path.relative(src, f))); console.log(`await fsp.copyFile x${n}:`, ms(a));
-          const s1 = sched(); const [r0, w0] = s0.split(' ').map(Number), [r1, w1] = s1.split(' ').map(Number);
-          console.log(`schedstat delta: on-cpu ${((r1 - r0) / 1e6).toFixed(0)}ms, runqueue-wait ${((w1 - w0) / 1e6).toFixed(0)}ms`);
-          JS
-          sed -i 's/^          //' "$RUNNER_TEMP/bench.mjs"
-          node --version; node "$RUNNER_TEMP/bench.mjs" "$RUNNER_TOOL_CACHE/node/24.20.0/x64" "$RUNNER_TEMP/bench-out"
-          rm -rf "$RUNNER_TEMP/bench-out"
-          cat /proc/pressure/cpu
-
-      - name: Alternative install path (npmmirror curl + tar into RUNNER_TEMP)
-        run: |
-          set +e +o pipefail
-          now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
-          s=$(now_ms); curl -sSL --max-time 300 -o "$RUNNER_TEMP/node.tgz" https://registry.npmmirror.com/-/binary/node/v24.20.0/node-v24.20.0-linux-x64.tar.gz; echo "curl npmmirror: $(( $(now_ms) - s ))ms size=$(stat -c %s "$RUNNER_TEMP/node.tgz")"
-          s=$(now_ms); mkdir -p "$RUNNER_TEMP/node-alt" && tar xzf "$RUNNER_TEMP/node.tgz" --strip 1 -C "$RUNNER_TEMP/node-alt"; echo "tar extract: $(( $(now_ms) - s ))ms"; "$RUNNER_TEMP/node-alt/bin/node" --version
-          s=$(now_ms); curl -sSL --max-time 300 -o /dev/null https://github.com/actions/node-versions/releases/download/24.20.0-33034074684/node-24.20.0-linux-x64.tar.gz; echo "curl github release: $(( $(now_ms) - s ))ms"
-          s=$(now_ms); cp -r "$RUNNER_TEMP/node-alt" "$RUNNER_TOOL_CACHE/node-alt-copy"; echo "cp -r node tree -> RUNNER_TOOL_CACHE: $(( $(now_ms) - s ))ms"
-          rm -rf "$RUNNER_TEMP/node-alt" "$RUNNER_TEMP/node.tgz" "$RUNNER_TOOL_CACHE/node-alt-copy"
-          uptime; cat /proc/pressure/cpu
+          grep -E 'Dirty|Writeback:' /proc/meminfo; uptime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,28 @@ jobs:
         with:
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Env and start wchan sampler
+      - name: Env, block devices, cgroup io, start sampler
         run: |
           set +e +o pipefail
           echo "runner=$RUNNER_NAME"; nproc; uptime; grep -E 'Dirty|Writeback:' /proc/meminfo; cat /proc/pressure/io
+          echo "== block devices"; ls /sys/block | tr '\n' ' '; echo
+          for d in /sys/block/*; do [ -e "$d/queue/wbt_lat_usec" ] && echo "$(basename $d): wbt_lat_usec=$(cat $d/queue/wbt_lat_usec 2>&1) scheduler=$(cat $d/queue/scheduler 2>&1) rotational=$(cat $d/queue/rotational 2>&1) size=$(cat $d/size 2>&1)"; done
+          echo "== cgroup"; cat /proc/self/cgroup; ls /sys/fs/cgroup | tr '\n' ' '; echo; echo "-- io.stat"; cat /sys/fs/cgroup/io.stat 2>&1 | head -5; echo "-- io.pressure"; cat /sys/fs/cgroup/io.pressure 2>&1
+          echo "== diskstats (major dev only)"; grep -E ' (sd[a-z]+|nvme[0-9]+n[0-9]+|vd[a-z]+) ' /proc/diskstats
           nohup bash -c '
             while true; do
+              now=$(date +%s%3N)
               for p in $(pgrep -f "setup-node/[^ ]*/dist/setup/index.js"); do
                 for t in /proc/$p/task/*; do
                   st=$(awk "{print \$3}" "$t/stat" 2>/dev/null); w=$(cat "$t/wchan" 2>/dev/null)
-                  echo "$(date +%s%3N) $p ${t##*/} $st $w"
+                  echo "W $now $p ${t##*/} $st $w"
                 done
+                echo "IO $now $p $(tr "\n" " " < /proc/$p/io 2>/dev/null)"
               done
+              echo "DS $now $(grep -E " (sd[a-z]+|nvme[0-9]+n[0-9]+|vd[a-z]+) " /proc/diskstats | awk "{printf \"%s:r%s:w%s:t%s:q%s \", \$3, \$6, \$10, \$13, \$12}")"
+              echo "PSI $now $(head -1 /proc/pressure/io)"
               sleep 0.05
-            done' > "$RUNNER_TEMP/wchan.log" 2>&1 &
+            done' > "$RUNNER_TEMP/sampler.log" 2>&1 &
           echo $! > "$RUNNER_TEMP/sampler.pid"; echo "sampler pid $(cat "$RUNNER_TEMP/sampler.pid")"
 
       - name: Real pnpm setup (timed by setup-node log lines)
@@ -60,14 +68,20 @@ jobs:
         with:
           node-version: 24
 
-      - name: Stop sampler and summarize kernel wait channels
+      - name: Stop sampler and summarize
         run: |
           set +e +o pipefail
           kill "$(cat "$RUNNER_TEMP/sampler.pid")" 2>/dev/null; sleep 0.2
           grep -E 'Dirty|Writeback:' /proc/meminfo; uptime; cat /proc/pressure/io
-          L="$RUNNER_TEMP/wchan.log"; echo "samples: $(wc -l < "$L") lines, $(awk '{print $1}' "$L" | sort -u | wc -l) ticks, span $(( $(tail -1 "$L" | awk '{print $1}') - $(head -1 "$L" | awk '{print $1}') ))ms"
-          echo "== (state wchan) histogram, all threads"; awk '{print $4, $5}' "$L" | sort | uniq -c | sort -rn | head -25
-          echo "== ticks with at least one thread in D state: $(awk '$4=="D"{print $1}' "$L" | sort -u | wc -l)"
-          echo "== D-state wchan histogram"; awk '$4=="D"{print $5}' "$L" | sort | uniq -c | sort -rn | head -15
-          echo "== R-state wchan histogram"; awk '$4=="R"{print $5}' "$L" | sort | uniq -c | sort -rn | head -10
-          echo "== per-second D count timeline"; awk '$4=="D"{print int($1/1000)}' "$L" | sort | uniq -c | awk '{printf "%s:%s ", $2%100000, $1}'; echo
+          L="$RUNNER_TEMP/sampler.log"
+          echo "== wchan (state wchan) histogram"; awk '$1=="W"{print $5, $6}' "$L" | sort | uniq -c | sort -rn | head -12
+          echo "== D ticks: $(awk '$1=="W" && $5=="D"{print $2}' "$L" | sort -u | wc -l) of $(awk '$1=="W"{print $2}' "$L" | sort -u | wc -l) ticks"
+          echo "== setup-node process /proc/pid/io first vs last (rchar wchar syscr syscw read_bytes write_bytes cancelled)"
+          awk '$1=="IO"{ if(!($3 in f)) f[$3]=$0; l[$3]=$0 } END{ for(p in f){ print "first:", f[p]; print "last: ", l[p] } }' "$L" | sed -E 's/(rchar|wchar|syscr|syscw|read_bytes|write_bytes|cancelled_write_bytes): //g'
+          echo "== host diskstats over the whole sampled window (sectors r/w -> MB, io_ticks busy%)"
+          first=$(awk '$1=="DS"{print; exit}' "$L"); last=$(awk '$1=="DS"' "$L" | tail -1)
+          t0=$(echo "$first" | awk '{print $2}'); t1=$(echo "$last" | awk '{print $2}'); echo "window $(( t1 - t0 ))ms"
+          paste <(echo "$first" | tr ' ' '\n' | grep :r) <(echo "$last" | tr ' ' '\n' | grep :r) | awk -F'[ :]' -v span=$(( t1 - t0 )) '{ split($2,r0,"r"); split($3,w0,"w"); split($4,t0,"t"); split($5,q0,"q"); split($7,r1,"r"); split($8,w1,"w"); split($9,t1,"t"); split($10,q1,"q"); printf "%s: read %.0fMB write %.0fMB busy %.0f%% avg-inflight %.1f\n", $1, (r1[2]-r0[2])*512/1048576, (w1[2]-w0[2])*512/1048576, (t1[2]-t0[2])*100/span, (q1[2]-q0[2])/span }'
+          echo "== PSI io 'some avg10' max during window: $(awk '$1=="PSI"{print $3}' "$L" | sed 's/avg10=//' | sort -n | tail -1)"
+          echo "== per-second: D-ticks / disk write MB / disk busy%"
+          awk '$1=="W" && $5=="D"{d[int($2/1000)]++} $1=="DS"{ s=int($2/1000); if(!(s in w0)){ w0[s]=$0 } w1[s]=$0 } END{ for(s in w1){ split(w0[s],a," "); split(w1[s],b," "); split(a[3],x,":"); split(b[3],y,":"); sub("w","",x[3]); sub("w","",y[3]); sub("t","",x[4]); sub("t","",y[4]); printf "%d: D=%d wMB=%.0f busy=%d%%\n", s%100000, d[s], (y[3]-x[3])*512/1048576, (y[4]-x[4])/10 } }' "$L" | sort -n | tr '\n' ' '; echo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,45 +39,54 @@ jobs:
         with:
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Env, mounts, cgroup limits
+      - name: Env, load, cgroup, pressure
         run: |
           set +e +o pipefail
-          echo "runner=$RUNNER_NAME RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE RUNNER_TEMP=$RUNNER_TEMP HOME=$HOME"
-          echo "== tool cache content"; ls -la "$RUNNER_TOOL_CACHE" 2>&1 | head -20; ls -la "$RUNNER_TOOL_CACHE/node" 2>&1 | head
-          echo "== df"; df -hT "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP" "$HOME" /tmp / 2>&1
-          echo "== mountinfo"; cat /proc/self/mountinfo
-          echo "== cgroup"; for f in io.max io.stat io.pressure io.weight memory.max memory.current memory.stat cpu.max; do echo "-- $f"; head -30 /sys/fs/cgroup/$f 2>&1; done
-          echo "== pressure"; cat /proc/pressure/io /proc/pressure/memory 2>&1
-          echo "== cpu/mem"; nproc; free -m; uptime
-          echo "== dirty"; grep -E 'Dirty|Writeback' /proc/meminfo; cat /proc/sys/vm/dirty_ratio /proc/sys/vm/dirty_background_ratio
-
-      - name: Write latency probe (tool cache vs RUNNER_TEMP vs HOME vs /tmp)
-        run: |
-          set +e +o pipefail
-          now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
-          probe() {
-            d="$1/probe.$$"; mkdir -p "$d"
-            s=$(now_ms); for i in $(seq 1 3000); do echo x > "$d/f$i"; done; echo "$1: create 3000 small files $(( $(now_ms) - s ))ms"
-            s=$(now_ms); cp -r "$d" "$d.copy"; echo "$1: cp -r 3000 small files $(( $(now_ms) - s ))ms"
-            s=$(now_ms); dd if=/dev/zero of="$d/big" bs=1M count=192 conv=fsync 2>/dev/null; echo "$1: 192MB write+fsync $(( $(now_ms) - s ))ms"
-            s=$(now_ms); rm -rf "$d" "$d.copy"; echo "$1: rm -rf $(( $(now_ms) - s ))ms"
-          }
-          probe "$RUNNER_TOOL_CACHE"; probe "$RUNNER_TEMP"; probe "$HOME"; probe /tmp
-          echo "== io.stat after probe"; cat /sys/fs/cgroup/io.stat 2>&1; cat /proc/pressure/io 2>&1
+          echo "runner=$RUNNER_NAME RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE RUNNER_TEMP=$RUNNER_TEMP"
+          echo "== cpu"; nproc; uptime; cat /proc/pressure/cpu /proc/pressure/io /proc/pressure/memory
+          echo "== cgroup"; cat /proc/self/cgroup; ls /sys/fs/cgroup | tr '\n' ' '; echo
+          for f in cpu.stat cpu.max cpu.pressure cpu.weight memory.max cgroup.controllers; do echo "-- $f"; cat /sys/fs/cgroup/$f 2>&1 | head -12; done
+          echo "== mem"; free -m | head -2; grep -E 'Dirty|Writeback:' /proc/meminfo
 
       - name: Real pnpm setup (timed by setup-node log lines)
         uses: ./.github/actions/pnpm/setup
         with:
           node-version: 24
 
-      - name: Copy the real node tree both ways
+      - name: Node sync vs async fs micro-benchmark on the real node tree
+        run: |
+          set +e +o pipefail
+          cat /proc/pressure/cpu
+          cat > "$RUNNER_TEMP/bench.mjs" <<'JS'
+          import fs from 'node:fs'; import fsp from 'node:fs/promises'; import path from 'node:path';
+          const src = process.argv[2], dst = process.argv[3];
+          const t = () => process.hrtime.bigint(); const ms = (a) => (Number(t() - a) / 1e6).toFixed(0) + 'ms';
+          const walk = (d, out) => { for (const e of fs.readdirSync(d, { withFileTypes: true })) { const p = path.join(d, e.name); e.isDirectory() ? walk(p, out) : out.push(p); } return out; };
+          const files = walk(src, []); const n = files.length;
+          const sched = () => fs.readFileSync('/proc/self/schedstat', 'utf8').trim();
+          const s0 = sched();
+          let a = t(); for (let i = 0; i < 5000; i++) await new Promise(r => setImmediate(r)); console.log('setImmediate x5000 (event loop only):', ms(a));
+          a = t(); for (let i = 0; i < 5000; i++) await fsp.stat('/'); console.log("await fsp.stat('/') x5000 (threadpool round trip, no disk):", ms(a));
+          a = t(); for (const f of files) fs.lstatSync(f); console.log(`lstatSync x${n}:`, ms(a));
+          a = t(); for (const f of files) await fsp.lstat(f); console.log(`await fsp.lstat x${n}:`, ms(a));
+          const mk = (d) => { for (const f of files) fs.mkdirSync(path.dirname(path.join(d, path.relative(src, f))), { recursive: true }); };
+          mk(dst + '/sync'); a = t(); for (const f of files) fs.copyFileSync(f, path.join(dst + '/sync', path.relative(src, f))); console.log(`copyFileSync x${n}:`, ms(a));
+          mk(dst + '/async'); a = t(); for (const f of files) await fsp.copyFile(f, path.join(dst + '/async', path.relative(src, f))); console.log(`await fsp.copyFile x${n}:`, ms(a));
+          const s1 = sched(); const [r0, w0] = s0.split(' ').map(Number), [r1, w1] = s1.split(' ').map(Number);
+          console.log(`schedstat delta: on-cpu ${((r1 - r0) / 1e6).toFixed(0)}ms, runqueue-wait ${((w1 - w0) / 1e6).toFixed(0)}ms`);
+          JS
+          sed -i 's/^          //' "$RUNNER_TEMP/bench.mjs"
+          node --version; node "$RUNNER_TEMP/bench.mjs" "$RUNNER_TOOL_CACHE/node/24.20.0/x64" "$RUNNER_TEMP/bench-out"
+          rm -rf "$RUNNER_TEMP/bench-out"
+          cat /proc/pressure/cpu
+
+      - name: Alternative install path (npmmirror curl + tar into RUNNER_TEMP)
         run: |
           set +e +o pipefail
           now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
-          src="$RUNNER_TOOL_CACHE/node/24.20.0/x64"; ls "$src" >/dev/null
-          echo "files=$(find "$src" -type f | wc -l)"
-          s=$(now_ms); cp -r "$src" "$RUNNER_TEMP/node-copy"; echo "cp node tree -> RUNNER_TEMP $(( $(now_ms) - s ))ms"
-          s=$(now_ms); cp -r "$src" "$RUNNER_TOOL_CACHE/node-copy-probe"; echo "cp node tree -> RUNNER_TOOL_CACHE $(( $(now_ms) - s ))ms"
-          s=$(now_ms); cp -r "$RUNNER_TEMP/node-copy" "$RUNNER_TOOL_CACHE/node-copy-probe2"; echo "cp node tree RUNNER_TEMP -> RUNNER_TOOL_CACHE $(( $(now_ms) - s ))ms"
-          rm -rf "$RUNNER_TEMP/node-copy" "$RUNNER_TOOL_CACHE/node-copy-probe" "$RUNNER_TOOL_CACHE/node-copy-probe2"
-          echo "== io.stat end"; cat /sys/fs/cgroup/io.stat 2>&1; cat /proc/pressure/io 2>&1
+          s=$(now_ms); curl -sSL --max-time 300 -o "$RUNNER_TEMP/node.tgz" https://registry.npmmirror.com/-/binary/node/v24.20.0/node-v24.20.0-linux-x64.tar.gz; echo "curl npmmirror: $(( $(now_ms) - s ))ms size=$(stat -c %s "$RUNNER_TEMP/node.tgz")"
+          s=$(now_ms); mkdir -p "$RUNNER_TEMP/node-alt" && tar xzf "$RUNNER_TEMP/node.tgz" --strip 1 -C "$RUNNER_TEMP/node-alt"; echo "tar extract: $(( $(now_ms) - s ))ms"; "$RUNNER_TEMP/node-alt/bin/node" --version
+          s=$(now_ms); curl -sSL --max-time 300 -o /dev/null https://github.com/actions/node-versions/releases/download/24.20.0-33034074684/node-24.20.0-linux-x64.tar.gz; echo "curl github release: $(( $(now_ms) - s ))ms"
+          s=$(now_ms); cp -r "$RUNNER_TEMP/node-alt" "$RUNNER_TOOL_CACHE/node-alt-copy"; echo "cp -r node tree -> RUNNER_TOOL_CACHE: $(( $(now_ms) - s ))ms"
+          rm -rf "$RUNNER_TEMP/node-alt" "$RUNNER_TEMP/node.tgz" "$RUNNER_TOOL_CACHE/node-alt-copy"
+          uptime; cat /proc/pressure/cpu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Env, mounts, cgroup limits
         run: |
+          set +e +o pipefail
           echo "runner=$RUNNER_NAME RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE RUNNER_TEMP=$RUNNER_TEMP HOME=$HOME"
           echo "== tool cache content"; ls -la "$RUNNER_TOOL_CACHE" 2>&1 | head -20; ls -la "$RUNNER_TOOL_CACHE/node" 2>&1 | head
           echo "== df"; df -hT "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP" "$HOME" /tmp / 2>&1
@@ -52,6 +53,7 @@ jobs:
 
       - name: Write latency probe (tool cache vs RUNNER_TEMP vs HOME vs /tmp)
         run: |
+          set +e +o pipefail
           now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
           probe() {
             d="$1/probe.$$"; mkdir -p "$d"
@@ -70,6 +72,7 @@ jobs:
 
       - name: Copy the real node tree both ways
         run: |
+          set +e +o pipefail
           now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
           src="$RUNNER_TOOL_CACHE/node/24.20.0/x64"; ls "$src" >/dev/null
           echo "files=$(find "$src" -type f | wc -l)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,302 +21,60 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
 
-permissions:
-  # Allow commenting on issues for `reusable-build.yml`
-  issues: write
-  # Allow commenting on pull requests for `size-limit.yml`
-  pull-requests: write
-
 jobs:
-  check-changed:
-    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    name: Check Source Changed
-    outputs:
-      code_changed: ${{ steps.filter.outputs.code_changed == 'true' }}
-      document_changed: ${{ steps.filter.outputs.document_changed == 'true' }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
-        id: filter
-        with:
-          predicate-quantifier: 'every'
-          filters: |
-            code_changed:
-              - "!**/*.md"
-              - "!**/*.mdx"
-              - "!.agents/**"
-              - "!website/**"
-            document_changed:
-              - "website/**"
-
-  build-linux:
-    name: Build Linux
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: x86_64-unknown-linux-gnu
-      profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  build-website-for-fork:
-    name: Build Website for Fork PR
-    needs: [check-changed]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && needs.check-changed.outputs.document_changed == 'true' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Pnpm Setup
-        uses: ./.github/actions/pnpm/setup
-
-      - name: Pnpm Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Build Website
-        run: pnpm --dir website run build
-
-  test-linux:
-    name: Test Linux
-    needs: [check-changed, build-linux]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-test.yml
-    with:
-      target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
-
-  bench-rust:
-    name: Rust Bench
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/bench-rust.yml
-    with:
-      target: x86_64-unknown-linux-gnu
-      runner: '"ubuntu-22.04"'
-
-  bench-rust-walltime:
-    name: Rust Bench Walltime
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
-    uses: ./.github/workflows/bench-rust.yml
-    with:
-      target: x86_64-unknown-linux-gnu
-      measurement: walltime
-      bench_target: walltime
-      runner: '"physical-1-exclusive"'
-
-  test-windows:
-    name: Test Windows
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      target: x86_64-pc-windows-msvc
-      profile: 'ci'
-      runner: ${{ vars.WINDOWS_SELF_HOSTED_RUNNER_LABELS || '"windows-latest"' }}
-      test-runner: '"windows-latest"'
-      test: true
-
-  test-mac:
-    name: Test Mac ARM64
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      target: aarch64-apple-darwin
-      profile: 'ci'
-      runner: ${{ vars.MAC_SELF_HOSTED_RUNNER_LABELS || '"macos-latest"' }}
-      test-runner: ${{ '"macos-latest"' }}
-      test: true
-
-  build-wasm:
-    name: Build WASM
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: wasm32-wasip1-threads
-      profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  test-wasm:
-    name: Test WASM
-    needs: [check-changed, build-wasm]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' }}
-    uses: ./.github/workflows/reusable-build-test.yml
-    with:
-      target: wasm32-wasip1-threads
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  build-riscv64:
-    name: Build riscv64
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: riscv64gc-unknown-linux-gnu
-      profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  build-ppc64:
-    name: Build ppc64
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: powerpc64le-unknown-linux-gnu
-      profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  build-s390x:
-    name: Build s390x
-    needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    uses: ./.github/workflows/reusable-build-build.yml
-    with:
-      target: s390x-unknown-linux-gnu
-      profile: 'ci'
-      runner: ${{ vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"' }}
-
-  # TODO: Enable this job after Rspack portable cache is implemented.
-  check-cache:
-    name: Check Cache Portable
-    needs: [test-linux, test-windows]
-    if: ${{ false }}
+  # Temporary probe: why does setup-node "Adding to the cache" take 0.7s..278s on self-hosted Linux pods
+  probe-toolcache:
+    name: Probe tool cache volume
+    strategy:
+      fail-fast: false
+      matrix:
+        sample: [1, 2, 3, 4, 5, 6]
     runs-on: ${{ fromJSON(vars.LINUX_SELF_HOSTED_RUNNER_LABELS || '"ubuntu-22.04"') }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Install Rust Toolchain
-        uses: ./.github/actions/rustup
         with:
-          key: test_cache
-          save-if: true
-      - name: Download linux cache
-        uses: ./.github/actions/artifact/download
+          clean: ${{ runner.environment == 'github-hosted' }}
+
+      - name: Env, mounts, cgroup limits
+        run: |
+          echo "runner=$RUNNER_NAME RUNNER_TOOL_CACHE=$RUNNER_TOOL_CACHE RUNNER_TEMP=$RUNNER_TEMP HOME=$HOME"
+          echo "== tool cache content"; ls -la "$RUNNER_TOOL_CACHE" 2>&1 | head -20; ls -la "$RUNNER_TOOL_CACHE/node" 2>&1 | head
+          echo "== df"; df -hT "$RUNNER_TOOL_CACHE" "$RUNNER_TEMP" "$HOME" /tmp / 2>&1
+          echo "== mountinfo"; cat /proc/self/mountinfo
+          echo "== cgroup"; for f in io.max io.stat io.pressure io.weight memory.max memory.current memory.stat cpu.max; do echo "-- $f"; head -30 /sys/fs/cgroup/$f 2>&1; done
+          echo "== pressure"; cat /proc/pressure/io /proc/pressure/memory 2>&1
+          echo "== cpu/mem"; nproc; free -m; uptime
+          echo "== dirty"; grep -E 'Dirty|Writeback' /proc/meminfo; cat /proc/sys/vm/dirty_ratio /proc/sys/vm/dirty_background_ratio
+
+      - name: Write latency probe (tool cache vs RUNNER_TEMP vs HOME vs /tmp)
+        run: |
+          now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
+          probe() {
+            d="$1/probe.$$"; mkdir -p "$d"
+            s=$(now_ms); for i in $(seq 1 3000); do echo x > "$d/f$i"; done; echo "$1: create 3000 small files $(( $(now_ms) - s ))ms"
+            s=$(now_ms); cp -r "$d" "$d.copy"; echo "$1: cp -r 3000 small files $(( $(now_ms) - s ))ms"
+            s=$(now_ms); dd if=/dev/zero of="$d/big" bs=1M count=192 conv=fsync 2>/dev/null; echo "$1: 192MB write+fsync $(( $(now_ms) - s ))ms"
+            s=$(now_ms); rm -rf "$d" "$d.copy"; echo "$1: rm -rf $(( $(now_ms) - s ))ms"
+          }
+          probe "$RUNNER_TOOL_CACHE"; probe "$RUNNER_TEMP"; probe "$HOME"; probe /tmp
+          echo "== io.stat after probe"; cat /sys/fs/cgroup/io.stat 2>&1; cat /proc/pressure/io 2>&1
+
+      - name: Real pnpm setup (timed by setup-node log lines)
+        uses: ./.github/actions/pnpm/setup
         with:
-          name: testCase-persistentCache-linux
-          path: ./cache-linux
-          force-use-github-only: true
-      - name: Download windows cache
-        uses: ./.github/actions/artifact/download
-        with:
-          name: testCase-persistentCache-windows
-          path: ./cache-windows
-          force-use-github-only: true
-      - name: Run compare kit
-        run: cargo run -p rspack_tools -- compare ./cache-linux ./cache-windows
+          node-version: 24
 
-  test_required_check:
-    # this job will be used for GitHub actions to determine required job success or not;
-    # When code changed, it will check if any of the test jobs failed.
-    # For fork PRs that change the website, it also requires the website build to pass.
-    name: Test Required Check
-    needs:
-      [
-        build-linux,
-        build-website-for-fork,
-        test-linux,
-        test-windows,
-        test-mac,
-        build-wasm,
-        build-riscv64,
-        build-ppc64,
-        build-s390x,
-        test-wasm,
-        check-changed,
-        check-cache,
-      ]
-    if: ${{ always() && !cancelled() }}
-    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    steps:
-      - name: Log
-        run: echo ${{ join(needs.*.result, ',') }}
-      - name: Test check
-        if: >-
-          ${{
-            needs.check-changed.result != 'success' ||
-            (needs.check-changed.outputs.code_changed == 'true' &&
-              (needs.build-linux.result != 'success' ||
-                needs.test-linux.result != 'success' ||
-                needs.test-windows.result != 'success' ||
-                needs.test-mac.result != 'success' ||
-                needs.build-wasm.result != 'success' ||
-                (github.event_name == 'push' && github.ref == 'refs/heads/main' &&
-                  (needs.build-riscv64.result != 'success' ||
-                    needs.build-ppc64.result != 'success' ||
-                    needs.build-s390x.result != 'success')) ||
-                needs.test-wasm.result != 'success' ||
-                needs.check-cache.result != 'skipped'))
-          }}
-        run: echo "Test Failed" && exit 1
-
-      - name: Website check
-        if: >-
-          ${{
-            github.event_name == 'pull_request' &&
-            github.event.pull_request.head.repo.fork &&
-            needs.check-changed.outputs.document_changed == 'true' &&
-            needs.build-website-for-fork.result != 'success'
-          }}
-        run: echo "Website Build Failed" && exit 1
-
-      - name: No check to Run test
-        run: echo "Success"
-
-  size-limit:
-    name: Binary Size Limit
-    needs: [check-changed, build-linux]
-    # On a PR this only comments (it is deliberately not part of Test Required Check).
-    # On a trunk push it gates: exceeding the threshold fails the job, and with it the run.
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'web-infra-dev/rspack')) }}
-    uses: ./.github/workflows/size-limit.yml
-
-  ecosystem_ci_per_commit:
-    name: Run ecosystem CI per commit
-    needs: [check-changed, build-linux]
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    permissions:
-      contents: write
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' }}
-    steps:
-      - name: Trigger Ecosystem CI
-        uses: rstackjs/rstack-ecosystem-ci/.github/actions/ecosystem_ci_per_commit@4b0ec855ccbd27595a0df4781ed58b77e64d25ee # v0.3.5
-        with:
-          github-token: ${{ secrets.REPO_RSTACK_ECO_CI_GITHUB_TOKEN }}
-          ecosystem-owner: web-infra-dev
-          ecosystem-repo: rspack
-          workflow-file: rspack-ecosystem-ci-from-commit.yml
-          client-payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rspack","suite":"-","suiteRefType":"precoded","suiteRef":"precoded","sourceRunId":"${{ github.run_id }}","sourceRepo":"web-infra-dev/rspack"}'
-
-  upload-binary-size:
-    name: Upload Binary Size
-    needs: [check-changed, build-linux]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.repository == 'web-infra-dev/rspack' }}
-    runs-on: ${{ fromJSON(vars.CI_LINUX_MINI_RUNNER || '"ubuntu-latest"') }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Download binding artifact
-        uses: ./.github/actions/artifact/download
-        with:
-          name: bindings-x86_64-unknown-linux-gnu
-          path: crates/node_binding/
-
-      # Must mirror size-limit.yml: the uploaded size is the baseline PRs compare against.
-      - name: Strip binary
-        run: strip crates/node_binding/rspack.linux-x64-gnu.node
-
-      # github-script rather than `run: node`: this runner has no Node installed.
-      - name: Upload binary size
-        uses: actions/github-script@450193c5abd4cdb17ba9f3ffcfe8f635c4bb6c2a
-        env:
-          PERF_DATA_TOKEN: ${{ secrets.PERF_DATA_TOKEN }}
-        with:
-          script: |
-            const upload = require('./.github/actions/binary-limit/upload-binary-size.js');
-            upload({ sha: context.sha, token: process.env.PERF_DATA_TOKEN });
+      - name: Copy the real node tree both ways
+        run: |
+          now_ms() { echo $(( $(date +%s%N) / 1000000 )); }
+          src="$RUNNER_TOOL_CACHE/node/24.20.0/x64"; ls "$src" >/dev/null
+          echo "files=$(find "$src" -type f | wc -l)"
+          s=$(now_ms); cp -r "$src" "$RUNNER_TEMP/node-copy"; echo "cp node tree -> RUNNER_TEMP $(( $(now_ms) - s ))ms"
+          s=$(now_ms); cp -r "$src" "$RUNNER_TOOL_CACHE/node-copy-probe"; echo "cp node tree -> RUNNER_TOOL_CACHE $(( $(now_ms) - s ))ms"
+          s=$(now_ms); cp -r "$RUNNER_TEMP/node-copy" "$RUNNER_TOOL_CACHE/node-copy-probe2"; echo "cp node tree RUNNER_TEMP -> RUNNER_TOOL_CACHE $(( $(now_ms) - s ))ms"
+          rm -rf "$RUNNER_TEMP/node-copy" "$RUNNER_TOOL_CACHE/node-copy-probe" "$RUNNER_TOOL_CACHE/node-copy-probe2"
+          echo "== io.stat end"; cat /sys/fs/cgroup/io.stat 2>&1; cat /proc/pressure/io 2>&1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,68 +39,35 @@ jobs:
         with:
           clean: ${{ runner.environment == 'github-hosted' }}
 
-      - name: Env, fs type, reflink support, dirty pages
+      - name: Env and start wchan sampler
         run: |
           set +e +o pipefail
           echo "runner=$RUNNER_NAME"; nproc; uptime; grep -E 'Dirty|Writeback:' /proc/meminfo; cat /proc/pressure/io
-          echo "== filesystems"; grep -E 'xfs|ext4|btrfs|overlay' /proc/filesystems | tr '\n' ' '; echo; ls /proc/fs; head -2 /proc/fs/xfs/stat 2>&1
-          echo "== reflink test on RUNNER_TEMP"; echo x > "$RUNNER_TEMP/rl.src"; cp --reflink=always "$RUNNER_TEMP/rl.src" "$RUNNER_TEMP/rl.dst" && echo "reflink: SUPPORTED" || echo "reflink: not supported"; rm -f "$RUNNER_TEMP/rl.src" "$RUNNER_TEMP/rl.dst"
-          echo "== python"; command -v python3; python3 -c 'import os; print("copy_file_range" in dir(os))'
-
-      - name: copy_file_range vs read/write vs sendfile on fresh (dirty) source, then after sync
-        run: |
-          set +e +o pipefail
-          D="$RUNNER_TEMP/cfr"; mkdir -p "$D/src" "$D/dst"
-          python3 - "$D" <<'PY'
-          import os, sys, time
-          D = sys.argv[1]; N = 100; SZ = 1 << 20
-          def dirty(): return next(int(l.split()[1]) // 1024 for l in open('/proc/meminfo') if l.startswith('Dirty:'))
-          def mk():
-              for i in range(N):
-                  with open(f"{D}/src/f{i}", "wb") as f: f.write(os.urandom(SZ))
-          def cfr(tag):
-              t = time.time()
-              for i in range(N):
-                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-cfr{i}", "wb") as b:
-                      n = SZ
-                      while n > 0:
-                          r = os.copy_file_range(a.fileno(), b.fileno(), n)
-                          if r == 0: break
-                          n -= r
-              return (time.time() - t) * 1000
-          def rw(tag):
-              t = time.time()
-              for i in range(N):
-                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-rw{i}", "wb") as b:
-                      while True:
-                          buf = a.read(1 << 17)
-                          if not buf: break
-                          b.write(buf)
-              return (time.time() - t) * 1000
-          def sf(tag):
-              t = time.time()
-              for i in range(N):
-                  with open(f"{D}/src/f{i}", "rb") as a, open(f"{D}/dst/{tag}-sf{i}", "wb") as b:
-                      off = 0
-                      while off < SZ:
-                          r = os.sendfile(b.fileno(), a.fileno(), off, SZ - off)
-                          if r == 0: break
-                          off += r
-              return (time.time() - t) * 1000
-          mk(); print(f"host dirty after writing 100MB src: {dirty()}MB")
-          print(f"DIRTY src : read/write {rw('d'):.0f}ms | sendfile {sf('d'):.0f}ms | copy_file_range {cfr('d'):.0f}ms   (dirty now {dirty()}MB)")
-          t = time.time(); os.sync(); print(f"sync() took {(time.time()-t)*1000:.0f}ms, dirty now {dirty()}MB")
-          print(f"CLEAN src : read/write {rw('s'):.0f}ms | sendfile {sf('s'):.0f}ms | copy_file_range {cfr('s'):.0f}ms")
-          mk(); print(f"re-dirtied src, dirty {dirty()}MB")
-          print(f"DIRTY src2: copy_file_range FIRST {cfr('e'):.0f}ms | then read/write {rw('e'):.0f}ms")
-          PY
-          rm -rf "$D"; cat /proc/pressure/io
+          nohup bash -c '
+            while true; do
+              for p in $(pgrep -f "setup-node/[^ ]*/dist/setup/index.js"); do
+                for t in /proc/$p/task/*; do
+                  st=$(awk "{print \$3}" "$t/stat" 2>/dev/null); w=$(cat "$t/wchan" 2>/dev/null)
+                  echo "$(date +%s%3N) $p ${t##*/} $st $w"
+                done
+              done
+              sleep 0.05
+            done' > "$RUNNER_TEMP/wchan.log" 2>&1 &
+          echo $! > "$RUNNER_TEMP/sampler.pid"; echo "sampler pid $(cat "$RUNNER_TEMP/sampler.pid")"
 
       - name: Real pnpm setup (timed by setup-node log lines)
         uses: ./.github/actions/pnpm/setup
         with:
           node-version: 24
 
-      - name: After setup-node
+      - name: Stop sampler and summarize kernel wait channels
         run: |
-          grep -E 'Dirty|Writeback:' /proc/meminfo; uptime
+          set +e +o pipefail
+          kill "$(cat "$RUNNER_TEMP/sampler.pid")" 2>/dev/null; sleep 0.2
+          grep -E 'Dirty|Writeback:' /proc/meminfo; uptime; cat /proc/pressure/io
+          L="$RUNNER_TEMP/wchan.log"; echo "samples: $(wc -l < "$L") lines, $(awk '{print $1}' "$L" | sort -u | wc -l) ticks, span $(( $(tail -1 "$L" | awk '{print $1}') - $(head -1 "$L" | awk '{print $1}') ))ms"
+          echo "== (state wchan) histogram, all threads"; awk '{print $4, $5}' "$L" | sort | uniq -c | sort -rn | head -25
+          echo "== ticks with at least one thread in D state: $(awk '$4=="D"{print $1}' "$L" | sort -u | wc -l)"
+          echo "== D-state wchan histogram"; awk '$4=="D"{print $5}' "$L" | sort | uniq -c | sort -rn | head -15
+          echo "== R-state wchan histogram"; awk '$4=="R"{print $5}' "$L" | sort | uniq -c | sort -rn | head -10
+          echo "== per-second D count timeline"; awk '$4=="D"{print int($1/1000)}' "$L" | sort | uniq -c | awk '{printf "%s:%s ", $2%100000, $1}'; echo


### PR DESCRIPTION
## Why

On self-hosted Linux runners, `actions/setup-node`'s "Adding to the cache ..." step (copying the extracted Node tree, 4,797 files / 192MB, file by file into `$RUNNER_TOOL_CACHE`) takes anywhere from 0.7s to 278s on different pods, while extracting the same tarball into `$RUNNER_TEMP` on the same pod is consistently 1-2s. With `timeout-minutes: 5` on the pnpm setup step this kills jobs: 7 job failures today across `ci.yml` and `ci-diff.yml` (e.g. run 34119614737).

This PR temporarily replaces `ci.yml` with a 6-sample probe job that records mount layout, cgroup io limits, and small-file write latency for `$RUNNER_TOOL_CACHE` vs `$RUNNER_TEMP` / `$HOME` / `/tmp`, then runs the real pnpm setup and copies the node tree both ways for timing.

Heavy jobs in `ci-diff.yml` / `ci-rust.yaml` are disabled on this branch to save runner time. Will be closed after data is collected.