### PR TITLE
chore(docs): clarify target defaults and Lightning CSS inheritance

### DIFF
--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -20,14 +20,12 @@ type Target = false | string | string[];
 
 ## Default behavior \{#default-behavior}
 
-When `target` is not set, Rspack looks for a Browserslist configuration starting from [`context`](/config/context), which defaults to the current working directory:
+When `target` is not set, Rspack looks for a [Browserslist configuration](#browserslist) starting from [`context`](/config/context):
 
-- If a configuration is found, Rspack uses `browserslist` and determines the target environment from the nearest `browserslist` or `.browserslistrc` file, or the `browserslist` field in `package.json`. See [Browserslist](#browserslist) for details.
-- Otherwise, Rspack uses `web`, meaning the code will run in a browser environment without specifying particular browser versions or an ECMAScript syntax version. To define a compatibility range, configure Browserslist or combine `web` with an `esX` target.
+- If found, `target` defaults to `browserslist` and uses that configuration.
+- Otherwise, it defaults to `web`, which selects a browser environment without specifying browser versions or an ECMAScript version.
 
-Built-in loaders and minimizers can also [inherit this default](#target-inheritance). If `target` does not provide the target information they need, they use their own defaults. See each tool's documentation for details.
-
-If you explicitly set `target: 'browserslist'`, you must provide a Browserslist configuration or set the `BROWSERSLIST` environment variable. Otherwise, Rspack reports an error instead of using `web`.
+Explicitly setting `target: 'browserslist'` requires a Browserslist configuration or the `BROWSERSLIST` environment variable; otherwise, Rspack reports an error.
 
 ## Recommended configurations
 

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -20,14 +20,14 @@ type Target = false | string | string[];
 
 ## Default behavior \{#default-behavior}
 
-When `target` is omitted, Rspack looks for a standard Browserslist configuration starting from [`context`](/config/context), which defaults to the current working directory:
+When `target` is not set, Rspack looks for a Browserslist configuration starting from [`context`](/config/context), which defaults to the current working directory:
 
-- If a configuration is found, `target` defaults to `browserslist`. Rspack uses the nearest `browserslist` or `.browserslistrc` file, or the `browserslist` field in `package.json`, to determine the target environment. See [Browserslist](#browserslist) for details.
-- Otherwise, `target` defaults to `web`. This selects a browser-like platform without specifying browser versions or a fixed ECMAScript syntax version. To specify compatibility requirements, configure Browserslist or combine `web` with an `esX` target.
+- If a configuration is found, Rspack uses `browserslist` and determines the target environment from the nearest `browserslist` or `.browserslistrc` file, or the `browserslist` field in `package.json`. See [Browserslist](#browserslist) for details.
+- Otherwise, Rspack uses `web`, meaning the code will run in a browser environment without specifying particular browser versions or an ECMAScript syntax version. To define a compatibility range, configure Browserslist or combine `web` with an `esX` target.
 
-The resolved default also applies to [built-in tools that inherit `target`](#target-inheritance). See each loader or minimizer's documentation for its default behavior when no compatible target can be inherited.
+Built-in loaders and minimizers can also [inherit this default](#target-inheritance). If `target` does not provide the target information they need, they use their own defaults. See each tool's documentation for details.
 
-If you explicitly set `target: 'browserslist'`, Rspack throws an error when no Browserslist configuration is found and the `BROWSERSLIST` environment variable is not set. It does not fall back to `web` in this case.
+If you explicitly set `target: 'browserslist'`, you must provide a Browserslist configuration or set the `BROWSERSLIST` environment variable. Otherwise, Rspack reports an error instead of using `web`.
 
 ## Recommended configurations
 

--- a/website/docs/en/config/target.mdx
+++ b/website/docs/en/config/target.mdx
@@ -18,6 +18,17 @@ type Target = false | string | string[];
 
 - **Default:** `browserslist` when the project includes a standard Browserslist configuration; otherwise `web`
 
+## Default behavior \{#default-behavior}
+
+When `target` is omitted, Rspack looks for a standard Browserslist configuration starting from [`context`](/config/context), which defaults to the current working directory:
+
+- If a configuration is found, `target` defaults to `browserslist`. Rspack uses the nearest `browserslist` or `.browserslistrc` file, or the `browserslist` field in `package.json`, to determine the target environment. See [Browserslist](#browserslist) for details.
+- Otherwise, `target` defaults to `web`. This selects a browser-like platform without specifying browser versions or a fixed ECMAScript syntax version. To specify compatibility requirements, configure Browserslist or combine `web` with an `esX` target.
+
+The resolved default also applies to [built-in tools that inherit `target`](#target-inheritance). See each loader or minimizer's documentation for its default behavior when no compatible target can be inherited.
+
+If you explicitly set `target: 'browserslist'`, Rspack throws an error when no Browserslist configuration is found and the `BROWSERSLIST` environment variable is not set. It does not fall back to `web` in this case.
+
 ## Recommended configurations
 
 ### Browsers

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -130,7 +130,9 @@ Browserslist query string or a `Targets` object specifying browser versions.
 :::tip Default targets from Rspack
 If `targets` is not configured, `builtin:lightningcss-loader` will automatically derive a default targets from Rspack's [`target`](/config/target) configuration when using browserslist-related targets (e.g., `browserslist` or `browserslist:modern`). Since Lightning CSS only supports browser-related targets, non-browser targets like `node` will not provide default targets for this loader.
 
-This means you can rely on your Rspack `target` configuration without manually specifying the same targets in the loader options.
+This also applies when Rspack `target` is omitted. See [`target` default behavior](/config/target#default-behavior) for how Rspack selects the default. You can rely on the resolved `target` without manually specifying the same targets in the loader options.
+
+If no Browserslist configuration is found and Rspack `target` defaults to `web`, there are no browser versions for the loader to inherit. In this case, the loader's `targets` remains unset unless you configure it explicitly.
 :::
 
 Here are some examples of setting targets.

--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -127,12 +127,12 @@ type LightningcssLoaderOptions = {
 
 Browserslist query string or a `Targets` object specifying browser versions.
 
-:::tip Default targets from Rspack
-If `targets` is not configured, `builtin:lightningcss-loader` will automatically derive a default targets from Rspack's [`target`](/config/target) configuration when using browserslist-related targets (e.g., `browserslist` or `browserslist:modern`). Since Lightning CSS only supports browser-related targets, non-browser targets like `node` will not provide default targets for this loader.
+:::tip Default browser targets
+When `targets` is not set, the loader gets its browser targets from Rspack's [`target`](/config/target). For example, with `browserslist` or `browserslist:modern`, you do not need to repeat the configuration in the loader. Lightning CSS only supports browser targets, so it cannot get browser versions from non-browser targets such as `node`.
 
-This also applies when Rspack `target` is omitted. See [`target` default behavior](/config/target#default-behavior) for how Rspack selects the default. You can rely on the resolved `target` without manually specifying the same targets in the loader options.
+When Rspack `target` is not set, the loader also tries to get browser targets from its default value. See [`target` default behavior](/config/target#default-behavior) for details.
 
-If no Browserslist configuration is found and Rspack `target` defaults to `web`, there are no browser versions for the loader to inherit. In this case, the loader's `targets` remains unset unless you configure it explicitly.
+If no Browserslist configuration is found, Rspack defaults to `web`, which does not specify browser versions. The loader's `targets` then remains unset, and you can configure it as needed.
 :::
 
 Here are some examples of setting targets.

--- a/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -86,10 +86,8 @@ Below are the configurations supported, `targets` configuration is plain browser
 
 1. The plugin determines `targets` in this order:
    - Use `minimizerOptions.targets` if explicitly configured.
-   - Otherwise, get browser targets from Rspack's [`target`](/config/target), such as the browsers specified by `browserslist` or `browserslist:modern`. Non-browser targets such as `node` do not provide this information.
-   - If no browser targets are available, use browsers with full ES6 support through the Browserslist query `"fully supports es6"`.
-
-   This also applies to Rspack's [default `target`](/config/target#default-behavior). For example, when `target` is not set and no Browserslist configuration is found, Rspack uses `web`. Since `web` does not specify browser versions, the plugin uses `"fully supports es6"` unless you set `minimizerOptions.targets`.
+   - Otherwise, get browser targets from Rspack's [`target`](/config/target#default-behavior), such as the browsers specified by `browserslist` or `browserslist:modern`. Non-browser targets such as `node` do not provide this information.
+   - If no browser targets are available, use `"fully supports es6"` by default.
 
    During minification, Lightning CSS may use shorter, newer syntax to reduce file size. This default limits the syntax it can use to keep the result compatible with those browsers.
 

--- a/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -86,8 +86,8 @@ Below are the configurations supported, `targets` configuration is plain browser
 
 1. The plugin determines `targets` in this order:
    - Use `minimizerOptions.targets` if explicitly configured.
-   - Otherwise, get browser targets from Rspack's [`target`](/config/target#default-behavior), such as the browsers specified by `browserslist` or `browserslist:modern`. Non-browser targets such as `node` do not provide this information.
-   - If no browser targets are available, use `"fully supports es6"` by default.
+   - Otherwise, inherit the target data from Rspack's [`target`](/config/target#default-behavior), keeping only supported browsers. If it contains no supported browsers, as with `browserslist:node 18`, use an empty target object.
+   - If Rspack provides no target data, as with `web`, use `"fully supports es6"` by default.
 
    During minification, Lightning CSS may use shorter, newer syntax to reduce file size. This default limits the syntax it can use to keep the result compatible with those browsers.
 

--- a/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -84,16 +84,14 @@ Below are the configurations supported, `targets` configuration is plain browser
 
 :::info
 
-1. The `targets` option is resolved in the following priority order:
-   - User-specified `targets` in plugin options (highest priority)
-   - Targets derived from Rspack's [`target`](/config/target) configuration when using browserslist-related targets (e.g., `browserslist` or `browserslist:modern`), since Lightning CSS only supports browser-related targets, non-browser targets like `node` will not provide default targets for this plugin.
-   - If neither is available, targets browsers with full ES6 support by default, using the Browserslist query `"fully supports es6"`
+1. The plugin determines `targets` in this order:
+   - Use `minimizerOptions.targets` if explicitly configured.
+   - Otherwise, get browser targets from Rspack's [`target`](/config/target), such as the browsers specified by `browserslist` or `browserslist:modern`. Non-browser targets such as `node` do not provide this information.
+   - If no browser targets are available, use browsers with full ES6 support through the Browserslist query `"fully supports es6"`.
 
-   Inheritance also applies when Rspack `target` is omitted. See [`target` default behavior](/config/target#default-behavior) for how Rspack selects the default.
+   This also applies to Rspack's [default `target`](/config/target#default-behavior). For example, when `target` is not set and no Browserslist configuration is found, Rspack uses `web`. Since `web` does not specify browser versions, the plugin uses `"fully supports es6"` unless you set `minimizerOptions.targets`.
 
-   For example, if no Browserslist configuration is found and Rspack `target` defaults to `web`, there are no browser versions to inherit. The plugin then uses `"fully supports es6"` unless you configure `minimizerOptions.targets` explicitly.
-
-   The fallback ensures that minification does not introduce advanced syntax that could cause browser incompatibility (minification might turn lower-level syntax into advanced syntax because it is shorter).
+   During minification, Lightning CSS may use shorter, newer syntax to reduce file size. This default limits the syntax it can use to keep the result compatible with those browsers.
 
 2. The `exclude` option is configured with all features by default. We usually do syntax degradation in [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader) or other loaders, so this plugin excludes all features by default to avoid syntax downgrading during the minimize process.
 

--- a/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -87,7 +87,11 @@ Below are the configurations supported, `targets` configuration is plain browser
 1. The `targets` option is resolved in the following priority order:
    - User-specified `targets` in plugin options (highest priority)
    - Targets derived from Rspack's [`target`](/config/target) configuration when using browserslist-related targets (e.g., `browserslist` or `browserslist:modern`), since Lightning CSS only supports browser-related targets, non-browser targets like `node` will not provide default targets for this plugin.
-   - Falls back to `"fully supports es6"` if neither is available
+   - If neither is available, targets browsers with full ES6 support by default, using the Browserslist query `"fully supports es6"`
+
+   Inheritance also applies when Rspack `target` is omitted. See [`target` default behavior](/config/target#default-behavior) for how Rspack selects the default.
+
+   For example, if no Browserslist configuration is found and Rspack `target` defaults to `web`, there are no browser versions to inherit. The plugin then uses `"fully supports es6"` unless you configure `minimizerOptions.targets` explicitly.
 
    The fallback ensures that minification does not introduce advanced syntax that could cause browser incompatibility (minification might turn lower-level syntax into advanced syntax because it is shorter).
 

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -20,14 +20,12 @@ type Target = false | string | string[];
 
 ## 默认行为 \{#default-behavior}
 
-未设置 `target` 时，Rspack 会以 [`context`](/config/context) 指定的目录为起点查找 Browserslist 配置。`context` 默认为当前工作目录。
+未设置 `target` 时，Rspack 会从 [`context`](/config/context) 指定的目录开始查找 [Browserslist 配置](#browserslist)：
 
-- 如果找到配置，`target` 默认为 `browserslist`，Rspack 会根据最近的配置确定目标环境。配置可以来自 `browserslist` 文件、`.browserslistrc` 文件或 `package.json` 中的 `browserslist` 字段。详见 [Browserslist](#browserslist)。
-- 如果找不到配置，`target` 默认为 `web`，表示代码将在浏览器环境中运行。`web` 不指定具体的浏览器版本或 ECMAScript 语法版本；如果需要指定兼容范围，可以配置 Browserslist，或将 `web` 与 `esX` target 组合使用。
+- 找到配置时，`target` 默认为 `browserslist`，并使用该配置。
+- 找不到配置时，`target` 默认为 `web`，表示浏览器环境，但不指定浏览器版本或 ECMAScript 版本。
 
-内置 loader 和压缩插件也可以[继承 `target` 的默认值](#目标环境继承)。如果无法从 `target` 中获取所需的目标信息，它们会使用各自的默认设置，具体行为见对应工具的文档。
-
-如果显式设置了 `target: 'browserslist'`，则需要提供 Browserslist 配置或设置 `BROWSERSLIST` 环境变量，否则 Rspack 会报错，不会改用 `web`。
+如果显式设置 `target: 'browserslist'`，则必须提供 Browserslist 配置或设置 `BROWSERSLIST` 环境变量，否则 Rspack 会报错。
 
 ## 推荐配置
 

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -20,14 +20,14 @@ type Target = false | string | string[];
 
 ## 默认行为 \{#default-behavior}
 
-省略 `target` 时，Rspack 会从 [`context`](/config/context) 开始查找标准的 Browserslist 配置；`context` 默认为当前工作目录：
+未设置 `target` 时，Rspack 会以 [`context`](/config/context) 指定的目录为起点查找 Browserslist 配置。`context` 默认为当前工作目录。
 
-- 如果找到配置，`target` 默认为 `browserslist`。Rspack 会使用最近的 `browserslist` 或 `.browserslistrc` 文件，或 `package.json` 中的 `browserslist` 字段来确定目标环境。详见 [Browserslist](#browserslist)。
-- 否则，`target` 默认为 `web`。它只选择类浏览器平台，不指定浏览器版本或固定的 ECMAScript 语法版本。如果需要指定兼容范围，请配置 Browserslist，或组合使用 `web` 和 `esX` target。
+- 如果找到配置，`target` 默认为 `browserslist`，Rspack 会根据最近的配置确定目标环境。配置可以来自 `browserslist` 文件、`.browserslistrc` 文件或 `package.json` 中的 `browserslist` 字段。详见 [Browserslist](#browserslist)。
+- 如果找不到配置，`target` 默认为 `web`，表示代码将在浏览器环境中运行。`web` 不指定具体的浏览器版本或 ECMAScript 语法版本；如果需要指定兼容范围，可以配置 Browserslist，或将 `web` 与 `esX` target 组合使用。
 
-解析后的默认值也适用于[继承 `target` 的内置工具](#目标环境继承)。无法继承兼容目标时，各 loader 和压缩插件的默认行为请参阅其各自的文档。
+内置 loader 和压缩插件也可以[继承 `target` 的默认值](#目标环境继承)。如果无法从 `target` 中获取所需的目标信息，它们会使用各自的默认设置，具体行为见对应工具的文档。
 
-如果显式设置 `target: 'browserslist'`，但找不到 Browserslist 配置，且未设置 `BROWSERSLIST` 环境变量，Rspack 会报错，此时不会回退到 `web`。
+如果显式设置了 `target: 'browserslist'`，则需要提供 Browserslist 配置或设置 `BROWSERSLIST` 环境变量，否则 Rspack 会报错，不会改用 `web`。
 
 ## 推荐配置
 

--- a/website/docs/zh/config/target.mdx
+++ b/website/docs/zh/config/target.mdx
@@ -18,6 +18,17 @@ type Target = false | string | string[];
 
 - **默认值：** 当项目中包含标准的 Browserslist 配置时为 `browserslist`，否则为 `web`
 
+## 默认行为 \{#default-behavior}
+
+省略 `target` 时，Rspack 会从 [`context`](/config/context) 开始查找标准的 Browserslist 配置；`context` 默认为当前工作目录：
+
+- 如果找到配置，`target` 默认为 `browserslist`。Rspack 会使用最近的 `browserslist` 或 `.browserslistrc` 文件，或 `package.json` 中的 `browserslist` 字段来确定目标环境。详见 [Browserslist](#browserslist)。
+- 否则，`target` 默认为 `web`。它只选择类浏览器平台，不指定浏览器版本或固定的 ECMAScript 语法版本。如果需要指定兼容范围，请配置 Browserslist，或组合使用 `web` 和 `esX` target。
+
+解析后的默认值也适用于[继承 `target` 的内置工具](#目标环境继承)。无法继承兼容目标时，各 loader 和压缩插件的默认行为请参阅其各自的文档。
+
+如果显式设置 `target: 'browserslist'`，但找不到 Browserslist 配置，且未设置 `BROWSERSLIST` 环境变量，Rspack 会报错，此时不会回退到 `web`。
+
 ## 推荐配置
 
 ### 浏览器

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -130,7 +130,9 @@ browserslist 查询字符串或指定浏览器版本的 `Targets` 对象。
 :::tip 来自 Rspack 的默认 Targets
 如果未配置 `targets`，当 Rspack 的 [`target`](/config/target) 配置使用与 browserslist 相关的 targets（例如 `browserslist` 或 `browserslist:modern`）时，`builtin:lightningcss-loader` 将自动从 Rspack 的 [`target`](/config/target) 配置中推断出默认 targets，因为 Lightning CSS 仅支持浏览器相关的 targets，所以像 `node` 这样的非浏览器 target 不会为此 loader 提供默认 targets。
 
-这意味着你可以依赖 Rspack 的 `target` 配置，而无需在 loader 选项中手动指定相同的 targets。
+省略 Rspack `target` 时也会应用这一行为，默认值的选择规则详见 [`target` 的默认行为](/config/target#default-behavior)。你可以依赖解析后的 `target`，而无需在 loader 选项中手动指定相同的 targets。
+
+如果找不到 Browserslist 配置，Rspack `target` 默认为 `web`，则没有可供 loader 继承的浏览器版本。此时，除非显式配置，否则 loader 的 `targets` 会保持未设置。
 :::
 
 下面是一些 targets 的用法示例。

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -127,12 +127,12 @@ type LightningcssLoaderOptions = {
 
 browserslist 查询字符串或指定浏览器版本的 `Targets` 对象。
 
-:::tip 来自 Rspack 的默认 Targets
-如果未配置 `targets`，当 Rspack 的 [`target`](/config/target) 配置使用与 browserslist 相关的 targets（例如 `browserslist` 或 `browserslist:modern`）时，`builtin:lightningcss-loader` 将自动从 Rspack 的 [`target`](/config/target) 配置中推断出默认 targets，因为 Lightning CSS 仅支持浏览器相关的 targets，所以像 `node` 这样的非浏览器 target 不会为此 loader 提供默认 targets。
+:::tip 默认目标浏览器
+未设置 `targets` 时，loader 会根据 Rspack 的 [`target`](/config/target) 确定需要兼容的浏览器。例如，如果 `target` 为 `browserslist` 或 `browserslist:modern`，loader 就会使用相应的浏览器配置，无需重复设置。Lightning CSS 只支持浏览器环境，因此无法继承 `node` 等非浏览器 target。
 
-省略 Rspack `target` 时也会应用这一行为，默认值的选择规则详见 [`target` 的默认行为](/config/target#default-behavior)。你可以依赖解析后的 `target`，而无需在 loader 选项中手动指定相同的 targets。
+即使没有显式设置 Rspack 的 `target`，loader 也会尝试继承它的默认值，详见 [`target` 的默认行为](/config/target#default-behavior)。
 
-如果找不到 Browserslist 配置，Rspack `target` 默认为 `web`，则没有可供 loader 继承的浏览器版本。此时，除非显式配置，否则 loader 的 `targets` 会保持未设置。
+如果没有设置 `target`，也找不到 Browserslist 配置，Rspack 就会使用默认值 `web`。由于 `web` 不包含浏览器版本信息，loader 不会自动设置 `targets`，需要时可以手动配置。
 :::
 
 下面是一些 targets 的用法示例。

--- a/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -84,16 +84,14 @@ document.body.className = styles.a;
 
 :::info
 
-1. `targets` 选项按照以下优先级解析：
-   - 用户在插件选项中指定的 `targets`（最高优先级）
-   - 当 Rspack 的 [`target`](/config/target) 配置使用与 browserslist 相关的 targets（例如 `browserslist` 或 `browserslist:modern`）时，从 Rspack 的 [`target`](/config/target) 配置中推断出。因为 Lightning CSS 仅支持浏览器相关的 targets，像 `node` 这样的非浏览器 target 不会为此插件提供默认 targets。
-   - 如果上述均未提供，默认以完整支持 ES6 的浏览器为目标，对应的 Browserslist 查询为 `"fully supports es6"`
+1. 插件按以下顺序确定 `targets`：
+   - 优先使用显式配置的 `minimizerOptions.targets`。
+   - 未配置时，使用 Rspack 的 [`target`](/config/target) 提供的浏览器信息。例如，`browserslist` 或 `browserslist:modern` 可以提供这类信息，`node` 等非浏览器 target 则不能。
+   - 如果仍无法确定需要兼容的浏览器，则默认使用 `"fully supports es6"`，即通过 Browserslist 选择完整支持 ES6 的浏览器。
 
-   省略 Rspack `target` 时也会继承其默认值，默认值的选择规则详见 [`target` 的默认行为](/config/target#default-behavior)。
+   即使没有显式设置 Rspack 的 `target`，插件也会尝试继承它的[默认值](/config/target#default-behavior)。例如，未设置 `target` 且找不到 Browserslist 配置时，Rspack 会使用 `web`。由于 `web` 不包含浏览器版本信息，如果也没有设置 `minimizerOptions.targets`，插件就会使用 `"fully supports es6"`。
 
-   例如，找不到 Browserslist 配置且 Rspack `target` 默认为 `web` 时，没有可供继承的浏览器版本。此时，除非显式配置 `minimizerOptions.targets`，否则插件会使用 `"fully supports es6"`。
-
-   回退机制确保压缩过程不会引入可能导致浏览器不兼容的高级语法（压缩可能会因为高级语法更短而将低级语法转换为高级语法）。
+   为了减小体积，Lightning CSS 在压缩时可能会改用更短的新语法。这个默认值限定了可以使用的语法范围，让压缩后的代码也能兼容上述浏览器。
 
 2. `exclude` 选项默认配置了所有的 features。我们通常会在 [builtin:lightningcss-loader](/guide/features/builtin-lightningcss-loader) 或其他 loaders 中进行语法降级，所以此插件默认 exclude 所有的 features，避免在 minimize 过程中进行语法降级。
 

--- a/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -86,8 +86,8 @@ document.body.className = styles.a;
 
 1. 插件按以下顺序确定 `targets`：
    - 优先使用显式配置的 `minimizerOptions.targets`。
-   - 未配置时，使用 Rspack 的 [`target`](/config/target#default-behavior) 提供的浏览器信息。例如，`browserslist` 或 `browserslist:modern` 可以提供这类信息，`node` 等非浏览器 target 则不能。
-   - 如果仍无法确定需要兼容的浏览器，则默认使用 `"fully supports es6"`。
+   - 未配置时，继承 Rspack 的 [`target`](/config/target#default-behavior) 提供的目标信息，只保留支持的浏览器。如果目标中不包含支持的浏览器（如 `browserslist:node 18`），则使用空目标。
+   - 如果 Rspack 未提供目标信息（如 `web`），则默认使用 `"fully supports es6"`。
 
    为了减小体积，Lightning CSS 在压缩时可能会改用更短的新语法。这个默认值限定了可以使用的语法范围，让压缩后的代码也能兼容上述浏览器。
 

--- a/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -87,7 +87,11 @@ document.body.className = styles.a;
 1. `targets` 选项按照以下优先级解析：
    - 用户在插件选项中指定的 `targets`（最高优先级）
    - 当 Rspack 的 [`target`](/config/target) 配置使用与 browserslist 相关的 targets（例如 `browserslist` 或 `browserslist:modern`）时，从 Rspack 的 [`target`](/config/target) 配置中推断出。因为 Lightning CSS 仅支持浏览器相关的 targets，像 `node` 这样的非浏览器 target 不会为此插件提供默认 targets。
-   - 如果上述均未提供，则回退到 `"fully supports es6"`
+   - 如果上述均未提供，默认以完整支持 ES6 的浏览器为目标，对应的 Browserslist 查询为 `"fully supports es6"`
+
+   省略 Rspack `target` 时也会继承其默认值，默认值的选择规则详见 [`target` 的默认行为](/config/target#default-behavior)。
+
+   例如，找不到 Browserslist 配置且 Rspack `target` 默认为 `web` 时，没有可供继承的浏览器版本。此时，除非显式配置 `minimizerOptions.targets`，否则插件会使用 `"fully supports es6"`。
 
    回退机制确保压缩过程不会引入可能导致浏览器不兼容的高级语法（压缩可能会因为高级语法更短而将低级语法转换为高级语法）。
 

--- a/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -86,10 +86,8 @@ document.body.className = styles.a;
 
 1. 插件按以下顺序确定 `targets`：
    - 优先使用显式配置的 `minimizerOptions.targets`。
-   - 未配置时，使用 Rspack 的 [`target`](/config/target) 提供的浏览器信息。例如，`browserslist` 或 `browserslist:modern` 可以提供这类信息，`node` 等非浏览器 target 则不能。
-   - 如果仍无法确定需要兼容的浏览器，则默认使用 `"fully supports es6"`，即通过 Browserslist 选择完整支持 ES6 的浏览器。
-
-   即使没有显式设置 Rspack 的 `target`，插件也会尝试继承它的[默认值](/config/target#default-behavior)。例如，未设置 `target` 且找不到 Browserslist 配置时，Rspack 会使用 `web`。由于 `web` 不包含浏览器版本信息，如果也没有设置 `minimizerOptions.targets`，插件就会使用 `"fully supports es6"`。
+   - 未配置时，使用 Rspack 的 [`target`](/config/target#default-behavior) 提供的浏览器信息。例如，`browserslist` 或 `browserslist:modern` 可以提供这类信息，`node` 等非浏览器 target 则不能。
+   - 如果仍无法确定需要兼容的浏览器，则默认使用 `"fully supports es6"`。
 
    为了减小体积，Lightning CSS 在压缩时可能会改用更短的新语法。这个默认值限定了可以使用的语法范围，让压缩后的代码也能兼容上述浏览器。
 


### PR DESCRIPTION
## Summary

Clarify the default `target` selection and link the Lightning CSS loader and minimizer documentation to it in both English and Chinese. Keep tool-specific defaults in each tool's documentation, and explain the error when `target: 'browserslist'` is explicitly selected without a configuration or the `BROWSERSLIST` environment variable.

For example, when `target` is omitted and no Browserslist configuration exists, Rspack defaults to `web`. If the tools' own targets are also omitted, the Lightning CSS loader leaves `targets` unset, while the minimizer targets browsers with full ES6 support using `"fully supports es6"`. With a browser Browserslist configuration, both tools can inherit browser targets even when Rspack `target` is omitted.

Validation: `git diff --check` passed. Documentation build was not run because dependencies are not installed in this worktree.

## Related links

None.

## Checklist

- [x] Tests updated (or not required; documentation only).
- [x] Documentation updated (or not required).

---
_by OpenAI Codex_