### PR TITLE
fix(cache): retain live modules across compilations

### DIFF
--- a/crates/rspack_binding_api/src/async_dependency_block.rs
+++ b/crates/rspack_binding_api/src/async_dependency_block.rs
@@ -71,7 +71,6 @@ impl AsyncDependenciesBlock {
       Ok(
         block
           .get_dependencies()
-          .iter()
           .filter_map(|dependency_id| {
             internal::try_dependency_by_id(module_graph, dependency_id)
               .map(|dep| DependencyWrapper::new(dep, compilation.id(), Some(compilation)))

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -505,7 +505,6 @@ impl Module {
       let dependencies = module.get_dependencies();
       Ok(
         dependencies
-          .iter()
           .filter_map(|dependency_id| {
             internal::try_dependency_by_id(module_graph, dependency_id).map(|dep| {
               DependencyWrapper::new(

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1236,7 +1236,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         };
         let root_modules = block
           .get_dependencies()
-          .iter()
           .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
           .copied()
           .collect::<Vec<_>>();

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -145,6 +145,7 @@ impl Task<TaskContext> for AddTask {
     if cached {
       return Ok(vec![Box::new(BuildResultTask {
         module,
+        from_cache: true,
         plugin_driver: context.plugin_driver.clone(),
         forwarded_ids,
       })]);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -29,7 +29,7 @@ impl Task<TaskContext> for AddTask {
   async fn main_run(self: Box<Self>, context: &mut TaskContext) -> TaskResult<TaskContext> {
     let Self {
       original_module_identifier,
-      mut module,
+      module,
       module_graph_module,
       dependencies,
       from_unlazy,
@@ -109,16 +109,16 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let cached_module_state = if let Some(module_build_cache) = &context.module_build_cache {
+    let (module, cached) = if let Some(module_build_cache) = &context.module_build_cache {
       module_build_cache
         .restore(
-          &module,
+          module,
           &context.file_system_info,
           &context.value_cache_versions,
         )
         .await?
     } else {
-      None
+      (module, false)
     };
     context
       .artifact
@@ -142,11 +142,7 @@ impl Task<TaskContext> for AddTask {
       .affected_modules
       .mark_as_add(&module_identifier);
 
-    if let Some(module_state) = cached_module_state {
-      module
-        .as_normal_module_mut()
-        .expect("module cache entries are only restored for normal modules")
-        .restore_module_state(module_state);
+    if cached {
       return Ok(vec![Box::new(BuildResultTask {
         module,
         plugin_driver: context.plugin_driver.clone(),

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -118,17 +118,18 @@ impl Task<TaskContext> for BuildResultTask {
       mut forwarded_ids,
     } = *self;
     if from_cache {
-      let dependencies = module.get_dependency_refs().to_vec();
-      module
-        .restore_from_cache(context.compilation_id, &dependencies)
+      plugin_driver
+        .compilation_hooks
+        .still_valid_module
+        .call(context.compiler_id, context.compilation_id, &mut module)
+        .await?;
+    } else {
+      plugin_driver
+        .compilation_hooks
+        .succeed_module
+        .call(context.compiler_id, context.compilation_id, &mut module)
         .await?;
     }
-
-    plugin_driver
-      .compilation_hooks
-      .succeed_module
-      .call(context.compiler_id, context.compilation_id, &mut module)
-      .await?;
 
     let build_info = module.build_info();
 

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -90,6 +90,7 @@ impl Task<TaskContext> for BuildTask {
 
     Ok(vec![Box::new(BuildResultTask {
       module: result,
+      from_cache: false,
       plugin_driver,
       forwarded_ids,
     })])
@@ -99,6 +100,7 @@ impl Task<TaskContext> for BuildTask {
 #[derive(Debug)]
 pub(super) struct BuildResultTask {
   pub module: BoxModule,
+  pub from_cache: bool,
   pub plugin_driver: SharedPluginDriver,
   pub forwarded_ids: ForwardedIdSet,
 }
@@ -111,9 +113,17 @@ impl Task<TaskContext> for BuildResultTask {
   async fn main_run(self: Box<Self>, context: &mut TaskContext) -> TaskResult<TaskContext> {
     let BuildResultTask {
       mut module,
+      from_cache,
       plugin_driver,
       mut forwarded_ids,
     } = *self;
+    if from_cache {
+      let dependencies = module.get_dependency_refs().to_vec();
+      module
+        .restore_from_cache(context.compilation_id, &dependencies)
+        .await?;
+    }
+
     plugin_driver
       .compilation_hooks
       .succeed_module

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -7,11 +7,12 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 
 use crate::{
   BoxModule, BuildModuleGraphArtifact, FileSystemInfo, ModuleGraph, ModuleIdentifier,
-  NormalModuleState, ValueCacheVersions,
+  NeedBuildContext, ValueCacheVersions,
+  cache::SnapshotStrategyOptions,
   new_cache::{Cache, CacheFacade, CacheValue, MemoryCacheGetResult},
 };
 
-/// Cache for completed normal module builds.
+/// Cache for completed module builds.
 ///
 /// A compilation exclusively owns its live modules until the next full build
 /// transfers them back to the memory cache. Filesystem writes borrow the latest
@@ -28,14 +29,14 @@ type ModuleCacheSlot = Mutex<Option<BoxModule>>;
 #[cacheable]
 struct StoredModule<'a> {
   #[cacheable(with=AsOwned)]
-  module_state: OwnedOrRef<'a, NormalModuleState>,
+  module: OwnedOrRef<'a, BoxModule>,
 }
 
 impl ModuleBuildCache {
   pub(crate) fn new(cache: &Cache) -> Self {
     Self {
       // The owned filesystem representation differs from the previous state cache.
-      cache: cache.facade("Compilation/modules/owned-v1"),
+      cache: cache.facade("Compilation/modules/owned-v2"),
       pending: Default::default(),
     }
   }
@@ -51,10 +52,6 @@ impl ModuleBuildCache {
     file_system_info: &FileSystemInfo,
     value_cache_versions: &ValueCacheVersions,
   ) -> Result<(BoxModule, bool)> {
-    if module.as_normal_module().is_none() {
-      return Ok((module, false));
-    }
-
     let identifier = module.identifier();
     let cached = match self
       .cache
@@ -65,45 +62,27 @@ impl ModuleBuildCache {
         .expect("module cache slot should not be poisoned")
         .take(),
       MemoryCacheGetResult::Miss => None,
-      MemoryCacheGetResult::NotCached => {
-        let stored = self
-          .cache
-          .restore_owned::<StoredModule<'static>>(identifier.as_str(), None);
-        self.mark_acquired(identifier);
-        if let Some(StoredModule {
-          module_state,
-        }) = stored
-          && !module_state
-            .as_ref()
-            .need_build_with_context(file_system_info, value_cache_versions)
-            .await?
-        {
-          module
-            .as_normal_module_mut()
-            .expect("normal module was checked")
-            .restore_module_state(module_state.into_owned());
-          return Ok((module, true));
-        }
-        return Ok((module, false));
-      }
+      MemoryCacheGetResult::NotCached => self
+        .cache
+        .restore_owned::<StoredModule<'static>>(identifier.as_str(), None)
+        .map(|stored| stored.module.into_owned()),
     };
     self.mark_acquired(identifier);
     let Some(mut cached) = cached else {
       return Ok((module, false));
     };
-    let fresh = module
-      .as_normal_module_mut()
-      .expect("normal module was checked");
-    let normal = cached
-      .as_normal_module_mut()
-      .expect("only normal modules are cached");
-    normal.update_cache_module(fresh);
-    if normal
-      .need_build_with_context(file_system_info, value_cache_versions)
-      .await?
+    // Identifiers can be reused by factories producing different module types.
+    if cached.as_ref().as_any().type_id() != module.as_ref().as_any().type_id()
+      || !module.build_info().cacheable
+      || cached
+        .need_build(&NeedBuildContext {
+          file_system_info,
+          value_cache_versions,
+        })
+        .await?
+      || !cached.update_cache_module(module.as_mut())
     {
-      normal.reset_cached_build(fresh);
-      return Ok((cached, false));
+      return Ok((module, false));
     }
 
     Ok((cached, true))
@@ -139,12 +118,23 @@ impl ModuleBuildCache {
           let Some(module) = module_graph.module_by_identifier(&module_identifier) else {
             return Ok(None);
           };
-          let Some(module) = module.as_normal_module() else {
-            return Ok(None);
-          };
-          let snapshot = module
-            .create_cache_snapshot(file_system_info, build_start_time)
-            .await?;
+          let build_info = module.build_info();
+          let snapshot =
+            if build_info.cacheable && !module.diagnostics().iter().any(|d| d.is_error()) {
+              Some(
+                file_system_info
+                  .create_snapshot(
+                    Some(build_start_time),
+                    &build_info.dependencies.file,
+                    &build_info.dependencies.context,
+                    &build_info.dependencies.missing,
+                    SnapshotStrategyOptions::timestamp(),
+                  )
+                  .await?,
+              )
+            } else {
+              None
+            };
           Ok(Some((module_identifier, snapshot)))
         });
       }
@@ -171,20 +161,17 @@ impl ModuleBuildCache {
     if !self.cache.has_file_cache() {
       return;
     }
-    self.cache.store_borrowed(
-      module_graph
-        .modules_par()
-        .filter_map(|(identifier, module)| {
-          let normal = module.as_normal_module()?;
-          Some((
-            identifier.as_str(),
-            None,
-            StoredModule {
-              module_state: OwnedOrRef::Borrowed(normal.module_state()),
-            },
-          ))
-        }),
-    );
+    self
+      .cache
+      .store_borrowed(module_graph.modules_par().map(|(identifier, module)| {
+        (
+          identifier.as_str(),
+          None,
+          StoredModule {
+            module: OwnedOrRef::Borrowed(module),
+          },
+        )
+      }));
   }
 
   /// Returns live modules immediately before a full build discards their graph.
@@ -194,9 +181,6 @@ impl ModuleBuildCache {
       return;
     }
     for module in module_graph.take_modules() {
-      if module.as_normal_module().is_none() {
-        continue;
-      }
       let identifier = module.identifier();
       self.cache.store_memory(
         identifier.as_str(),

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -1,70 +1,124 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
+use rayon::prelude::*;
+use rspack_cacheable::{cacheable, utils::OwnedOrRef, with::AsOwned};
 use rspack_collections::{Identifiable, IdentifierDashMap};
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 
 use crate::{
   BoxModule, BuildModuleGraphArtifact, FileSystemInfo, ModuleGraph, ModuleIdentifier,
   NormalModuleState, ValueCacheVersions,
-  new_cache::{CacheFacade, CacheValue},
+  new_cache::{Cache, CacheFacade, CacheValue, MemoryCacheGetResult},
 };
 
 /// Cache for completed normal module builds.
 ///
-/// Cache entries store [`NormalModuleState`], including its dependency and block
-/// objects. Factory-owned module data is supplied by the fresh module.
+/// A compilation exclusively owns its live modules until the next full build
+/// transfers them back to the memory cache. Filesystem writes borrow the latest
+/// state at compiler boundaries and queue only encoded bytes for background I/O.
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCache {
   cache: CacheFacade,
   pending: Arc<IdentifierDashMap<u64>>,
 }
 
+// None records an acquired module, preventing fallback to stale filesystem data.
+type ModuleCacheSlot = Mutex<Option<BoxModule>>;
+
+#[cacheable]
+struct StoredModule<'a> {
+  #[cacheable(with=AsOwned)]
+  module_state: OwnedOrRef<'a, NormalModuleState>,
+}
+
 impl ModuleBuildCache {
-  pub(crate) fn new(cache: CacheFacade) -> Self {
+  pub(crate) fn new(cache: &Cache) -> Self {
     Self {
-      cache,
+      // The owned filesystem representation differs from the previous state cache.
+      cache: cache.facade("Compilation/modules/owned-v1"),
       pending: Default::default(),
     }
   }
 
-  /// Defers publishing a built module until the build-module-graph phase has
-  /// completed, so make-stage mutations are included in the cache entry.
+  /// Defers filesystem dependency snapshot creation until make-stage mutations finish.
   pub(crate) fn mark_pending(&self, module_identifier: ModuleIdentifier, build_start_time: u64) {
     self.pending.insert(module_identifier, build_start_time);
   }
 
   pub(crate) async fn restore(
     &self,
-    module: &BoxModule,
+    mut module: BoxModule,
     file_system_info: &FileSystemInfo,
     value_cache_versions: &ValueCacheVersions,
-  ) -> Result<Option<NormalModuleState>> {
+  ) -> Result<(BoxModule, bool)> {
     if module.as_normal_module().is_none() {
-      return Ok(None);
+      return Ok((module, false));
     }
 
     let identifier = module.identifier();
-    let Some(result) = self
+    let cached = match self
       .cache
-      .get::<NormalModuleState>(identifier.as_str(), None)
-    else {
-      return Ok(None);
+      .get_memory::<ModuleCacheSlot>(identifier.as_str(), None)
+    {
+      MemoryCacheGetResult::Hit(slot) => slot
+        .lock()
+        .expect("module cache slot should not be poisoned")
+        .take(),
+      MemoryCacheGetResult::Miss => None,
+      MemoryCacheGetResult::NotCached => {
+        let stored = self
+          .cache
+          .restore_owned::<StoredModule<'static>>(identifier.as_str(), None);
+        self.mark_acquired(identifier);
+        if let Some(StoredModule {
+          module_state,
+        }) = stored
+          && !module_state
+            .as_ref()
+            .need_build_with_context(file_system_info, value_cache_versions)
+            .await?
+        {
+          module
+            .as_normal_module_mut()
+            .expect("normal module was checked")
+            .restore_module_state(module_state.into_owned());
+          return Ok((module, true));
+        }
+        return Ok((module, false));
+      }
     };
-    if result
+    self.mark_acquired(identifier);
+    let Some(mut cached) = cached else {
+      return Ok((module, false));
+    };
+    let fresh = module
+      .as_normal_module_mut()
+      .expect("normal module was checked");
+    let normal = cached
+      .as_normal_module_mut()
+      .expect("only normal modules are cached");
+    normal.update_cache_module(fresh);
+    if normal
       .need_build_with_context(file_system_info, value_cache_versions)
       .await?
     {
-      return Ok(None);
+      normal.reset_cached_build(fresh);
+      return Ok((cached, false));
     }
 
-    Ok(Some(result.as_arc().as_ref().clone()))
+    Ok((cached, true))
   }
 
-  /// Stores modules built during this phase from the final module graph.
-  ///
-  /// Snapshot creation and cache-entry construction are parallel. The module's
-  /// state is cloned, while dependency and block objects retain shared identity.
-  pub(crate) async fn store_pending(
+  fn mark_acquired(&self, identifier: ModuleIdentifier) {
+    self.cache.store_memory(
+      identifier.as_str(),
+      None,
+      CacheValue::new(ModuleCacheSlot::new(None)),
+    );
+  }
+
+  /// Creates validity snapshots without copying the mutable module state.
+  pub(crate) async fn snapshot_pending(
     &self,
     artifact: &mut BuildModuleGraphArtifact,
     file_system_info: &FileSystemInfo,
@@ -100,55 +154,55 @@ impl ModuleBuildCache {
     .map(|result| result.to_rspack_result().and_then(|result| result))
     .collect::<Result<Vec<_>>>()?;
 
-    let module_identifiers = snapshots
-      .into_iter()
-      .flatten()
-      .filter_map(|(module_identifier, snapshot)| {
-        let module = artifact
-          .get_module_graph_mut()
-          .module_by_identifier_mut(&module_identifier)?;
+    for (module_identifier, snapshot) in snapshots.into_iter().flatten() {
+      if let Some(module) = artifact
+        .get_module_graph_mut()
+        .module_by_identifier_mut(&module_identifier)
+      {
         module.build_info_mut().snapshot = snapshot;
-        Some(module_identifier)
-      })
-      .collect::<Vec<_>>();
-
-    let module_graph = artifact.get_module_graph();
-    let cache_entries = rspack_parallel::scope::<_, Result<_>>(|token| {
-      for module_identifier in module_identifiers {
-        // SAFETY: the scope is awaited before the cache entries are published.
-        let task = unsafe { token.used(module_graph) };
-        task.spawn(move |module_graph| async move {
-          Ok((
-            module_identifier,
-            create_cache_entry(module_graph, module_identifier),
-          ))
-        });
       }
-    })
-    .await
-    .into_iter()
-    .map(|result| result.to_rspack_result().and_then(|result| result))
-    .collect::<Result<Vec<_>>>()?;
-
-    for (module_identifier, entry) in cache_entries {
-      self
-        .cache
-        .store(module_identifier.as_str(), None, CacheValue::new(entry));
     }
     Ok(())
   }
-}
 
-fn create_cache_entry(
-  module_graph: &ModuleGraph,
-  module_identifier: ModuleIdentifier,
-) -> NormalModuleState {
-  let source_module = module_graph
-    .module_by_identifier(&module_identifier)
-    .expect("pending module should exist in the final module graph");
-  source_module
-    .as_normal_module()
-    .expect("only normal modules are marked pending for the module build cache")
-    .module_state()
-    .clone()
+  /// Encodes current module state while the compilation is exclusively borrowed.
+  /// Include cache hits too: later hooks may have changed their state.
+  pub(crate) fn store_modules(&self, module_graph: &ModuleGraph) {
+    if !self.cache.has_file_cache() {
+      return;
+    }
+    self.cache.store_borrowed(
+      module_graph
+        .modules_par()
+        .filter_map(|(identifier, module)| {
+          let normal = module.as_normal_module()?;
+          Some((
+            identifier.as_str(),
+            None,
+            StoredModule {
+              module_state: OwnedOrRef::Borrowed(normal.module_state()),
+            },
+          ))
+        }),
+    );
+  }
+
+  /// Returns live modules immediately before a full build discards their graph.
+  /// Incremental rebuilds keep ownership in their recovered graph instead.
+  pub(crate) fn release_modules(&self, module_graph: &mut ModuleGraph) {
+    if !self.cache.has_memory_cache() {
+      return;
+    }
+    for module in module_graph.take_modules() {
+      if module.as_normal_module().is_none() {
+        continue;
+      }
+      let identifier = module.identifier();
+      self.cache.store_memory(
+        identifier.as_str(),
+        None,
+        CacheValue::new(ModuleCacheSlot::new(Some(module))),
+      );
+    }
+  }
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -35,8 +35,7 @@ struct StoredModule<'a> {
 impl ModuleBuildCache {
   pub(crate) fn new(cache: &Cache) -> Self {
     Self {
-      // The owned filesystem representation differs from the previous state cache.
-      cache: cache.facade("Compilation/modules/owned-v2"),
+      cache: cache.facade("Compilation/modules"),
       pending: Default::default(),
     }
   }

--- a/crates/rspack_core/src/compilation/build_module_graph/pass.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/pass.rs
@@ -63,7 +63,7 @@ impl PassExt for BuildModuleGraphPhasePass {
   async fn after_pass(&self, compilation: &mut Compilation, cache: &mut dyn Cache) -> Result<()> {
     if let Some(module_build_cache) = compilation.module_build_cache.clone() {
       module_build_cache
-        .store_pending(
+        .snapshot_pending(
           &mut compilation.build_module_graph_artifact,
           &compilation.file_system_info,
         )

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -364,9 +364,9 @@ impl Compilation {
     // Incremental make reuses the previous module graph and owns its own
     // invalidation path. Keep that fast path unchanged.
     let module_build_cache = (options.experiments.new_cache.module
-      && !is_rebuild
+      && !incremental.mutations_readable(IncrementalPasses::BUILD_MODULE_GRAPH)
       && !matches!(&options.cache, CacheOptions::Disabled))
-    .then(|| ModuleBuildCache::new(cache.facade("Compilation/modules")));
+    .then(|| ModuleBuildCache::new(&cache));
     let snapshot_options = match &options.cache {
       CacheOptions::Disabled => SnapshotOptions::default(),
       CacheOptions::Memory { snapshot, .. } => snapshot.clone(),

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -23,7 +23,7 @@ use crate::{
   CompilerOptions, CompilerPlatform, ContextModuleFactory, Filename, InfrastructureLogSink,
   KeepPattern, NormalModuleFactory, PluginDriver, ResolverFactory, SharedPluginDriver,
   artifacts::IncrementalArtifacts,
-  compilation::build_module_graph::ModuleExecutor,
+  compilation::build_module_graph::{ModuleExecutor, module_build_cache::ModuleBuildCache},
   fast_set,
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
@@ -236,13 +236,37 @@ impl Compiler {
     self.new_cache.facade(name)
   }
 
+  fn module_build_cache(&self) -> Option<ModuleBuildCache> {
+    (self.options.experiments.new_cache.module
+      && !matches!(&self.options.cache, CacheOptions::Disabled))
+    .then(|| ModuleBuildCache::new(&self.new_cache))
+  }
+
+  fn store_modules(&self) {
+    if let Some(cache) = self.module_build_cache()
+      && let Some(module_graph) = self.compilation.try_get_module_graph()
+    {
+      cache.store_modules(module_graph);
+    }
+  }
+
+  fn release_modules(&mut self) {
+    if let Some(cache) = self.module_build_cache()
+      && let Some(artifact) = self.compilation.build_module_graph_artifact.try_write()
+    {
+      cache.release_modules(artifact.get_module_graph_mut());
+    }
+  }
+
   fn end_idle(&self) -> Instant {
     self.new_cache.end_idle();
     Instant::now()
   }
 
   fn begin_idle(&mut self, build_time: Duration) {
-    if self.new_cache.has_file_cache() {
+    self.store_modules();
+    if self.new_cache.has_file_cache() && !self.compilation.build_module_graph_artifact.is_stolen()
+    {
       if let CacheOptions::Persistent(options) = &self.options.cache {
         self.compilation.build_dependencies.extend(
           options
@@ -312,6 +336,10 @@ impl Compiler {
     compilation_logging.clear();
     self.incremental_artifacts.reset();
 
+    // Capture the latest state and transfer ownership before fast_set starts
+    // dropping the old graph off-thread.
+    self.store_modules();
+    self.release_modules();
     fast_set(
       &mut self.compilation,
       Compilation::new(
@@ -662,6 +690,7 @@ impl Compiler {
       .await?;
 
     self.cache.close().await;
+    self.store_modules();
     self.new_cache.shutdown().await;
     Ok(())
   }

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -108,6 +108,15 @@ impl Compiler {
 
       self.cache.store_hot_cache(&mut self.compilation);
 
+      self.store_modules();
+      if !next_compilation
+        .incremental
+        .mutations_readable(IncrementalPasses::BUILD_MODULE_GRAPH)
+      {
+        // A rebuild without graph recovery still reuses individual module builds.
+        self.release_modules();
+      }
+
       // Artifact recovery belongs to incremental compilation and is independent
       // from the configured build cache.
       let old_compilation = std::mem::replace(&mut self.compilation, next_compilation);

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -605,7 +605,7 @@ impl ContextModule {
       .iter()
       .filter_map(|b| {
         let block = module_graph.block_by_id(b)?;
-        let dep = block.get_dependencies().first()?;
+        let dep = block.get_dependencies().next()?;
         let dependency = module_graph.dependency_by_id(dep);
         let user_request = dependency
           .as_module_dependency()
@@ -669,12 +669,11 @@ impl ContextModule {
         self.get_glob_object_export_source(runtime_template, entries)
       }
       _ => {
-        if self.get_dependencies().is_empty() {
+        if self.get_dependency_refs().is_empty() {
           return self.get_empty_object_export_source(runtime_template);
         }
-        let dependencies = self.get_dependencies();
-        let map = self.get_user_request_map(dependencies, compilation);
-        let fake_map = self.get_fake_map(dependencies, compilation);
+        let map = self.get_user_request_map(self.get_dependencies(), compilation);
+        let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
         let return_module_object = self.get_return_module_object_source(
           &fake_map,
           false,
@@ -733,7 +732,7 @@ impl ContextModule {
         }
       }
       ContextMode::Eager => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_eager_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
@@ -747,21 +746,21 @@ impl ContextModule {
         }
       }
       ContextMode::AsyncWeak => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_async_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
         }
       }
       ContextMode::Weak => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_sync_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
         }
       }
       ContextMode::Sync => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_sync_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
@@ -782,7 +781,7 @@ impl ContextModule {
       .filter_map(|b| module_graph.block_by_id(b));
     let block_and_first_dependency_list = blocks
       .clone()
-      .filter_map(|b| b.get_dependencies().first().map(|d| (b, d)));
+      .filter_map(|b| b.get_dependencies().next().map(|d| (b, d)));
     let first_dependencies = block_and_first_dependency_list.clone().map(|(_, d)| d);
     let mut has_multiple_or_no_chunks = false;
     let mut has_no_chunk = true;
@@ -989,17 +988,16 @@ impl ContextModule {
   ) -> String {
     let mg = compilation.get_module_graph();
     let block = mg.block_by_id_expect(block_id);
-    let dependencies = block.get_dependencies();
     let promise = runtime_template.block_promise(Some(block_id), compilation, "lazy-once context");
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(block.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(block.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(block.get_dependencies(), compilation));
 
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
@@ -1056,16 +1054,15 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
 
     let return_module_object = self.get_return_module_object_source(
       &fake_map,
@@ -1135,9 +1132,8 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, true, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"
@@ -1181,16 +1177,15 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
       true,
@@ -1247,9 +1242,8 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, false, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"
@@ -1530,14 +1524,6 @@ impl Module for ContextModule {
       compilation,
     );
     code_generation_result.add(SourceType::JavaScript, source);
-    let mut all_deps = self.get_dependencies().to_vec();
-    let module_graph = compilation.get_module_graph();
-    for block in self.get_blocks() {
-      let block = module_graph
-        .block_by_id(block)
-        .expect("should have block in ContextModule code_generation");
-      all_deps.extend(block.get_dependencies());
-    }
 
     Ok(code_generation_result)
   }

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1307,6 +1307,27 @@ impl DependenciesBlock for ContextModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ContextModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.options.resolve_options != fresh.options.resolve_options
+      || self.options.context_options.category != fresh.options.context_options.category
+      || self.options.context_options.context != fresh.options.context_options.context
+      || self.build_info.strict != fresh.build_info.strict
+    {
+      return false;
+    }
+    std::mem::swap(&mut self.options, &mut fresh.options);
+    std::mem::swap(
+      &mut self.resolve_dependencies,
+      &mut fresh.resolve_dependencies,
+    );
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn module_type(&self) -> &ModuleType {

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -34,8 +34,8 @@ pub trait DependenciesBlock {
     self.dependencies_block_mut().remove_dependency(dependency);
   }
 
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies_block().dependency_ids
+  fn get_dependencies(&self) -> DependencyIds<'_> {
+    DependencyIds(self.get_dependency_refs().iter())
   }
 
   fn get_dependency_refs(&self) -> &[DependencyRef] {
@@ -43,9 +43,29 @@ pub trait DependenciesBlock {
   }
 }
 
+/// Iterates dependency IDs directly from their owning references without allocating an ID list.
+/// Cloning only copies the cursor so code generation can traverse the same dependencies multiple times.
+#[derive(Clone)]
+pub struct DependencyIds<'a>(std::slice::Iter<'a, DependencyRef>);
+
+impl<'a> Iterator for DependencyIds<'a> {
+  type Item = &'a DependencyId;
+
+  #[inline]
+  fn next(&mut self) -> Option<Self::Item> {
+    self.0.next().map(|dependency| dependency.id())
+  }
+
+  #[inline]
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    self.0.size_hint()
+  }
+}
+
+impl ExactSizeIterator for DependencyIds<'_> {}
+
 /// Build-owned dependency objects and blocks. The graph indexes the same shared objects.
-/// ID slices are read indexes maintained together with their owning references, so existing
-/// graph algorithms can keep borrowing contiguous IDs without collecting them on every read.
+/// Dependency IDs are read from the objects; block IDs remain a contiguous read index.
 /// Cloning copies these containers for normal-module state cache entries; the dependency
 /// and block objects themselves remain shared.
 #[cacheable]
@@ -54,17 +74,12 @@ pub struct DependenciesBlockData {
   dependencies: Vec<DependencyRef>,
   #[cacheable(omit_bounds)]
   blocks: Vec<AsyncDependenciesBlockRef>,
-  dependency_ids: Vec<DependencyId>,
   block_ids: Vec<AsyncDependenciesBlockIdentifier>,
 }
 
 impl DependenciesBlockData {
   pub fn new(dependencies: Vec<DependencyRef>, blocks: Vec<AsyncDependenciesBlockRef>) -> Self {
     Self {
-      dependency_ids: dependencies
-        .iter()
-        .map(|dependency| *dependency.id())
-        .collect(),
       block_ids: blocks.iter().map(|block| block.identifier()).collect(),
       dependencies,
       blocks,
@@ -72,12 +87,10 @@ impl DependenciesBlockData {
   }
 
   fn add_dependency(&mut self, dependency: DependencyRef) {
-    self.dependency_ids.push(*dependency.id());
     self.dependencies.push(dependency);
   }
 
   fn remove_dependency(&mut self, dependency: DependencyId) {
-    self.dependency_ids.retain(|id| *id != dependency);
     self.dependencies.retain(|value| *value.id() != dependency);
   }
 
@@ -105,7 +118,7 @@ pub type AsyncDependenciesBlockIdentifierSet =
   std::collections::HashSet<AsyncDependenciesBlockIdentifier, BuildHasherDefault<IdentifierHasher>>;
 
 pub fn dependencies_block_update_hash(
-  deps: &[DependencyId],
+  deps: DependencyIds<'_>,
   blocks: &[AsyncDependenciesBlockIdentifier],
   hasher: &mut RspackHasher,
   compilation: &Compilation,

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -66,10 +66,8 @@ impl ExactSizeIterator for DependencyIds<'_> {}
 
 /// Build-owned dependency objects and blocks. The graph indexes the same shared objects.
 /// Dependency IDs are read from the objects; block IDs remain a contiguous read index.
-/// Cloning copies these containers for normal-module state cache entries; the dependency
-/// and block objects themselves remain shared.
 #[cacheable]
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct DependenciesBlockData {
   dependencies: Vec<DependencyRef>,
   #[cacheable(omit_bounds)]

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1079,6 +1079,23 @@ impl DependenciesBlock for ExternalModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for ExternalModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.dependency_meta.source_type != fresh.dependency_meta.source_type {
+      return false;
+    }
+    std::mem::swap(&mut self.user_request, &mut fresh.user_request);
+    std::mem::swap(&mut self.request, &mut fresh.request);
+    std::mem::swap(&mut self.external_type, &mut fresh.external_type);
+    std::mem::swap(&mut self.dependency_meta, &mut fresh.dependency_meta);
+    std::mem::swap(&mut self.place_in_initial, &mut fresh.place_in_initial);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn get_concatenation_bailout_reason(

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -29,7 +29,7 @@ pub mod incremental;
 pub use dependencies_block::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierMap,
   AsyncDependenciesBlockIdentifierSet, AsyncDependenciesBlockRef, DependenciesBlock,
-  DependenciesBlockData,
+  DependenciesBlockData, DependencyIds,
 };
 mod fake_namespace_object;
 pub use fake_namespace_object::*;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -291,7 +291,7 @@ pub struct BuildInfo {
   pub module_argument: ModuleArgument,
   pub exports_argument: ExportsArgument,
   pub dependencies: crate::LoaderDependencies,
-  /// Snapshot used by full `need_build` validation. `NormalModule` populates
+  /// Snapshot used by full `need_build` validation. The module build cache populates
   /// this when the module build cache is enabled; other builds leave it empty
   /// to avoid snapshot creation overhead.
   pub snapshot: Option<Snapshot>,
@@ -324,6 +324,29 @@ pub struct BuildInfo {
   pub extras: serde_json::Map<String, serde_json::Value>,
   #[cacheable(with=AsVec)]
   pub deferred_pure_checks: HashSet<DeferredPureCheck>,
+}
+
+impl BuildInfo {
+  /// Validates the cacheability and dependencies recorded by a completed build.
+  pub async fn need_build(&self, context: &NeedBuildContext<'_>) -> Result<bool> {
+    if !self.cacheable
+      || context
+        .value_cache_versions
+        .has_diff(&self.value_dependencies)
+    {
+      return Ok(true);
+    }
+    let Some(snapshot) = &self.snapshot else {
+      return Ok(true);
+    };
+    Ok(matches!(
+      context
+        .file_system_info
+        .check_snapshot_valid(snapshot)
+        .await?,
+      crate::SnapshotValidationResult::Invalid { .. }
+    ))
+  }
 }
 
 impl Default for BuildInfo {
@@ -845,14 +868,36 @@ pub trait Module:
     ConnectionState::Active(true)
   }
 
-  /// Determines whether a module needs to be rebuilt using the complete build
-  /// context.
-  ///
-  /// Implementations may inspect or mutate module state and perform asynchronous
-  /// work. As in webpack's base `Module`, the default is conservative: module
-  /// types that can prove an existing build is valid should override this.
-  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
-    Ok(true)
+  /// Refreshes factory data while retaining the cached build and module identity.
+  /// Return false if factory inputs changed in a way that invalidates the build.
+  /// When returning false, leave `fresh` intact so it can be built normally.
+  /// The default assumes the module identifier covers all build inputs other than
+  /// the filesystem and value dependencies recorded in `BuildInfo`.
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    self.set_factory_meta(fresh.factory_meta().cloned().unwrap_or_default());
+    true
+  }
+
+  /// Replays compilation-local registrations that are not part of the cached build.
+  async fn restore_from_cache(
+    &mut self,
+    _compilation_id: CompilationId,
+    _dependencies: &[DependencyRef],
+  ) -> Result<()> {
+    Ok(())
+  }
+
+  /// Checks a completed build's cacheability, value dependencies, diagnostics and
+  /// filesystem snapshot. Types with additional invalidation conditions may override this.
+  async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
+    if self
+      .diagnostics()
+      .iter()
+      .any(|diagnostic| diagnostic.is_error())
+    {
+      return Ok(true);
+    }
+    self.build_info().need_build(context).await
   }
 
   /// Performs the synchronous rebuild decision used by incremental make.

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -878,15 +878,6 @@ pub trait Module:
     true
   }
 
-  /// Replays compilation-local registrations that are not part of the cached build.
-  async fn restore_from_cache(
-    &mut self,
-    _compilation_id: CompilationId,
-    _dependencies: &[DependencyRef],
-  ) -> Result<()> {
-    Ok(())
-  }
-
   /// Checks a completed build's cacheability, value dependencies, diagnostics and
   /// filesystem snapshot. Types with additional invalidation conditions may override this.
   async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -110,7 +110,6 @@ pub(crate) struct ModuleGraphData {
   /// let parent_module_id = parent_module.identifier();
   /// parent_module
   ///   .get_dependencies()
-  ///   .iter()
   ///   .map(|dependency_id| {
   ///     let parents_info = module_graph_partial
   ///       .dependency_id_to_parents

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -179,6 +179,12 @@ impl ModuleGraph {
     self.inner.modules.iter()
   }
 
+  /// Transfers modules out of a graph whose compilation is about to be discarded.
+  /// Incremental artifact recovery must keep the graph intact instead.
+  pub(crate) fn take_modules(&mut self) -> impl Iterator<Item = BoxModule> + use<> {
+    std::mem::take(&mut self.inner.modules).into_values()
+  }
+
   #[inline]
   pub fn modules_par(
     &self,

--- a/crates/rspack_core/src/module_graph/rollback/map.rs
+++ b/crates/rspack_core/src/module_graph/rollback/map.rs
@@ -135,6 +135,11 @@ where
     self.map.iter()
   }
 
+  /// Consumes a retired map without retaining its undo history.
+  pub fn into_values(self) -> impl Iterator<Item = V> {
+    self.map.into_values()
+  }
+
   #[inline]
   #[allow(clippy::len_without_is_empty)]
   pub fn len(&self) -> usize {

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,5 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{any::Any, sync::Arc, time::Duration};
 
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
 use rspack_error::Result;
 use rspack_paths::InternedPathSet;
 
@@ -114,6 +116,73 @@ impl Cache {
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.store(key, etag, value)
     }
+  }
+
+  pub(crate) fn get_memory<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> MemoryCacheGetResult<T> {
+    self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.memory_cache.as_ref())
+      .map_or(MemoryCacheGetResult::NotCached, |cache| {
+        cache.get(&key, etag.as_ref())
+      })
+  }
+
+  pub(crate) fn store_memory<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
+    if let Some(cache) = self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.memory_cache.as_ref())
+    {
+      cache.store(key, etag, value);
+    }
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self
+      .inner
+      .storage
+      .as_ref()?
+      .idle_file_cache
+      .as_ref()?
+      .restore_owned(key, etag)
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    if let Some(cache) = self
+      .inner
+      .storage
+      .as_ref()
+      .and_then(|storage| storage.idle_file_cache.as_ref())
+    {
+      cache.store_borrowed(entries);
+    }
+  }
+
+  pub(crate) fn has_memory_cache(&self) -> bool {
+    self
+      .inner
+      .storage
+      .as_ref()
+      .is_some_and(|storage| storage.memory_cache.is_some())
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -1,6 +1,9 @@
-use std::sync::Arc;
+use std::{any::Any, sync::Arc};
 
-use super::{Cache, CacheKey, CacheValue, Etag, cache_value::CacheValueData};
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
+
+use super::{Cache, CacheKey, CacheValue, Etag, MemoryCacheGetResult, cache_value::CacheValueData};
 
 /// A namespaced view of the shared cache.
 ///
@@ -50,6 +53,51 @@ impl CacheFacade {
     value: CacheValue<T>,
   ) {
     self.cache.store(self.key(identifier), etag, value)
+  }
+
+  /// Looks up a runtime value without falling through to filesystem storage.
+  pub(crate) fn get_memory<T: Any + Send + Sync>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+  ) -> MemoryCacheGetResult<T> {
+    self.cache.get_memory(self.key(identifier), etag)
+  }
+
+  pub(crate) fn store_memory<T: Any + Send + Sync>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
+    self.cache.store_memory(self.key(identifier), etag, value)
+  }
+
+  /// Restores an exclusively owned value from bytes written by `store_borrowed`.
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    identifier: &str,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self.cache.restore_owned(self.key(identifier), etag)
+  }
+
+  /// Encodes borrowed values in parallel; only bytes are queued for idle I/O.
+  pub(crate) fn store_borrowed<'a, T: for<'s> Serialize<Serializer<'s>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (&'a str, Option<Etag>, T)>,
+  ) {
+    self
+      .cache
+      .store_borrowed(entries.map(|(identifier, etag, value)| (self.key(identifier), etag, value)))
+  }
+
+  pub(crate) fn has_memory_cache(&self) -> bool {
+    self.cache.has_memory_cache()
+  }
+
+  pub(crate) fn has_file_cache(&self) -> bool {
+    self.cache.has_file_cache()
   }
 
   fn key(&self, identifier: &str) -> CacheKey {

--- a/crates/rspack_core/src/new_cache/cache_value.rs
+++ b/crates/rspack_core/src/new_cache/cache_value.rs
@@ -9,10 +9,10 @@ use rspack_error::Result;
 use super::etag::Etag;
 use crate::cache::CacheCodec;
 
-/// Shared immutable cache value.
+/// Shared cache value.
 ///
 /// Cloning this wrapper only increments an `Arc`; the cached object itself is
-/// never cloned.
+/// never cloned. Runtime values may manage exclusive ownership internally.
 pub struct CacheValue<T>(Arc<T>);
 
 impl<T> CacheValue<T> {
@@ -126,16 +126,18 @@ impl CacheEntry {
 }
 
 impl<T: CacheValueData> CacheValue<T> {
-  pub(super) fn erase(self) -> ErasedCacheValue {
-    ErasedCacheValue::new(self.0)
-  }
-
   pub(super) fn encoder() -> CacheValueEncoder {
     encode_cache_entry::<T>
   }
 
   pub(super) fn decoder() -> CacheValueDecoder {
     decode_cache_entry::<T>
+  }
+}
+
+impl<T: Any + Send + Sync> CacheValue<T> {
+  pub(super) fn erase(self) -> ErasedCacheValue {
+    ErasedCacheValue::new(self.0)
   }
 }
 

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer, utils::OwnedOrRef};
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use rspack_util::fx_hash::FxDashMap;
@@ -11,8 +12,11 @@ use tokio::sync::Notify;
 
 use super::{
   CacheKey, Etag, Meta,
-  cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
+  cache_value::{
+    CacheEntry, CacheValueData, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue,
+  },
   db::{Database, DatabaseFamily},
+  owned_cache_value::StoredOwnedCacheEntry,
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
@@ -29,9 +33,12 @@ struct PendingWrites {
 }
 
 #[derive(Debug)]
-struct PendingWrite {
-  entry: CacheEntry,
-  encoder: CacheValueEncoder,
+enum PendingWrite {
+  Shared {
+    entry: CacheEntry,
+    encoder: CacheValueEncoder,
+  },
+  Encoded(Vec<u8>),
 }
 
 impl PendingWrites {
@@ -250,11 +257,100 @@ impl FileCacheStrategy {
     };
     state.pending_writes.entries.insert(
       key,
-      PendingWrite {
+      PendingWrite::Shared {
         entry: CacheEntry::new(etag, value),
         encoder,
       },
     );
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    if self.readonly || self.read_state().is_none() {
+      return;
+    }
+    // Never wait for the state lock from Rayon workers: the idle writer may
+    // hold that lock while it waits for parallel serialization of shared values.
+    let encoded: Vec<_> = entries
+      .map(|(key, etag, value)| {
+        let mut entry = StoredOwnedCacheEntry {
+          etag,
+          value: Some(OwnedOrRef::Borrowed(&value)),
+        };
+        let bytes = match self.codec.encode(&entry) {
+          Ok(bytes) => bytes,
+          Err(error) => {
+            self.logger.warn(format!(
+              "Failed to encode cache entry for key {key}: {error}"
+            ));
+            // Persist a miss rather than allowing an older value to reappear.
+            entry.value = None;
+            self
+              .codec
+              .encode(&entry)
+              .expect("an empty cache entry should serialize")
+          }
+        };
+        (key, bytes)
+      })
+      .collect();
+    let state = self.read_state();
+    let Some(state) = state.as_ref() else {
+      return;
+    };
+    for (key, bytes) in encoded {
+      state
+        .pending_writes
+        .entries
+        .insert(key, PendingWrite::Encoded(bytes));
+    }
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: &CacheKey,
+    etag: Option<&Etag>,
+  ) -> Option<T> {
+    let decode = |bytes: &[u8]| -> Result<Option<T>> {
+      let entry = self
+        .codec
+        .decode::<StoredOwnedCacheEntry<'static, T>>(bytes)?;
+      Ok(
+        (entry.etag.as_ref() == etag)
+          .then_some(entry.value)
+          .flatten()
+          .map(OwnedOrRef::into_owned),
+      )
+    };
+    let state_guard = self.read_state();
+    let state = state_guard.as_ref()?;
+    let result = if let Some(pending) = state.pending_writes.entries.get(key) {
+      match pending.value() {
+        PendingWrite::Encoded(bytes) => decode(bytes),
+        PendingWrite::Shared { .. } => return None,
+      }
+    } else {
+      match state.database.get(DatabaseFamily::Cache, key) {
+        Ok(Some(bytes)) => decode(&bytes),
+        Ok(None) => return None,
+        Err(error) => {
+          drop(state_guard);
+          self.session_unavailable(Some(&error));
+          return None;
+        }
+      }
+    };
+    match result {
+      Ok(value) => value,
+      Err(error) => {
+        self.logger.warn(format!(
+          "Failed to decode cache entry for key {key}: {error}"
+        ));
+        None
+      }
+    }
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {
@@ -309,10 +405,10 @@ impl FileCacheStrategy {
     let state_guard = self.read_state();
     let state = state_guard.as_ref()?;
     if let Some(pending) = state.pending_writes.entries.get(key) {
-      return pending
-        .entry
-        .matches(etag)
-        .then(|| pending.entry.value().clone());
+      let PendingWrite::Shared { entry, .. } = pending.value() else {
+        return None;
+      };
+      return entry.matches(etag).then(|| entry.value().clone());
     }
 
     let result = state.database.get(DatabaseFamily::Cache, key);
@@ -373,8 +469,12 @@ impl FileCacheStrategy {
 
         writes = std::mem::take(&mut state.pending_writes.entries)
           .into_par_iter()
-          .filter_map(
-            |(key, pending)| match (pending.encoder)(&pending.entry, codec) {
+          .filter_map(|(key, pending)| {
+            let encoded = match pending {
+              PendingWrite::Shared { entry, encoder } => encoder(&entry, codec),
+              PendingWrite::Encoded(bytes) => Ok(bytes),
+            };
+            match encoded {
               Ok(value) => Some((DatabaseFamily::Cache, key, value)),
               Err(error) => {
                 self.logger.warn(format!(
@@ -382,8 +482,8 @@ impl FileCacheStrategy {
                 ));
                 None
               }
-            },
-          )
+            }
+          })
           .collect::<Vec<_>>();
 
         new_build_dependencies = state.pending_writes.new_build_dependencies().take();

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -7,6 +7,8 @@ use std::{
   time::Duration,
 };
 
+use rayon::prelude::*;
+use rspack_cacheable::{__private::rkyv::Serialize, Serializer};
 use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use tokio::{
@@ -217,6 +219,21 @@ impl IdleFileCache {
     self
       .strategy
       .store(key, etag, value.erase(), CacheValue::<T>::encoder());
+  }
+
+  pub(crate) fn store_borrowed<T: for<'a> Serialize<Serializer<'a>> + Send>(
+    &self,
+    entries: impl ParallelIterator<Item = (CacheKey, Option<Etag>, T)>,
+  ) {
+    self.strategy.store_borrowed(entries);
+  }
+
+  pub(crate) fn restore_owned<T: CacheValueData>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+  ) -> Option<T> {
+    self.strategy.restore_owned(&key, etag.as_ref())
   }
 
   pub fn restore<T: CacheValueData>(

--- a/crates/rspack_core/src/new_cache/memory_cache.rs
+++ b/crates/rspack_core/src/new_cache/memory_cache.rs
@@ -1,11 +1,11 @@
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::{
+  any::Any,
+  sync::atomic::{AtomicU32, Ordering},
+};
 
 use rspack_util::fx_hash::FxDashMap;
 
-use super::{
-  CacheKey, CacheValue, Etag,
-  cache_value::{CacheEntry, CacheValueData},
-};
+use super::{CacheKey, CacheValue, Etag, cache_value::CacheEntry};
 
 /// Result of looking up an item in the memory cache.
 ///
@@ -97,7 +97,7 @@ impl MemoryCache {
     }
   }
 
-  pub fn get<T: CacheValueData>(
+  pub fn get<T: Any + Send + Sync>(
     &self,
     key: &CacheKey,
     etag: Option<&Etag>,
@@ -123,7 +123,12 @@ impl MemoryCache {
     }
   }
 
-  pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
+  pub fn store<T: Any + Send + Sync>(
+    &self,
+    key: CacheKey,
+    etag: Option<Etag>,
+    value: CacheValue<T>,
+  ) {
     self.entries.insert(
       key,
       MemoryCacheEntry::new(

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -8,6 +8,7 @@ mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
 mod meta;
+mod owned_cache_value;
 pub(crate) mod snapshot;
 mod validator;
 

--- a/crates/rspack_core/src/new_cache/owned_cache_value.rs
+++ b/crates/rspack_core/src/new_cache/owned_cache_value.rs
@@ -1,0 +1,17 @@
+use rspack_cacheable::{
+  cacheable,
+  utils::OwnedOrRef,
+  with::{AsOption, AsOwned},
+};
+
+use super::Etag;
+
+/// Filesystem representation for values exclusively owned by the caller.
+/// Serialization borrows the live value; restoration creates a new owned value.
+#[cacheable]
+pub(super) struct StoredOwnedCacheEntry<'a, T> {
+  pub etag: Option<Etag>,
+  /// None invalidates a previously stored entry when serialization fails.
+  #[cacheable(with=AsOption<AsOwned>)]
+  pub value: Option<OwnedOrRef<'a, T>>,
+}

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -848,7 +848,7 @@ impl Module for NormalModule {
         }
         module_chain.insert(self.identifier());
         let mut current = ConnectionState::Active(false);
-        for dependency_id in self.get_dependencies().iter() {
+        for dependency_id in self.get_dependencies() {
           let dependency = module_graph.dependency_by_id(dependency_id);
           let state = dependency.get_module_evaluation_side_effects_state(
             module_graph,

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -32,17 +32,13 @@ use crate::{
   CodeGenerationResultBuilder, Compilation, ConnectionState, Context, DependenciesBlock,
   DependenciesBlockData, DependencyCodeGenerationRef, DependencyId, FactoryMeta, GenerateContext,
   GeneratorOptions, ImportPhase, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, NeedBuildContext,
-  OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
-  ParserOptions, Resolve, ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext,
-  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SnapshotValidationResult, SourceType,
-  ValueCacheVersions,
-  cache::SnapshotStrategyOptions,
-  contextify,
+  ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, OptimizationBailoutItem,
+  OutputOptions, ParseContext, ParseResult, ParserAndGenerator, ParserOptions, Resolve,
+  ResolvedModuleOptions, RspackLoaderRunnerPlugin, RunnerContext, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, contextify,
   diagnostics::ModuleBuildError,
   get_context, module_analyzed_side_effect_free, module_declared_side_effect_free,
   module_update_hash,
-  new_cache::{FileSystemInfo, Snapshot},
   utils::{SourceSizeCache, SourceSizeCacheSerde},
 };
 
@@ -97,27 +93,6 @@ pub struct NormalModuleHooks {
   pub additional_data: NormalModuleAdditionalDataHook,
 }
 
-/// Build-owned state of a [`NormalModule`].
-///
-/// Filesystem serialization borrows this state. Memory caching transfers the
-/// owning module instead, so mutations made after building remain observable.
-/// Factory-owned values are refreshed from the current module factory.
-#[cacheable]
-#[derive(Debug)]
-pub(crate) struct NormalModuleState {
-  dependencies_block: DependenciesBlockData,
-  #[cacheable(with=AsOption<AsPreset>)]
-  source: Option<BoxSource>,
-  diagnostics: Vec<Diagnostic>,
-  code_generation_dependencies: Option<Vec<DependencyId>>,
-  presentational_dependencies: Option<Vec<DependencyCodeGenerationRef>>,
-  build_info: BuildInfo,
-  build_meta: BuildMeta,
-  parsed: bool,
-  force_build: bool,
-  source_map_kind: SourceMapKind,
-}
-
 #[cacheable]
 #[derive(Debug)]
 pub struct NormalModule {
@@ -159,7 +134,16 @@ pub struct NormalModule {
   cached_source_sizes: SourceSizeCache,
 
   factory_meta: Option<FactoryMeta>,
-  state: NormalModuleState,
+  dependencies_block: DependenciesBlockData,
+  #[cacheable(with=AsOption<AsPreset>)]
+  source: Option<BoxSource>,
+  diagnostics: Vec<Diagnostic>,
+  code_generation_dependencies: Option<Vec<DependencyId>>,
+  presentational_dependencies: Option<Vec<DependencyCodeGenerationRef>>,
+  build_info: BuildInfo,
+  build_meta: BuildMeta,
+  parsed: bool,
+  source_map_kind: SourceMapKind,
 }
 
 static DEBUG_ID: AtomicUsize = AtomicUsize::new(1);
@@ -231,20 +215,15 @@ impl NormalModule {
 
       cached_source_sizes: SourceSizeCache::default(),
       factory_meta: None,
-      state: NormalModuleState {
-        dependencies_block: Default::default(),
-        source: None,
-        diagnostics: Default::default(),
-        code_generation_dependencies: None,
-        presentational_dependencies: None,
-        build_info,
-        build_meta: Default::default(),
-        parsed: false,
-        // Mirrors webpack's `_forceBuild`: a new module has no reusable build
-        // until its first build starts.
-        force_build: true,
-        source_map_kind: SourceMapKind::empty(),
-      },
+      dependencies_block: Default::default(),
+      source: None,
+      diagnostics: Default::default(),
+      code_generation_dependencies: None,
+      presentational_dependencies: None,
+      build_info,
+      build_meta: Default::default(),
+      parsed: false,
+      source_map_kind: SourceMapKind::empty(),
     }
   }
 
@@ -298,7 +277,7 @@ impl NormalModule {
     "source".hash(&mut hasher);
     if let Some(error) = self.first_error() {
       error.message.hash(&mut hasher);
-    } else if let Some(s) = &self.state.source {
+    } else if let Some(s) = &self.source {
       std::hash::Hash::hash(s, &mut hasher);
     }
     "meta".hash(&mut hasher);
@@ -313,115 +292,6 @@ impl NormalModule {
   pub fn get_generator_options(&self) -> Option<&GeneratorOptions> {
     self.parser_and_generator_options.generator_options()
   }
-
-  pub(crate) fn module_state(&self) -> &NormalModuleState {
-    &self.state
-  }
-
-  pub(crate) fn restore_module_state(&mut self, state: NormalModuleState) {
-    self.state = state;
-    self.cached_source_sizes = SourceSizeCache::default();
-  }
-
-  /// Refreshes factory data while retaining this module's build state and identity.
-  /// Dependency and block ids are reattached when integrating the cached build output.
-  pub(crate) fn update_cache_module(&mut self, fresh: &mut NormalModule) {
-    std::mem::swap(&mut self.state, &mut fresh.state);
-    std::mem::swap(&mut self.debug_id, &mut fresh.debug_id);
-    std::mem::swap(self, fresh);
-  }
-
-  /// Restores the fresh, unbuilt state after a cached module fails validation.
-  pub(crate) fn reset_cached_build(&mut self, fresh: &mut NormalModule) {
-    std::mem::swap(&mut self.state, &mut fresh.state);
-  }
-
-  pub(crate) async fn need_build_with_context(
-    &self,
-    file_system_info: &FileSystemInfo,
-    value_cache_versions: &ValueCacheVersions,
-  ) -> Result<bool> {
-    self
-      .state
-      .need_build_with_context(file_system_info, value_cache_versions)
-      .await
-  }
-
-  pub(crate) async fn create_cache_snapshot(
-    &self,
-    file_system_info: &FileSystemInfo,
-    build_start_time: u64,
-  ) -> Result<Option<Snapshot>> {
-    self
-      .state
-      .create_cache_snapshot(file_system_info, build_start_time)
-      .await
-  }
-}
-
-impl NormalModuleState {
-  pub(crate) async fn need_build_with_context(
-    &self,
-    file_system_info: &FileSystemInfo,
-    value_cache_versions: &ValueCacheVersions,
-  ) -> Result<bool> {
-    if self.force_build {
-      return Ok(true);
-    }
-
-    if self
-      .diagnostics
-      .iter()
-      .any(|diagnostic| diagnostic.is_error())
-    {
-      return Ok(true);
-    }
-
-    if !self.build_info.cacheable {
-      return Ok(true);
-    }
-
-    let Some(snapshot) = &self.build_info.snapshot else {
-      return Ok(true);
-    };
-
-    if value_cache_versions.has_diff(&self.build_info.value_dependencies) {
-      return Ok(true);
-    }
-
-    Ok(matches!(
-      file_system_info.check_snapshot_valid(snapshot).await?,
-      SnapshotValidationResult::Invalid { .. }
-    ))
-  }
-
-  async fn create_cache_snapshot(
-    &self,
-    file_system_info: &FileSystemInfo,
-    build_start_time: u64,
-  ) -> Result<Option<Snapshot>> {
-    if !self.build_info.cacheable
-      || self
-        .diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.is_error())
-    {
-      return Ok(None);
-    }
-
-    Ok(Some(
-      file_system_info
-        .create_snapshot(
-          Some(build_start_time),
-          &self.build_info.dependencies.file,
-          &self.build_info.dependencies.context,
-          &self.build_info.dependencies.missing,
-          // Rspack does not expose webpack's `snapshot.module` strategy yet.
-          SnapshotStrategyOptions::timestamp(),
-        )
-        .await?,
-    ))
-  }
 }
 
 impl Identifiable for NormalModule {
@@ -433,11 +303,11 @@ impl Identifiable for NormalModule {
 
 impl DependenciesBlock for NormalModule {
   fn dependencies_block(&self) -> &DependenciesBlockData {
-    &self.state.dependencies_block
+    &self.dependencies_block
   }
 
   fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
-    &mut self.state.dependencies_block
+    &mut self.dependencies_block
   }
 }
 
@@ -453,7 +323,7 @@ impl Module for NormalModule {
   }
 
   fn source(&self) -> Option<&BoxSource> {
-    self.state.source.as_ref()
+    self.source.as_ref()
   }
 
   fn readable_identifier(&self, context: &Context) -> Cow<'_, str> {
@@ -474,10 +344,37 @@ impl Module for NormalModule {
     }
   }
 
-  async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
-    self
-      .need_build_with_context(context.file_system_info, context.value_cache_versions)
-      .await
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    std::mem::swap(&mut self.context, &mut fresh.context);
+    std::mem::swap(&mut self.request, &mut fresh.request);
+    std::mem::swap(&mut self.user_request, &mut fresh.user_request);
+    std::mem::swap(&mut self.raw_request, &mut fresh.raw_request);
+    std::mem::swap(&mut self.module_type, &mut fresh.module_type);
+    std::mem::swap(&mut self.layer, &mut fresh.layer);
+    std::mem::swap(
+      &mut self.parser_and_generator,
+      &mut fresh.parser_and_generator,
+    );
+    std::mem::swap(&mut self.match_resource, &mut fresh.match_resource);
+    std::mem::swap(&mut self.resource_data, &mut fresh.resource_data);
+    std::mem::swap(&mut self.loaders, &mut fresh.loaders);
+    std::mem::swap(&mut self.loader_options, &mut fresh.loader_options);
+    std::mem::swap(&mut self.resolve_options, &mut fresh.resolve_options);
+    std::mem::swap(
+      &mut self.parser_and_generator_options,
+      &mut fresh.parser_and_generator_options,
+    );
+    std::mem::swap(&mut self.extract_source_map, &mut fresh.extract_source_map);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    std::mem::swap(
+      &mut self.cached_source_sizes,
+      &mut fresh.cached_source_sizes,
+    );
+    true
   }
 
   #[tracing::instrument("NormalModule:build", skip_all, fields(
@@ -492,13 +389,12 @@ impl Module for NormalModule {
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BoxModule> {
-    self.state.dependencies_block = Default::default();
-    self.state.force_build = false;
-    self.state.build_info.snapshot = None;
-    self.state.build_info.optimization_bailouts.clear();
+    self.dependencies_block = Default::default();
+    self.build_info.snapshot = None;
+    self.build_info.optimization_bailouts.clear();
 
     // so does webpack
-    self.state.parsed = true;
+    self.parsed = true;
 
     let no_parse = if let Some(no_parse) = build_context.compiler_options.module.no_parse.as_ref() {
       no_parse.try_match(self.request.as_str()).await?
@@ -536,7 +432,7 @@ impl Module for NormalModule {
         loader_cache: build_context.loader_cache,
         file_system_info: build_context.file_system_info,
         resolver_factory,
-        source_map_kind: self.state.source_map_kind,
+        source_map_kind: self.source_map_kind,
         module: self,
       },
       fs,
@@ -546,10 +442,10 @@ impl Module for NormalModule {
     self = loader_result.context.module;
 
     if let Some(err) = err {
-      self.state.build_info.cacheable = loader_result.cacheable;
-      self.state.build_info.dependencies = loader_result.dependencies;
+      self.build_info.cacheable = loader_result.cacheable;
+      self.build_info.dependencies = loader_result.dependencies;
 
-      self.state.source = None;
+      self.source = None;
 
       let current_loader = loader_result.current_loader.map(|current_loader| {
         contextify(
@@ -561,12 +457,10 @@ impl Module for NormalModule {
         err,
         current_loader,
       )));
-      self.state.diagnostics.push(diagnostic);
+      self.diagnostics.push(diagnostic);
 
-      self.state.build_info.hash = Some(self.init_build_hash(
-        &build_context.compiler_options.output,
-        &self.state.build_meta,
-      ));
+      self.build_info.hash =
+        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
       return Ok(BoxModule::new(self));
     };
 
@@ -598,19 +492,17 @@ impl Module for NormalModule {
       loader_result.source_map.map(|source_map| *source_map),
     )?;
 
-    self.state.build_info.cacheable = loader_result.cacheable;
-    self.state.build_info.dependencies = loader_result.dependencies;
+    self.build_info.cacheable = loader_result.cacheable;
+    self.build_info.dependencies = loader_result.dependencies;
 
     if no_parse {
-      self.state.parsed = false;
-      self.state.source = Some(source);
-      self.state.code_generation_dependencies = Some(Vec::new());
-      self.state.presentational_dependencies = Some(Vec::new());
+      self.parsed = false;
+      self.source = Some(source);
+      self.code_generation_dependencies = Some(Vec::new());
+      self.presentational_dependencies = Some(Vec::new());
 
-      self.state.build_info.hash = Some(self.init_build_hash(
-        &build_context.compiler_options.output,
-        &self.state.build_meta,
-      ));
+      self.build_info.hash =
+        Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
       return Ok(BoxModule::new(self));
     }
@@ -637,21 +529,21 @@ impl Module for NormalModule {
         module_layer: self.layer.as_ref(),
         module_user_request: &self.user_request,
         module_match_resource: self.match_resource.as_ref(),
-        module_source_map_kind: self.state.source_map_kind,
+        module_source_map_kind: self.source_map_kind,
         loaders: &self.loaders,
         resource_data: &self.resource_data,
         compiler_options: &build_context.compiler_options,
         additional_data: loader_result.additional_data,
         factory_meta: self.factory_meta.as_ref(),
-        build_info: &mut self.state.build_info,
-        build_meta: &mut self.state.build_meta,
+        build_info: &mut self.build_info,
+        build_meta: &mut self.build_meta,
         parse_meta: loader_result.parse_meta,
         runtime_template: &build_context.runtime_template,
       })
       .await?
       .split_into_parts();
     if diagnostics.iter().any(|d| d.is_error()) {
-      self.state.build_meta = Default::default();
+      self.build_meta = Default::default();
     }
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
@@ -661,7 +553,6 @@ impl Module for NormalModule {
         .readable_identifier(&build_context.compiler_options.context)
         .to_string();
       self
-        .state
         .build_info
         .optimization_bailouts
         .push(OptimizationBailoutItem::SideEffects {
@@ -672,14 +563,12 @@ impl Module for NormalModule {
     }
     // Only side effects used in code_generate can stay here
     // Other side effects should be set outside use_cache
-    self.state.source = Some(source);
-    self.state.code_generation_dependencies = Some(code_generation_dependencies);
-    self.state.presentational_dependencies = Some(presentational_dependencies);
+    self.source = Some(source);
+    self.code_generation_dependencies = Some(code_generation_dependencies);
+    self.presentational_dependencies = Some(presentational_dependencies);
 
-    self.state.build_info.hash = Some(self.init_build_hash(
-      &build_context.compiler_options.output,
-      &self.state.build_meta,
-    ));
+    self.build_info.hash =
+      Some(self.init_build_hash(&build_context.compiler_options.output, &self.build_meta));
 
     Ok(BoxModule::new(self).with_dependencies(
       dependencies.into_iter().map(Into::into).collect(),
@@ -717,7 +606,7 @@ impl Module for NormalModule {
       }
       return Ok(code_generation_result);
     }
-    let Some(source) = &self.state.source else {
+    let Some(source) = &self.source else {
       return Err(error!(
         "Failed to generate code because ast or source is not set for module {}",
         self.request
@@ -725,7 +614,7 @@ impl Module for NormalModule {
     };
 
     let mut code_generation_result = CodeGenerationResultBuilder::default();
-    if !self.state.parsed {
+    if !self.parsed {
       runtime_template
         .runtime_requirements_mut()
         .insert(RuntimeGlobals::MODULE | RuntimeGlobals::EXPORTS | RuntimeGlobals::THIS_AS_EXPORTS);
@@ -766,9 +655,9 @@ impl Module for NormalModule {
     runtime: Option<&RuntimeSpec>,
   ) -> Result<RspackHashDigest> {
     let mut hasher = RspackHasher::from(&compilation.options.output);
-    self.state.build_info.hash.hash(&mut hasher);
+    self.build_info.hash.hash(&mut hasher);
     // For built failed NormalModule, hash will be calculated by build_info.hash, which contains error message
-    if self.state.source.is_some() && self.parser_and_generator.has_runtime_hash() {
+    if self.source.is_some() && self.parser_and_generator.has_runtime_hash() {
       let runtime_hash = self
         .parser_and_generator
         .get_runtime_hash(self, compilation, runtime)
@@ -808,7 +697,7 @@ impl Module for NormalModule {
   }
 
   fn get_code_generation_dependencies(&self) -> Option<&[DependencyId]> {
-    if let Some(deps) = self.state.code_generation_dependencies.as_deref()
+    if let Some(deps) = self.code_generation_dependencies.as_deref()
       && !deps.is_empty()
     {
       Some(deps)
@@ -818,7 +707,7 @@ impl Module for NormalModule {
   }
 
   fn get_presentational_dependencies(&self) -> Option<&[DependencyCodeGenerationRef]> {
-    if let Some(deps) = self.state.presentational_dependencies.as_deref()
+    if let Some(deps) = self.presentational_dependencies.as_deref()
       && !deps.is_empty()
     {
       Some(deps)
@@ -905,43 +794,43 @@ impl Module for NormalModule {
   }
 
   fn build_info(&self) -> &BuildInfo {
-    &self.state.build_info
+    &self.build_info
   }
 
   fn build_info_mut(&mut self) -> &mut BuildInfo {
-    &mut self.state.build_info
+    &mut self.build_info
   }
 
   fn build_meta(&self) -> &BuildMeta {
-    &self.state.build_meta
+    &self.build_meta
   }
 
   fn build_meta_mut(&mut self) -> &mut BuildMeta {
-    &mut self.state.build_meta
+    &mut self.build_meta
   }
 }
 
 impl ModuleSourceMapConfig for NormalModule {
   fn get_source_map_kind(&self) -> &SourceMapKind {
-    &self.state.source_map_kind
+    &self.source_map_kind
   }
 
   fn set_source_map_kind(&mut self, source_map_kind: SourceMapKind) {
-    self.state.source_map_kind = source_map_kind;
+    self.source_map_kind = source_map_kind;
   }
 }
 
 impl Diagnosable for NormalModule {
   fn add_diagnostic(&mut self, diagnostic: Diagnostic) {
-    self.state.diagnostics.push(diagnostic);
+    self.diagnostics.push(diagnostic);
   }
 
   fn add_diagnostics(&mut self, mut diagnostics: Vec<Diagnostic>) {
-    self.state.diagnostics.append(&mut diagnostics);
+    self.diagnostics.append(&mut diagnostics);
   }
 
   fn diagnostics(&self) -> Cow<'_, [Diagnostic]> {
-    Cow::Borrowed(&self.state.diagnostics)
+    Cow::Borrowed(&self.diagnostics)
   }
 }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -99,12 +99,11 @@ pub struct NormalModuleHooks {
 
 /// Build-owned state of a [`NormalModule`].
 ///
-/// This mirrors webpack's serialized module state: cache entries retain build
-/// output, while factory-owned values such as loaders, parser/generator
-/// instances, and their options always come from the fresh module created for
-/// the current compilation.
+/// Filesystem serialization borrows this state. Memory caching transfers the
+/// owning module instead, so mutations made after building remain observable.
+/// Factory-owned values are refreshed from the current module factory.
 #[cacheable]
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct NormalModuleState {
   dependencies_block: DependenciesBlockData,
   #[cacheable(with=AsOption<AsPreset>)]
@@ -322,6 +321,19 @@ impl NormalModule {
   pub(crate) fn restore_module_state(&mut self, state: NormalModuleState) {
     self.state = state;
     self.cached_source_sizes = SourceSizeCache::default();
+  }
+
+  /// Refreshes factory data while retaining this module's build state and identity.
+  /// Dependency and block ids are reattached when integrating the cached build output.
+  pub(crate) fn update_cache_module(&mut self, fresh: &mut NormalModule) {
+    std::mem::swap(&mut self.state, &mut fresh.state);
+    std::mem::swap(&mut self.debug_id, &mut fresh.debug_id);
+    std::mem::swap(self, fresh);
+  }
+
+  /// Restores the fresh, unbuilt state after a cached module fails validation.
+  pub(crate) fn reset_cached_build(&mut self, fresh: &mut NormalModule) {
+    std::mem::swap(&mut self.state, &mut fresh.state);
   }
 
   pub(crate) async fn need_build_with_context(

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -82,6 +82,24 @@ impl DependenciesBlock for RawModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for RawModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.source_str != fresh.source_str
+      || self.runtime_requirements != fresh.runtime_requirements
+    {
+      return false;
+    }
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn module_type(&self) -> &ModuleType {

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1804,9 +1804,12 @@ return {}
     let block = module_graph
       .block_by_id(block_id)
       .expect("should have block");
-    let dep = block.get_dependencies()[0];
+    let dep = block
+      .get_dependencies()
+      .next()
+      .expect("should have dependency");
     let ensure_chunk = self.block_promise(Some(block_id), compilation, "");
-    let return_value = self.module_raw(compilation, &dep, request, false);
+    let return_value = self.module_raw(compilation, dep, request, false);
     let factory = self.returning_function(&return_value, "");
     self.returning_function(
       &if ensure_chunk.starts_with("Promise.resolve(") {

--- a/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
+++ b/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
@@ -122,7 +122,7 @@ fn resolve_icss_import(
   request: &str,
 ) -> Option<String> {
   let module_graph = compilation.get_module_graph();
-  let imported_module = module.get_dependencies().iter().find_map(|id| {
+  let imported_module = module.get_dependencies().find_map(|id| {
     let dependency = module_graph.dependency_by_id(id);
     let dependency_request = dependency
       .as_module_dependency()

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -296,7 +296,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     };
 
     let module_graph = compilation.get_module_graph();
-    self.module.get_dependencies().iter().for_each(|id| {
+    self.module.get_dependencies().for_each(|id| {
       let dep = module_graph.dependency_by_id(id);
 
       if let Some(dependency) = dep.as_dependency_code_generation() {
@@ -317,7 +317,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
 
   fn css_text_expr_with_imports(&mut self) -> String {
     let module_graph = self.generate_context.compilation.get_module_graph();
-    let has_css_imports = self.module.get_dependencies().iter().any(|dependency_id| {
+    let has_css_imports = self.module.get_dependencies().any(|dependency_id| {
       let dependency = module_graph.dependency_by_id(dependency_id);
       matches!(dependency.dependency_type(), DependencyType::CssImport)
     });
@@ -392,7 +392,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     self
       .module
       .get_dependencies()
-      .iter()
       .filter_map(move |dependency_id| {
         let dependency = module_graph.dependency_by_id(dependency_id);
         if !matches!(dependency.dependency_type(), DependencyType::CssImport) {
@@ -791,7 +790,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     let from = id
       .and_then(find_target_module)
       .or_else(|| {
-        self.module.get_dependencies().iter().find_map(|id| {
+        self.module.get_dependencies().find_map(|id| {
           let dependency = module_graph.dependency_by_id(id);
           let request = dependency_request(dependency);
           if let Some(request) = request
@@ -806,7 +805,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
         let dependency_requests = self
           .module
           .get_dependencies()
-          .iter()
           .filter_map(|id| {
             let dependency = module_graph.dependency_by_id(id);
             dependency_request(dependency)
@@ -899,7 +897,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       .or_else(|| {
         module
           .get_dependencies()
-          .iter()
           .filter(|dep_id| {
             let dependency = module_graph.dependency_by_id(dep_id);
             dependency_request(dependency) == Some(from_name)
@@ -1167,7 +1164,7 @@ fn find_static_export_target(
       .map(|module| module.identifier())
   })
   .or_else(|| {
-    module.get_dependencies().iter().find_map(|id| {
+    module.get_dependencies().find_map(|id| {
       let dependency = module_graph.dependency_by_id(id);
       let request = dependency_request(dependency);
       (request == Some(from_request)).then(|| {

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -57,6 +57,18 @@ impl DllModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DllModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.entries != fresh.entries || self.context != fresh.context {
+      return false;
+    }
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn module_type(&self) -> &ModuleType {
@@ -118,10 +130,6 @@ impl Module for DllModule {
 
   fn need_build_for_incremental(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
     false
-  }
-
-  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
-    Ok(false)
   }
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -6,9 +6,9 @@ use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder,
   Compilation, Context, DependenciesBlock, DependenciesBlockData, EntryDependency, FactoryMeta,
-  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleType, NeedBuildContext,
-  RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleType, RuntimeGlobals,
+  RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info, impl_source_map_config,
+  module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -127,11 +127,14 @@ impl Module for DelegatedModule {
 
     let mut code_generation_result = CodeGenerationResultBuilder::default();
 
-    let dep = self.get_dependencies()[0];
+    let dep = self
+      .get_dependencies()
+      .next()
+      .expect("should have source dependency");
     let mg = compilation.get_module_graph();
-    let source_module = mg.get_module_by_dependency_id(&dep);
+    let source_module = mg.get_module_by_dependency_id(dep);
     let dependency = mg
-      .dependency_by_id(&dep)
+      .dependency_by_id(dep)
       .downcast_ref::<DelegatedSourceDependency>()
       .expect("Should be module dependency");
 
@@ -140,7 +143,7 @@ impl Module for DelegatedModule {
         let mut s = format!(
           "{}.exports = ({})",
           runtime_template.render_module_argument(ModuleArgument::Module),
-          runtime_template.module_raw(compilation, &dep, dependency.request(), false,)
+          runtime_template.module_raw(compilation, dep, dependency.request(), false,)
         );
 
         let request = json_stringify(

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -7,7 +7,7 @@ use rspack_core::{
   BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder,
   Compilation, Context, DependenciesBlock, DependenciesBlockData, FactoryMeta, LibIdentOptions,
   Module, ModuleArgument, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph, ModuleId,
-  ModuleType, NeedBuildContext, RuntimeSpec, SourceType, StaticExportsDependency,
+  ModuleType, RuntimeSpec, SourceType, StaticExportsDependency,
   StaticExportsSpec, ValueCacheVersions, impl_module_meta_info, impl_source_map_config,
   module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
@@ -60,6 +60,24 @@ impl DelegatedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for DelegatedModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.request != fresh.request
+      || self.delegation_type != fresh.delegation_type
+      || serde_json::to_value(&self.delegate_data).expect("serializable DLL manifest")
+        != serde_json::to_value(&fresh.delegate_data).expect("serializable DLL manifest")
+    {
+      return false;
+    }
+    std::mem::swap(&mut self.user_request, &mut fresh.user_request);
+    std::mem::swap(&mut self.original_request, &mut fresh.original_request);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn module_type(&self) -> &ModuleType {
@@ -186,10 +204,6 @@ impl Module for DelegatedModule {
 
   fn need_build_for_incremental(&self, _value_cache_versions: &ValueCacheVersions) -> bool {
     false
-  }
-
-  async fn need_build(&mut self, _context: &NeedBuildContext<'_>) -> Result<bool> {
-    Ok(false)
   }
 
   async fn get_runtime_hash(

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -7,9 +7,8 @@ use rspack_core::{
   BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder,
   Compilation, Context, DependenciesBlock, DependenciesBlockData, FactoryMeta, LibIdentOptions,
   Module, ModuleArgument, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph, ModuleId,
-  ModuleType, RuntimeSpec, SourceType, StaticExportsDependency,
-  StaticExportsSpec, ValueCacheVersions, impl_module_meta_info, impl_source_map_config,
-  module_update_hash,
+  ModuleType, RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec,
+  ValueCacheVersions, impl_module_meta_info, impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -128,7 +128,6 @@ fn get_module_deps(module: ModuleIdentifier, module_graph: &ModuleGraph) -> Vec<
     .module_by_identifier(&module)
     .expect("should have module")
     .get_dependencies()
-    .iter()
     .filter_map(|dep_id| module_graph.module_identifier_by_dependency_id(dep_id))
     .copied()
     .collect()

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -95,6 +95,22 @@ impl CssModule {
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for CssModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.content != fresh.content
+      || self.source_map != fresh.source_map
+      || self.module_layer != fresh.module_layer
+    {
+      return false;
+    }
+    std::mem::swap(&mut self._context, &mut fresh._context);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn readable_identifier(&self, context: &rspack_core::Context) -> std::borrow::Cow<'_, str> {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -184,7 +184,7 @@ impl JavaScriptParserAndGenerator {
       .block_by_id(block_id)
       .expect("should have block");
     //    let block = block_id.expect_get(compilation);
-    block.get_dependencies().iter().for_each(|dependency_id| {
+    block.get_dependencies().for_each(|dependency_id| {
       self.source_dependency(compilation, dependency_id, source, context)
     });
     block
@@ -439,7 +439,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         runtime_template: generate_context.runtime_template,
       };
 
-      module.get_dependencies().iter().for_each(|dependency_id| {
+      module.get_dependencies().for_each(|dependency_id| {
         self.source_dependency(compilation, dependency_id, &mut source, &mut context)
       });
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1151,7 +1151,6 @@ impl ModuleConcatenationPlugin {
 
         let connections = module
           .get_dependencies()
-          .iter()
           .filter_map(|d| {
             let dep = module_graph.dependency_by_id(d);
             if !is_esm_dep_like(dep) {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -247,11 +247,14 @@ impl Module for LazyCompilationProxyModule {
       ..
     } = code_generation_context;
 
-    let client_dep_id = self.get_dependencies()[0];
+    let client_dep_id = self
+      .get_dependencies()
+      .next()
+      .expect("should have client dependency");
     let module_graph = &compilation.get_module_graph();
 
     let client_module = module_graph
-      .module_identifier_by_dependency_id(&client_dep_id)
+      .module_identifier_by_dependency_id(client_dep_id)
       .expect("should have module");
 
     let block = self.get_blocks().first();
@@ -276,9 +279,12 @@ impl Module for LazyCompilationProxyModule {
         .block_by_id(block_id)
         .expect("should have block");
 
-      let dep_id = block.get_dependencies()[0];
+      let dep_id = block
+        .get_dependencies()
+        .next()
+        .expect("should have dependency");
       let module = module_graph
-        .module_identifier_by_dependency_id(&dep_id)
+        .module_identifier_by_dependency_id(dep_id)
         .expect("should have module");
 
       RawStringSource::from(format!(
@@ -295,7 +301,7 @@ impl Module for LazyCompilationProxyModule {
         runtime_template.module_namespace_promise(
           compilation,
           *module,
-          &dep_id,
+          dep_id,
           Some(block_id),
           &self.resource,
           "import()",

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -134,6 +134,30 @@ impl_empty_diagnosable_trait!(LazyCompilationProxyModule);
 #[cacheable_dyn]
 #[async_trait::async_trait]
 impl Module for LazyCompilationProxyModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.active != fresh.active
+      || self.client != fresh.client
+      || self.reserved_externals != fresh.reserved_externals
+    {
+      return false;
+    }
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(&mut self.context, &mut fresh.context);
+    std::mem::swap(&mut self.layer, &mut fresh.layer);
+    std::mem::swap(&mut self.dep_options, &mut fresh.dep_options);
+    std::mem::swap(&mut self.resource, &mut fresh.resource);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn source_types(&self, _module_graph: &ModuleGraph) -> &[SourceType] {
@@ -184,7 +208,10 @@ impl Module for LazyCompilationProxyModule {
   }
 
   async fn need_build(&mut self, context: &NeedBuildContext<'_>) -> Result<bool> {
-    Ok(self.need_build_for_incremental(context.value_cache_versions))
+    Ok(
+      self.need_build_for_incremental(context.value_cache_versions)
+        || self.build_info.need_build(context).await?,
+    )
   }
 
   async fn build(

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -468,7 +468,7 @@ impl ExposeModuleMap {
       let block = module_graph
         .block_by_id(block_id)
         .expect("should have block");
-      let modules_iter = block.get_dependencies().iter().map(|dependency_id| {
+      let modules_iter = block.get_dependencies().map(|dependency_id| {
         let dep = module_graph.dependency_by_id(dependency_id);
         let dep = dep
           .downcast_ref::<ContainerExposedDependency>()

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -140,6 +140,25 @@ impl DependenciesBlock for ContainerEntryModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ContainerEntryModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.exposes != fresh.exposes
+      || self.request != fresh.request
+      || self.dependency_type != fresh.dependency_type
+    {
+      return false;
+    }
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(&mut self.enhanced, &mut fresh.enhanced);
+    std::mem::swap(&mut self.version, &mut fresh.version);
+    std::mem::swap(&mut self.name, &mut fresh.name);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_mf/src/container/container_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/container_plugin.rs
@@ -29,7 +29,7 @@ pub struct ContainerPluginOptions {
 }
 
 #[rspack_cacheable::cacheable]
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExposeOptions {
   pub name: Option<String>,
   pub import: Vec<String>,

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -150,7 +150,6 @@ impl Module for FallbackModule {
     let module_graph = compilation.get_module_graph();
     let ids: Vec<_> = self
       .get_dependencies()
-      .iter()
       .filter_map(|dep| module_graph.get_module_by_dependency_id(dep))
       .filter_map(|module| {
         ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -82,6 +82,20 @@ impl DependenciesBlock for FallbackModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for FallbackModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/federation_modules_plugin.rs
@@ -77,19 +77,6 @@ impl FederationModulesPlugin {
       .or_insert_with(|| Arc::new(FederationModulesPluginCompilationHooks::default()))
       .clone()
   }
-
-  pub fn get_compilation_hooks_by_id(
-    compilation_id: CompilationId,
-  ) -> Arc<FederationModulesPluginCompilationHooks> {
-    let mut map = FEDERATION_MODULES_PLUGIN_HOOKS_MAP
-      .get_or_init(|| Mutex::new(FxHashMap::default()))
-      .lock()
-      .expect("Failed to lock FEDERATION_MODULES_PLUGIN_HOOKS_MAP");
-    map
-      .entry(compilation_id)
-      .or_insert_with(|| Arc::new(FederationModulesPluginCompilationHooks::default()))
-      .clone()
-  }
 }
 
 #[plugin_hook(CompilerCompilation for FederationModulesPlugin)]

--- a/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
+++ b/crates/rspack_plugin_mf/src/container/module_federation_runtime_plugin.rs
@@ -8,7 +8,7 @@ use rspack_core::{
   AsyncModulesArtifact, BoxDependency, ChunkUkey, Compilation,
   CompilationAdditionalTreeRuntimeRequirements, CompilationFinishModules, CompilationParams,
   CompilerCompilation, CompilerFinishMake, DependencyType, EntryOptions, ExportsInfoArtifact,
-  Plugin, RuntimeGlobals, RuntimeModule, SideEffectsStateArtifact,
+  ModuleType, Plugin, RuntimeGlobals, RuntimeModule, SideEffectsStateArtifact,
 };
 use rspack_error::Result;
 use rspack_hook::{plugin, plugin_hook};
@@ -102,10 +102,6 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
   Ok(())
 }
 
-// When MF async startup is enabled, STARTUP may resolve asynchronously even if the entry module
-// itself doesn't have top-level await. Mark MF container entry modules as async so downstream
-// renderers (e.g. library wrappers) can safely `await` exports without sprinkling MF-specific
-// RuntimeGlobals checks across generic plugins.
 #[plugin_hook(CompilationFinishModules for ModuleFederationRuntimePlugin, stage = 1000)]
 async fn finish_modules(
   &self,
@@ -114,17 +110,27 @@ async fn finish_modules(
   _exports_info_artifact: &mut ExportsInfoArtifact,
   _side_effects_state_artifact: &mut SideEffectsStateArtifact,
 ) -> Result<()> {
-  if !self.options.experiments.async_startup {
-    return Ok(());
-  }
-
   let module_graph = compilation.get_module_graph();
+  let hooks = FederationModulesPlugin::get_compilation_hooks(compilation);
+  let add_remote_dependency = hooks.add_remote_dependency.lock().await;
   for (module_identifier, module) in module_graph.modules() {
-    if module
-      .as_ref()
-      .as_any()
-      .downcast_ref::<ContainerEntryModule>()
-      .is_some()
+    // Register from the current graph so cached and incrementally reused modules
+    // participate even when their build method did not run in this compilation.
+    if module.module_type() == &ModuleType::Remote {
+      for dependency_id in module.get_dependencies() {
+        add_remote_dependency
+          .call(module_graph.dependency_by_id(dependency_id))
+          .await?;
+      }
+    }
+    // MF async startup can be asynchronous without top-level await. Mark container
+    // entries so downstream renderers can safely await their exports.
+    if self.options.experiments.async_startup
+      && module
+        .as_ref()
+        .as_any()
+        .downcast_ref::<ContainerEntryModule>()
+        .is_some()
     {
       async_modules_artifact.insert(*module_identifier);
     }

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -190,7 +190,12 @@ impl Module for RemoteModule {
   ) -> Result<CodeGenerationResultBuilder> {
     let mut codegen = CodeGenerationResultBuilder::default();
     let module_graph = code_generation_context.compilation.get_module_graph();
-    let module = module_graph.get_module_by_dependency_id(&self.get_dependencies()[0]);
+    let module = module_graph.get_module_by_dependency_id(
+      self
+        .get_dependencies()
+        .next()
+        .expect("should have external dependency"),
+    );
     let id = module.and_then(|m| {
       ChunkGraph::get_module_id(
         &code_generation_context.compilation.module_ids_artifact,

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -5,8 +5,8 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph,
-  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
-  Dependency, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
+  CodeGenerationResultBuilder, Compilation, CompilationId, Context, DependenciesBlock, DependenciesBlockData,
+  Dependency, DependencyRef, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
   ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
@@ -100,6 +100,35 @@ impl DependenciesBlock for RemoteModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for RemoteModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(&mut self.request, &mut fresh.request);
+    std::mem::swap(&mut self.remote_key, &mut fresh.remote_key);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
+  async fn restore_from_cache(
+    &mut self,
+    compilation_id: CompilationId,
+    dependencies: &[DependencyRef],
+  ) -> Result<()> {
+    let hooks = FederationModulesPlugin::get_compilation_hooks_by_id(compilation_id);
+    let hooks = hooks.add_remote_dependency.lock().await;
+    for dependency in dependencies {
+      hooks.call(dependency.as_ref()).await?;
+    }
+    Ok(())
+  }
+
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -5,9 +5,9 @@ use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
   BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph,
-  CodeGenerationResultBuilder, Compilation, CompilationId, Context, DependenciesBlock, DependenciesBlockData,
-  Dependency, DependencyRef, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
-  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
@@ -17,7 +17,7 @@ use rspack_hash::{RspackHashDigest, RspackHasher};
 use rspack_util::source_map::SourceMapKind;
 
 use super::{
-  fallback_dependency::FallbackDependency, federation_modules_plugin::FederationModulesPlugin,
+  fallback_dependency::FallbackDependency,
   remote_to_external_dependency::RemoteToExternalDependency,
 };
 use crate::{
@@ -116,19 +116,6 @@ impl Module for RemoteModule {
     true
   }
 
-  async fn restore_from_cache(
-    &mut self,
-    compilation_id: CompilationId,
-    dependencies: &[DependencyRef],
-  ) -> Result<()> {
-    let hooks = FederationModulesPlugin::get_compilation_hooks_by_id(compilation_id);
-    let hooks = hooks.add_remote_dependency.lock().await;
-    for dependency in dependencies {
-      hooks.call(dependency.as_ref()).await?;
-    }
-    Ok(())
-  }
-
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {
@@ -170,46 +157,19 @@ impl Module for RemoteModule {
   }
 
   async fn build(
-    mut self: Box<Self>,
-    build_context: BuildContext,
+    self: Box<Self>,
+    _build_context: BuildContext,
     _compilation: Option<&Compilation>,
   ) -> Result<BoxModule> {
-    let mut dependencies: Vec<BoxDependency> = Vec::new();
-
-    if self.external_requests.len() == 1 {
-      let dep = RemoteToExternalDependency::new(self.external_requests[0].clone());
-
-      // Call federation hooks here using the BuildContext - this runs before optimize_chunks!
-      let hooks =
-        FederationModulesPlugin::get_compilation_hooks_by_id(build_context.compilation_id);
-      hooks
-        .add_remote_dependency
-        .lock()
-        .await
-        .call(&dep as &dyn Dependency)
-        .await?;
-
-      dependencies.push(BoxDependency::new(dep));
+    let dependency = if self.external_requests.len() == 1 {
+      BoxDependency::new(RemoteToExternalDependency::new(
+        self.external_requests[0].clone(),
+      ))
     } else {
-      let dep = FallbackDependency::new(self.external_requests.clone());
+      BoxDependency::new(FallbackDependency::new(self.external_requests.clone()))
+    };
 
-      // Call federation hooks here using the BuildContext - this runs before optimize_chunks!
-      let hooks =
-        FederationModulesPlugin::get_compilation_hooks_by_id(build_context.compilation_id);
-      hooks
-        .add_remote_dependency
-        .lock()
-        .await
-        .call(&dep as &dyn Dependency)
-        .await?;
-
-      dependencies.push(BoxDependency::new(dep));
-    }
-
-    Ok(
-      BoxModule::new(self)
-        .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
-    )
+    Ok(BoxModule::new(self).with_dependencies(vec![dependency.into()], vec![]))
   }
 
   // #[tracing::instrument("RemoteModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -98,9 +98,12 @@ impl RuntimeModule for RemoteRuntimeModule {
           ShareScope::Single(s) => ShareScopeField::Single(s.as_str()),
           ShareScope::Multiple(v) => ShareScopeField::Multiple(v.as_slice()),
         };
-        let dep = m.get_dependencies()[0];
+        let dep = m
+          .get_dependencies()
+          .next()
+          .expect("should have external dependency");
         let external_module = module_graph
-          .get_module_by_dependency_id(&dep)
+          .get_module_by_dependency_id(dep)
           .expect("should have module");
         let external_module_id = ChunkGraph::get_module_id(
           &compilation.module_ids_artifact,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -215,7 +215,14 @@ impl Module for ConsumeSharedModule {
     }
     let factory = self.options.import.as_ref().map(|fallback| {
       if self.options.eager {
-        runtime_template.sync_module_factory(&self.get_dependencies()[0], fallback, compilation)
+        runtime_template.sync_module_factory(
+          self
+            .get_dependencies()
+            .next()
+            .expect("should have fallback dependency"),
+          fallback,
+          compilation,
+        )
       } else {
         runtime_template.async_module_factory(&self.get_blocks()[0], fallback, compilation)
       }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -116,6 +116,23 @@ impl DependenciesBlock for ConsumeSharedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ConsumeSharedModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.context != fresh.context || self.options != fresh.options {
+      return false;
+    }
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_plugin.rs
@@ -24,7 +24,7 @@ use super::{
 use crate::ShareScope;
 
 #[cacheable]
-#[derive(Debug, Clone, rspack_hash::RspackHash)]
+#[derive(Debug, Clone, PartialEq, Eq, rspack_hash::RspackHash)]
 pub struct ConsumeOptions {
   pub import: Option<String>,
   pub import_resolved: Option<String>,

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -187,7 +187,14 @@ impl Module for ProvideSharedModule {
       .runtime_requirements_mut()
       .insert(RuntimeGlobals::INITIALIZE_SHARING);
     let factory = if self.eager {
-      runtime_template.sync_module_factory(&self.get_dependencies()[0], &self.request, compilation)
+      runtime_template.sync_module_factory(
+        self
+          .get_dependencies()
+          .next()
+          .expect("should have shared dependency"),
+        &self.request,
+        compilation,
+      )
     } else {
       runtime_template.async_module_factory(&self.get_blocks()[0], &self.request, compilation)
     };

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -124,6 +124,27 @@ impl DependenciesBlock for ProvideSharedModule {
 #[cacheable_dyn]
 #[async_trait]
 impl Module for ProvideSharedModule {
+  fn update_cache_module(&mut self, fresh: &mut dyn Module) -> bool {
+    let fresh = fresh
+      .as_any_mut()
+      .downcast_mut::<Self>()
+      .expect("module type must match");
+    if self.request != fresh.request || self.eager != fresh.eager {
+      return false;
+    }
+    std::mem::swap(&mut self.lib_ident, &mut fresh.lib_ident);
+    std::mem::swap(
+      &mut self.readable_identifier,
+      &mut fresh.readable_identifier,
+    );
+    std::mem::swap(&mut self.singleton, &mut fresh.singleton);
+    std::mem::swap(&mut self.required_version, &mut fresh.required_version);
+    std::mem::swap(&mut self.strict_version, &mut fresh.strict_version);
+    std::mem::swap(&mut self.tree_shaking_mode, &mut fresh.tree_shaking_mode);
+    std::mem::swap(&mut self.factory_meta, &mut fresh.factory_meta);
+    true
+  }
+
   impl_module_meta_info!();
 
   fn size(&self, _source_type: Option<&SourceType>, _compilation: Option<&Compilation>) -> f64 {

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -99,10 +99,10 @@ impl SharedUsedExportsOptimizerPlugin {
   }
 }
 
-fn collect_processed_modules(
+fn collect_processed_modules<'a>(
   module_graph: &ModuleGraph,
   module_blocks: &[AsyncDependenciesBlockIdentifier],
-  module_deps: &[DependencyId],
+  module_deps: impl IntoIterator<Item = &'a DependencyId>,
   out: &mut Vec<ModuleIdentifier>,
 ) {
   for dep_id in module_deps {

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -164,7 +164,6 @@ fn collect_css_files_from_block_modules(
 
   block
     .get_dependencies()
-    .iter()
     .filter_map(|dependency_id| module_graph.connection_by_dependency_id(dependency_id))
     .filter_map(|connection| chunk_graph.try_get_module_chunks(connection.module_identifier()))
     .flat_map(|chunk_ukeys| collect_css_files_from_chunks(module_loading, chunk_ukeys, compilation))

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -101,7 +101,7 @@ pub fn cutout_star_re_export_externals(
       exports_info.other_exports_info().provided(),
       Some(rspack_core::ExportProvided::Unknown)
     ) {
-      let has_unknown_exports = module.get_dependencies().iter().any(|dep_id| {
+      let has_unknown_exports = module.get_dependencies().any(|dep_id| {
         if connections_to_disable.contains(dep_id) {
           return false;
         }

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -236,7 +236,6 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 
         module
           .get_dependencies()
-          .iter()
           .map(|id| module_graph.dependency_by_id(id))
           .filter(|dep| dep.dependency_type() == &DependencyType::WasmImport)
           .map(|dep| {

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -198,7 +198,7 @@ impl<'a> ArtifactComparator<'a> {
     }
 
     // Compare each dependency by type in order and build mapping
-    for (i, (dep_id1, dep_id2)) in deps1.iter().zip(deps2.iter()).enumerate() {
+    for (i, (dep_id1, dep_id2)) in deps1.zip(deps2).enumerate() {
       let dep_debug_info = debug_info.with_field("dependency_index", &i.to_string());
 
       let dep1 = self.mg1.dependency_by_id(dep_id1);

--- a/tests/rspack-test/cacheCases/common/module-cache-new-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/module-cache-new-cache/rspack.config.js
@@ -96,7 +96,8 @@ module.exports = {
               'stable.js',
             ]);
           } else {
-            expect(builtModules).toEqual(['changed.js']);
+            // JSON.parse is a factory callback that cannot be persisted.
+            expect(builtModules).toEqual(['changed.js', 'data.json']);
           }
           loaderOptions.builtModules = [];
           compilerIndex++;

--- a/tests/rspack-test/compilerCases/module-cache-federation.js
+++ b/tests/rspack-test/compilerCases/module-cache-federation.js
@@ -9,11 +9,13 @@ const PLUGIN = "FederationModuleCacheTest";
 module.exports = [
   { name: "memory" },
   { name: "persistent-reopen", reopen: true },
-  { name: "enhanced-memory", enhanced: true }
+  { name: "enhanced-memory", enhanced: true },
+  { name: "enhanced-persistent-reopen", enhanced: true, reopen: true }
 ].map(({ name, reopen, enhanced }) => {
   let root;
   let built;
   let succeeded;
+  let stillValid;
   return {
     description: `should restore federation module builds with ${name}`,
     options(context) {
@@ -22,7 +24,7 @@ module.exports = [
       fs.mkdirSync(root, { recursive: true });
       const timestamp = new Date(Date.now() - 20000);
       for (const [file, source] of Object.entries({
-        "index.js": 'import("remote/exposed"); import("./shared.js");',
+        "index.js": 'import("remote/exposed"); import("direct/exposed"); import("./shared.js");',
         "exposed.js": 'module.exports = "exposed";',
         "shared.js": 'module.exports = "shared";'
       })) {
@@ -38,6 +40,7 @@ module.exports = [
         devtool: false,
         incremental: false,
         output: { path: path.join(root, "dist"), publicPath: "" },
+        optimization: { runtimeChunk: "single" },
         cache: reopen ? {
           type: "persistent",
           storage: { type: "filesystem", location: path.join(root, "cache") }
@@ -48,7 +51,10 @@ module.exports = [
             name: "test_container",
             filename: "remoteEntry.js",
             exposes: { "./exposed": "./exposed.js" },
-            remotes: { remote: ["remote@http://localhost/remote.js", "fallback@http://localhost/fallback.js"] },
+            remotes: {
+              remote: ["remote@http://localhost/remote.js", "fallback@http://localhost/fallback.js"],
+              direct: "direct@http://localhost/direct.js"
+            },
             shared: { "./shared.js": { import: "./shared.js", requiredVersion: false, version: "1.0.0" } }
           }),
           {
@@ -59,10 +65,12 @@ module.exports = [
                   const kind = kindOf(module);
                   if (kind) built.push(kind);
                 });
-                compilation.hooks.succeedModule.tap(PLUGIN, module => {
-                  const kind = kindOf(module);
-                  if (kind) succeeded.push(kind);
-                });
+                for (const hook of ["succeedModule", "stillValidModule"]) {
+                  compilation.hooks[hook].tap(PLUGIN, module => {
+                    const kind = kindOf(module);
+                    if (kind) (hook === "succeedModule" ? succeeded : stillValid).push(kind);
+                  });
+                }
               });
             }
           }
@@ -78,15 +86,21 @@ module.exports = [
       for (let iteration = 0; iteration < 3; iteration++) {
         built = [];
         succeeded = [];
+        stillValid = [];
         const stats = await manager.build();
         expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
-        expect([...new Set(succeeded)].sort()).toEqual([...kinds].sort());
-        expect([...new Set(built)].sort()).toEqual(
-          iteration === 0 ? [...kinds].sort() : reopen ? ["consume shared module"] : []
-        );
+        const expectedBuilt = iteration === 0 ? [...kinds].sort() : reopen ? ["consume shared module"] : [];
+        expect([...new Set(built)].sort()).toEqual(expectedBuilt);
+        expect([...new Set(succeeded)].sort()).toEqual(expectedBuilt);
+        expect([...new Set(stillValid)].sort()).toEqual(kinds.filter(kind => !expectedBuilt.includes(kind)).sort());
         const output = Object.fromEntries(stats.compilation.getAssets()
           .filter(asset => asset.name.endsWith(".js"))
           .map(asset => [asset.name, asset.source.source().toString()]));
+        if (enhanced) {
+          for (const remote of ["remote", "fallback", "direct"]) {
+            expect(output["runtime.js"]).toContain(`http://localhost/${remote}.js`);
+          }
+        }
         if (iteration === 0) expectedOutput = output;
         else expect(output).toEqual(expectedOutput);
         if (reopen && iteration < 2) {

--- a/tests/rspack-test/compilerCases/module-cache-federation.js
+++ b/tests/rspack-test/compilerCases/module-cache-federation.js
@@ -1,0 +1,99 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { container } = require("@rspack/core");
+
+const kinds = ["container entry", "remote", "fallback", "consume shared module", "provide shared module"];
+const PLUGIN = "FederationModuleCacheTest";
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  { name: "memory" },
+  { name: "persistent-reopen", reopen: true },
+  { name: "enhanced-memory", enhanced: true }
+].map(({ name, reopen, enhanced }) => {
+  let root;
+  let built;
+  let succeeded;
+  return {
+    description: `should restore federation module builds with ${name}`,
+    options(context) {
+      root = context.getDist(name);
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(root, { recursive: true });
+      const timestamp = new Date(Date.now() - 20000);
+      for (const [file, source] of Object.entries({
+        "index.js": 'import("remote/exposed"); import("./shared.js");',
+        "exposed.js": 'module.exports = "exposed";',
+        "shared.js": 'module.exports = "shared";'
+      })) {
+        const filename = path.join(root, file);
+        fs.writeFileSync(filename, source);
+        fs.utimesSync(filename, timestamp, timestamp);
+      }
+      const FederationPlugin = enhanced ? container.ModuleFederationPlugin : container.ModuleFederationPluginV1;
+      return {
+        context: root,
+        entry: "./index.js",
+        mode: "production",
+        devtool: false,
+        incremental: false,
+        output: { path: path.join(root, "dist"), publicPath: "" },
+        cache: reopen ? {
+          type: "persistent",
+          storage: { type: "filesystem", location: path.join(root, "cache") }
+        } : true,
+        experiments: { newCache: { module: true, loader: false, codeGeneration: false, devtool: false, minimize: false } },
+        plugins: [
+          new FederationPlugin({
+            name: "test_container",
+            filename: "remoteEntry.js",
+            exposes: { "./exposed": "./exposed.js" },
+            remotes: { remote: ["remote@http://localhost/remote.js", "fallback@http://localhost/fallback.js"] },
+            shared: { "./shared.js": { import: "./shared.js", requiredVersion: false, version: "1.0.0" } }
+          }),
+          {
+            apply(compiler) {
+              compiler.hooks.compilation.tap(PLUGIN, compilation => {
+                const kindOf = module => kinds.find(kind => module.identifier().startsWith(`${kind} `));
+                compilation.hooks.buildModule.tap(PLUGIN, module => {
+                  const kind = kindOf(module);
+                  if (kind) built.push(kind);
+                });
+                compilation.hooks.succeedModule.tap(PLUGIN, module => {
+                  const kind = kindOf(module);
+                  if (kind) succeeded.push(kind);
+                });
+              });
+            }
+          }
+        ]
+      };
+    },
+    compiler(_, compiler) {
+      compiler.outputFileSystem = fs;
+    },
+    async build(context) {
+      const manager = context.getCompiler();
+      let expectedOutput;
+      for (let iteration = 0; iteration < 3; iteration++) {
+        built = [];
+        succeeded = [];
+        const stats = await manager.build();
+        expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+        expect([...new Set(succeeded)].sort()).toEqual([...kinds].sort());
+        expect([...new Set(built)].sort()).toEqual(
+          iteration === 0 ? [...kinds].sort() : reopen ? ["consume shared module"] : []
+        );
+        const output = Object.fromEntries(stats.compilation.getAssets()
+          .filter(asset => asset.name.endsWith(".js"))
+          .map(asset => [asset.name, asset.source.source().toString()]));
+        if (iteration === 0) expectedOutput = output;
+        else expect(output).toEqual(expectedOutput);
+        if (reopen && iteration < 2) {
+          await manager.close();
+          manager.createCompiler().outputFileSystem = fs;
+        }
+      }
+    }
+  };
+});

--- a/tests/rspack-test/compilerCases/module-cache-live-state.js
+++ b/tests/rspack-test/compilerCases/module-cache-live-state.js
@@ -18,6 +18,7 @@ module.exports = [
   let expectedAssets = [];
   let built = 0;
   let succeeded = 0;
+  let stillValid = 0;
   let failBuild = false;
   let expectedBailouts;
 
@@ -65,14 +66,17 @@ module.exports = [
               compilation.hooks.buildModule.tap(PLUGIN, module => {
                 if (module.resource === input) built++;
               });
-              compilation.hooks.succeedModule.tap(PLUGIN, module => {
-                if (module.resource !== input) return;
-                if (failBuild) throw new Error("module cache build failure");
-                succeeded++;
-                expect(Object.keys(module.buildInfo.assets).sort()).toEqual(expectedAssets);
-                // This also runs on cache hits. The next build must observe this mutation.
-                module.emitFile(`module-state-${iteration}.txt`, new RawSource(`${iteration}`));
-              });
+              for (const hook of ["succeedModule", "stillValidModule"]) {
+                compilation.hooks[hook].tap(PLUGIN, module => {
+                  if (module.resource !== input) return;
+                  if (failBuild) throw new Error("module cache build failure");
+                  if (hook === "succeedModule") succeeded++;
+                  else stillValid++;
+                  expect(Object.keys(module.buildInfo.assets).sort()).toEqual(expectedAssets);
+                  // Mutations in either hook must survive the next cache hit.
+                  module.emitFile(`module-state-${iteration}.txt`, new RawSource(`${iteration}`));
+                });
+              }
             });
           }
         }]
@@ -95,7 +99,8 @@ module.exports = [
         const stats = await manager.build();
         expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
         expect(built - before).toBe(rebuild ? 1 : 0);
-        expect(succeeded).toBe(iteration + 1);
+        expect(succeeded).toBe(built);
+        expect(stillValid).toBe(iteration + 1 - built);
         const bailouts = stats.toJson({
           all: false,
           modules: true,

--- a/tests/rspack-test/compilerCases/module-cache-live-state.js
+++ b/tests/rspack-test/compilerCases/module-cache-live-state.js
@@ -1,0 +1,122 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { RawSource } = require("webpack-sources");
+
+const PLUGIN = "ModuleCacheLiveStateTest";
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  { name: "memory", cache: true },
+  { name: "persistent", cache: "persistent" },
+  { name: "persistent-without-memory", cache: "persistent", maxMemoryGenerations: 0 },
+  { name: "persistent-reopen", cache: "persistent", reopen: true },
+  { name: "disabled", cache: false }
+].map(({ name, cache, maxMemoryGenerations, reopen }) => {
+  let root;
+  let input;
+  let iteration = 0;
+  let expectedAssets = [];
+  let built = 0;
+  let succeeded = 0;
+  let failBuild = false;
+  let expectedBailouts;
+
+  return {
+    description: `should retain mutations of cached modules with ${name}`,
+    options(context) {
+      root = context.getDist(name);
+      input = path.join(root, "input.js");
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(root, { recursive: true });
+      fs.writeFileSync(input, 'module.exports = require("./data.json");');
+      fs.writeFileSync(path.join(root, "data.json"), '{"value": 42}');
+      // Keep timestamps outside the filesystem accuracy window for deterministic hits.
+      const timestamp = new Date(Date.now() - 10000);
+      fs.utimesSync(input, timestamp, timestamp);
+      fs.utimesSync(path.join(root, "data.json"), timestamp, timestamp);
+      return {
+        context: root,
+        entry: "./input.js",
+        mode: "production",
+        devtool: false,
+        incremental: false,
+        output: { path: path.join(root, "dist") },
+        cache: cache === "persistent" ? {
+          type: "persistent",
+          ...(maxMemoryGenerations === undefined ? {} : { maxMemoryGenerations }),
+          storage: { type: "filesystem", location: path.join(root, "cache") }
+        } : cache,
+        experiments: {
+          newCache: {
+            module: true,
+            loader: false,
+            codeGeneration: false,
+            devtool: false,
+            minimize: false
+          }
+        },
+        module: {
+          // Factory-owned functions must come from the fresh module after restoration.
+          rules: [{ test: /\.json$/, type: "json", parser: { parse: JSON.parse } }]
+        },
+        plugins: [{
+          apply(compiler) {
+            compiler.hooks.compilation.tap(PLUGIN, compilation => {
+              compilation.hooks.buildModule.tap(PLUGIN, module => {
+                if (module.resource === input) built++;
+              });
+              compilation.hooks.succeedModule.tap(PLUGIN, module => {
+                if (module.resource !== input) return;
+                if (failBuild) throw new Error("module cache build failure");
+                succeeded++;
+                expect(Object.keys(module.buildInfo.assets).sort()).toEqual(expectedAssets);
+                // This also runs on cache hits. The next build must observe this mutation.
+                module.emitFile(`module-state-${iteration}.txt`, new RawSource(`${iteration}`));
+              });
+            });
+          }
+        }]
+      };
+    },
+    compiler(_, compiler) {
+      compiler.outputFileSystem = fs;
+    },
+    async build(context) {
+      const manager = context.getCompiler();
+      for (iteration = 0; iteration < 5; iteration++) {
+        const rebuild = cache === false || iteration === 0 || iteration === 3;
+        if (iteration === 3) {
+          const timestamp = new Date(fs.statSync(input).mtimeMs + 1000);
+          fs.writeFileSync(input, 'module.exports = require("./data.json").value + 1;');
+          fs.utimesSync(input, timestamp, timestamp);
+        }
+        if (rebuild) expectedAssets = [];
+        const before = built;
+        const stats = await manager.build();
+        expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+        expect(built - before).toBe(rebuild ? 1 : 0);
+        expect(succeeded).toBe(iteration + 1);
+        const bailouts = stats.toJson({
+          all: false,
+          modules: true,
+          cachedModules: true,
+          optimizationBailout: true
+        }).modules.find(module => module.identifier === input).optimizationBailout;
+        if (rebuild) expectedBailouts = bailouts;
+        else expect(bailouts).toEqual(expectedBailouts);
+        expectedAssets.push(`module-state-${iteration}.txt`);
+        for (const asset of expectedAssets) {
+          expect(stats.compilation.getAsset(asset)).toBeDefined();
+        }
+        if (reopen && iteration < 4) {
+          await manager.close();
+          manager.createCompiler().outputFileSystem = fs;
+        }
+      }
+      // A failed make may have moved the graph out of the compilation. Cache
+      // cleanup and compiler.close must preserve the original error without panicking.
+      failBuild = true;
+      await expect(manager.build()).rejects.toThrow("module cache build failure");
+    }
+  };
+});

--- a/tests/rspack-test/compilerCases/module-cache-live-state.js
+++ b/tests/rspack-test/compilerCases/module-cache-live-state.js
@@ -56,7 +56,7 @@ module.exports = [
           }
         },
         module: {
-          // Factory-owned functions must come from the fresh module after restoration.
+          // Unsupported factory functions must not prevent other modules from being cached.
           rules: [{ test: /\.json$/, type: "json", parser: { parse: JSON.parse } }]
         },
         plugins: [{

--- a/tests/rspack-test/compilerCases/module-cache-module-types.js
+++ b/tests/rspack-test/compilerCases/module-cache-module-types.js
@@ -19,6 +19,7 @@ module.exports = [
   let iteration;
   let built;
   let succeeded;
+  let stillValid;
   let timestamp;
   const assets = new Map(kinds.map(kind => [kind, []]));
 
@@ -105,16 +106,18 @@ module.exports = [
                 const kind = kindOf(module);
                 if (kind) built.push(kind);
               });
-              compilation.hooks.succeedModule.tap(PLUGIN, module => {
-                const kind = kindOf(module);
-                if (!kind) return;
-                succeeded.push(kind);
-                if (built.includes(kind)) assets.set(kind, []);
-                expect(Object.keys(module.buildInfo.assets).sort()).toEqual(assets.get(kind));
-                const asset = `${kind}-${iteration}.txt`;
-                module.emitFile(asset, new RawSource(asset));
-                assets.get(kind).push(asset);
-              });
+              for (const hook of ["succeedModule", "stillValidModule"]) {
+                compilation.hooks[hook].tap(PLUGIN, module => {
+                  const kind = kindOf(module);
+                  if (!kind) return;
+                  (hook === "succeedModule" ? succeeded : stillValid).push(kind);
+                  if (hook === "succeedModule") assets.set(kind, []);
+                  expect(Object.keys(module.buildInfo.assets).sort()).toEqual(assets.get(kind));
+                  const asset = `${kind}-${iteration}.txt`;
+                  module.emitFile(asset, new RawSource(asset));
+                  assets.get(kind).push(asset);
+                });
+              }
             });
           }
         }]
@@ -129,6 +132,7 @@ module.exports = [
       for (iteration = 0; iteration < 5; iteration++) {
         built = [];
         succeeded = [];
+        stillValid = [];
         timestamp = new Date(timestamp.getTime() + 1000);
         if (iteration === 2) {
           write("items/b.js", 'module.exports = "b";');
@@ -140,7 +144,6 @@ module.exports = [
         }
         const stats = await manager.build();
         expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
-        expect(succeeded.sort()).toEqual([...kinds].sort());
         const expected = kinds.filter(kind => {
           if (iteration === 0 || cache === false) return true;
           if (kind === "sync" || kind === "lazy") return !memory || iteration === 2 || iteration === 4;
@@ -148,6 +151,8 @@ module.exports = [
           return kind === "css" && iteration === 2;
         });
         expect(built.sort()).toEqual(expected.sort());
+        expect(succeeded.sort()).toEqual(expected);
+        expect(stillValid.sort()).toEqual(kinds.filter(kind => !expected.includes(kind)).sort());
         const filename = path.join(root, "dist/main.js");
         const output = { exports: {} };
         new Function("require", "module", "exports", fs.readFileSync(filename, "utf8"))(

--- a/tests/rspack-test/compilerCases/module-cache-module-types.js
+++ b/tests/rspack-test/compilerCases/module-cache-module-types.js
@@ -1,0 +1,169 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { createRequire } = require("node:module");
+const { CssExtractRspackPlugin } = require("@rspack/core");
+const { RawSource } = require("webpack-sources");
+
+const PLUGIN = "ModuleCacheTypesTest";
+const kinds = ["external", "raw", "sync", "lazy", "css", "json"];
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  { name: "memory", cache: true },
+  { name: "persistent", cache: "persistent" },
+  { name: "persistent-without-memory", cache: "persistent", maxMemoryGenerations: 0 },
+  { name: "persistent-reopen", cache: "persistent", reopen: true },
+  { name: "disabled", cache: false }
+].map(({ name, cache, maxMemoryGenerations, reopen }) => {
+  let root;
+  let iteration;
+  let built;
+  let succeeded;
+  let timestamp;
+  const assets = new Map(kinds.map(kind => [kind, []]));
+
+  function write(relative, content) {
+    const file = path.join(root, relative);
+    fs.writeFileSync(file, content);
+    fs.utimesSync(file, timestamp, timestamp);
+  }
+
+  function kindOf(module) {
+    const identifier = module.identifier();
+    if (identifier.startsWith("external ")) return "external";
+    if (identifier.startsWith("ignored|")) return "raw";
+    if (identifier.startsWith(`${path.join(root, "items")}|sync`)) return "sync";
+    if (identifier.startsWith(`${path.join(root, "items")}|lazy`)) return "lazy";
+    if (module.type === "css/mini-extract") return "css";
+    if (module.resource === path.join(root, "data.json")) return "json";
+  }
+
+  return {
+    description: `should cache module types and skip unsupported serialization with ${name}`,
+    options(context) {
+      root = context.getDist(name);
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(path.join(root, "items"), { recursive: true });
+      timestamp = new Date(Date.now() - 20000);
+      write("index.js", `
+        require("./style.css");
+        const sync = require.context("./items", false, /\\.js$/);
+        const lazy = require.context("./items", false, /\\.js$/, "lazy");
+        module.exports = async () => ({
+          sync: sync.keys().sort().map(key => sync(key)),
+          lazy: await Promise.all(lazy.keys().sort().map(key => lazy(key))),
+          external: require("external").join("a", "b"),
+          ignored: require("ignored"),
+          json: require("./data.json")
+        });
+      `);
+      write("items/a.js", 'module.exports = "a";');
+      write("style.css", ".example { color: red; }");
+      write("data.json", '{"value": 42}');
+      fs.utimesSync(path.join(root, "items"), timestamp, timestamp);
+      return {
+        context: root,
+        entry: "./index.js",
+        target: "node",
+        mode: "production",
+        devtool: false,
+        incremental: false,
+        output: {
+          path: path.join(root, "dist"),
+          filename: "main.js",
+          publicPath: "",
+          library: { type: "commonjs2" }
+        },
+        cache: cache === "persistent" ? {
+          type: "persistent",
+          ...(maxMemoryGenerations === undefined ? {} : { maxMemoryGenerations }),
+          storage: { type: "filesystem", location: path.join(root, "cache") }
+        } : cache,
+        experiments: {
+          css: false,
+          newCache: {
+            module: true,
+            loader: false,
+            codeGeneration: false,
+            devtool: false,
+            minimize: false
+          }
+        },
+        resolve: { alias: { ignored: false } },
+        externals: { external: "commonjs node:path" },
+        module: {
+          rules: [
+            { test: /\.css$/, type: "javascript/auto", use: [CssExtractRspackPlugin.loader, require.resolve("css-loader")] },
+            // A function in parser options is deliberately unsupported by serialization.
+            { test: /\.json$/, type: "json", parser: { parse: JSON.parse } }
+          ]
+        },
+        plugins: [new CssExtractRspackPlugin({ filename: "main.css" }), {
+          apply(compiler) {
+            compiler.hooks.compilation.tap(PLUGIN, compilation => {
+              compilation.hooks.buildModule.tap(PLUGIN, module => {
+                const kind = kindOf(module);
+                if (kind) built.push(kind);
+              });
+              compilation.hooks.succeedModule.tap(PLUGIN, module => {
+                const kind = kindOf(module);
+                if (!kind) return;
+                succeeded.push(kind);
+                if (built.includes(kind)) assets.set(kind, []);
+                expect(Object.keys(module.buildInfo.assets).sort()).toEqual(assets.get(kind));
+                const asset = `${kind}-${iteration}.txt`;
+                module.emitFile(asset, new RawSource(asset));
+                assets.get(kind).push(asset);
+              });
+            });
+          }
+        }]
+      };
+    },
+    compiler(_, compiler) {
+      compiler.outputFileSystem = fs;
+    },
+    async build(context) {
+      const manager = context.getCompiler();
+      const memory = cache !== false && maxMemoryGenerations !== 0 && !reopen;
+      for (iteration = 0; iteration < 5; iteration++) {
+        built = [];
+        succeeded = [];
+        timestamp = new Date(timestamp.getTime() + 1000);
+        if (iteration === 2) {
+          write("items/b.js", 'module.exports = "b";');
+          write("style.css", ".example { color: blue; }");
+        }
+        if (iteration === 4) fs.unlinkSync(path.join(root, "items/a.js"));
+        if (iteration === 2 || iteration === 4) {
+          fs.utimesSync(path.join(root, "items"), timestamp, timestamp);
+        }
+        const stats = await manager.build();
+        expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+        expect(succeeded.sort()).toEqual([...kinds].sort());
+        const expected = kinds.filter(kind => {
+          if (iteration === 0 || cache === false) return true;
+          if (kind === "sync" || kind === "lazy") return !memory || iteration === 2 || iteration === 4;
+          if (kind === "json") return !memory;
+          return kind === "css" && iteration === 2;
+        });
+        expect(built.sort()).toEqual(expected.sort());
+        const filename = path.join(root, "dist/main.js");
+        const output = { exports: {} };
+        new Function("require", "module", "exports", fs.readFileSync(filename, "utf8"))(
+          createRequire(filename), output, output.exports
+        );
+        const values = iteration < 2 ? ["a"] : iteration < 4 ? ["a", "b"] : ["b"];
+        expect(await output.exports()).toEqual({
+          sync: values, lazy: values, external: path.join("a", "b"), ignored: {}, json: { value: 42 }
+        });
+        expect(fs.readFileSync(path.join(root, "dist/main.css"), "utf8"))
+          .toContain(iteration < 2 ? "color: red" : "color: blue");
+        if (reopen && iteration < 4) {
+          await manager.close();
+          manager.createCompiler().outputFileSystem = fs;
+        }
+      }
+    }
+  };
+});

--- a/tests/rspack-test/compilerCases/module-owned-dependencies.js
+++ b/tests/rspack-test/compilerCases/module-owned-dependencies.js
@@ -98,8 +98,8 @@ module.exports = [
 				const stats = await manager.build();
 				expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
 				if (!legacy) {
-					// Consecutive run() calls use rebuild(), which bypasses the module cache.
-					const cacheHit = reopen && iteration % 2 === 1;
+					// Unchanged entries are reusable even when graph recovery is disabled.
+					const cacheHit = cache !== false && iteration % 2 === 1;
 					expect(built).toBe(cacheHit ? 0 : 1);
 				}
 				const filename = path.join(root, "dist/main.js");


### PR DESCRIPTION
## Summary

Reuse live module instances across compilations and module types, removing `NormalModuleState` and skipping unsupported filesystem serialization. Refresh factory data on reuse, dispatch `stillValidModule` for cache hits, and collect Federation dependencies from the current module graph.

Stacked on #15556.