### PR TITLE
chore(ci): enable workflows for release/2.3.0

### DIFF
--- a/.github/workflows/ci-diff.yml
+++ b/.github/workflows/ci-diff.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     # Ignore files that do not affect build output to skip unnecessary builds
     paths-ignore:
@@ -29,7 +30,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' && github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`
@@ -104,5 +105,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           file_path: '../build-tools-performance/**/dist/rsdoctor-data.json'
-          target_branch: ${{ inputs.target_branch || 'main' }}
+          target_branch: ${{ github.event_name == 'push' && github.ref_name || github.event_name == 'pull_request' && github.base_ref || inputs.target_branch || 'main' }}
           ai_model: qwen3.5-plus

--- a/.github/workflows/ci-dylint.yaml
+++ b/.github/workflows/ci-dylint.yaml
@@ -17,6 +17,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths:
       - '.github/workflows/ci-dylint.yaml'

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     tags-ignore:
       - '**'

--- a/.github/workflows/ci-resolver.yml
+++ b/.github/workflows/ci-resolver.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
     paths:
       - 'crates/rspack_resolver/**'
       - '.github/workflows/ci-resolver.yml'
@@ -20,7 +21,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths:
       - '.github/workflows/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths-ignore:
       - '**/*.md'
@@ -19,7 +20,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'v1.x' }}
+  cancel-in-progress: ${{ github.ref_name != 'main' && github.ref_name != 'release/2.3.0' && github.ref_name != 'v1.x' }}
 
 permissions:
   # Allow commenting on issues for `reusable-build.yml`
@@ -100,7 +101,7 @@ jobs:
   bench-rust-walltime:
     name: Rust Bench Walltime
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main')) }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && (github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0'))) }}
     uses: ./.github/workflows/bench-rust.yml
     with:
       target: x86_64-unknown-linux-gnu
@@ -154,7 +155,7 @@ jobs:
   build-riscv64:
     name: Build riscv64
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0') }}
     uses: ./.github/workflows/reusable-build-build.yml
     with:
       target: riscv64gc-unknown-linux-gnu
@@ -164,7 +165,7 @@ jobs:
   build-ppc64:
     name: Build ppc64
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0') }}
     uses: ./.github/workflows/reusable-build-build.yml
     with:
       target: powerpc64le-unknown-linux-gnu
@@ -174,7 +175,7 @@ jobs:
   build-s390x:
     name: Build s390x
     needs: [check-changed]
-    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ needs.check-changed.outputs.code_changed == 'true' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0') }}
     uses: ./.github/workflows/reusable-build-build.yml
     with:
       target: s390x-unknown-linux-gnu
@@ -245,7 +246,8 @@ jobs:
                 needs.test-windows.result != 'success' ||
                 needs.test-mac.result != 'success' ||
                 needs.build-wasm.result != 'success' ||
-                (github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+                (github.event_name == 'push' &&
+                  (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/release/2.3.0') &&
                   (needs.build-riscv64.result != 'success' ||
                     needs.build-ppc64.result != 'success' ||
                     needs.build-s390x.result != 'success')) ||

--- a/.github/workflows/ecosystem-benchmark.yml
+++ b/.github/workflows/ecosystem-benchmark.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+      - release/2.3.0
       - v1.x
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
## Summary

- Enable automatic CI workflows on pushes to release/2.3.0.
- Apply the same non-canceling concurrency and main-only job behavior to the release baseline.
- Select the CI Diff target branch from the triggering push or pull request while preserving the manual input.

## Related links

Follow-up to #15521, which was merged into release/2.3.0.

## Checklist

- [x] Tests updated (not required; workflow configuration only).
- [x] Documentation updated (not required).