### PR TITLE
chore: release version 2.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,7 +1157,7 @@ dependencies = [
 
 [[package]]
 name = "css-module-lexer"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "bitflags 2.13.1",
  "indoc",
@@ -3838,7 +3838,7 @@ dependencies = [
 
 [[package]]
 name = "rspack"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "bitflags 2.13.1",
  "derive_more",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_allocator"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "mimalloc",
  "sftrace-setup",
@@ -3953,7 +3953,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_benchmark"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_api"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4091,21 +4091,21 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_build"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "napi-build",
 ]
 
 [[package]]
 name = "rspack_binding_builder"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_binding_api",
 ]
 
 [[package]]
 name = "rspack_binding_builder_macros"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_binding_builder_testing"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "napi",
  "napi-derive",
@@ -4129,7 +4129,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_browserslist"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "browserslist-rs",
  "lightningcss",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "camino",
  "dashmap",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_macros"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_cacheable_test"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "camino",
  "dashmap",
@@ -4192,7 +4192,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_collections"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "dashmap",
  "hashlink",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_core"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anymap3",
  "async-recursion",
@@ -4285,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_dojang"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "html-escape",
  "rustc-hash",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_error"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "miette",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_fs"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hash"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "base64-simd 0.8.0",
  "itoa",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_hook"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_error",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_ids"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_intern"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "dashmap",
  "hstr",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_javascript_compiler"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "indoc",
@@ -4417,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_lightningcss"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_preact_refresh"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_react_refresh"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_runner"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -4489,7 +4489,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_swc"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "either",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_loader_testing"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_location"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "itoa",
  "memchr",
@@ -4545,7 +4545,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "heck",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_macros_test"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "napi",
  "oneshot",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_napi_macros"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_node"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "napi-derive",
  "rspack_binding_api",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_parallel"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rayon",
  "rspack_tasks",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_paths"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "camino",
  "dashmap",
@@ -4626,7 +4626,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_asset"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "mime_guess",
@@ -4643,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_banner"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "futures",
@@ -4657,7 +4657,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_case_sensitive"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "itertools 0.14.0",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_circular_dependencies"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_copy"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4742,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_css_chunking"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "indexmap",
  "rspack_collections",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_devtool"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "derive_more",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dll"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_dynamic_entry"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "atomic_refcell",
  "derive_more",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ensure_chunk_conditions"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_entry"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_esm_library"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_externals"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "regex",
  "rspack_core",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_extract_css"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_hmr"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -4930,7 +4930,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_html"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "atomic_refcell",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_ignore"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -4972,7 +4972,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_javascript"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anymap3",
  "async-trait",
@@ -5021,7 +5021,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_json"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lazy_compilation"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "rspack_cacheable",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_library"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "futures",
  "regex",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_lightning_css_minimizer"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "lightningcss",
  "parcel_sourcemap",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_limit_chunk_count"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5103,7 +5103,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_merge_duplicate_chunks"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rayon",
  "rspack_core",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_mf"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "camino",
@@ -5143,7 +5143,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_info_header"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_cacheable",
  "rspack_core",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_module_replacement"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_no_emit_on_errors"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_progress"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "futures",
  "indicatif",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_real_content_hash"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "aho-corasick",
  "atomic_refcell",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_duplicate_modules"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rayon",
  "rspack_collections",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_remove_empty_chunks"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsc"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5274,7 +5274,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rsdoctor"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "atomic_refcell",
  "json",
@@ -5297,7 +5297,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rslib"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_rstest"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "camino",
  "cow-utils",
@@ -5346,7 +5346,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "atomic_refcell",
@@ -5371,7 +5371,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_runtime_chunk"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "futures",
  "rspack_core",
@@ -5382,7 +5382,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_schemes"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_size_limits"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -5422,7 +5422,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_split_chunks"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "derive_more",
  "futures",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_sri"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_swc_js_minimizer"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "once_cell",
@@ -5499,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_wasm"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5518,7 +5518,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_plugin_worker"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "rspack_core",
  "rspack_error",
@@ -5528,7 +5528,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_regex"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "napi",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_resolver"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_sources"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "memchr",
  "regex",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_storage"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "async-trait",
  "cow-utils",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_import"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "heck",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_swc_plugin_ts_collector"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "glob",
  "insta",
@@ -5624,14 +5624,14 @@ dependencies = [
 
 [[package]]
 name = "rspack_tasks"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "rspack_tools"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "clap",
  "itertools 0.14.0",
@@ -5646,7 +5646,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "chrono",
  "rspack_tracing_perfetto",
@@ -5658,7 +5658,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_tracing_perfetto"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "bytes",
  "micromegas-perfetto",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_util"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "anyhow",
  "base64-simd 0.8.0",
@@ -5709,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_watcher"
-version = "0.102.2"
+version = "0.102.3"
 dependencies = [
  "cow-utils",
  "dashmap",
@@ -5727,7 +5727,7 @@ dependencies = [
 
 [[package]]
 name = "rspack_workspace"
-version = "0.102.2"
+version = "0.102.3"
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition       = "2024"
 homepage      = "https://rspack.rs/"
 license       = "MIT"
 repository    = "https://github.com/web-infra-dev/rspack"
-version       = "0.102.2"
+version       = "0.102.3"
 
 [workspace.metadata.dylint]
 libraries = [{ path = "linting/*" }]
@@ -169,96 +169,96 @@ wasmtime     = { version = "36.0.13", default-features = false }
 
 
 # all rspack workspace dependencies
-css-module-lexer                       = { version = "=0.102.2", path = "crates/css-module-lexer", default-features = false }
-rspack                                 = { version = "=0.102.2", path = "crates/rspack", default-features = false }
-rspack_allocator                       = { version = "=0.102.2", path = "crates/rspack_allocator", default-features = false }
-rspack_binding_api                     = { version = "=0.102.2", path = "crates/rspack_binding_api", default-features = false }
-rspack_binding_build                   = { version = "=0.102.2", path = "crates/rspack_binding_build", default-features = false }
-rspack_binding_builder                 = { version = "=0.102.2", path = "crates/rspack_binding_builder", default-features = false }
-rspack_binding_builder_macros          = { version = "=0.102.2", path = "crates/rspack_binding_builder_macros", default-features = false }
-rspack_browserslist                    = { version = "=0.102.2", path = "crates/rspack_browserslist", default-features = false }
-rspack_cacheable                       = { version = "=0.102.2", path = "crates/rspack_cacheable", default-features = false }
-rspack_cacheable_macros                = { version = "=0.102.2", path = "crates/rspack_cacheable_macros", default-features = false }
-rspack_collections                     = { version = "=0.102.2", path = "crates/rspack_collections", default-features = false }
-rspack_core                            = { version = "=0.102.2", path = "crates/rspack_core", default-features = false }
-rspack_dojang                          = { version = "=0.102.2", path = "crates/rspack_dojang", default-features = false }
-rspack_error                           = { version = "=0.102.2", path = "crates/rspack_error", default-features = false }
-rspack_fs                              = { version = "=0.102.2", path = "crates/rspack_fs", default-features = false }
-rspack_hash                            = { version = "=0.102.2", path = "crates/rspack_hash", default-features = false }
-rspack_hook                            = { version = "=0.102.2", path = "crates/rspack_hook", default-features = false }
-rspack_ids                             = { version = "=0.102.2", path = "crates/rspack_ids", default-features = false }
-rspack_intern                          = { version = "=0.102.2", path = "crates/rspack_intern", default-features = false }
-rspack_javascript_compiler             = { version = "=0.102.2", path = "crates/rspack_javascript_compiler", default-features = false }
-rspack_loader_lightningcss             = { version = "=0.102.2", path = "crates/rspack_loader_lightningcss", default-features = false }
-rspack_loader_preact_refresh           = { version = "=0.102.2", path = "crates/rspack_loader_preact_refresh", default-features = false }
-rspack_loader_react_refresh            = { version = "=0.102.2", path = "crates/rspack_loader_react_refresh", default-features = false }
-rspack_loader_runner                   = { version = "=0.102.2", path = "crates/rspack_loader_runner", default-features = false }
-rspack_loader_swc                      = { version = "=0.102.2", path = "crates/rspack_loader_swc", default-features = false }
-rspack_loader_testing                  = { version = "=0.102.2", path = "crates/rspack_loader_testing", default-features = false }
-rspack_location                        = { version = "=0.102.2", path = "crates/rspack_location", default-features = false }
-rspack_macros                          = { version = "=0.102.2", path = "crates/rspack_macros", default-features = false }
-rspack_napi                            = { version = "=0.102.2", path = "crates/rspack_napi", default-features = false }
-rspack_napi_macros                     = { version = "=0.102.2", path = "crates/rspack_napi_macros", default-features = false }
-rspack_parallel                        = { version = "=0.102.2", path = "crates/rspack_parallel", default-features = false }
-rspack_paths                           = { version = "=0.102.2", path = "crates/rspack_paths", default-features = false }
-rspack_plugin_asset                    = { version = "=0.102.2", path = "crates/rspack_plugin_asset", default-features = false }
-rspack_plugin_banner                   = { version = "=0.102.2", path = "crates/rspack_plugin_banner", default-features = false }
-rspack_plugin_case_sensitive           = { version = "=0.102.2", path = "crates/rspack_plugin_case_sensitive", default-features = false }
-rspack_plugin_circular_dependencies    = { version = "=0.102.2", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
-rspack_plugin_copy                     = { version = "=0.102.2", path = "crates/rspack_plugin_copy", default-features = false }
-rspack_plugin_css                      = { version = "=0.102.2", path = "crates/rspack_plugin_css", default-features = false }
-rspack_plugin_css_chunking             = { version = "=0.102.2", path = "crates/rspack_plugin_css_chunking", default-features = false }
-rspack_plugin_devtool                  = { version = "=0.102.2", path = "crates/rspack_plugin_devtool", default-features = false }
-rspack_plugin_dll                      = { version = "=0.102.2", path = "crates/rspack_plugin_dll", default-features = false }
-rspack_plugin_dynamic_entry            = { version = "=0.102.2", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
-rspack_plugin_ensure_chunk_conditions  = { version = "=0.102.2", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
-rspack_plugin_entry                    = { version = "=0.102.2", path = "crates/rspack_plugin_entry", default-features = false }
-rspack_plugin_esm_library              = { version = "=0.102.2", path = "crates/rspack_plugin_esm_library", default-features = false }
-rspack_plugin_externals                = { version = "=0.102.2", path = "crates/rspack_plugin_externals", default-features = false }
-rspack_plugin_extract_css              = { version = "=0.102.2", path = "crates/rspack_plugin_extract_css", default-features = false }
-rspack_plugin_hmr                      = { version = "=0.102.2", path = "crates/rspack_plugin_hmr", default-features = false }
-rspack_plugin_html                     = { version = "=0.102.2", path = "crates/rspack_plugin_html", default-features = false }
-rspack_plugin_ignore                   = { version = "=0.102.2", path = "crates/rspack_plugin_ignore", default-features = false }
-rspack_plugin_javascript               = { version = "=0.102.2", path = "crates/rspack_plugin_javascript", default-features = false }
-rspack_plugin_json                     = { version = "=0.102.2", path = "crates/rspack_plugin_json", default-features = false }
-rspack_plugin_lazy_compilation         = { version = "=0.102.2", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
-rspack_plugin_library                  = { version = "=0.102.2", path = "crates/rspack_plugin_library", default-features = false }
-rspack_plugin_lightning_css_minimizer  = { version = "=0.102.2", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
-rspack_plugin_limit_chunk_count        = { version = "=0.102.2", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
-rspack_plugin_merge_duplicate_chunks   = { version = "=0.102.2", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
-rspack_plugin_mf                       = { version = "=0.102.2", path = "crates/rspack_plugin_mf", default-features = false }
-rspack_plugin_module_info_header       = { version = "=0.102.2", path = "crates/rspack_plugin_module_info_header", default-features = false }
-rspack_plugin_module_replacement       = { version = "=0.102.2", path = "crates/rspack_plugin_module_replacement", default-features = false }
-rspack_plugin_no_emit_on_errors        = { version = "=0.102.2", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
-rspack_plugin_progress                 = { version = "=0.102.2", path = "crates/rspack_plugin_progress", default-features = false }
-rspack_plugin_real_content_hash        = { version = "=0.102.2", path = "crates/rspack_plugin_real_content_hash", default-features = false }
-rspack_plugin_remove_duplicate_modules = { version = "=0.102.2", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
-rspack_plugin_remove_empty_chunks      = { version = "=0.102.2", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
-rspack_plugin_rsc                      = { version = "=0.102.2", path = "crates/rspack_plugin_rsc", default-features = false }
-rspack_plugin_rsdoctor                 = { version = "=0.102.2", path = "crates/rspack_plugin_rsdoctor", default-features = false }
-rspack_plugin_rslib                    = { version = "=0.102.2", path = "crates/rspack_plugin_rslib", default-features = false }
-rspack_plugin_rstest                   = { version = "=0.102.2", path = "crates/rspack_plugin_rstest", default-features = false }
-rspack_plugin_runtime                  = { version = "=0.102.2", path = "crates/rspack_plugin_runtime", default-features = false }
-rspack_plugin_runtime_chunk            = { version = "=0.102.2", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
-rspack_plugin_schemes                  = { version = "=0.102.2", path = "crates/rspack_plugin_schemes", default-features = false }
-rspack_plugin_size_limits              = { version = "=0.102.2", path = "crates/rspack_plugin_size_limits", default-features = false }
-rspack_plugin_split_chunks             = { version = "=0.102.2", path = "crates/rspack_plugin_split_chunks", default-features = false }
-rspack_plugin_sri                      = { version = "=0.102.2", path = "crates/rspack_plugin_sri", default-features = false }
-rspack_plugin_swc_js_minimizer         = { version = "=0.102.2", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
-rspack_plugin_wasm                     = { version = "=0.102.2", path = "crates/rspack_plugin_wasm", default-features = false }
-rspack_plugin_worker                   = { version = "=0.102.2", path = "crates/rspack_plugin_worker", default-features = false }
-rspack_regex                           = { version = "=0.102.2", path = "crates/rspack_regex", default-features = false }
-rspack_resolver                        = { version = "=0.102.2", path = "crates/rspack_resolver", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
-rspack_sources                         = { version = "=0.102.2", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
-rspack_storage                         = { version = "=0.102.2", path = "crates/rspack_storage", default-features = false }
-rspack_swc_plugin_import               = { version = "=0.102.2", path = "crates/swc_plugin_import", default-features = false }
-rspack_swc_plugin_ts_collector         = { version = "=0.102.2", path = "crates/swc_plugin_ts_collector", default-features = false }
-rspack_tasks                           = { version = "=0.102.2", path = "crates/rspack_tasks", default-features = false }
-rspack_tracing                         = { version = "=0.102.2", path = "crates/rspack_tracing", default-features = false }
-rspack_tracing_perfetto                = { version = "=0.102.2", path = "crates/rspack_tracing_perfetto", default-features = false }
-rspack_util                            = { version = "=0.102.2", path = "crates/rspack_util", default-features = false }
-rspack_watcher                         = { version = "=0.102.2", path = "crates/rspack_watcher", default-features = false }
-rspack_workspace                       = { version = "=0.102.2", path = "crates/rspack_workspace", default-features = false }
+css-module-lexer                       = { version = "=0.102.3", path = "crates/css-module-lexer", default-features = false }
+rspack                                 = { version = "=0.102.3", path = "crates/rspack", default-features = false }
+rspack_allocator                       = { version = "=0.102.3", path = "crates/rspack_allocator", default-features = false }
+rspack_binding_api                     = { version = "=0.102.3", path = "crates/rspack_binding_api", default-features = false }
+rspack_binding_build                   = { version = "=0.102.3", path = "crates/rspack_binding_build", default-features = false }
+rspack_binding_builder                 = { version = "=0.102.3", path = "crates/rspack_binding_builder", default-features = false }
+rspack_binding_builder_macros          = { version = "=0.102.3", path = "crates/rspack_binding_builder_macros", default-features = false }
+rspack_browserslist                    = { version = "=0.102.3", path = "crates/rspack_browserslist", default-features = false }
+rspack_cacheable                       = { version = "=0.102.3", path = "crates/rspack_cacheable", default-features = false }
+rspack_cacheable_macros                = { version = "=0.102.3", path = "crates/rspack_cacheable_macros", default-features = false }
+rspack_collections                     = { version = "=0.102.3", path = "crates/rspack_collections", default-features = false }
+rspack_core                            = { version = "=0.102.3", path = "crates/rspack_core", default-features = false }
+rspack_dojang                          = { version = "=0.102.3", path = "crates/rspack_dojang", default-features = false }
+rspack_error                           = { version = "=0.102.3", path = "crates/rspack_error", default-features = false }
+rspack_fs                              = { version = "=0.102.3", path = "crates/rspack_fs", default-features = false }
+rspack_hash                            = { version = "=0.102.3", path = "crates/rspack_hash", default-features = false }
+rspack_hook                            = { version = "=0.102.3", path = "crates/rspack_hook", default-features = false }
+rspack_ids                             = { version = "=0.102.3", path = "crates/rspack_ids", default-features = false }
+rspack_intern                          = { version = "=0.102.3", path = "crates/rspack_intern", default-features = false }
+rspack_javascript_compiler             = { version = "=0.102.3", path = "crates/rspack_javascript_compiler", default-features = false }
+rspack_loader_lightningcss             = { version = "=0.102.3", path = "crates/rspack_loader_lightningcss", default-features = false }
+rspack_loader_preact_refresh           = { version = "=0.102.3", path = "crates/rspack_loader_preact_refresh", default-features = false }
+rspack_loader_react_refresh            = { version = "=0.102.3", path = "crates/rspack_loader_react_refresh", default-features = false }
+rspack_loader_runner                   = { version = "=0.102.3", path = "crates/rspack_loader_runner", default-features = false }
+rspack_loader_swc                      = { version = "=0.102.3", path = "crates/rspack_loader_swc", default-features = false }
+rspack_loader_testing                  = { version = "=0.102.3", path = "crates/rspack_loader_testing", default-features = false }
+rspack_location                        = { version = "=0.102.3", path = "crates/rspack_location", default-features = false }
+rspack_macros                          = { version = "=0.102.3", path = "crates/rspack_macros", default-features = false }
+rspack_napi                            = { version = "=0.102.3", path = "crates/rspack_napi", default-features = false }
+rspack_napi_macros                     = { version = "=0.102.3", path = "crates/rspack_napi_macros", default-features = false }
+rspack_parallel                        = { version = "=0.102.3", path = "crates/rspack_parallel", default-features = false }
+rspack_paths                           = { version = "=0.102.3", path = "crates/rspack_paths", default-features = false }
+rspack_plugin_asset                    = { version = "=0.102.3", path = "crates/rspack_plugin_asset", default-features = false }
+rspack_plugin_banner                   = { version = "=0.102.3", path = "crates/rspack_plugin_banner", default-features = false }
+rspack_plugin_case_sensitive           = { version = "=0.102.3", path = "crates/rspack_plugin_case_sensitive", default-features = false }
+rspack_plugin_circular_dependencies    = { version = "=0.102.3", path = "crates/rspack_plugin_circular_dependencies", default-features = false }
+rspack_plugin_copy                     = { version = "=0.102.3", path = "crates/rspack_plugin_copy", default-features = false }
+rspack_plugin_css                      = { version = "=0.102.3", path = "crates/rspack_plugin_css", default-features = false }
+rspack_plugin_css_chunking             = { version = "=0.102.3", path = "crates/rspack_plugin_css_chunking", default-features = false }
+rspack_plugin_devtool                  = { version = "=0.102.3", path = "crates/rspack_plugin_devtool", default-features = false }
+rspack_plugin_dll                      = { version = "=0.102.3", path = "crates/rspack_plugin_dll", default-features = false }
+rspack_plugin_dynamic_entry            = { version = "=0.102.3", path = "crates/rspack_plugin_dynamic_entry", default-features = false }
+rspack_plugin_ensure_chunk_conditions  = { version = "=0.102.3", path = "crates/rspack_plugin_ensure_chunk_conditions", default-features = false }
+rspack_plugin_entry                    = { version = "=0.102.3", path = "crates/rspack_plugin_entry", default-features = false }
+rspack_plugin_esm_library              = { version = "=0.102.3", path = "crates/rspack_plugin_esm_library", default-features = false }
+rspack_plugin_externals                = { version = "=0.102.3", path = "crates/rspack_plugin_externals", default-features = false }
+rspack_plugin_extract_css              = { version = "=0.102.3", path = "crates/rspack_plugin_extract_css", default-features = false }
+rspack_plugin_hmr                      = { version = "=0.102.3", path = "crates/rspack_plugin_hmr", default-features = false }
+rspack_plugin_html                     = { version = "=0.102.3", path = "crates/rspack_plugin_html", default-features = false }
+rspack_plugin_ignore                   = { version = "=0.102.3", path = "crates/rspack_plugin_ignore", default-features = false }
+rspack_plugin_javascript               = { version = "=0.102.3", path = "crates/rspack_plugin_javascript", default-features = false }
+rspack_plugin_json                     = { version = "=0.102.3", path = "crates/rspack_plugin_json", default-features = false }
+rspack_plugin_lazy_compilation         = { version = "=0.102.3", path = "crates/rspack_plugin_lazy_compilation", default-features = false }
+rspack_plugin_library                  = { version = "=0.102.3", path = "crates/rspack_plugin_library", default-features = false }
+rspack_plugin_lightning_css_minimizer  = { version = "=0.102.3", path = "crates/rspack_plugin_lightning_css_minimizer", default-features = false }
+rspack_plugin_limit_chunk_count        = { version = "=0.102.3", path = "crates/rspack_plugin_limit_chunk_count", default-features = false }
+rspack_plugin_merge_duplicate_chunks   = { version = "=0.102.3", path = "crates/rspack_plugin_merge_duplicate_chunks", default-features = false }
+rspack_plugin_mf                       = { version = "=0.102.3", path = "crates/rspack_plugin_mf", default-features = false }
+rspack_plugin_module_info_header       = { version = "=0.102.3", path = "crates/rspack_plugin_module_info_header", default-features = false }
+rspack_plugin_module_replacement       = { version = "=0.102.3", path = "crates/rspack_plugin_module_replacement", default-features = false }
+rspack_plugin_no_emit_on_errors        = { version = "=0.102.3", path = "crates/rspack_plugin_no_emit_on_errors", default-features = false }
+rspack_plugin_progress                 = { version = "=0.102.3", path = "crates/rspack_plugin_progress", default-features = false }
+rspack_plugin_real_content_hash        = { version = "=0.102.3", path = "crates/rspack_plugin_real_content_hash", default-features = false }
+rspack_plugin_remove_duplicate_modules = { version = "=0.102.3", path = "crates/rspack_plugin_remove_duplicate_modules", default-features = false }
+rspack_plugin_remove_empty_chunks      = { version = "=0.102.3", path = "crates/rspack_plugin_remove_empty_chunks", default-features = false }
+rspack_plugin_rsc                      = { version = "=0.102.3", path = "crates/rspack_plugin_rsc", default-features = false }
+rspack_plugin_rsdoctor                 = { version = "=0.102.3", path = "crates/rspack_plugin_rsdoctor", default-features = false }
+rspack_plugin_rslib                    = { version = "=0.102.3", path = "crates/rspack_plugin_rslib", default-features = false }
+rspack_plugin_rstest                   = { version = "=0.102.3", path = "crates/rspack_plugin_rstest", default-features = false }
+rspack_plugin_runtime                  = { version = "=0.102.3", path = "crates/rspack_plugin_runtime", default-features = false }
+rspack_plugin_runtime_chunk            = { version = "=0.102.3", path = "crates/rspack_plugin_runtime_chunk", default-features = false }
+rspack_plugin_schemes                  = { version = "=0.102.3", path = "crates/rspack_plugin_schemes", default-features = false }
+rspack_plugin_size_limits              = { version = "=0.102.3", path = "crates/rspack_plugin_size_limits", default-features = false }
+rspack_plugin_split_chunks             = { version = "=0.102.3", path = "crates/rspack_plugin_split_chunks", default-features = false }
+rspack_plugin_sri                      = { version = "=0.102.3", path = "crates/rspack_plugin_sri", default-features = false }
+rspack_plugin_swc_js_minimizer         = { version = "=0.102.3", path = "crates/rspack_plugin_swc_js_minimizer", default-features = false }
+rspack_plugin_wasm                     = { version = "=0.102.3", path = "crates/rspack_plugin_wasm", default-features = false }
+rspack_plugin_worker                   = { version = "=0.102.3", path = "crates/rspack_plugin_worker", default-features = false }
+rspack_regex                           = { version = "=0.102.3", path = "crates/rspack_regex", default-features = false }
+rspack_resolver                        = { version = "=0.102.3", path = "crates/rspack_resolver", default-features = false, features = ["package_json_raw_json_api", "yarn_pnp"] }
+rspack_sources                         = { version = "=0.102.3", path = "crates/rspack_sources", default-features = false, features = ["rspack_cacheable"] }
+rspack_storage                         = { version = "=0.102.3", path = "crates/rspack_storage", default-features = false }
+rspack_swc_plugin_import               = { version = "=0.102.3", path = "crates/swc_plugin_import", default-features = false }
+rspack_swc_plugin_ts_collector         = { version = "=0.102.3", path = "crates/swc_plugin_ts_collector", default-features = false }
+rspack_tasks                           = { version = "=0.102.3", path = "crates/rspack_tasks", default-features = false }
+rspack_tracing                         = { version = "=0.102.3", path = "crates/rspack_tracing", default-features = false }
+rspack_tracing_perfetto                = { version = "=0.102.3", path = "crates/rspack_tracing_perfetto", default-features = false }
+rspack_util                            = { version = "=0.102.3", path = "crates/rspack_util", default-features = false }
+rspack_watcher                         = { version = "=0.102.3", path = "crates/rspack_watcher", default-features = false }
+rspack_workspace                       = { version = "=0.102.3", path = "crates/rspack_workspace", default-features = false }
 
 
 [workspace.metadata.release]

--- a/crates/node_binding/package.json
+++ b/crates/node_binding/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "binding.js",

--- a/crates/rspack_workspace/src/generated.rs
+++ b/crates/rspack_workspace/src/generated.rs
@@ -6,5 +6,5 @@ pub const fn rspack_swc_core_version() -> &'static str {
 
 /// The version of the JavaScript `@rspack/core` package.
 pub const fn rspack_pkg_version() -> &'static str {
-  "2.2.2"
+  "2.2.3"
 }

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-arm64",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-arm64.node",

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-darwin-x64",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.darwin-x64.node",

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-gnu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-gnu.node",

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-arm64-musl",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-arm64-musl.node",

--- a/npm/linux-ppc64-gnu/package.json
+++ b/npm/linux-ppc64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-ppc64-gnu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-ppc64-gnu.node",

--- a/npm/linux-riscv64-gnu/package.json
+++ b/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-gnu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-gnu.node",

--- a/npm/linux-riscv64-musl/package.json
+++ b/npm/linux-riscv64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-riscv64-musl",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-riscv64-musl.node",

--- a/npm/linux-s390x-gnu/package.json
+++ b/npm/linux-s390x-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-s390x-gnu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-s390x-gnu.node",

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-gnu",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-gnu.node",

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-linux-x64-musl",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.linux-x64-musl.node",

--- a/npm/wasm32-wasi/package.json
+++ b/npm/wasm32-wasi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-wasm32-wasi",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.wasi.cjs",

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-arm64-msvc",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-arm64-msvc.node",

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-ia32-msvc",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-ia32-msvc.node",

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/binding-win32-x64-msvc",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Node binding for rspack",
   "main": "rspack.win32-x64-msvc.node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monorepo",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",
   "private": true,

--- a/packages/create-rspack/package.json
+++ b/packages/create-rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rspack",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",
   "repository": {

--- a/packages/rspack-browser/package.json
+++ b/packages/rspack-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/browser",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Rspack for running in the browser. This is still in early stage and may not follow the semver.",

--- a/packages/rspack-cli/package.json
+++ b/packages/rspack-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/cli",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "CLI for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack-test-tools/package.json
+++ b/packages/rspack-test-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/test-tools",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Test tools for rspack",
   "homepage": "https://rspack.rs",
   "bugs": "https://github.com/web-infra-dev/rspack/issues",

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rspack/core",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "webpackVersion": "5.75.0",
   "license": "MIT",
   "description": "Fast Rust-based bundler for the web with a modernized webpack API",


### PR DESCRIPTION
## Summary

Prepare the v2.2.3 patch release by updating published JavaScript packages to 2.2.3 and Rust workspace crates to 0.102.3, including exact internal dependency versions, Cargo.lock, and generated version metadata.

## Release Information

- Released By: SyMind
- Release Date: 2026-09-08
- JavaScript Packages Version: 2.2.3
- Rust Crates Version: 0.102.3

## Validation

- Completed `./x version patch`, including `cargo codegen` and `pnpm run format:js`.
- Verified all 24 changed files contain only the expected version updates: 21 npm manifests, 90 Rust dependency pins, and 96 Rust workspace packages.
- Passed `cargo metadata --format-version 1 --no-deps --locked --offline` and `git diff origin/main --check`.
- Full build and test suites were not run locally; Ecosystem CI will be triggered for this PR.

## Related links

- [Release procedure](https://github.com/web-infra-dev/rspack/blob/main/website/docs/en/contribute/development/releasing.md)

## Checklist

- [x] Tests updated (or not required): version-only changes.
- [x] Documentation updated (or not required): no API changes.
