### PR TITLE
fix(ids): stabilize named external module ids

### DIFF
--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -116,6 +116,43 @@ pub fn get_short_module_name(module: &BoxModule, context: &str) -> String {
   String::new()
 }
 
+pub(crate) fn get_short_module_name_with_graph(
+  module: &BoxModule,
+  context: &str,
+  module_graph: &ModuleGraph,
+) -> String {
+  if module.as_external_module().is_some()
+    && let Some(module_graph_module) =
+      module_graph.module_graph_module_by_identifier(&module.identifier())
+  {
+    let mut requests = module_graph_module
+      .incoming_connections()
+      .iter()
+      .filter_map(|dependency_id| {
+        module_graph
+          .dependency_by_id(dependency_id)
+          .as_module_dependency()
+      })
+      .map(|dependency| dependency.request());
+    if let Some(first_request) = requests.next() {
+      let mut min_request = first_request;
+      let mut has_multiple_requests = false;
+      for request in requests {
+        has_multiple_requests |= request != first_request;
+        min_request = min_request.min(request);
+      }
+      if has_multiple_requests {
+        // External modules are deduplicated by their resolved request. Choose a stable
+        // name from all incoming requests instead of the request whose factorization
+        // happened to finish first.
+        return avoid_number(min_request).to_string();
+      }
+    }
+  }
+
+  get_short_module_name(module, context)
+}
+
 fn avoid_number(s: &str) -> Cow<'_, str> {
   if s.len() > 21 {
     return Cow::Borrowed(s);
@@ -461,7 +498,7 @@ pub fn get_short_chunk_name(
   let short_module_names = modules
     .iter()
     .map(|module| {
-      let name = get_short_module_name(module, context);
+      let name = get_short_module_name_with_graph(module, context, module_graph);
       request_to_id(&name)
     })
     .collect::<Vec<_>>();
@@ -525,7 +562,7 @@ pub fn get_long_chunk_name(
 
   let short_module_names = modules
     .iter()
-    .map(|m| request_to_id(&get_short_module_name(m, context)))
+    .map(|m| request_to_id(&get_short_module_name_with_graph(m, context, module_graph)))
     .collect::<Vec<_>>();
 
   let long_module_names = modules

--- a/crates/rspack_ids/src/named_module_ids_plugin.rs
+++ b/crates/rspack_ids/src/named_module_ids_plugin.rs
@@ -11,7 +11,7 @@ use rspack_hook::{plugin, plugin_hook};
 use rspack_util::{comparators::compare_ids, itoa};
 
 use crate::id_helpers::{
-  get_long_module_name, get_short_module_name, should_assign_module_id_without_chunk,
+  get_long_module_name, get_short_module_name_with_graph, should_assign_module_id_without_chunk,
 };
 
 fn add_conflicted_module_name(
@@ -44,7 +44,11 @@ fn assign_named_module_ids(
       let module = module_graph
         .module_by_identifier(&item)
         .expect("should have module");
-      let name = ModuleId::from(get_short_module_name(module, context));
+      let name = ModuleId::from(get_short_module_name_with_graph(
+        module,
+        context,
+        module_graph,
+      ));
       (item, name)
     })
     .collect();

--- a/tests/rspack-test/hashCases/external-module-id-resolution-order/index.js
+++ b/tests/rspack-test/hashCases/external-module-id-resolution-order/index.js
@@ -1,0 +1,1 @@
+module.exports = [require('./shared'), require('../shared')];

--- a/tests/rspack-test/hashCases/external-module-id-resolution-order/rspack.config.js
+++ b/tests/rspack-test/hashCases/external-module-id-resolution-order/rspack.config.js
@@ -1,0 +1,40 @@
+const path = require('path');
+
+function config(name, delayedRequest) {
+  return {
+    name,
+    mode: 'production',
+    context: __dirname,
+    entry: './index.js',
+    target: 'node',
+    cache: false,
+    devtool: 'source-map',
+    output: {
+      path: path.resolve(__dirname, `dist/${name}`),
+      filename: 'bundle.js',
+      library: { type: 'commonjs2' },
+    },
+    optimization: {
+      moduleIds: 'named',
+      minimize: false,
+      concatenateModules: false,
+    },
+    externals: [
+      ({ request }, callback) => {
+        if (request !== './shared' && request !== '../shared') {
+          return callback();
+        }
+        setTimeout(
+          () => callback(null, 'commonjs node:path'),
+          request === delayedRequest ? 100 : 0,
+        );
+      },
+    ],
+  };
+}
+
+/** @type {import('@rspack/core').Configuration[]} */
+module.exports = [
+  config('delay-parent-request', '../shared'),
+  config('delay-current-request', './shared'),
+];

--- a/tests/rspack-test/hashCases/external-module-id-resolution-order/test.config.js
+++ b/tests/rspack-test/hashCases/external-module-id-resolution-order/test.config.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+
+/** @type {import('@rspack/test-tools').THashCaseConfig} */
+module.exports = {
+  validate(stats) {
+    const [delayParent, delayCurrent] = stats.stats;
+    const getExternalModule = (childStats) =>
+      childStats
+        .toJson({ all: false, modules: true, ids: true })
+        .modules.find((module) => module.identifier.startsWith('external '));
+
+    const delayParentExternal = getExternalModule(delayParent);
+    const delayCurrentExternal = getExternalModule(delayCurrent);
+    expect(delayParentExternal).toBeDefined();
+    expect(delayCurrentExternal).toBeDefined();
+    expect(delayParentExternal.identifier).toBe(delayCurrentExternal.identifier);
+    expect(delayParentExternal.id).toBe(delayCurrentExternal.id);
+
+    for (const asset of ['bundle.js', 'bundle.js.map']) {
+      const delayParentSource = fs.readFileSync(
+        path.resolve(__dirname, 'dist/delay-parent-request', asset),
+      );
+      const delayCurrentSource = fs.readFileSync(
+        path.resolve(__dirname, 'dist/delay-current-request', asset),
+      );
+      expect(delayParentSource).toEqual(delayCurrentSource);
+    }
+  },
+};


### PR DESCRIPTION
## Summary

- derive named external module IDs from the lexicographically smallest incoming request when multiple requests resolve to the same external module
- preserve the existing module ID for single-request external modules
- add regression coverage for reversed async external resolution order, including byte-identical JavaScript and source maps

## Related links

Closes #15529

## Testing

- pnpm run test:unit (47 rspack-test files passed; 9230 passed, 4 skipped; CLI tests passed)
- pnpm run build:js
- pnpm run build:binding:dev
- pnpm --dir tests/rspack-test test -t external-module-id-resolution-order
- pnpm --dir tests/rspack-test test -t configCases/externals
- cargo check -p rspack_ids --all-targets --locked
- pnpm run lint:js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).