### PR TITLE
feat: add array chunk loading

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -2333,6 +2333,7 @@ export interface RawExperiments {
   deferImport: boolean
   sourceImport: boolean
   pureFunctions: boolean
+  chunkArrayLoading: boolean
   runtimeMode?: "webpack" | "rspack"
 }
 

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -3713,6 +3713,7 @@ pub struct ExperimentsBuilder {
   source_import: Option<bool>,
   // TODO: lazy compilation
   pure_functions: Option<bool>,
+  chunk_array_loading: Option<bool>,
   runtime_mode: Option<RuntimeMode>,
 }
 
@@ -3726,6 +3727,7 @@ impl From<Experiments> for ExperimentsBuilder {
       defer_import: Some(value.defer_import),
       source_import: Some(value.source_import),
       pure_functions: Some(value.pure_functions),
+      chunk_array_loading: Some(value.chunk_array_loading),
       runtime_mode: Some(value.runtime_mode),
     }
   }
@@ -3741,12 +3743,19 @@ impl From<&mut ExperimentsBuilder> for ExperimentsBuilder {
       defer_import: value.defer_import.take(),
       source_import: value.source_import.take(),
       pure_functions: value.pure_functions.take(),
+      chunk_array_loading: value.chunk_array_loading.take(),
       runtime_mode: value.runtime_mode.take(),
     }
   }
 }
 
 impl ExperimentsBuilder {
+  /// Set whether to load asynchronous chunk lists with a single array call.
+  pub fn chunk_array_loading(&mut self, enabled: bool) -> &mut Self {
+    self.chunk_array_loading = Some(enabled);
+    self
+  }
+
   /// Set whether to enable future defaults.
   pub fn future_defaults(&mut self, future_defaults: bool) -> &mut Self {
     self.future_defaults = Some(future_defaults);
@@ -3807,6 +3816,7 @@ impl ExperimentsBuilder {
       defer_import: d!(self.defer_import, false),
       source_import: d!(self.source_import, false),
       pure_functions: d!(self.pure_functions, _production),
+      chunk_array_loading: d!(self.chunk_array_loading, false),
       runtime_mode: d!(self.runtime_mode, RuntimeMode::Webpack),
     })
   }

--- a/crates/rspack/tests/snapshots/defaults__default_options.snap
+++ b/crates/rspack/tests/snapshots/defaults__default_options.snap
@@ -1759,6 +1759,7 @@ CompilerOptions {
         defer_import: false,
         source_import: false,
         pure_functions: false,
+        chunk_array_loading: false,
         runtime_mode: Webpack,
     },
     incremental: IncrementalOptions {

--- a/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
+++ b/crates/rspack_binding_api/src/raw_options/raw_experiments/mod.rs
@@ -20,6 +20,7 @@ pub struct RawExperiments {
   pub defer_import: bool,
   pub source_import: bool,
   pub pure_functions: bool,
+  pub chunk_array_loading: bool,
   #[napi(ts_type = "\"webpack\" | \"rspack\"")]
   pub runtime_mode: Option<String>,
 }
@@ -41,6 +42,7 @@ impl From<RawExperiments> for Experiments {
       defer_import: value.defer_import,
       source_import: value.source_import,
       pure_functions: value.pure_functions,
+      chunk_array_loading: value.chunk_array_loading,
       runtime_mode,
     }
   }

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -324,10 +324,18 @@ pub struct Compilation {
   ///
   /// Rebuild will include previous compilation data, so persistent cache will not recovery anything
   pub is_rebuild: bool,
+  /// HMR wraps require per module; keep its chunk-loading calls in their scalar form.
+  pub hot_module_replacement_enabled: bool,
   pub compiler_context: Arc<CompilerContext>,
 }
 
 impl Compilation {
+  pub fn chunk_array_loading_enabled(&self) -> bool {
+    self.options.experiments.chunk_array_loading
+      && self.options.mode == crate::Mode::Production
+      && !self.hot_module_replacement_enabled
+  }
+
   pub const OPTIMIZE_CHUNKS_STAGE_BASIC: i32 = -10;
   pub const OPTIMIZE_CHUNKS_STAGE_ADVANCED: i32 = 10;
 
@@ -383,6 +391,7 @@ impl Compilation {
       id: CompilationId::new(),
       compiler_id,
       hot_index: 0,
+      hot_module_replacement_enabled: false,
       runtime_template: RuntimeTemplate::new(options.clone()),
       records,
       options: options.clone(),

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -227,6 +227,9 @@ impl AsyncDependenciesBlock {
     runtime: Option<&RuntimeSpec>,
   ) {
     self.group_options.hash(hasher);
+    if compilation.chunk_array_loading_enabled() {
+      "chunk array loading".hash(hasher);
+    }
     if let Some(chunk_group) = compilation
       .build_chunk_graph_artifact
       .chunk_graph

--- a/crates/rspack_core/src/options/experiments/mod.rs
+++ b/crates/rspack_core/src/options/experiments/mod.rs
@@ -55,5 +55,6 @@ pub struct Experiments {
   pub defer_import: bool,
   pub source_import: bool,
   pub pure_functions: bool,
+  pub chunk_array_loading: bool,
   pub runtime_mode: RuntimeMode,
 }

--- a/crates/rspack_core/src/runtime_globals.rs
+++ b/crates/rspack_core/src/runtime_globals.rs
@@ -312,6 +312,9 @@ define_runtime_globals! {
 
   // reexport
   const REEXPORT;
+
+  // A code-generation capability flag, not a property on the runtime object.
+  const HAS_CHUNK_ARRAY;
 }
 
 impl Default for RuntimeGlobals {
@@ -332,6 +335,7 @@ pub static REQUIRE_SCOPE_GLOBALS: LazyLock<RuntimeGlobals> = LazyLock::new(|| {
       | RuntimeGlobals::THIS_AS_EXPORTS
       | RuntimeGlobals::HAS_CSS_MODULES
       | RuntimeGlobals::HAS_FETCH_PRIORITY
+      | RuntimeGlobals::HAS_CHUNK_ARRAY
       | RuntimeGlobals::STARTUP_NO_DEFAULT
       | RuntimeGlobals::STARTUP_CHUNK_DEPENDENCIES
       | RuntimeGlobals::ENSURE_CHUNK_INCLUDE_ENTRIES
@@ -449,6 +453,7 @@ pub fn runtime_globals_property_name(runtime_globals: &RuntimeGlobals) -> Option
     RuntimeGlobals::CSS_STYLE_SHEET => "css",
     RuntimeGlobals::ASYNC_STARTUP => "asyncStartup",
     RuntimeGlobals::HAS_FETCH_PRIORITY => "has fetch priority",
+    RuntimeGlobals::HAS_CHUNK_ARRAY => "has chunk array",
 
     RuntimeGlobals::RSC_MANIFEST => "rscM",
     RuntimeGlobals::TO_BINARY => "tb",

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1132,6 +1132,27 @@ impl ModuleCodeTemplate {
           .insert(RuntimeGlobals::HAS_FETCH_PRIORITY);
       }
 
+      if compilation.chunk_array_loading_enabled() {
+        self
+          .runtime_requirements
+          .insert(RuntimeGlobals::HAS_CHUNK_ARRAY);
+        return format!(
+          "{}({comment}[{}]{})",
+          self.render_runtime_globals(&RuntimeGlobals::ENSURE_CHUNK),
+          chunks
+            .iter()
+            .map(
+              |chunk| simd_json::to_string(chunk.id().expect("should have chunk.id"))
+                .expect("should able to json stringify")
+            )
+            .collect::<Vec<_>>()
+            .join(", "),
+          fetch_priority
+            .map(|priority| format!(r#", "{priority}""#))
+            .unwrap_or_default()
+        );
+      }
+
       format!(
         "Promise.all({comment}[{}])",
         chunks

--- a/crates/rspack_plugin_esm_library/src/runtime.rs
+++ b/crates/rspack_plugin_esm_library/src/runtime.rs
@@ -1,8 +1,9 @@
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeModuleStage,
-  RuntimeTemplate, impl_runtime_module,
+  RuntimeTemplate, RuntimeTemplateRenderMode, impl_runtime_module,
 };
 use rspack_plugin_javascript::impl_plugin_for_js_plugin::chunk_has_js;
+use rspack_plugin_runtime::{get_chunk_runtime_requirements, render_ensure_chunk_array};
 use rspack_util::json_stringify_str;
 
 const ESM_CHUNK_LOADING_RUNTIME_MODULE_VARIABLES: &[&str] = &["esmInstalledChunks", "esmChunkMap"];
@@ -76,12 +77,19 @@ impl RuntimeModule for EsmEnsureChunkRuntimeModule {
     Ok(format!(
       r#"{ensure_chunk_handlers_definition} = {{}};
 {ensure_chunk_definition} = function(chunkId, fetchPriority) {{
-	return Promise.all(Object.keys({ensure_chunk_handlers}).reduce(function(promises, key) {{
+{chunk_array}	return Promise.all(Object.keys({ensure_chunk_handlers}).reduce(function(promises, key) {{
 		{ensure_chunk_handlers}[key](chunkId, promises, fetchPriority);
 		return promises;
 	}}, []));
 }};
 "#,
+      chunk_array = render_ensure_chunk_array(
+        context,
+        get_chunk_runtime_requirements(
+          context.compilation,
+          &self.chunk().expect("should have chunk")
+        )
+      ),
       ensure_chunk_definition = context
         .runtime_template
         .render_runtime_global_definition(&RuntimeGlobals::ENSURE_CHUNK),
@@ -95,11 +103,21 @@ impl RuntimeModule for EsmEnsureChunkRuntimeModule {
   }
   fn runtime_requirements(
     &self,
-    _compilation: &Compilation,
+    compilation: &Compilation,
   ) -> rspack_core::RuntimeModuleRuntimeRequirements {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies: RuntimeGlobals::REQUIRE_SCOPE | RuntimeGlobals::ENSURE_CHUNK_HANDLERS,
       define: { RuntimeGlobals::ENSURE_CHUNK | RuntimeGlobals::ENSURE_CHUNK_HANDLERS },
+      force_context: if compilation.runtime_template.render_mode()
+        == RuntimeTemplateRenderMode::Rspack
+        && self.chunk().is_some_and(|chunk| {
+          get_chunk_runtime_requirements(compilation, &chunk)
+            .contains(RuntimeGlobals::HAS_CHUNK_ARRAY)
+        }) {
+        RuntimeGlobals::ENSURE_CHUNK
+      } else {
+        RuntimeGlobals::default()
+      },
       ..Default::default()
     }
   }

--- a/crates/rspack_plugin_hmr/src/lib.rs
+++ b/crates/rspack_plugin_hmr/src/lib.rs
@@ -79,6 +79,7 @@ async fn compilation(
   compilation: &mut Compilation,
   params: &mut CompilationParams,
 ) -> Result<()> {
+  compilation.hot_module_replacement_enabled = true;
   compilation.set_dependency_factory(
     DependencyType::ImportMetaHotAccept,
     params.normal_module_factory.clone(),

--- a/crates/rspack_plugin_runtime/src/lib.rs
+++ b/crates/rspack_plugin_runtime/src/lib.rs
@@ -20,7 +20,8 @@ pub use import_scripts_chunk_loading::ImportScriptsChunkLoadingPlugin;
 mod runtime_module;
 pub use runtime_module::{
   EXPORT_REQUIRE_RUNTIME_MODULE_ID, GetChunkFilenameRuntimeModule, chunk_has_css,
-  is_enabled_for_chunk, render_chunk_loading_hmr_state_expression, stringify_chunks,
+  is_enabled_for_chunk, render_chunk_loading_hmr_state_expression, render_ensure_chunk_array,
+  stringify_chunks,
 };
 mod startup_chunk_dependencies;
 pub use startup_chunk_dependencies::StartupChunkDependenciesPlugin;

--- a/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/ensure_chunk.rs
@@ -1,6 +1,6 @@
 use rspack_core::{
   Compilation, RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeTemplate,
-  impl_runtime_module,
+  RuntimeTemplateRenderMode, impl_runtime_module,
 };
 
 use crate::get_chunk_runtime_requirements;
@@ -20,6 +20,7 @@ impl EnsureChunkRuntimeModule {
 enum TemplateId {
   Raw,
   WithInline,
+  WithInlineArray,
 }
 
 impl EnsureChunkRuntimeModule {
@@ -27,6 +28,7 @@ impl EnsureChunkRuntimeModule {
     match id {
       TemplateId::Raw => self.id().to_string(),
       TemplateId::WithInline => format!("{}_inline", self.id()),
+      TemplateId::WithInlineArray => format!("{}_inline_array", self.id()),
     }
   }
 }
@@ -46,6 +48,10 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
       (
         self.template_id(TemplateId::WithInline),
         include_str!("runtime/ensure_chunk_with_inline.ejs").to_string(),
+      ),
+      (
+        self.template_id(TemplateId::WithInlineArray),
+        include_str!("runtime/ensure_chunk_with_inline_array.ejs").to_string(),
       ),
     ]
   }
@@ -69,6 +75,14 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
         &self.template_id(TemplateId::Raw),
         Some(serde_json::json!({
           "_fetch_priority": fetch_priority,
+          "_chunk_array": render_ensure_chunk_array(context, runtime_requirements),
+        })),
+      )?
+    } else if runtime_requirements.contains(RuntimeGlobals::HAS_CHUNK_ARRAY) {
+      runtime_template.render(
+        &self.template_id(TemplateId::WithInlineArray),
+        Some(serde_json::json!({
+          "_chunk_array": render_ensure_chunk_array(context, runtime_requirements),
         })),
       )?
     } else {
@@ -98,7 +112,43 @@ impl RuntimeModule for EnsureChunkRuntimeModule {
     rspack_core::RuntimeModuleRuntimeRequirements {
       dependencies,
       define,
+      force_context: if compilation.runtime_template.render_mode()
+        == RuntimeTemplateRenderMode::Rspack
+        && self.chunk().is_some_and(|chunk| {
+          get_chunk_runtime_requirements(compilation, &chunk)
+            .contains(RuntimeGlobals::HAS_CHUNK_ARRAY)
+        }) {
+        RuntimeGlobals::ENSURE_CHUNK
+      } else {
+        RuntimeGlobals::default()
+      },
       ..Default::default()
     }
   }
+}
+
+/// Shared by the regular and modern-module loaders. Keep per-chunk Promise.all results
+/// nested, and look up the current loader for each ID so wrappers and receivers still work.
+pub fn render_ensure_chunk_array(
+  context: &RuntimeModuleGenerateContext<'_>,
+  requirements: &RuntimeGlobals,
+) -> String {
+  if !requirements.contains(RuntimeGlobals::HAS_CHUNK_ARRAY) {
+    return String::new();
+  }
+  let ensure_chunk = context
+    .compilation
+    .runtime_template
+    .create_module_code_template()
+    .render_runtime_globals_without_adding(&RuntimeGlobals::ENSURE_CHUNK);
+  let call = if requirements.contains(RuntimeGlobals::HAS_FETCH_PRIORITY) {
+    format!(
+      "fetchPriority === undefined ? {ensure_chunk}(chunkId[i]) : {ensure_chunk}(chunkId[i], fetchPriority)"
+    )
+  } else {
+    format!("{ensure_chunk}(chunkId[i])")
+  };
+  format!(
+    "\tif (Array.isArray(chunkId)) {{\n\t\tvar promises = [];\n\t\tfor (var i = 0; i < chunkId.length; i++) {{\n\t\t\tpromises.push({call});\n\t\t}}\n\t\treturn Promise.all(promises);\n\t}}\n"
+  )
 }

--- a/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/mod.rs
@@ -61,7 +61,7 @@ pub use create_fake_namespace_object::CreateFakeNamespaceObjectRuntimeModule;
 pub use create_script::CreateScriptRuntimeModule;
 pub use create_script_url::CreateScriptUrlRuntimeModule;
 pub use define_property_getters::DefinePropertyGettersRuntimeModule;
-pub use ensure_chunk::EnsureChunkRuntimeModule;
+pub use ensure_chunk::{EnsureChunkRuntimeModule, render_ensure_chunk_array};
 pub use esm_module_decorator::ESMModuleDecoratorRuntimeModule;
 pub use export_require::{EXPORT_REQUIRE_RUNTIME_MODULE_ID, ExportRequireRuntimeModule};
 pub use get_chunk_filename::GetChunkFilenameRuntimeModule;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk.ejs
@@ -2,7 +2,7 @@
 // This file contains only the entry chunk.
 // The chunk loading function for additional chunks
 <%- define(ENSURE_CHUNK) %> = <%- basicFunction("chunkId" + _fetch_priority) %> {
-	return Promise.all(
+<%- _chunk_array %>	return Promise.all(
 		Object.keys(<%- ENSURE_CHUNK_HANDLERS %>).reduce(<%- basicFunction("promises, key") %> {
 			<%- ENSURE_CHUNK_HANDLERS %>[key](chunkId, promises<%- _fetch_priority %>);
 			return promises;

--- a/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk_with_inline_array.ejs
+++ b/crates/rspack_plugin_runtime/src/runtime_module/runtime/ensure_chunk_with_inline_array.ejs
@@ -1,0 +1,4 @@
+// All referenced chunks are already included, but array calls still return ordered results.
+<%- define(ENSURE_CHUNK) %> = <%- basicFunction("chunkId, fetchPriority") %> {
+<%- _chunk_array %>	return Promise.resolve();
+};

--- a/packages/rspack/src/RuntimeGlobals.ts
+++ b/packages/rspack/src/RuntimeGlobals.ts
@@ -245,6 +245,9 @@ enum RuntimeGlobals {
    */
   hasFetchPriority,
 
+  /** A capability flag for ensureChunk array arguments, not a runtime property. */
+  hasChunkArray,
+
   /**
    * the chunk name of the chunk with the runtime
    */
@@ -614,6 +617,8 @@ function renderRuntimeGlobals(
       return `${scope_name}.tt`;
     case RuntimeGlobals.hasFetchPriority:
       return `has fetch priority`;
+    case RuntimeGlobals.hasChunkArray:
+      return `has chunk array`;
     case RuntimeGlobals.chunkName:
       return `${scope_name}.cn`;
     case RuntimeGlobals.runtimeId:

--- a/packages/rspack/src/config/defaults.ts
+++ b/packages/rspack/src/config/defaults.ts
@@ -303,6 +303,7 @@ const applyExperimentsDefaults = (
 
   // IGNORE(experiments.pureFunctions): Rspack specific configuration for pure function annotations and hints
   D(experiments, 'pureFunctions', production);
+  D(experiments, 'chunkArrayLoading', false);
   D(experiments, 'runtimeMode', 'webpack');
 };
 

--- a/packages/rspack/src/config/normalization.ts
+++ b/packages/rspack/src/config/normalization.ts
@@ -677,6 +677,7 @@ export interface ExperimentsNormalized {
   deferImport?: boolean;
   sourceImport?: boolean;
   pureFunctions?: boolean;
+  chunkArrayLoading?: boolean;
   runtimeMode?: 'webpack' | 'rspack';
 }
 

--- a/packages/rspack/src/config/types.ts
+++ b/packages/rspack/src/config/types.ts
@@ -3236,6 +3236,12 @@ export type Experiments = {
    * @default false
    */
   pureFunctions?: boolean;
+
+  /**
+   * Load asynchronous chunk lists with a single ensureChunk array call.
+   * Only takes effect in production mode without HMR. Defaults to false.
+   */
+  chunkArrayLoading?: boolean;
   /**
    * Select runtime proxy context behavior. `webpack` keeps the webpack startup hook,
    * while `rspack` uses `__rspack_context`.

--- a/tests/rspack-test/compilerCases/chunk-array-cache.js
+++ b/tests/rspack-test/compilerCases/chunk-array-cache.js
@@ -1,0 +1,62 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { rspack } = require('@rspack/core');
+
+const run = (compiler, changed = []) => new Promise((resolve, reject) => compiler.run((error, stats) => {
+  if (error) return reject(error);
+  if (stats.hasErrors()) return reject(new Error(stats.toString({ all: false, errors: true })));
+  resolve(stats);
+}, { modifiedFiles: new Set(changed) }));
+const close = compiler => new Promise((resolve, reject) => compiler.close(error => error ? reject(error) : resolve()));
+const sources = stats => Object.fromEntries(stats.compilation.getAssets().filter(asset => asset.name.endsWith('.js')).map(asset => [asset.name, asset.source.source().toString()]));
+
+module.exports = [false, true].flatMap(newCache => [false, true].map(concatenateModules => {
+  let root, options;
+  const write = (file, source) => { const dest = path.join(root, file); fs.writeFileSync(dest, source); return dest; };
+  return {
+    description: `chunk array cache new=${newCache} concatenate=${concatenateModules}`,
+    options(context) {
+      root = context.getDist(`chunk-array-cache-${newCache}-${concatenateModules}`);
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(root, { recursive: true });
+      write('index.js', 'export { load } from "./calls";');
+      write('calls.js', 'export const load = () => import("./lazy");');
+      write('lazy.js', 'import a from "./a"; import b from "./b"; export default [a,b];');
+      for (const name of ['a', 'b', 'c']) write(`${name}.js`, `export default globalThis.${name} || '${name}';`);
+      options = {
+        context: root, mode: 'production', target: 'node', entry: './index.js', devtool: false,
+        cache: { type: 'persistent', storage: { type: 'filesystem', directory: path.join(root, 'cache') } },
+        incremental: { modulesCodegen: false },
+        experiments: { chunkArrayLoading: true, newCache },
+        output: { path: path.join(root, 'dist'), filename: '[name].[contenthash].js', chunkFilename: '[name].[contenthash].js', library: { type: 'commonjs2' } },
+        optimization: { minimize: false, concatenateModules, splitChunks: { minSize: 0, cacheGroups: Object.fromEntries(['a', 'b', 'c'].map(name => [name, { test: new RegExp(`[/\\\\]${name}\\.js$`), name, enforce: true, chunks: 'async' }])) } },
+      };
+      return options;
+    },
+    compiler(context, compiler) { compiler.outputFileSystem = fs; },
+    async build(context, compiler) {
+      const first = sources(await run(compiler));
+      expect(Object.values(first).join('\n')).toContain('Array.isArray(');
+      const warm = await run(compiler, [path.join(root, 'calls.js')]);
+      expect(sources(warm)).toEqual(first);
+      const cacheLog = warm.toJson({ all: false, logging: 'verbose' }).logging['rspack.Compilation'].entries.find(entry => entry.message?.startsWith('module code generation cache:'));
+      expect(Number(cacheLog.message.match(/\((\d+)\/\d+\)/)[1])).toBeGreaterThan(0);
+      const lazy = write('lazy.js', 'import a from "./a"; import b from "./b"; import c from "./c"; export default [a,b,c];');
+      const changed = await run(compiler, [lazy]);
+      const updated = sources(changed);
+      expect(updated).not.toEqual(first);
+      const main = changed.toJson({ all: false, entrypoints: true }).entrypoints.main.assets[0].name;
+      expect((await require(path.join(root, 'dist', main)).load()).default).toEqual(['a', 'b', 'c']);
+      await close(compiler);
+      compiler.close = callback => callback();
+      const restored = rspack(options);
+      try { expect(sources(await run(restored))).toEqual(updated); } finally { await close(restored); }
+      const disabled = rspack({ ...options, experiments: { ...options.experiments, chunkArrayLoading: false } });
+      try {
+        const inline = Object.values(sources(await run(disabled))).join('\n');
+        expect(inline).not.toContain('Array.isArray(');
+        expect(inline).toContain('Promise.all(');
+      } finally { await close(disabled); }
+    },
+  };
+}));

--- a/tests/rspack-test/compilerCases/chunk-array-loading.js
+++ b/tests/rspack-test/compilerCases/chunk-array-loading.js
@@ -1,0 +1,149 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+const { HotModuleReplacementPlugin, RuntimeGlobals, container } = require('@rspack/core');
+
+const variants = [
+  {},
+  { concatenate: true },
+  { runtimeMode: 'rspack', concatenate: true },
+  { arrow: false, named: true },
+  { esm: true, runtimeMode: 'rspack' },
+  { modern: true, runtimeMode: 'rspack', kind: 'ensure' },
+  { kind: 'ensure' },
+  { kind: 'amd' },
+  { kind: 'lazy-once' },
+  { kind: 'lazy' },
+  { kind: 'container' },
+  { mode: 'development' },
+  { hmr: true },
+  { enabled: false },
+  { onlySingle: true },
+  { minimize: true },
+  { priority: false },
+  { multi: true },
+];
+
+module.exports = variants.map((variant, index) => {
+  let root;
+  const active = variant.enabled !== false && variant.mode !== 'development' && !variant.hmr && !variant.onlySingle && variant.kind !== 'lazy';
+  const esm = variant.esm || variant.modern;
+  return {
+    description: `chunk array loading ${JSON.stringify(variant)}`,
+    options(context) {
+      root = context.getDist(`chunk-array-${index}`);
+      fs.rmSync(root, { recursive: true, force: true });
+      fs.mkdirSync(path.join(root, 'context'), { recursive: true });
+      const write = (name, source) => fs.writeFileSync(path.join(root, name), source);
+      write('a.js', 'export default globalThis.chunkArrayA || "a";');
+      write('b.js', 'export default globalThis.chunkArrayB || "b";');
+      write('context/lazy.js', 'import a from "../a"; import b from "../b"; export default [a,b];');
+      write('high.js', 'import a from "./a"; import b from "./b"; export default [a,b];');
+      write('single.js', 'export default "single";');
+      write('other.js', 'export default 42;');
+      const load = variant.onlySingle ? 'import("./single")'
+        : variant.kind === 'ensure' ? 'new Promise((resolve, reject) => require.ensure([], require => resolve(require("./context/lazy")), error => reject(error), "group"))'
+        : variant.kind === 'amd' ? 'new Promise(resolve => require(["./context/lazy"], resolve))'
+        : variant.kind?.startsWith('lazy') ? `require.context('./context', false, /lazy/, '${variant.kind}')('./lazy.js')`
+        : 'import("./context/lazy")';
+      write('index.js', `export const load = () => ${load};
+        export const single = () => import('./single');
+        export const local = () => import('./index');
+        export const getEnsure = () => __webpack_chunk_load__;
+        export const setEnsure = next => { __webpack_chunk_load__ = next; };
+        ${active && variant.priority !== false ? 'export const high = () => import(/* webpackFetchPriority: "high" */ "./high");' : ''}`);
+      return {
+        context: root,
+        mode: variant.mode || 'production',
+        target: 'node',
+        entry: variant.kind === 'container' ? {} : variant.multi ? { main: './index.js', other: './other.js' } : './index.js',
+        amd: {},
+        devtool: 'source-map',
+        experiments: { chunkArrayLoading: variant.enabled !== false, runtimeMode: variant.runtimeMode || 'webpack', outputModule: !!esm },
+        plugins: [
+          ...(variant.hmr ? [new HotModuleReplacementPlugin()] : []),
+          ...(variant.kind === 'container' ? [new container.ContainerPlugin({ name: 'remote', filename: 'remote.js', library: { type: 'commonjs2' }, exposes: { './lazy': './context/lazy' } })] : []),
+        ],
+        output: { path: path.join(root, 'dist'), filename: esm ? '[name].mjs' : '[name].js', chunkFilename: esm ? '[id].mjs' : '[id].js', module: !!esm, library: { type: variant.modern ? 'modern-module' : esm ? 'module' : 'commonjs2' }, environment: { arrowFunction: variant.arrow !== false } },
+        optimization: {
+          minimize: !!variant.minimize,
+          concatenateModules: !!variant.concatenate,
+          chunkIds: variant.named ? 'named' : 'deterministic',
+          runtimeChunk: variant.multi ? { name: entry => entry.name + '-runtime' } : false,
+          splitChunks: { minSize: 0, cacheGroups: Object.fromEntries(['a', 'b'].map(name => [name, { test: new RegExp(`[/\\\\]${name}\\.js$`), name: `shared-${name}`, enforce: true, chunks: 'async' }])) },
+        },
+      };
+    },
+    compiler(context, compiler) { compiler.outputFileSystem = fs; },
+    async check() {
+      const output = path.join(root, 'dist');
+      const sources = fs.readdirSync(output).filter(name => /\.(m?js)$/.test(name)).map(name => fs.readFileSync(path.join(output, name), 'utf8')).join('\n');
+      expect(sources.includes('Array.isArray(')).toBe(active);
+      expect(sources).not.toContain('__webpack_require__.q');
+      expect(sources).not.toContain('chunkGroups');
+      expect(RuntimeGlobals.ensureChunk).toBe('__webpack_require__.e');
+      expect(RuntimeGlobals.ensureChunkGroup).toBeUndefined();
+      expect(fs.readdirSync(output).some(name => name.endsWith('.map'))).toBe(true);
+      if (variant.multi) expect(fs.readFileSync(path.join(output, 'other-runtime.js'), 'utf8')).not.toContain('Array.isArray(');
+      if (variant.kind === 'container') {
+        const remote = require(path.join(output, 'remote.js'));
+        const factory = await remote.get('./lazy');
+        expect(factory().default).toEqual(['a', 'b']);
+        return;
+      }
+      const main = path.join(output, esm ? 'main.mjs' : 'main.js');
+      const exports = esm ? await import(pathToFileURL(main).href) : require(main);
+      expect((await exports.single()).default).toBe('single');
+      expect((await exports.local()).load).toBe(exports.load);
+      const first = exports.load();
+      const second = exports.load();
+      expect(first).not.toBe(second);
+      for (const loaded of await Promise.all([first, second])) expect(loaded.default).toEqual(variant.onlySingle ? 'single' : ['a', 'b']);
+      if (!active) return;
+      // Modern ESM imports are immutable bindings, so replacing the loader is unsupported.
+      if (variant.modern) { expect((await exports.high()).default).toEqual(['a', 'b']); return; }
+
+      const original = exports.getEnsure();
+      const calls = [];
+      exports.setEnsure(function (ids, priority) {
+        calls.push({ ids, priority, length: arguments.length, receiver: this });
+        return original.apply(this, arguments);
+      });
+      try {
+        await exports.load();
+        const ids = calls[0].ids;
+        expect(Array.isArray(ids)).toBe(true);
+        expect(ids).toHaveLength(3);
+        expect(calls.slice(1).map(call => call.ids)).toEqual(ids);
+        expect(calls.every(call => call.length === 1)).toBe(true);
+        expect(calls.every(call => call.receiver === calls[0].receiver)).toBe(true);
+        if (variant.priority !== false) {
+          calls.length = 0;
+          await exports.high();
+          expect(calls).toHaveLength(4);
+          expect(calls.every(call => call.length === 2 && call.priority === 'high')).toBe(true);
+        }
+
+        // Scalar results remain nested and ordered; duplicate and string IDs are not removed.
+        exports.setEnsure(id => Promise.resolve([id]));
+        const ordered = ['a', 2, 'a'];
+        const one = original(ordered);
+        const two = original(ordered);
+        expect(one).not.toBe(two);
+        expect(await one).toEqual([['a'], [2], ['a']]);
+        expect(await two).toEqual(await one);
+        expect(await original([])).toEqual([]);
+        const error = new Error('chunk failed');
+        let attempts = 0;
+        exports.setEnsure(() => { if (++attempts === 2) throw error; return Promise.resolve(); });
+        expect(() => original(ordered)).toThrow(error);
+        expect(attempts).toBe(2);
+        exports.setEnsure(() => Promise.reject(error));
+        await expect(original(ordered)).rejects.toBe(error);
+      } finally {
+        exports.setEnsure(original);
+      }
+      expect((await exports.load()).default).toEqual(['a', 'b']);
+    },
+  };
+});

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/dep.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/dep.js
@@ -1,0 +1,1 @@
+export default globalThis.chunkArrayRetry || 'ok';

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/index.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/index.js
@@ -1,0 +1,16 @@
+const load = () => import('./lazy');
+it('retries failed resources in an array chunk load', async () => {
+  const first = load();
+  const suffix = FAIL_CSS ? 'css-group-' + CASE_INDEX + '.css' : 'js-group-' + CASE_INDEX + '.js';
+  const resource = document.head._children.find(element => (element.src || element.href || '').endsWith(suffix));
+  expect(resource).toBeDefined();
+  resource.onerror({ type: 'error', target: resource });
+  await expect(first).rejects.toThrow();
+  const retry = load();
+  const concurrent = load();
+  expect(retry).not.toBe(concurrent);
+  const [a, b] = await Promise.all([retry, concurrent]);
+  expect(a.default).toBe('ok');
+  expect(a).toBe(b);
+  expect((await load()).default).toBe('ok');
+});

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/lazy.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/lazy.js
@@ -1,0 +1,3 @@
+import value from './dep';
+import './style.css';
+export default value;

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/rspack.config.js
@@ -1,0 +1,44 @@
+const { DefinePlugin } = require('@rspack/core');
+module.exports = [0, 1].map((index) => ({
+  mode: 'production',
+  target: 'web',
+  experiments: { chunkArrayLoading: true, css: true },
+  output: {
+    filename: 'main-' + index + '.js',
+    chunkFilename: '[name].js',
+    cssChunkFilename: '[name].css',
+  },
+  module: { rules: [{ test: /\.css$/, type: 'css' }] },
+  plugins: [
+    new DefinePlugin({
+      FAIL_CSS: JSON.stringify(index === 1),
+      CASE_INDEX: JSON.stringify(index),
+    }),
+  ],
+  optimization: {
+    minimize: false,
+    splitChunks: {
+      minSize: 0,
+      cacheGroups: {
+        dep: {
+          test: /dep\.js$/,
+          name: 'dep-' + index,
+          enforce: true,
+          chunks: 'async',
+        },
+        lazy: {
+          test: /lazy\.js$/,
+          name: 'js-group-' + index,
+          enforce: true,
+          chunks: 'async',
+        },
+        css: {
+          test: /\.css$/,
+          name: 'css-group-' + index,
+          enforce: true,
+          chunks: 'async',
+        },
+      },
+    },
+  },
+}));

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/style.css
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/style.css
@@ -1,0 +1,1 @@
+.chunk-array { color: red; }

--- a/tests/rspack-test/configCases/runtime/chunk-array-retry/test.config.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-retry/test.config.js
@@ -1,0 +1,10 @@
+const failed = new Set();
+module.exports = {
+  findBundle(index) { return 'main-' + index + '.js'; },
+  resourceLoader(url) {
+    if (/(js-group-0\.js|css-group-1\.css)$/.test(url) && !failed.has(url)) {
+      failed.add(url);
+      return null;
+    }
+  },
+};

--- a/tests/rspack-test/configCases/runtime/chunk-array-worker/dep.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-worker/dep.js
@@ -1,0 +1,1 @@
+export default globalThis.chunkArrayWorker || 'ok';

--- a/tests/rspack-test/configCases/runtime/chunk-array-worker/index.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-worker/index.js
@@ -1,0 +1,7 @@
+it('loads chunk arrays with importScripts', async () => {
+  const load = () => import('./lazy');
+  const [a, b] = await Promise.all([load(), load()]);
+  expect(a.default).toBe('ok');
+  expect(a).toBe(b);
+  expect((await load()).default).toBe('ok');
+});

--- a/tests/rspack-test/configCases/runtime/chunk-array-worker/lazy.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-worker/lazy.js
@@ -1,0 +1,1 @@
+export { default } from './dep';

--- a/tests/rspack-test/configCases/runtime/chunk-array-worker/rspack.config.js
+++ b/tests/rspack-test/configCases/runtime/chunk-array-worker/rspack.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  mode: 'production',
+  target: 'webworker',
+  experiments: { chunkArrayLoading: true },
+  optimization: {
+    minimize: false,
+    splitChunks: {
+      minSize: 0,
+      cacheGroups: {
+        dep: { test: /dep\.js$/, name: 'dep', chunks: 'async', enforce: true },
+      },
+    },
+  },
+};

--- a/tests/rspack-test/defaultsCases/default/base.js
+++ b/tests/rspack-test/defaultsCases/default/base.js
@@ -22,6 +22,7 @@ module.exports = {
 			  experiments: Object {
 			    asyncWebAssembly: true,
 			    buildHttp: undefined,
+			    chunkArrayLoading: false,
 			    deferImport: false,
 			    futureDefaults: false,
 			    newCache: false,

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/calls.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/calls.js
@@ -1,0 +1,1 @@
+export const load = () => import('./lazy');

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/dep.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/dep.js
@@ -1,0 +1,1 @@
+export default globalThis.chunkArrayWatch || 'shared';

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/index.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/index.js
@@ -1,0 +1,5 @@
+import { load } from './calls';
+it('recomputes array loading when the chunk list changes', async () => {
+  expect((await load()).default).toBe(WATCH_STEP === '1' || WATCH_STEP === 1 ? 'single' : 'shared');
+  expect(__webpack_chunk_load__.toString().includes('Array.isArray')).toBe(!(WATCH_STEP === '1' || WATCH_STEP === 1));
+});

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/lazy.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/0/lazy.js
@@ -1,0 +1,1 @@
+export { default } from './dep';

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/1/lazy.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/1/lazy.js
@@ -1,0 +1,1 @@
+export default 'single';

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/2/lazy.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/2/lazy.js
@@ -1,0 +1,1 @@
+export { default } from './dep';

--- a/tests/rspack-test/watchCases/runtime/chunk-array-loading/rspack.config.js
+++ b/tests/rspack-test/watchCases/runtime/chunk-array-loading/rspack.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  mode: 'production',
+  target: 'node',
+  experiments: { chunkArrayLoading: true },
+  optimization: {
+    minimize: false,
+    concatenateModules: true,
+    splitChunks: {
+      minSize: 0,
+      cacheGroups: {
+        dep: { test: /dep\.js$/, name: 'dep', chunks: 'async', enforce: true },
+      },
+    },
+  },
+};

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -262,6 +262,30 @@ export default {
 This option depends on `optimization.sideEffects`. If you disable [`optimization.sideEffects`](/config/optimization#optimizationsideeffects), pure-function hints will not be analyzed.
 :::
 
+## experiments.chunkArrayLoading
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Reduces repeated chunk-loading calls by letting the runtime's existing `ensureChunk` function accept an ordered array of chunk IDs:
+
+```js title="rspack.config.mjs"
+export default {
+  mode: 'production',
+  experiments: {
+    chunkArrayLoading: true,
+  },
+};
+```
+
+For example, `Promise.all([__webpack_require__.e(12), __webpack_require__.e(34)])` becomes `__webpack_require__.e([12, 34])`. The array stays at the call site; no shared table or additional runtime property is created.
+
+Only calls that load at least two chunks use arrays. Zero- and single-chunk calls keep their existing form, and runtimes without array calls do not receive the array-handling code. This applies to dynamic imports, `require.ensure`, AMD asynchronous dependencies, and `lazy-once` contexts. Ordinary lazy contexts, startup, prefetch, and preload keep their existing generation paths.
+
+The runtime forwards each ID in order to the existing scalar loader, including fetch priority. The returned Promise preserves the ordered per-chunk results, concurrency, and retry behavior. Plugins that wrap `ensureChunk` must accept both a chunk ID and an array of IDs, or forward the arguments unchanged.
+
+The option only takes effect in production mode without hot module replacement. It adds a small branch to the runtime and reduces code at each multi-chunk call site; measure the combined bundle size for your application before enabling it.
+
 ## experiments.runtimeMode
 
 <ApiMeta addedVersion="2.2.0" />

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -262,6 +262,30 @@ export default {
 这个选项依赖 `optimization.sideEffects`。如果你关闭了 [`optimization.sideEffects`](/config/optimization#optimizationsideeffects)，pure function 相关提示将不会被分析。
 :::
 
+## experiments.chunkArrayLoading
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+让现有 runtime 的 `ensureChunk` 函数支持有序 chunk ID 数组，减少调用点中重复的加载代码：
+
+```js title="rspack.config.mjs"
+export default {
+  mode: 'production',
+  experiments: {
+    chunkArrayLoading: true,
+  },
+};
+```
+
+例如，`Promise.all([__webpack_require__.e(12), __webpack_require__.e(34)])` 会变为 `__webpack_require__.e([12, 34])`。数组保留在调用点，不创建共享表或额外的 runtime 属性。
+
+只有至少加载两个 chunk 的调用使用数组。零个或单个 chunk 的调用保持原有形式，没有数组调用的 runtime 也不会增加数组处理代码。覆盖动态导入、`require.ensure`、AMD 异步依赖和 `lazy-once` context；普通 lazy context、startup、prefetch 和 preload 保持原有生成方式。
+
+runtime 按顺序将每个 ID 及 fetch priority 传给原有单 chunk 加载函数，保留 Promise 中各 chunk 的结果顺序、并发和失败重试行为。包装 `ensureChunk` 的插件需要同时接受单个 ID 和 ID 数组，或原样转发参数。
+
+该选项仅在生产模式且未启用 HMR 时生效。它会增加少量 runtime 分支代码，并缩短每个多 chunk 调用点；启用前应测量应用产物的总体积。
+
 ## experiments.runtimeMode
 
 <ApiMeta addedVersion="2.2.0" />


### PR DESCRIPTION
## Summary

Multi-chunk asynchronous loads repeat `__webpack_require__.e` calls inside `Promise.all`. Add the default-off `experiments.chunkArrayLoading` option to emit a single array call in production builds without HMR:

```js
// Before
Promise.all([__webpack_require__.e(12), __webpack_require__.e(34)]);

// With experiments.chunkArrayLoading: true
__webpack_require__.e([12, 34]);
```

The existing scalar loader handles each ID in order, preserving per-chunk Promise results, fetch priority, synchronous errors, concurrent loading, and retries. Array handling is emitted only for runtimes that use it. Zero- and single-chunk calls keep their existing output.

This covers dynamic imports, `require.ensure`, AMD asynchronous dependencies, and `lazy-once` contexts, including the regular and modern-module runtimes. It adds the JS/Rust configuration plumbing, cache invalidation, and English/Chinese documentation. Plugins that wrap `ensureChunk` must accept array arguments or forward them unchanged.

## Validation

Validated after rebasing onto `main`:

- `pnpm run build:cli:dev`
- `pnpm run lint:js`
- `cargo fmt --all --check`
- `pnpm run lint:rs`
- `cargo lint`
- `pnpm run test:unit` — 9,265 Rspack tests and 90 CLI tests passed; binding type tests passed.
- `pnpm run test:rs` — 1,079 passed, 2 ignored.
- `pnpm exec rs test --project base -t chunk-array` in `tests/rspack-test` — 32 passed.

Added cases cover loading semantics, JS/CSS failure retries, fetch priority, wrapped loaders, multiple runtimes, workers, ESM, Federation, module concatenation, both cache backends, production watch, and development/HMR fallback.

## Related links

None.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
