### PR TITLE
fix(cache): retain live module state across builds

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -109,17 +109,18 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let cached_build_result = if let Some(module_build_cache) = &context.module_build_cache {
-      module_build_cache
-        .restore(
-          &module,
-          &context.file_system_info,
-          &context.value_cache_versions,
-        )
-        .await?
-    } else {
-      None
-    };
+    let (module, cached_build_result) =
+      if let Some(module_build_cache) = &context.module_build_cache {
+        module_build_cache
+          .restore(
+            module,
+            &context.file_system_info,
+            &context.value_cache_versions,
+          )
+          .await?
+      } else {
+        (module, None)
+      };
     context
       .artifact
       .module_graph

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -1,103 +1,157 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use rspack_cacheable::cacheable;
-use rspack_collections::{Identifiable, IdentifierDashMap};
+use rayon::prelude::*;
+use rspack_cacheable::{cacheable, utils::OwnedOrRef, with::AsOwned};
+use rspack_collections::{Identifiable, IdentifierDashMap, IdentifierMap};
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 
 use crate::{
   AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockIdentifier, BoxModule,
   BuildModuleGraphArtifact, BuildResult, DependenciesBlock, DependencyRef, FileSystemInfo,
-  ModuleGraph, ModuleIdentifier, NormalModuleState, OptimizationBailoutItem, ValueCacheVersions,
-  new_cache::{CacheFacade, CacheValue},
+  ModuleGraph, ModuleIdentifier, NormalModuleState, ValueCacheVersions,
+  new_cache::{Cache, CacheFacade, CacheValue, MemoryCacheGetResult},
 };
 
 /// Cache for completed normal module builds.
 ///
-/// Cache entries store only [`NormalModuleState`] plus the graph-owned build
-/// output. Factory-owned module data is always supplied by the fresh module.
+/// A compilation exclusively owns its live modules until the next full build
+/// transfers them back to the memory cache. Filesystem writes borrow the latest
+/// state at compiler boundaries and queue only encoded bytes for background I/O.
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCache {
   cache: CacheFacade,
   pending: Arc<IdentifierDashMap<u64>>,
 }
 
-#[cacheable]
-#[derive(Debug, Clone)]
-pub(crate) struct ModuleBuildCacheEntry {
-  module_state: NormalModuleState,
+#[derive(Debug)]
+struct CachedModule {
+  module: BoxModule,
   graph_result: ModuleGraphBuildResult,
 }
 
+// None records an acquired module, preventing fallback to stale filesystem data.
+type ModuleCacheSlot = Mutex<Option<CachedModule>>;
+
 #[cacheable]
-#[derive(Debug, Clone)]
-struct ModuleGraphBuildResult {
-  dependencies: Vec<DependencyRef>,
-  blocks: Vec<AsyncDependenciesBlockBuildResult>,
-  optimization_bailouts: Vec<OptimizationBailoutItem>,
+struct StoredModule<'a> {
+  #[cacheable(with=AsOwned)]
+  module_state: OwnedOrRef<'a, NormalModuleState>,
+  graph_result: Option<ModuleGraphBuildResult>,
 }
 
-impl ModuleBuildCacheEntry {
-  pub(crate) fn into_build_result(self, mut module: BoxModule) -> BuildResult {
-    module
-      .as_normal_module_mut()
-      .expect("module cache entries are only restored for normal modules")
-      .restore_module_state(self.module_state);
+#[cacheable]
+#[derive(Debug)]
+pub(crate) struct ModuleGraphBuildResult {
+  dependencies: Vec<DependencyRef>,
+  blocks: Vec<AsyncDependenciesBlockBuildResult>,
+}
+
+impl ModuleGraphBuildResult {
+  pub(crate) fn into_build_result(self, module: BoxModule) -> BuildResult {
+    let optimization_bailouts = module
+      .as_normal_module()
+      .expect("only normal modules are cached")
+      .build_optimization_bailouts()
+      .to_vec();
     BuildResult {
       module,
-      dependencies: self.graph_result.dependencies,
-      blocks: self.graph_result.blocks,
-      optimization_bailouts: self.graph_result.optimization_bailouts,
+      dependencies: self.dependencies,
+      blocks: self.blocks,
+      optimization_bailouts,
     }
   }
 }
 
 impl ModuleBuildCache {
-  pub(crate) fn new(cache: CacheFacade) -> Self {
+  pub(crate) fn new(cache: &Cache) -> Self {
     Self {
-      cache,
+      // The owned filesystem representation differs from the previous state cache.
+      cache: cache.facade("Compilation/modules/owned-v1"),
       pending: Default::default(),
     }
   }
 
-  /// Defers publishing a built module until the build-module-graph phase has
-  /// completed, so make-stage mutations are included in the cache entry.
+  /// Defers filesystem dependency snapshot creation until make-stage mutations finish.
   pub(crate) fn mark_pending(&self, module_identifier: ModuleIdentifier, build_start_time: u64) {
     self.pending.insert(module_identifier, build_start_time);
   }
 
   pub(crate) async fn restore(
     &self,
-    module: &BoxModule,
+    mut module: BoxModule,
     file_system_info: &FileSystemInfo,
     value_cache_versions: &ValueCacheVersions,
-  ) -> Result<Option<ModuleBuildCacheEntry>> {
+  ) -> Result<(BoxModule, Option<ModuleGraphBuildResult>)> {
     if module.as_normal_module().is_none() {
-      return Ok(None);
+      return Ok((module, None));
     }
 
     let identifier = module.identifier();
-    let Some(result) = self
+    let cached = match self
       .cache
-      .get::<ModuleBuildCacheEntry>(identifier.as_str(), None)
-    else {
-      return Ok(None);
+      .get_memory::<ModuleCacheSlot>(identifier.as_str(), None)
+    {
+      MemoryCacheGetResult::Hit(slot) => slot
+        .lock()
+        .expect("module cache slot should not be poisoned")
+        .take(),
+      MemoryCacheGetResult::Miss => None,
+      MemoryCacheGetResult::NotCached => {
+        let stored = self
+          .cache
+          .restore_owned::<StoredModule<'static>>(identifier.as_str(), None);
+        self.mark_acquired(identifier);
+        if let Some(StoredModule {
+          module_state,
+          graph_result: Some(graph_result),
+        }) = stored
+          && !module_state
+            .as_ref()
+            .need_build_with_context(file_system_info, value_cache_versions)
+            .await?
+        {
+          module
+            .as_normal_module_mut()
+            .expect("normal module was checked")
+            .restore_module_state(module_state.into_owned());
+          return Ok((module, Some(graph_result)));
+        }
+        return Ok((module, None));
+      }
     };
-    if result
-      .module_state
+    self.mark_acquired(identifier);
+    let Some(mut cached) = cached else {
+      return Ok((module, None));
+    };
+    let fresh = module
+      .as_normal_module_mut()
+      .expect("normal module was checked");
+    let normal = cached
+      .module
+      .as_normal_module_mut()
+      .expect("only normal modules are cached");
+    normal.update_cache_module(fresh);
+    if normal
       .need_build_with_context(file_system_info, value_cache_versions)
       .await?
     {
-      return Ok(None);
+      normal.reset_cached_build(fresh);
+      return Ok((cached.module, None));
     }
 
-    Ok(Some(result.as_arc().as_ref().clone()))
+    Ok((cached.module, Some(cached.graph_result)))
   }
 
-  /// Stores modules built during this phase from the final module graph.
-  ///
-  /// Snapshot creation and cache-entry construction are parallel. Module state
-  /// and graph containers are cloned, while blocks and dependencies retain shared identity.
-  pub(crate) async fn store_pending(
+  fn mark_acquired(&self, identifier: ModuleIdentifier) {
+    self.cache.store_memory(
+      identifier.as_str(),
+      None,
+      CacheValue::new(ModuleCacheSlot::new(None)),
+    );
+  }
+
+  /// Creates validity snapshots without copying the mutable module state.
+  pub(crate) async fn snapshot_pending(
     &self,
     artifact: &mut BuildModuleGraphArtifact,
     file_system_info: &FileSystemInfo,
@@ -133,75 +187,86 @@ impl ModuleBuildCache {
     .map(|result| result.to_rspack_result().and_then(|result| result))
     .collect::<Result<Vec<_>>>()?;
 
-    let module_identifiers = snapshots
-      .into_iter()
-      .flatten()
-      .filter_map(|(module_identifier, snapshot)| {
-        let module = artifact
-          .get_module_graph_mut()
-          .module_by_identifier_mut(&module_identifier)?;
+    for (module_identifier, snapshot) in snapshots.into_iter().flatten() {
+      if let Some(module) = artifact
+        .get_module_graph_mut()
+        .module_by_identifier_mut(&module_identifier)
+      {
         module.build_info_mut().snapshot = snapshot;
-        Some(module_identifier)
-      })
-      .collect::<Vec<_>>();
-
-    let module_graph = artifact.get_module_graph();
-    let cache_entries = rspack_parallel::scope::<_, Result<_>>(|token| {
-      for module_identifier in module_identifiers {
-        // SAFETY: the scope is awaited before the cache entries are published.
-        let task = unsafe { token.used(module_graph) };
-        task.spawn(move |module_graph| async move {
-          Ok((
-            module_identifier,
-            create_cache_entry(module_graph, module_identifier),
-          ))
-        });
       }
-    })
-    .await
-    .into_iter()
-    .map(|result| result.to_rspack_result().and_then(|result| result))
-    .collect::<Result<Vec<_>>>()?;
-
-    for (module_identifier, entry) in cache_entries {
-      let Some(entry) = entry else {
-        continue;
-      };
-      self
-        .cache
-        .store(module_identifier.as_str(), None, CacheValue::new(entry));
     }
     Ok(())
   }
+
+  /// Encodes current module state while the compilation is exclusively borrowed.
+  /// Include cache hits too: later hooks may have changed their state.
+  pub(crate) fn store_modules(&self, module_graph: &ModuleGraph) {
+    if !self.cache.has_file_cache() {
+      return;
+    }
+    self.cache.store_borrowed(
+      module_graph
+        .modules_par()
+        .filter_map(|(identifier, module)| {
+          let normal = module.as_normal_module()?;
+          Some((
+            identifier.as_str(),
+            None,
+            StoredModule {
+              module_state: OwnedOrRef::Borrowed(normal.module_state()),
+              graph_result: collect_graph_result(module_graph, module),
+            },
+          ))
+        }),
+    );
+  }
+
+  /// Returns live modules immediately before a full build discards their graph.
+  /// Incremental rebuilds keep ownership in their recovered graph instead.
+  pub(crate) fn release_modules(&self, module_graph: &mut ModuleGraph) {
+    if !self.cache.has_memory_cache() {
+      return;
+    }
+    let mut results: IdentifierMap<_> = module_graph
+      .modules()
+      .filter(|(_, module)| module.as_normal_module().is_some())
+      .filter_map(|(identifier, module)| {
+        collect_graph_result(module_graph, module).map(|result| (*identifier, result))
+      })
+      .collect();
+    for module in module_graph.take_modules() {
+      let identifier = module.identifier();
+      let Some(graph_result) = results.remove(&identifier) else {
+        if module.as_normal_module().is_some() {
+          self.mark_acquired(identifier);
+        }
+        continue;
+      };
+      self.cache.store_memory(
+        identifier.as_str(),
+        None,
+        CacheValue::new(ModuleCacheSlot::new(Some(CachedModule {
+          module,
+          graph_result,
+        }))),
+      );
+    }
+  }
 }
 
-fn create_cache_entry(
+fn collect_graph_result(
   module_graph: &ModuleGraph,
-  module_identifier: ModuleIdentifier,
-) -> Option<ModuleBuildCacheEntry> {
-  let source_module = module_graph
-    .module_by_identifier(&module_identifier)
-    .expect("pending module should exist in the final module graph");
-  let normal_module = source_module
-    .as_normal_module()
-    .expect("only normal modules are marked pending for the module build cache");
+  source_module: &BoxModule,
+) -> Option<ModuleGraphBuildResult> {
   let dependencies = clone_dependencies(module_graph, source_module.get_dependencies())?;
   let blocks = source_module
     .get_blocks()
     .iter()
     .map(|block_id| clone_block(module_graph, block_id))
     .collect::<Option<Vec<_>>>()?;
-  let optimization_bailouts = module_graph
-    .get_optimization_bailout(&module_identifier)
-    .clone();
-
-  Some(ModuleBuildCacheEntry {
-    module_state: normal_module.module_state().clone(),
-    graph_result: ModuleGraphBuildResult {
-      dependencies,
-      blocks,
-      optimization_bailouts,
-    },
+  Some(ModuleGraphBuildResult {
+    dependencies,
+    blocks,
   })
 }
 

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -63,7 +63,7 @@ impl PassExt for BuildModuleGraphPhasePass {
   async fn after_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) -> Result<()> {
     if let Some(module_build_cache) = compilation.module_build_cache.clone() {
       module_build_cache
-        .store_pending(
+        .snapshot_pending(
           &mut compilation.build_module_graph_artifact,
           &compilation.file_system_info,
         )

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -364,9 +364,9 @@ impl Compilation {
     // Incremental make reuses the previous module graph and owns its own
     // invalidation path. Keep that fast path unchanged.
     let module_build_cache = (options.experiments.new_cache.module
-      && !is_rebuild
+      && !incremental.mutations_readable(IncrementalPasses::BUILD_MODULE_GRAPH)
       && !matches!(&options.cache, CacheOptions::Disabled))
-    .then(|| ModuleBuildCache::new(cache.facade("Compilation/modules")));
+    .then(|| ModuleBuildCache::new(&cache));
     let snapshot_options = match &options.cache {
       CacheOptions::Disabled => SnapshotOptions::default(),
       CacheOptions::Memory { snapshot, .. } => snapshot.clone(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -23,7 +23,7 @@ use crate::{
   CompilerOptions, CompilerPlatform, ContextModuleFactory, Filename, InfrastructureLogSink,
   KeepPattern, NormalModuleFactory, PluginDriver, ResolverFactory, SharedPluginDriver,
   artifacts::IncrementalArtifacts,
-  compilation::build_module_graph::ModuleExecutor,
+  compilation::build_module_graph::{ModuleExecutor, module_build_cache::ModuleBuildCache},
   fast_set,
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
@@ -236,13 +236,37 @@ impl Compiler {
     self.new_cache.facade(name)
   }
 
+  fn module_build_cache(&self) -> Option<ModuleBuildCache> {
+    (self.options.experiments.new_cache.module
+      && !matches!(&self.options.cache, CacheOptions::Disabled))
+    .then(|| ModuleBuildCache::new(&self.new_cache))
+  }
+
+  fn store_modules(&self) {
+    if let Some(cache) = self.module_build_cache()
+      && let Some(module_graph) = self.compilation.try_get_module_graph()
+    {
+      cache.store_modules(module_graph);
+    }
+  }
+
+  fn release_modules(&mut self) {
+    if let Some(cache) = self.module_build_cache()
+      && let Some(artifact) = self.compilation.build_module_graph_artifact.try_write()
+    {
+      cache.release_modules(artifact.get_module_graph_mut());
+    }
+  }
+
   fn end_idle(&self) -> Instant {
     self.new_cache.end_idle();
     Instant::now()
   }
 
   fn begin_idle(&mut self, build_time: Duration) {
-    if self.new_cache.has_file_cache() {
+    self.store_modules();
+    if self.new_cache.has_file_cache() && !self.compilation.build_module_graph_artifact.is_stolen()
+    {
       if let CacheOptions::Persistent(options) = &self.options.cache {
         self.compilation.build_dependencies.extend(
           options
@@ -312,6 +336,10 @@ impl Compiler {
     compilation_logging.clear();
     self.incremental_artifacts.reset();
 
+    // Capture the latest state and transfer ownership before fast_set starts
+    // dropping the old graph off-thread.
+    self.store_modules();
+    self.release_modules();
     fast_set(
       &mut self.compilation,
       Compilation::new(
@@ -662,6 +690,7 @@ impl Compiler {
       .await?;
 
     self.cache.close().await;
+    self.store_modules();
     self.new_cache.shutdown().await;
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -108,6 +108,15 @@ impl Compiler {
 
       self.cache.store_hot_cache(&mut self.compilation);
 
+      self.store_modules();
+      if !next_compilation
+        .incremental
+        .mutations_readable(IncrementalPasses::BUILD_MODULE_GRAPH)
+      {
+        // A rebuild without graph recovery still reuses individual module builds.
+        self.release_modules();
+      }
+
       // Artifact recovery belongs to incremental compilation and is independent
       // from the configured build cache.
       let old_compilation = std::mem::replace(&mut self.compilation, next_compilation);

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -180,6 +180,12 @@ impl ModuleGraph {
     self.inner.modules.iter()
   }
 
+  /// Transfers modules out of a graph whose compilation is about to be discarded.
+  /// Incremental artifact recovery must keep the graph intact instead.
+  pub(crate) fn take_modules(&mut self) -> impl Iterator<Item = BoxModule> + use<> {
+    std::mem::take(&mut self.inner.modules).into_values()
+  }
+
   #[inline]
   pub fn modules_par(
     &self,

--- a/crates/rspack_core/src/module_graph/rollback/map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/map.rs
@@ -135,6 +135,11 @@ where
     self.map.iter()
   }
 
+  /// Consumes a retired map without retaining its undo history.
+  pub fn into_values(self) -> impl Iterator<Item = V> {
+    self.map.into_values()
+  }
+
   #[inline]
   #[allow(clippy::len_without_is_empty)]
   pub fn len(&self) -> usize {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,5 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{any::Any, sync::Arc, time::Duration};
 
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
 use rspack_error::Result;
 use rspack_paths::InternedPathSet;
 
@@ -114,6 +116,73 @@ impl Cache {
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.store(key, etag, value)
     }
+  }
+
+  pub(crate) fn get_memory<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> MemoryCacheGetResult<T> {
+    self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.memory_cache.as_ref())
+      .map_or(MemoryCacheGetResult::NotCached, |cache| {
+        cache.get(&key, etag.as_ref())
+      })
+  }
+
+  pub(crate) fn store_memory<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
+    if let Some(cache) = self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.memory_cache.as_ref())
+    {
+      cache.store(key, etag, value);
+    }
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self
+      .inner
+      .storage
+      .as_ref()?
+      .idle_file_cache
+      .as_ref()?
+      .restore_owned(key, etag)
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    if let Some(cache) = self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.idle_file_cache.as_ref())
+    {
+      cache.store_borrowed(entries);
+    }
+  }
+
+  pub(crate) fn has_memory_cache(&self) -> bool {
+    self
+      .inner
+      .storage
+      .as_ref()
+      .is_some_and(|storage| storage.memory_cache.is_some())
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -1,6 +1,9 @@
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
-use super::{Cache, CacheKey, CacheValue, Etag, cache_value::CacheValueData};
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
+
+use super::{Cache, CacheKey, CacheValue, Etag, MemoryCacheGetResult, cache_value::CacheValueData};
 
 /// A namespaced view of the shared cache.
 ///
@@ -50,6 +53,51 @@ impl CacheFacade {
     value: CacheValue<T>,
   ) {
     self.cache.store(self.key(identifier), etag, value)
+  }
+
+  /// Looks up a runtime value without falling through to filesystem storage.
+  pub(crate) fn get_memory<T: Any + Send + Sync>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+  ) -> MemoryCacheGetResult<T> {
+    self.cache.get_memory(self.key(identifier), etag)
+  }
+
+  pub(crate) fn store_memory<T: Any + Send + Sync>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
+    self.cache.store_memory(self.key(identifier), etag, value)
+  }
+
+  /// Restores an exclusively owned value from bytes written by `store_borrowed`.
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self.cache.restore_owned(self.key(identifier), etag)
+  }
+
+  /// Encodes borrowed values in parallel; only bytes are queued for idle I/O.
+  pub(crate) fn store_borrowed<'a, T: for<'s> Serialize<Serializer<'s>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (&'a str, Option<Etag>, T)>,
+  ) {
+    self
+      .cache
+      .store_borrowed(entries.map(|(identifier, etag, value)| (self.key(identifier), etag, value)))
+  }
+
+  pub(crate) fn has_memory_cache(&self) -> bool {
+    self.cache.has_memory_cache()
+  }
+
+  pub(crate) fn has_file_cache(&self) -> bool {
+    self.cache.has_file_cache()
   }
 
   fn key(&self, identifier: &str) -> CacheKey {

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -9,10 +9,10 @@ use rspack_error::Result;
 use super::etag::Etag;
 use crate::cache::CacheCodec;
 
-/// Shared immutable cache value.
+/// Shared cache value.
 ///
 /// Cloning this wrapper only increments an `Arc`; the cached object itself is
-/// never cloned.
+/// never cloned. Runtime values may manage exclusive ownership internally.
 pub struct CacheValue<T>(Arc<T>);
 
 impl<T> CacheValue<T> {
@@ -126,16 +126,18 @@ impl CacheEntry {
 }
 
 impl<T: CacheValueData> CacheValue<T> {
-  pub(super) fn erase(self) -> ErasedCacheValue {
-    ErasedCacheValue::new(self.0)
-  }
-
   pub(super) fn encoder() -> CacheValueEncoder {
     encode_cache_entry::<T>
   }
 
   pub(super) fn decoder() -> CacheValueDecoder {
     decode_cache_entry::<T>
+  }
+}
+
+impl<T: Any + Send + Sync> CacheValue<T> {
+  pub(super) fn erase(self) -> ErasedCacheValue {
+    ErasedCacheValue::new(self.0)
   }
 }
 

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer, utils::OwnedOrRef};
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashMap;
@@ -11,8 +12,11 @@ use tokio::sync::Notify;
 
 use super::{
   CacheKey, Etag, Meta,
-  cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
+  cache_value::{
+    CacheEntry, CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue,
+  },
   db::{Database, DatabaseFamily},
+  owned_cache_value::StoredOwnedCacheEntry,
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
@@ -29,9 +33,12 @@ struct PendingWrites {
 }
 
 #[derive(Debug)]
-struct PendingWrite {
-  entry: CacheEntry,
-  encoder: CacheValueEncoder,
+enum PendingWrite {
+  Shared {
+    entry: CacheEntry,
+    encoder: CacheValueEncoder,
+  },
+  Encoded(Vec<u8>),
 }
 
 impl PendingWrites {
@@ -250,11 +257,100 @@ impl FileCacheStrategy {
     };
     state.pending_writes.entries.insert(
       key,
-      PendingWrite {
+      PendingWrite::Shared {
         entry: CacheEntry::new(etag, value),
         encoder,
       },
     );
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    if self.readonly || self.read_state().is_none() {
+      return;
+    }
+    // Never wait for the state lock from Rayon workers: the idle writer may
+    // hold that lock while it waits for parallel serialization of shared values.
+    let encoded: Vec<_> = entries
+      .map(|(key, etag, value)| {
+        let mut entry = StoredOwnedCacheEntry {
+          etag,
+          value: Some(OwnedOrRef::Borrowed(&value)),
+        };
+        let bytes = match self.codec.encode(&entry) {
+          Ok(bytes) => bytes,
+          Err(error) => {
+            self.logger.warn(format!(
+              "Failed to encode cache entry for key {key}: {error}"
+            ));
+            // Persist a miss rather than allowing an older value to reappear.
+            entry.value = None;
+            self
+              .codec
+              .encode(&entry)
+              .expect("an empty cache entry should serialize")
+          }
+        };
+        (key, bytes)
+      })
+      .collect();
+    let state = self.read_state();
+    let Some(state) = state.as_ref() else {
+      return;
+    };
+    for (key, bytes) in encoded {
+      state
+        .pending_writes
+        .entries
+        .insert(key, PendingWrite::Encoded(bytes));
+    }
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: &CacheKey,
+    etag: Option<&Etag>,
+  ) -> Option<T> {
+    let decode = |bytes: &[u8]| -> Result<Option<T>> {
+      let entry = self
+        .codec
+        .decode::<StoredOwnedCacheEntry<'static, T>>(bytes)?;
+      Ok(
+        (entry.etag.as_ref() == etag)
+          .then_some(entry.value)
+          .flatten()
+          .map(OwnedOrRef::into_owned),
+      )
+    };
+    let state_guard = self.read_state();
+    let state = state_guard.as_ref()?;
+    let result = if let Some(pending) = state.pending_writes.entries.get(key) {
+      match pending.value() {
+        PendingWrite::Encoded(bytes) => decode(bytes),
+        PendingWrite::Shared { .. } => return None,
+      }
+    } else {
+      match state.database.get(DatabaseFamily::Cache, key) {
+        Ok(Some(bytes)) => decode(&bytes),
+        Ok(None) => return None,
+        Err(error) => {
+          drop(state_guard);
+          self.session_unavailable(Some(&error));
+          return None;
+        }
+      }
+    };
+    match result {
+      Ok(value) => value,
+      Err(error) => {
+        self.logger.warn(format!(
+          "Failed to decode cache entry for key {key}: {error}"
+        ));
+        None
+      }
+    }
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {
@@ -309,10 +405,10 @@ impl FileCacheStrategy {
     let state_guard = self.read_state();
     let state = state_guard.as_ref()?;
     if let Some(pending) = state.pending_writes.entries.get(key) {
-      return pending
-        .entry
-        .matches(etag)
-        .then(|| pending.entry.value().clone());
+      let PendingWrite::Shared { entry, .. } = pending.value() else {
+        return None;
+      };
+      return entry.matches(etag).then(|| entry.value().clone());
     }
 
     let result = state.database.get(DatabaseFamily::Cache, key);
@@ -373,8 +469,12 @@ impl FileCacheStrategy {
 
         writes = std::mem::take(&mut state.pending_writes.entries)
           .into_par_iter()
-          .filter_map(
-            |(key, pending)| match (pending.encoder)(&pending.entry, codec) {
+          .filter_map(|(key, pending)| {
+            let encoded = match pending {
+              PendingWrite::Shared { entry, encoder } => encoder(&entry, codec),
+              PendingWrite::Encoded(bytes) => Ok(bytes),
+            };
+            match encoded {
               Ok(value) => Some((DatabaseFamily::Cache, key, value)),
               Err(error) => {
                 self.logger.warn(format!(
@@ -382,8 +482,8 @@ impl FileCacheStrategy {
                 ));
                 None
               }
-            },
-          )
+            }
+          })
           .collect::<Vec<_>>();
 
         new_build_dependencies = state.pending_writes.new_build_dependencies().take();

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -7,6 +7,8 @@ use std::{
   time::Duration,
 };
 
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use tokio::{
@@ -217,6 +219,21 @@ impl IdleFileCache {
     self
       .strategy
       .store(key, etag, value.erase(), CacheValue::<T>::encoder());
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    self.strategy.store_borrowed(entries);
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self.strategy.restore_owned(&key, etag.as_ref())
   }
 
   pub fn restore<T: CacheValueData>(

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,11 +1,11 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+  any::Any,
+  sync::atomic::{AtomicU32, Ordering},
+};
 
 use rspack_util::fx_hash::FxDashMap;
 
-use super::{
-  CacheKey, CacheValue, Etag,
-  cache_value::{CacheEntry, CacheValueData},
-};
+use super::{CacheKey, CacheValue, Etag, cache_value::CacheEntry};
 
 /// Result of looking up an item in the memory cache.
 ///
@@ -97,7 +97,7 @@ impl MemoryCache {
     }
   }
 
-  pub fn get<T: CacheValueData>(
+  pub fn get<T: Any + Send + Sync>(
     &self,
     key: &CacheKey,
     etag: Option<&Etag>,
@@ -123,7 +123,12 @@ impl MemoryCache {
     }
   }
 
-  pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
+  pub fn store<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
     self.entries.insert(
       key,
       MemoryCacheEntry::new(

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -8,6 +8,7 @@ mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 mod meta;
+mod owned_cache_value;
 pub(crate) mod snapshot;
 mod validator;
 

--- a/crates/rspack_core/src/new_cache/owned_cache_value.rs
+++ b/crates/rspack_core/src/new_cache/owned_cache_value.rs
@@ -1,0 +1,17 @@
+use rspack_cacheable::{
+  cacheable,
+  utils::OwnedOrRef,
+  with::{AsOption, AsOwned},
+};
+
+use super::Etag;
+
+/// Filesystem representation for values exclusively owned by the caller.
+/// Serialization borrows the live value; restoration creates a new owned value.
+#[cacheable]
+pub(super) struct StoredOwnedCacheEntry<'a, T> {
+  pub etag: Option<Etag>,
+  /// None invalidates a previously stored entry when serialization fails.
+  #[cacheable(with=AsOption<AsOwned>)]
+  pub value: Option<OwnedOrRef<'a, T>>,
+}

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -99,16 +99,17 @@ pub struct NormalModuleHooks {
 
 /// Build-owned state of a [`NormalModule`].
 ///
-/// This mirrors webpack's serialized module state: cache entries retain build
-/// output, while factory-owned values such as loaders, parser/generator
-/// instances, and their options always come from the fresh module created for
-/// the current compilation.
+/// Filesystem serialization borrows this state. Memory caching transfers the
+/// owning module instead, so mutations made after building remain observable.
+/// Factory-owned values are refreshed from the current module factory.
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct NormalModuleState {
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
   diagnostics: Vec<Diagnostic>,
+  // Parse-time bailouts, independent of each compilation's optimization decisions.
+  optimization_bailouts: Vec<OptimizationBailoutItem>,
   code_generation_dependencies: Option<Vec<DependencyId>>,
   presentational_dependencies: Option<Vec<DependencyCodeGenerationRef>>,
   build_info: BuildInfo,
@@ -239,6 +240,7 @@ impl NormalModule {
       state: NormalModuleState {
         source: None,
         diagnostics: Default::default(),
+        optimization_bailouts: Default::default(),
         code_generation_dependencies: None,
         presentational_dependencies: None,
         build_info,
@@ -325,6 +327,23 @@ impl NormalModule {
   pub(crate) fn restore_module_state(&mut self, state: NormalModuleState) {
     self.state = state;
     self.cached_source_sizes = SourceSizeCache::default();
+  }
+
+  pub(crate) fn build_optimization_bailouts(&self) -> &[OptimizationBailoutItem] {
+    &self.state.optimization_bailouts
+  }
+
+  /// Refreshes factory data while retaining this module's build state and identity.
+  /// Dependency and block ids are reattached when integrating the cached build output.
+  pub(crate) fn update_cache_module(&mut self, fresh: &mut NormalModule) {
+    std::mem::swap(&mut self.state, &mut fresh.state);
+    std::mem::swap(&mut self.debug_id, &mut fresh.debug_id);
+    std::mem::swap(self, fresh);
+  }
+
+  /// Restores the fresh, unbuilt state after a cached module fails validation.
+  pub(crate) fn reset_cached_build(&mut self, fresh: &mut NormalModule) {
+    std::mem::swap(&mut self.state, &mut fresh.state);
   }
 
   pub(crate) async fn need_build_with_context(
@@ -497,6 +516,7 @@ impl Module for NormalModule {
   ) -> Result<BuildResult> {
     self.state.force_build = false;
     self.state.build_info.snapshot = None;
+    self.state.optimization_bailouts.clear();
 
     // so does webpack
     self.state.parsed = true;
@@ -667,7 +687,7 @@ impl Module for NormalModule {
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
     }
-    let optimization_bailouts = if let Some(side_effects_bailout) = side_effects_bailout {
+    self.state.optimization_bailouts = if let Some(side_effects_bailout) = side_effects_bailout {
       let short_id = self.readable_identifier(&build_context.compiler_options.context);
       vec![OptimizationBailoutItem::SideEffects {
         node_type: side_effects_bailout.ty,
@@ -688,6 +708,8 @@ impl Module for NormalModule {
       &self.state.build_meta,
     ));
 
+    // Each compilation owns its bailout list and may append optimization decisions.
+    let optimization_bailouts = self.state.optimization_bailouts.clone();
     Ok(BuildResult {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),

--- a/tests/rspack-test/compilerCases/module-cache-live-state.js
+++ b/tests/rspack-test/compilerCases/module-cache-live-state.js
@@ -1,0 +1,122 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { RawSource } = require("webpack-sources");
+
+const PLUGIN = "ModuleCacheLiveStateTest";
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  { name: "memory", cache: true },
+  { name: "persistent", cache: "persistent" },
+  { name: "persistent-without-memory", cache: "persistent", maxMemoryGenerations: 0 },
+  { name: "persistent-reopen", cache: "persistent", reopen: true },
+  { name: "disabled", cache: false }
+].map(({ name, cache, maxMemoryGenerations, reopen }) => {
+  let root;
+  let input;
+  let iteration = 0;
+  let expectedAssets = [];
+  let built = 0;
+  let succeeded = 0;
+  let failBuild = false;
+  let expectedBailouts;
+
+  return {
+    description: `should retain mutations of cached modules with ${name}`,
+    options(context) {
+      root = context.getDist(name);
+      input = path.join(root, "input.js");
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(input, 'module.exports = require("./data.json");');
+      fs.writeFileSync(path.join(root, "data.json"), '{"value": 42}');
+      // Keep timestamps outside the filesystem accuracy window for deterministic hits.
+      const timestamp = new Date(Date.now() - 10000);
+      fs.utimesSync(input, timestamp, timestamp);
+      fs.utimesSync(path.join(root, "data.json"), timestamp, timestamp);
+      return {
+        context: root,
+        entry: "./input.js",
+        mode: "production",
+        devtool: false,
+        incremental: false,
+        output: { path: path.join(root, "dist") },
+        cache: cache === "persistent" ? {
+          type: "persistent",
+          ...(maxMemoryGenerations === undefined ? {} : { maxMemoryGenerations }),
+          storage: { type: "filesystem", location: path.join(root, "cache") }
+        } : cache,
+        experiments: {
+          newCache: {
+            module: true,
+            loader: false,
+            codeGeneration: false,
+            devtool: false,
+            minimize: false
+          }
+        },
+        module: {
+          // Factory-owned functions must come from the fresh module after restoration.
+          rules: [{ test: /\.json$/, type: "json", parser: { parse: JSON.parse } }]
+        },
+        plugins: [{
+          apply(compiler) {
+            compiler.hooks.compilation.tap(PLUGIN, compilation => {
+              compilation.hooks.buildModule.tap(PLUGIN, module => {
+                if (module.resource === input) built++;
+              });
+              compilation.hooks.succeedModule.tap(PLUGIN, module => {
+                if (module.resource !== input) return;
+                if (failBuild) throw new Error("module cache build failure");
+                succeeded++;
+                expect(Object.keys(module.buildInfo.assets).sort()).toEqual(expectedAssets);
+                // This also runs on cache hits. The next build must observe this mutation.
+                module.emitFile(`module-state-${iteration}.txt`, new RawSource(`${iteration}`));
+              });
+            });
+          }
+        }]
+      };
+    },
+    compiler(_, compiler) {
+      compiler.outputFileSystem = fs;
+    },
+    async build(context) {
+      const manager = context.getCompiler();
+      for (iteration = 0; iteration < 5; iteration++) {
+        const rebuild = cache === false || iteration === 0 || iteration === 3;
+        if (iteration === 3) {
+          const timestamp = new Date(fs.statSync(input).mtimeMs + 1000);
+          fs.writeFileSync(input, 'module.exports = require("./data.json").value + 1;');
+          fs.utimesSync(input, timestamp, timestamp);
+        }
+        if (rebuild) expectedAssets = [];
+        const before = built;
+        const stats = await manager.build();
+        expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+        expect(built - before).toBe(rebuild ? 1 : 0);
+        expect(succeeded).toBe(iteration + 1);
+        const bailouts = stats.toJson({
+          all: false,
+          modules: true,
+          cachedModules: true,
+          optimizationBailout: true
+        }).modules.find(module => module.identifier === input).optimizationBailout;
+        if (rebuild) expectedBailouts = bailouts;
+        else expect(bailouts).toEqual(expectedBailouts);
+        expectedAssets.push(`module-state-${iteration}.txt`);
+        for (const asset of expectedAssets) {
+          expect(stats.compilation.getAsset(asset)).toBeDefined();
+        }
+        if (reopen && iteration < 4) {
+          await manager.close();
+          manager.createCompiler().outputFileSystem = fs;
+        }
+      }
+      // A failed make may have moved the graph out of the compilation. Cache
+      // cleanup and compiler.close must preserve the original error without panicking.
+      failBuild = true;
+      await expect(manager.build()).rejects.toThrow("module cache build failure");
+    }
+  };
+});


### PR DESCRIPTION
## Summary

Preserve mutations made by later hooks when reusing module builds. Transfer module ownership through the memory cache, refresh factory data on restore, and serialize the current state at compiler lifecycle boundaries for persistent caching.