### PR TITLE
refactor: remove BuildResult.optimization_bailouts

### DIFF
--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -136,7 +136,7 @@ impl Task<TaskContext> for BuildResultTask {
       .artifact
       .module_graph
       .get_optimization_bailout_mut(&module.identifier())
-      .extend(build_result.optimization_bailouts);
+      .extend_from_slice(&build_info.optimization_bailouts);
     let resource_id = ResourceId::from(module.identifier());
     context
       .artifact

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -7,7 +7,7 @@ use rspack_error::{Result, ToStringResultToRspackResultExt};
 use crate::{
   AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockIdentifier, BoxModule,
   BuildModuleGraphArtifact, BuildResult, DependenciesBlock, DependencyRef, FileSystemInfo,
-  ModuleGraph, ModuleIdentifier, NormalModuleState, OptimizationBailoutItem, ValueCacheVersions,
+  ModuleGraph, ModuleIdentifier, NormalModuleState, ValueCacheVersions,
   new_cache::{CacheFacade, CacheValue},
 };
 
@@ -33,7 +33,6 @@ pub(crate) struct ModuleBuildCacheEntry {
 struct ModuleGraphBuildResult {
   dependencies: Vec<DependencyRef>,
   blocks: Vec<AsyncDependenciesBlockBuildResult>,
-  optimization_bailouts: Vec<OptimizationBailoutItem>,
 }
 
 impl ModuleBuildCacheEntry {
@@ -46,7 +45,6 @@ impl ModuleBuildCacheEntry {
       module,
       dependencies: self.graph_result.dependencies,
       blocks: self.graph_result.blocks,
-      optimization_bailouts: self.graph_result.optimization_bailouts,
     }
   }
 }
@@ -191,16 +189,11 @@ fn create_cache_entry(
     .iter()
     .map(|block_id| clone_block(module_graph, block_id))
     .collect::<Option<Vec<_>>>()?;
-  let optimization_bailouts = module_graph
-    .get_optimization_bailout(&module_identifier)
-    .clone();
-
   Some(ModuleBuildCacheEntry {
     module_state: normal_module.module_state().clone(),
     graph_result: ModuleGraphBuildResult {
       dependencies,
       blocks,
-      optimization_bailouts,
     },
   })
 }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -887,7 +887,6 @@ impl Module for ConcatenatedModule {
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -1526,7 +1526,6 @@ impl Module for ContextModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -1217,7 +1217,6 @@ impl Module for ExternalModule {
         can_mangle,
       ))],
       blocks: Vec::new(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -129,7 +129,6 @@ impl Module for TempModule {
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 }

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -308,6 +308,8 @@ pub struct BuildInfo {
   pub side_effects_free: Option<AtomSet>,
   #[cacheable(with=AsOption<AsVec<AsPreset>>)]
   pub top_level_declarations: Option<AtomSet>,
+  /// Bailouts produced during module builds, before compilation-specific optimizations.
+  pub optimization_bailouts: Vec<OptimizationBailoutItem>,
   pub module_concatenation_bailout: Option<String>,
   pub assets: BindingCell<HashMap<String, CompilationAsset>>,
   pub module: bool,
@@ -343,6 +345,7 @@ impl Default for BuildInfo {
       css: None,
       side_effects_free: None,
       top_level_declarations: None,
+      optimization_bailouts: Vec::new(),
       module_concatenation_bailout: None,
       assets: Default::default(),
       module: false,
@@ -665,7 +668,6 @@ pub struct BuildResult {
   /// Dependencies are shared after the module build finishes.
   pub dependencies: Vec<DependencyRef>,
   pub blocks: Vec<AsyncDependenciesBlockBuildResult>,
-  pub optimization_bailouts: Vec<OptimizationBailoutItem>,
 }
 
 #[cacheable]

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -497,6 +497,7 @@ impl Module for NormalModule {
   ) -> Result<BuildResult> {
     self.state.force_build = false;
     self.state.build_info.snapshot = None;
+    self.state.build_info.optimization_bailouts.clear();
 
     // so does webpack
     self.state.parsed = true;
@@ -572,7 +573,6 @@ impl Module for NormalModule {
         module: BoxModule::new(self),
         dependencies: Vec::new(),
         blocks: Vec::new(),
-        optimization_bailouts: vec![],
       });
     };
 
@@ -622,7 +622,6 @@ impl Module for NormalModule {
         module: BoxModule::new(self),
         dependencies: vec![],
         blocks: vec![],
-        optimization_bailouts: vec![],
       });
     }
 
@@ -667,16 +666,20 @@ impl Module for NormalModule {
     if !diagnostics.is_empty() {
       self.add_diagnostics(diagnostics);
     }
-    let optimization_bailouts = if let Some(side_effects_bailout) = side_effects_bailout {
-      let short_id = self.readable_identifier(&build_context.compiler_options.context);
-      vec![OptimizationBailoutItem::SideEffects {
-        node_type: side_effects_bailout.ty,
-        loc: side_effects_bailout.msg,
-        short_id: short_id.to_string(),
-      }]
-    } else {
-      vec![]
-    };
+    if let Some(side_effects_bailout) = side_effects_bailout {
+      let short_id = self
+        .readable_identifier(&build_context.compiler_options.context)
+        .to_string();
+      self
+        .state
+        .build_info
+        .optimization_bailouts
+        .push(OptimizationBailoutItem::SideEffects {
+          node_type: side_effects_bailout.ty,
+          loc: side_effects_bailout.msg,
+          short_id,
+        });
+    }
     // Only side effects used in code_generate can stay here
     // Other side effects should be set outside use_cache
     self.state.source = Some(source);
@@ -692,7 +695,6 @@ impl Module for NormalModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts,
     })
   }
 

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -177,7 +177,6 @@ impl Module for RawModule {
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 }

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -138,7 +138,6 @@ impl Module for SelfModule {
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 }

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -207,7 +207,6 @@ pub fn impl_runtime_module(
           module: ::rspack_core::BoxModule::new(self),
           dependencies: vec![],
           blocks: vec![],
-          optimization_bailouts: vec![],
         })
       }
     }

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -94,7 +94,6 @@ impl Module for DllModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -114,7 +114,6 @@ impl Module for DelegatedModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -171,7 +171,6 @@ impl Module for CssModule {
       module: BoxModule::new(self),
       dependencies: vec![],
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -236,7 +236,6 @@ impl Module for LazyCompilationProxyModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -244,7 +244,6 @@ impl Module for ContainerEntryModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -148,7 +148,6 @@ impl Module for FallbackModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -195,7 +195,6 @@ impl Module for RemoteModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: vec![],
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -192,7 +192,6 @@ impl Module for ConsumeSharedModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -184,7 +184,6 @@ impl Module for ProvideSharedModule {
       module: BoxModule::new(self),
       dependencies: dependencies.into_iter().map(Into::into).collect(),
       blocks: blocks.into_iter().map(Into::into).collect(),
-      optimization_bailouts: vec![],
     })
   }
 

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -272,7 +272,6 @@ impl Module for RscEntryModule {
         module: BoxModule::new(self),
         dependencies: dependencies.into_iter().map(Into::into).collect(),
         blocks: vec![],
-        optimization_bailouts: vec![],
       })
     } else {
       // Non-eager: code-split points; use AsyncDependenciesBlock + ClientReferenceDependency.
@@ -377,7 +376,6 @@ impl Module for RscEntryModule {
         module: BoxModule::new(self),
         dependencies: dependencies.into_iter().map(Into::into).collect(),
         blocks: blocks.into_iter().map(Into::into).collect(),
-        optimization_bailouts: vec![],
       })
     }
   }

--- a/tests/rspack-test/cacheCases/common/module-cache-new-cache/changed.js
+++ b/tests/rspack-test/cacheCases/common/module-cache-new-cache/changed.js
@@ -1,3 +1,4 @@
 export default 1;
+console.log('changed module');
 ---
 export default 2;

--- a/tests/rspack-test/cacheCases/common/module-cache-new-cache/rspack.config.js
+++ b/tests/rspack-test/cacheCases/common/module-cache-new-cache/rspack.config.js
@@ -21,6 +21,10 @@ module.exports = {
   cache: {
     type: 'persistent',
   },
+  optimization: {
+    concatenateModules: false,
+    sideEffects: true,
+  },
   module: {
     rules: [
       {
@@ -56,6 +60,27 @@ module.exports = {
           });
         });
         compiler.hooks.done.tap('ModuleCacheTest', (stats) => {
+          const { modules } = stats.toJson({
+            all: false,
+            modules: true,
+            cachedModules: true,
+            orphanModules: true,
+            optimizationBailout: true,
+          });
+          const sideEffectsBailouts = (name) =>
+            modules
+              .find((module) => module.name === `./${name}`)
+              .optimizationBailout.filter((reason) =>
+                reason.includes('with side_effects in source code'),
+              );
+          expect(sideEffectsBailouts('stable.js')).toEqual([
+            expect.stringContaining('ExportDefaultExpr with side_effects'),
+          ]);
+          expect(sideEffectsBailouts('changed.js')).toEqual(
+            compilerIndex === 0
+              ? [expect.stringContaining('Statement with side_effects')]
+              : [],
+          );
           expect(
             stats.compilation
               .getAsset('from-succeed-module.txt')

--- a/tests/rspack-test/cacheCases/common/module-cache-new-cache/stable.js
+++ b/tests/rspack-test/cacheCases/common/module-cache-new-cache/stable.js
@@ -1,3 +1,3 @@
-export default 'stable';
+export default (() => 'stable')();
 
 export const loadAsync = () => import('./async');


### PR DESCRIPTION
## Summary

Move build-time optimization bailouts into module build info and remove `BuildResult.optimization_bailouts`. Keep compilation-specific bailouts in the module graph and restore build-time bailouts with cached module state.