### PR TITLE
fix(css): skip esm flag for concatenated modules

### DIFF
--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -5,7 +5,7 @@ use rspack_collections::IdentifierSet;
 use rspack_core::{
   ChunkGraph, Context, CssBuildInfo, CssExport, CssExportType, CssExports,
   CssModuleRenderCondition, Dependency, DependencyCodeGeneration, DependencyId, DependencyType,
-  ExportsArgument, GenerateContext, Module, ModuleArgument, ModuleIdentifier, ModuleInitFragments,
+  GenerateContext, Module, ModuleArgument, ModuleIdentifier, ModuleInitFragments,
   RESERVED_IDENTIFIER, RuntimeGlobals, SourceType, TemplateContext, UsageState, UsedNameItem,
   css_module_render_conditions_identifier,
   rspack_sources::{
@@ -702,19 +702,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       .exports_info_artifact
       .get_exports_info_data(&module.identifier());
     let mut state = CssConcatenationState::new(compilation);
-
-    if self.es_module {
-      let exports_argument = if compilation.options.output.module {
-        ExportsArgument::RspackExports
-      } else {
-        self.module.get_exports_argument()
-      };
-      let esm_flag = self
-        .generate_context
-        .runtime_template
-        .define_es_module_flag_statement(exports_argument);
-      self.concat_source.add(RawStringSource::from(esm_flag));
-    }
 
     if let Some(default_expr) = default_expr {
       let export_info = exports_info.get_read_only_export_info(&Atom::from("default"));

--- a/tests/rspack-test/configCases/css/external-in-node/index.js
+++ b/tests/rspack-test/configCases/css/external-in-node/index.js
@@ -1,4 +1,4 @@
 it("should import an external css", async () => {
 	const x = await import("../external/style.css");
-	expect(x).toEqual(nsObj({}));
+	expect(x).toEqual({});
 });

--- a/tests/rspack-test/configCases/css/issue-15537/index.js
+++ b/tests/rspack-test/configCases/css/issue-15537/index.js
@@ -1,0 +1,3 @@
+import getClassName from "./module";
+
+globalThis.cssClassName = getClassName();

--- a/tests/rspack-test/configCases/css/issue-15537/module.js
+++ b/tests/rspack-test/configCases/css/issue-15537/module.js
@@ -1,0 +1,5 @@
+import styles from "./style.css";
+
+export default function getClassName() {
+  return styles.foo;
+}

--- a/tests/rspack-test/configCases/css/issue-15537/rspack.config.js
+++ b/tests/rspack-test/configCases/css/issue-15537/rspack.config.js
@@ -1,0 +1,27 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  target: 'web',
+  mode: 'production',
+  devtool: false,
+  experiments: {
+    css: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        type: 'css/module',
+      },
+    ],
+    parser: {
+      'css/module': {
+        namedExports: false,
+        exportType: 'link',
+      },
+    },
+  },
+  optimization: {
+    concatenateModules: true,
+    minimize: false,
+  },
+};

--- a/tests/rspack-test/configCases/css/issue-15537/style.css
+++ b/tests/rspack-test/configCases/css/issue-15537/style.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/tests/rspack-test/configCases/css/issue-15537/test.config.js
+++ b/tests/rspack-test/configCases/css/issue-15537/test.config.js
@@ -1,0 +1,35 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+module.exports = {
+  findBundle: () => [],
+  validate(stats, _stderr, options) {
+    const config = Array.isArray(options) ? options[0] : options;
+    const source = fs.readFileSync(
+      path.resolve(config.output.path, "bundle0.js"),
+      "utf-8",
+    );
+    const context = vm.createContext({});
+
+    vm.runInContext(source, context);
+
+    expect(typeof context.cssClassName).toBe("string");
+
+    const statsJson = stats.toJson({
+      modules: true,
+      nestedModules: true,
+    });
+    const modules =
+      statsJson.modules ??
+      statsJson.children?.flatMap((child) => child.modules ?? []) ??
+      [];
+    const concatenatedModule = modules.find((module) =>
+      module.modules?.some((innerModule) =>
+        innerModule.identifier.endsWith("style.css"),
+      ),
+    );
+
+    expect(concatenatedModule).toBeDefined();
+  },
+};


### PR DESCRIPTION
## Summary

- Stop the CSS generator from emitting an ESM compatibility flag while rendering inside a concatenation scope.
- Add a regression case that executes the browser bundle without a CommonJS `exports` binding and verifies that the CSS module was actually concatenated.
- Align the existing empty CSS dynamic-import expectation with webpack's plain empty exports object.

## Why this fixes the crash

A normal module runs inside a module factory, so its `exports` argument exists. A concatenated inner module does not have its own factory or exports object: its source is hoisted into the concatenated module and its exports are represented by local bindings registered through `ConcatenationScope::register_export`.

The CSS concatenation branch already registers those local bindings correctly, but it additionally emitted `makeNamespaceObject(exports)`. In the browser bundle from #15537, that statement was hoisted alongside the CSS module source, where `exports` is unbound, causing `ReferenceError: exports is not defined` before the entry can run.

Removing the inner flag keeps export registration unchanged and removes the invalid reference. Export-object rendering remains owned by the outer concatenated module.

## webpack behavior

webpack does not give CSS a separate ESM-marker path during concatenation:

1. Its [`CssGenerator` concatenation branch](https://github.com/webpack/webpack/blob/v5.108.4/lib/css/CssGenerator.js#L383-L443) registers the default and named exports as local identifiers, then returns before the non-concatenated namespace-object logic.
2. Its [`ConcatenatedModule` renderer](https://github.com/webpack/webpack/blob/v5.108.4/lib/optimize/ConcatenatedModule.js#L2009-L2038) emits the outer ESM compatibility flag only together with a non-empty exports map.

I also compiled both relevant shapes with webpack 5.108.4:

- The #15537 reproduction contains no inner `makeNamespaceObject(exports)` call and executes successfully.
- An async chunk rooted at an empty CSS module contains zero `makeNamespaceObject` calls; its dynamic import resolves to a plain `{}` with no `Symbol.toStringTag`. The previous `external-in-node` expectation used `nsObj({})`, so this PR updates that assertion to match webpack instead of adding a CSS-only marker to the generic concatenation renderer.

## Related links

- Fixes #15537

## Validation

- `pnpm run build:binding:dev`
- `pnpm --dir tests/rspack-test run test -t "configCases/css/issue-15537"`
- `pnpm --dir tests/rspack-test run test -t "configCases/css/external-in-node"`
- `pnpm --dir tests/rspack-test run test -t "configCases/css/export-type-concatenation"`
- `pnpm --dir tests/rspack-test run test -t "configCases/css/concatenation-no-runtime"`
- `pnpm run test:unit` (Rspack: 9232 passed, 4 skipped; CLI: 90 passed, 1 skipped; binding type tests passed)
- `pnpm run lint:js`
- `cargo fmt --all --check`

## Checklist

- [x] Tests updated.
- [x] Documentation not required; there is no public API change.
