### PR TITLE
perf: defer parser Atom materialization

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -212,17 +212,20 @@ pub fn is_create_require_import(
   let Some(specifier) = create_require_import_specifier(parser, source) else {
     return false;
   };
-  export_name.is_some_and(|export_name| export_name == &specifier)
+  export_name.is_some_and(|export_name| export_name == specifier)
 }
 
 #[inline(never)]
-fn create_require_import_specifier(parser: &JavascriptParser, source: &Atom) -> Option<Atom> {
+fn create_require_import_specifier<'a>(
+  parser: &'a JavascriptParser,
+  source: &Atom,
+) -> Option<&'a str> {
   let option = parser.javascript_options.create_require_option()?;
   let (specifier, module) = option.split_once(" from ")?;
   (!specifier.is_empty()
     && !module.is_empty()
     && (source.as_ref() == module || (module == "module" && source.as_ref() == "node:module")))
-    .then(|| specifier.into())
+    .then_some(specifier)
 }
 
 #[inline(never)]
@@ -305,19 +308,26 @@ pub(crate) fn is_create_require_namespace_member(
   let Some(namespace) = member_expr.object(ast).as_identifier_reference(ast) else {
     return false;
   };
-  let Some(settings) = parser.get_tag_data::<ESMSpecifierData>(
-    &Atom::from(ast.get_utf8(namespace.name(ast))),
-    ESM_SPECIFIER_TAG,
-  ) else {
+  let Some(settings) =
+    parser.get_tag_data::<ESMSpecifierData>(ast.get_utf8(namespace.name(ast)), ESM_SPECIFIER_TAG)
+  else {
     return false;
   };
   let source = settings.source.clone();
   let module_object_import = is_create_require_module_object_import(settings);
-  let Some(member) = static_member_name(ast, member_expr) else {
-    return false;
-  };
   module_object_import
-    && create_require_import_specifier(parser, &source).is_some_and(|specifier| member == specifier)
+    && create_require_import_specifier(parser, &source).is_some_and(|specifier| {
+      let property = member_expr.property(ast);
+      if !member_expr.computed(ast) {
+        return property
+          .as_identifier_name(ast)
+          .is_some_and(|identifier| ast.get_utf8(identifier.name(ast)) == specifier);
+      }
+      if let PropertyKeyData::StringLiteral(string) = ast.property_key_data(property) {
+        return ast.get_wtf8(string.value(ast)).to_string_lossy() == specifier;
+      }
+      member_property_key_to_atom(ast, property).is_some_and(|member| member == specifier)
+    })
 }
 
 #[cold]
@@ -340,7 +350,7 @@ fn is_create_require_namespace_member_param(
   };
   is_create_require_module_object_import(settings)
     && create_require_import_specifier(parser, &settings.source)
-      .is_some_and(|specifier| property == specifier.as_ref())
+      .is_some_and(|specifier| property == specifier)
 }
 
 #[cold]
@@ -485,7 +495,7 @@ fn evaluate_create_require_argument(parser: &mut JavascriptParser, arg: Expr) ->
   let ast = parser.ast.ast;
   let new_expr = arg.as_new_expression(ast)?;
   if ast.get_utf8(new_expr.callee(ast).as_identifier_reference(ast)?.name(ast)) != "URL"
-    || parser.get_variable_info(&Atom::from("URL")).is_some()
+    || parser.get_variable_info("URL").is_some()
   {
     return None;
   }
@@ -560,7 +570,7 @@ fn is_side_effect_free_ignored_url_arg(parser: &mut JavascriptParser, expr: Expr
     | ExprData::RegExpLiteral(_) => true,
     ExprData::IdentifierReference(ident) => {
       ast.get_utf8(ident.name(ast)) == "undefined"
-        && parser.get_variable_info(&Atom::from("undefined")).is_none()
+        && parser.get_variable_info("undefined").is_none()
     }
     ExprData::UnaryExpression(unary) if unary.operator(ast) == UnaryOperator::Void => {
       is_side_effect_free_ignored_url_arg(parser, unary.argument(ast))
@@ -666,7 +676,7 @@ fn should_replace_create_require_argument(parser: &mut JavascriptParser, arg: Ex
     .callee(ast)
     .as_identifier_reference(ast)
     .is_some_and(|ident| ast.get_utf8(ident.name(ast)) == "URL")
-    && parser.get_variable_info(&Atom::from("URL")).is_none()
+    && parser.get_variable_info("URL").is_none()
   {
     let is_absolute_file_url = is_absolute_file_url_constructor_arg(parser, arg);
     let start = if is_absolute_file_url { 1 } else { 2 };
@@ -723,7 +733,7 @@ fn is_valid_ignored_url_base_arg(parser: &mut JavascriptParser, base: Argument) 
   };
   if let Some(ident) = base.as_identifier_reference(ast)
     && ast.get_utf8(ident.name(ast)) == "undefined"
-    && parser.get_variable_info(&Atom::from("undefined")).is_none()
+    && parser.get_variable_info("undefined").is_none()
   {
     return true;
   }
@@ -749,7 +759,7 @@ fn is_absolute_file_url_constructor_arg(parser: &mut JavascriptParser, arg: Expr
     .callee(ast)
     .as_identifier_reference(ast)
     .is_none_or(|ident| ast.get_utf8(ident.name(ast)) != "URL")
-    || parser.get_variable_info(&Atom::from("URL")).is_some()
+    || parser.get_variable_info("URL").is_some()
   {
     return false;
   };
@@ -779,7 +789,7 @@ fn is_unbound_url_constructor(parser: &mut JavascriptParser, callee: Expr) -> bo
   callee
     .as_identifier_reference(parser.ast.ast)
     .is_some_and(|ident| parser.ast.ast.get_utf8(ident.name(parser.ast.ast)) == "URL")
-    && parser.get_variable_info(&Atom::from("URL")).is_none()
+    && parser.get_variable_info("URL").is_none()
 }
 
 #[inline(never)]
@@ -1064,10 +1074,7 @@ fn deferred_create_require_callee(
   let (settings, range, ids, direct_import, ns_access) =
     if let Some(ident) = callee.as_identifier_reference(ast) {
       let settings = parser
-        .get_tag_data::<ESMSpecifierData>(
-          &Atom::from(ast.get_utf8(ident.name(ast))),
-          ESM_SPECIFIER_TAG,
-        )?
+        .get_tag_data::<ESMSpecifierData>(ast.get_utf8(ident.name(ast)), ESM_SPECIFIER_TAG)?
         .clone();
       let ids = settings.ids.clone().into_vec();
       (settings, ident.span(ast).into(), ids, true, false)
@@ -1075,10 +1082,7 @@ fn deferred_create_require_callee(
       let member = callee.as_member_expression(ast)?;
       let namespace = member.object(ast).as_identifier_reference(ast)?;
       let settings = parser
-        .get_tag_data::<ESMSpecifierData>(
-          &Atom::from(ast.get_utf8(namespace.name(ast))),
-          ESM_SPECIFIER_TAG,
-        )?
+        .get_tag_data::<ESMSpecifierData>(ast.get_utf8(namespace.name(ast)), ESM_SPECIFIER_TAG)?
         .clone();
       let mut ids = settings.ids.clone().into_vec();
       ids.push(static_member_name(ast, member)?);
@@ -1175,9 +1179,10 @@ fn pre_tag_created_require_declarator(
     return;
   };
   let callee = call.callee(ast);
-  let is_create_require_callee = callee.as_identifier_reference(ast).is_some_and(|ident| {
-    is_create_require_specifier(parser, &Atom::from(ast.get_utf8(ident.name(ast))))
-  }) || is_create_require_namespace_member(parser, callee);
+  let is_create_require_callee = callee
+    .as_identifier_reference(ast)
+    .is_some_and(|ident| is_create_require_specifier(parser, ast.get_utf8(ident.name(ast))))
+    || is_create_require_namespace_member(parser, callee);
   let args = call.arguments(ast);
   if !is_create_require_callee || !can_defer_create_require_call(parser, args) {
     return;
@@ -1538,7 +1543,8 @@ pub(crate) fn is_require_call_expr(parser: &mut JavascriptParser, call: CallExpr
   let callee = call.callee(ast);
 
   if let Some(ident) = callee.as_identifier_reference(ast) {
-    return Atom::from(ast.get_utf8(ident.name(ast)))
+    return ast
+      .get_utf8(ident.name(ast))
       .call_hooks_name(parser, |_, for_name| {
         (for_name == expr_name::REQUIRE).then_some(true)
       })
@@ -1619,7 +1625,7 @@ impl CommonJsImportsParserPlugin {
     };
 
     if parser
-      .get_variable_info(&Atom::from(ast.get_utf8(ident.name(ast))))
+      .get_variable_info(ast.get_utf8(ident.name(ast)))
       .is_some()
     {
       return false;
@@ -2052,8 +2058,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       return Some(true);
     }
     if let Some(ident) = expr.as_identifier_reference(ast)
-      && let Some(name_info) =
-        parser.get_name_info_from_variable(&Atom::from(ast.get_utf8(ident.name(ast))))
+      && let Some(name_info) = parser.get_name_info_from_variable(ast.get_utf8(ident.name(ast)))
       && let Some(info) = name_info.info
       && let Some(name) = info.name.clone()
       && parser
@@ -2108,7 +2113,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     if let Some(init) = init.as_identifier_reference(ast)
       && let Some(data) = parser
         .get_tag_data::<CreatedRequireTagData>(
-          &Atom::from(ast.get_utf8(init.name(ast))),
+          ast.get_utf8(init.name(ast)),
           CREATED_REQUIRE_IDENTIFIER_TAG,
         )
         .cloned()
@@ -2128,7 +2133,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
     }
 
     if let Some(init) = init.as_identifier_reference(ast)
-      && is_create_require_specifier(parser, &Atom::from(ast.get_utf8(init.name(ast))))
+      && is_create_require_specifier(parser, ast.get_utf8(init.name(ast)))
       && let Some(binding) = declarator.id(ast).as_binding_identifier(ast)
     {
       let name = Atom::from(ast.get_utf8(binding.name(ast)));
@@ -2187,7 +2192,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
 
     if parser
       .get_tag_data::<CreatedRequireTagData>(
-        &Atom::from(parser.ast.ast.get_utf8(binding.name(parser.ast.ast))),
+        parser.ast.ast.get_utf8(binding.name(parser.ast.ast)),
         CREATED_REQUIRE_IDENTIFIER_TAG,
       )
       .is_some()
@@ -2785,7 +2790,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CommonJsImportsParserPlugin {
       let Some(name) = source_for_span(parser, ident.span()) else {
         return Some(true);
       };
-      clear_create_require_tag(parser, &Atom::from(name));
+      clear_create_require_tag(parser, &name);
       return Some(true);
     }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/compatibility_plugin.rs
@@ -262,8 +262,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for CompatibilityPlugin {
       && (name == parser.parser_runtime_requirements.exports
         || name == self.nested_require_name(parser))
     {
-      let data =
-        parser.get_tag_data_mut::<NestedRequireData>(&Atom::from(name), NESTED_IDENTIFIER_TAG)?;
+      let data = parser.get_tag_data_mut::<NestedRequireData>(name, NESTED_IDENTIFIER_TAG)?;
       if !data.update {
         let dep = Arc::new(ConstDependency::new(data.loc, data.name.clone().into()));
         data.update = true;

--- a/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/drive.rs
@@ -739,7 +739,7 @@ impl<'p: 'a, 'a> JavascriptParserPlugin<'p, 'a> for JavaScriptParserPluginDrive 
   fn meta_property(
     &self,
     parser: &mut JavascriptParser<'p>,
-    root_name: &Atom,
+    root_name: &str,
     span: Span,
   ) -> Option<bool> {
     for plugin in self.plugins_for(JavascriptParserPluginHook::MetaProperty) {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/esm_export_dependency_parser_plugin.rs
@@ -43,10 +43,7 @@ fn create_default_exported_namespace_dependency(
     return None;
   };
   let settings = parser
-    .get_tag_data::<ESMSpecifierData>(
-      &Atom::from(ast.get_utf8(identifier.name(ast))),
-      ESM_SPECIFIER_TAG,
-    )
+    .get_tag_data::<ESMSpecifierData>(ast.get_utf8(identifier.name(ast)), ESM_SPECIFIER_TAG)
     .filter(|settings| settings.namespace_import && settings.ids.is_empty())?
     .clone();
   let statement_span = statement.span(ast);
@@ -358,10 +355,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       ExportDefaultExpression::Expr(expression) => {
         if let ExprData::IdentifierReference(identifier) = ast.expr_data(expression) {
           parser
-            .get_tag_data::<ConstValueData>(
-              &Atom::from(ast.get_utf8(identifier.name(ast))),
-              INLINABLE_CONST_TAG,
-            )
+            .get_tag_data::<ConstValueData>(ast.get_utf8(identifier.name(ast)), INLINABLE_CONST_TAG)
             .map(|data| data.value.clone())
         } else {
           to_evaluated_inlinable_value(&parser.evaluate_expression(expression))
@@ -379,10 +373,9 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ESMExportDependencyParserPlugin 
       parser.to_dependency_location(DependencyRange::from(expr_span)),
     );
     parser.add_dependency(BoxDependency::new(dep));
-    let name = expr.ident(ast).map_or_else(
-      || DEFAULT_STAR_JS_WORD.clone(),
-      |ident| Atom::from(ident.as_str()),
-    );
+    let name = expr
+      .ident(ast)
+      .unwrap_or_else(|| DEFAULT_STAR_JS_WORD.clone());
     InnerGraphParserPlugin::add_variable_usage(
       parser,
       &name,

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -519,16 +519,20 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
       && meta_expr
         .get_root_name(ast)
         .is_some_and(|name| name == expr_name::IMPORT_META)
-      && let Some(property) = (match ast.property_key_data(member_expr.property(ast)) {
+      && match ast.property_key_data(member_expr.property(ast)) {
         PropertyKeyData::IdentifierName(identifier) => {
-          Some(Atom::from(ast.get_utf8(identifier.name(ast))))
+          !self.preserve_property(Some(ast.get_utf8(identifier.name(ast))))
         }
+        PropertyKeyData::StringLiteral(string) if member_expr.computed(ast) => !self
+          .preserve_property(Some(
+            ast.get_wtf8(string.value(ast)).to_string_lossy().as_ref(),
+          )),
         _ if member_expr.computed(ast) => {
           member_property_key_to_atom(ast, member_expr.property(ast))
+            .is_some_and(|property| !self.preserve_property(Some(property.as_ref())))
         }
-        _ => None,
-      })
-      && !self.preserve_property(Some(property.as_ref()))
+        _ => false,
+      }
     {
       evaluated = Some("undefined".to_string())
     }
@@ -642,7 +646,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaPlugin {
   fn meta_property(
     &self,
     parser: &mut JavascriptParser<'p>,
-    root_name: &Atom,
+    root_name: &str,
     span: Span,
   ) -> Option<bool> {
     if root_name == expr_name::IMPORT_META {
@@ -928,7 +932,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportMetaDisabledPlugin {
   fn meta_property(
     &self,
     parser: &mut JavascriptParser<'p>,
-    root_name: &Atom,
+    root_name: &str,
     span: Span,
   ) -> Option<bool> {
     let import_meta_name = parser.compiler_options.output.import_meta_name.clone();

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_parser_plugin.rs
@@ -95,7 +95,7 @@ fn is_unbound_promise_all(parser: &mut JavascriptParser, call: CallExpression) -
       .property(ast)
       .as_identifier_name(ast)
       .is_some_and(|ident| ast.get_utf8(ident.name(ast)) == "all")
-    && parser.get_variable_info(&Atom::from("Promise")).is_none()
+    && parser.get_variable_info("Promise").is_none()
 }
 
 fn track_dynamic_import_pattern(
@@ -263,8 +263,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ImportParserPlugin {
       return Some(true);
     }
     if let Some(ident) = expr.as_identifier_reference(ast)
-      && let Some(name_info) =
-        parser.get_name_info_from_variable(&Atom::from(ast.get_utf8(ident.name(ast))))
+      && let Some(name_info) = parser.get_name_info_from_variable(ast.get_utf8(ident.name(ast)))
       && let Some(info) = name_info.info
       && let Some(name) = info.name.clone()
       && parser

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -557,7 +557,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
     if let Some(identifier) = decl.id(ast).as_binding_identifier(ast)
       && let Some(init) = decl.init(ast)
     {
-      let name = Atom::from(ast.get_utf8(identifier.name(ast)));
+      let name = ast.get_utf8(identifier.name(ast));
       let mut callees = vec![];
 
       if let Some(class) = init.as_class(ast)
@@ -569,7 +569,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           None,
         )
       {
-        let v = Self::tag_top_level_symbol(parser, &name);
+        let v = Self::tag_top_level_symbol(parser, &Atom::from(name));
 
         parser
           .inner_graph
@@ -584,7 +584,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           Some(&mut callees),
         )
       {
-        let v = Self::tag_top_level_symbol(parser, &name);
+        let v = Self::tag_top_level_symbol(parser, &Atom::from(name));
         for (symbol, span) in callees {
           v.add_depend_on(&mut parser.inner_graph, symbol, span);
         }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/javascript_meta_info_plugin.rs
@@ -1,4 +1,3 @@
-use rspack_intern::Atom;
 use swc_next_ecma_ast::CallExpression;
 
 use super::{
@@ -38,7 +37,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for JavascriptMetaInfoPlugin {
     }
     let variables: Vec<_> = parser
       .get_all_variables_from_current_scope()
-      .map(|(name, _)| Atom::new(name))
+      .map(|(name, _)| name.clone())
       .collect();
     for name in variables {
       if parser.is_variable_defined(&name) {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -1,9 +1,9 @@
-use std::sync::LazyLock;
+use std::{borrow::Cow, sync::LazyLock};
 
 use rspack_core::{
   DeferredPureCheck, Dependency, DependencyRange, ModuleDependency, SideEffectsBailoutItemWithSpan,
 };
-use rspack_intern::AtomSet;
+use rspack_intern::{AtomRef, AtomSet};
 use rspack_util::{
   SpanExt,
   swc::{AstSubRangeExt, RspackComments},
@@ -48,17 +48,13 @@ fn atom_from_binding(ast: &Ast<'_>, ident: swc_next_ecma_ast::BindingIdentifier)
   Atom::from(ast.get_utf8(ident.name(ast)))
 }
 
-fn atom_from_identifier(ast: &Ast<'_>, ident: swc_next_ecma_ast::IdentifierReference) -> Atom {
-  Atom::from(ast.get_utf8(ident.name(ast)))
-}
-
-fn atom_from_module_export_name(ast: &Ast<'_>, name: ModuleExportName) -> Atom {
+fn module_export_name<'ast>(ast: &'ast Ast<'_>, name: ModuleExportName) -> Cow<'ast, str> {
   match ast.module_export_name_data(name) {
     ModuleExportNameData::IdentifierName(identifier) => {
-      Atom::from(ast.get_utf8(identifier.name(ast)))
+      Cow::Borrowed(ast.get_utf8(identifier.name(ast)))
     }
     ModuleExportNameData::StringLiteral(string) => {
-      Atom::from(ast.get_wtf8(string.value(ast)).to_string_lossy().as_ref())
+      ast.get_wtf8(string.value(ast)).to_string_lossy()
     }
   }
 }
@@ -82,9 +78,13 @@ fn has_pure_comment(comments: &RspackComments<'_>, pos: u32) -> bool {
   })
 }
 
-fn visit_pattern_binding_names(ast: &Ast<'_>, pattern: BindingPattern, f: &mut impl FnMut(Atom)) {
+fn visit_pattern_binding_names<'ast>(
+  ast: &'ast Ast<'_>,
+  pattern: BindingPattern,
+  f: &mut impl FnMut(&'ast str),
+) {
   match ast.binding_pattern_data(pattern) {
-    BindingPatternData::BindingIdentifier(identifier) => f(atom_from_binding(ast, identifier)),
+    BindingPatternData::BindingIdentifier(identifier) => f(ast.get_utf8(identifier.name(ast))),
     BindingPatternData::ArrayPattern(array) => {
       for element in ast.nodes(array.elements(ast)).flatten() {
         visit_pattern_binding_names(ast, element, f);
@@ -111,16 +111,20 @@ fn visit_pattern_binding_names(ast: &Ast<'_>, pattern: BindingPattern, f: &mut i
   }
 }
 
-fn visit_decl_binding_names(ast: &Ast<'_>, declaration: Decl, f: &mut impl FnMut(Atom)) {
+fn visit_decl_binding_names<'ast>(
+  ast: &'ast Ast<'_>,
+  declaration: Decl,
+  f: &mut impl FnMut(&'ast str),
+) {
   match ast.decl_data(declaration) {
     DeclData::Function(function) => {
       if let Some(identifier) = function.id(ast) {
-        f(atom_from_binding(ast, identifier));
+        f(ast.get_utf8(identifier.name(ast)));
       }
     }
     DeclData::Class(class) => {
       if let Some(identifier) = class.id(ast) {
-        f(atom_from_binding(ast, identifier));
+        f(ast.get_utf8(identifier.name(ast)));
       }
     }
     DeclData::VariableDeclaration(variable) => {
@@ -132,7 +136,11 @@ fn visit_decl_binding_names(ast: &Ast<'_>, declaration: Decl, f: &mut impl FnMut
   }
 }
 
-fn visit_stmt_defined_binding_names(ast: &Ast<'_>, statement: Stmt, f: &mut impl FnMut(Atom)) {
+fn visit_stmt_defined_binding_names<'ast>(
+  ast: &'ast Ast<'_>,
+  statement: Stmt,
+  f: &mut impl FnMut(&'ast str),
+) {
   match ast.stmt_data(statement) {
     StmtData::Declaration(declaration) => visit_decl_binding_names(ast, declaration, f),
     StmtData::ImportDeclaration(import) => {
@@ -144,7 +152,7 @@ fn visit_stmt_defined_binding_names(ast: &Ast<'_>, statement: Stmt, f: &mut impl
             specifier.local(ast)
           }
         };
-        f(atom_from_binding(ast, local));
+        f(ast.get_utf8(local.name(ast)));
       }
     }
     StmtData::ExportNamedDeclaration(export) => {
@@ -156,23 +164,23 @@ fn visit_stmt_defined_binding_names(ast: &Ast<'_>, statement: Stmt, f: &mut impl
       match ast.export_default_declaration_kind_data(export.declaration(ast)) {
         ExportDefaultDeclarationKindData::Function(function) => {
           if let Some(identifier) = function.id(ast) {
-            f(atom_from_binding(ast, identifier));
+            f(ast.get_utf8(identifier.name(ast)));
           }
         }
         ExportDefaultDeclarationKindData::Class(class) => {
           if let Some(identifier) = class.id(ast) {
-            f(atom_from_binding(ast, identifier));
+            f(ast.get_utf8(identifier.name(ast)));
           }
         }
         ExportDefaultDeclarationKindData::Expr(expression) => match ast.expr_data(expression) {
           ExprData::Function(function) => {
             if let Some(identifier) = function.id(ast) {
-              f(atom_from_binding(ast, identifier));
+              f(ast.get_utf8(identifier.name(ast)));
             }
           }
           ExprData::Class(class) => {
             if let Some(identifier) = class.id(ast) {
-              f(atom_from_binding(ast, identifier));
+              f(ast.get_utf8(identifier.name(ast)));
             }
           }
           _ => {}
@@ -189,7 +197,7 @@ fn collect_pure_function_acceptable_names(ast: &Ast<'_>, program: Program) -> At
   let mut names = AtomSet::default();
   for statement in ast.nodes(statements) {
     visit_stmt_defined_binding_names(ast, statement, &mut |name| {
-      names.insert(name);
+      names.insert(Atom::from(name));
     });
   }
 
@@ -198,9 +206,9 @@ fn collect_pure_function_acceptable_names(ast: &Ast<'_>, program: Program) -> At
     match ast.stmt_data(statement) {
       StmtData::ExportNamedDeclaration(export) if export.source(ast).is_none() => {
         for specifier in ast.nodes(export.specifiers(ast)) {
-          let local = atom_from_module_export_name(ast, specifier.local(ast));
-          if local_bindings.contains(&local) {
-            names.insert(atom_from_module_export_name(ast, specifier.exported(ast)));
+          let local = module_export_name(ast, specifier.local(ast));
+          if local_bindings.contains(local.as_ref()) {
+            names.insert(Atom::from(module_export_name(ast, specifier.exported(ast))));
           }
         }
       }
@@ -231,15 +239,12 @@ fn collect_defined_configured_side_effects_free(
   let acceptable = collect_pure_function_acceptable_names(ast, program);
   configured_side_effects_free
     .iter()
-    .filter_map(|name| {
-      let atom = Atom::from(name.clone());
-      acceptable.contains(&atom).then_some(atom)
-    })
+    .filter_map(|name| acceptable.get(name).cloned())
     .collect()
 }
 
 fn collect_duplicate_top_level_names(ast: &Ast<'_>, program: Program) -> AtomSet {
-  let mut counts = FxHashMap::<Atom, usize>::default();
+  let mut counts = FxHashMap::<&str, usize>::default();
   for statement in ast.nodes(program.body(ast)) {
     visit_stmt_defined_binding_names(ast, statement, &mut |name| {
       *counts.entry(name).or_default() += 1;
@@ -247,7 +252,8 @@ fn collect_duplicate_top_level_names(ast: &Ast<'_>, program: Program) -> AtomSet
   }
   counts
     .into_iter()
-    .filter_map(|(name, count)| (count > 1).then_some(name))
+    .filter(|(_, count)| *count > 1)
+    .map(|(name, _)| Atom::from(name))
     .collect()
 }
 
@@ -369,17 +375,17 @@ fn collect_pure_annotations(
   side_effects_free
 }
 
-fn mark_side_effects_free(parser: &mut JavascriptParser, name: &Atom, export_name: Option<&Atom>) {
+fn mark_side_effects_free(parser: &mut JavascriptParser, name: &str, export_name: Option<&str>) {
   let side_effects_free = parser.build_info.side_effects_free.get_or_insert_default();
-  side_effects_free.insert(name.clone());
+  side_effects_free.insert(Atom::from(name));
   if let Some(export_name) = export_name {
-    side_effects_free.insert(export_name.clone());
+    side_effects_free.insert(Atom::from(export_name));
   }
 }
 
 fn already_marked_or_duplicate(
   parser: &JavascriptParser,
-  name: &Atom,
+  name: &str,
   duplicate_names: &AtomSet,
 ) -> bool {
   duplicate_names.contains(name)
@@ -394,7 +400,7 @@ fn try_mark_auto_side_effects_free_variable(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   variable: AstVariableDeclaration,
-  export_name: Option<&Atom>,
+  export_name: Option<&str>,
   duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
@@ -407,8 +413,8 @@ fn try_mark_auto_side_effects_free_variable(
     else {
       continue;
     };
-    let name = atom_from_binding(ast, identifier);
-    if already_marked_or_duplicate(parser, &name, duplicate_names) {
+    let name = ast.get_utf8(identifier.name(ast));
+    if already_marked_or_duplicate(parser, name, duplicate_names) {
       continue;
     }
     let Some(initializer) = declarator.init(ast) else {
@@ -424,7 +430,7 @@ fn try_mark_auto_side_effects_free_variable(
       _ => false,
     };
     if is_side_effects_free {
-      mark_side_effects_free(parser, &name, export_name);
+      mark_side_effects_free(parser, name, export_name);
     }
   }
 }
@@ -433,7 +439,7 @@ fn try_mark_auto_side_effects_free_decl(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   declaration: Decl,
-  export_name: Option<&Atom>,
+  export_name: Option<&str>,
   duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
@@ -442,11 +448,11 @@ fn try_mark_auto_side_effects_free_decl(
       let Some(identifier) = function.id(ast) else {
         return;
       };
-      let name = atom_from_binding(ast, identifier);
-      if !already_marked_or_duplicate(parser, &name, duplicate_names)
+      let name = ast.get_utf8(identifier.name(ast));
+      if !already_marked_or_duplicate(parser, name, duplicate_names)
         && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
       {
-        mark_side_effects_free(parser, &name, export_name);
+        mark_side_effects_free(parser, name, export_name);
       }
     }
     DeclData::VariableDeclaration(variable) => try_mark_auto_side_effects_free_variable(
@@ -488,28 +494,27 @@ fn mark_auto_side_effects_free_program(
         }
       }
       StmtData::ExportDefaultDeclaration(export) => {
-        let default_name = Atom::from("default");
         match ast.export_default_declaration_kind_data(export.declaration(ast)) {
           ExportDefaultDeclarationKindData::Function(function) => {
             let Some(identifier) = function.id(ast) else {
               continue;
             };
-            let name = atom_from_binding(ast, identifier);
-            if !already_marked_or_duplicate(parser, &name, duplicate_names)
+            let name = ast.get_utf8(identifier.name(ast));
+            if !already_marked_or_duplicate(parser, name, duplicate_names)
               && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
             {
-              mark_side_effects_free(parser, &name, Some(&default_name));
+              mark_side_effects_free(parser, name, Some("default"));
             }
           }
           ExportDefaultDeclarationKindData::Expr(expression) => {
             if let ExprData::Function(function) = ast.expr_data(expression)
               && let Some(identifier) = function.id(ast)
             {
-              let name = atom_from_binding(ast, identifier);
-              if !already_marked_or_duplicate(parser, &name, duplicate_names)
+              let name = ast.get_utf8(identifier.name(ast));
+              if !already_marked_or_duplicate(parser, name, duplicate_names)
                 && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
               {
-                mark_side_effects_free(parser, &name, Some(&default_name));
+                mark_side_effects_free(parser, name, Some("default"));
               }
             }
           }
@@ -635,16 +640,15 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
       configured.sort();
       let defined = parser.build_info.side_effects_free.as_ref();
       for name in configured {
-        let atom = Atom::from(name.clone());
-        if !defined.is_some_and(|defined| defined.contains(&atom)) {
-          not_defined.push(atom);
+        if !defined.is_some_and(|defined| defined.contains(name)) {
+          not_defined.push(name.as_str());
         }
       }
     }
     if !not_defined.is_empty() {
       if let Some(side_effects_free) = parser.build_info.side_effects_free.as_mut() {
         for name in &not_defined {
-          side_effects_free.remove(name);
+          side_effects_free.remove(*name);
         }
       }
       let resource = parser.resource_data.resource();
@@ -676,7 +680,7 @@ fn set_side_effects_bailout(parser: &mut JavascriptParser, span: Span, kind: &st
 
 fn process_deferred_callees(parser: &mut JavascriptParser, callees: Vec<(Atom, Span)>, kind: &str) {
   for (callee, span) in callees {
-    if let Some(deferred_check) = try_extract_deferred_check(parser, callee, span) {
+    if let Some(deferred_check) = try_extract_deferred_check(parser, &callee, span) {
       parser
         .build_info
         .deferred_pure_checks
@@ -697,7 +701,7 @@ enum ExplicitSideEffectsFreeCallee {
 
 fn resolve_explicit_side_effects_free_callee(
   parser: &mut JavascriptParser,
-  ident: &Atom,
+  ident: &str,
   span: Span,
   allow_unresolved_marked: bool,
 ) -> ExplicitSideEffectsFreeCallee {
@@ -710,12 +714,12 @@ fn resolve_explicit_side_effects_free_callee(
     return ExplicitSideEffectsFreeCallee::NotMarked;
   }
 
-  if try_extract_deferred_check(parser, ident.clone(), span).is_some() {
+  if try_extract_deferred_check(parser, ident, span).is_some() {
     let is_user_configured = parser
       .javascript_options
       .side_effects_free
       .as_ref()
-      .is_some_and(|names| names.iter().any(|name| name.as_str() == ident.as_str()));
+      .is_some_and(|names| names.iter().any(|name| name == ident));
     if !is_user_configured {
       return ExplicitSideEffectsFreeCallee::Deferred;
     }
@@ -737,12 +741,12 @@ fn resolve_explicit_side_effects_free_callee(
   }
 }
 
-fn try_extract_deferred_check(
+fn try_extract_deferred_check<'key>(
   parser: &mut JavascriptParser,
-  ident: Atom,
+  ident: impl Into<AtomRef<'key>>,
   span: Span,
 ) -> Option<DeferredPureCheck> {
-  let info = parser.get_variable_info(&ident)?;
+  let info = parser.get_variable_info(ident)?;
   let tag_info_id = info.tag_info?;
   let tag_info = parser.definitions_db.expect_get_tag_info(tag_info_id);
   if tag_info.tag != ESM_SPECIFIER_TAG {
@@ -795,11 +799,11 @@ fn arguments_are_pure(
   true
 }
 
-fn identifier_expression_name(ast: &Ast<'_>, expression: Expr) -> Option<Atom> {
+fn identifier_expression_name<'ast>(ast: &'ast Ast<'_>, expression: Expr) -> Option<&'ast str> {
   let ExprData::IdentifierReference(identifier) = ast.expr_data(expression) else {
     return None;
   };
-  Some(atom_from_identifier(ast, identifier))
+  Some(ast.get_utf8(identifier.name(ast)))
 }
 
 fn is_pure_call_expression(
@@ -827,7 +831,7 @@ fn is_pure_call_expression(
   if analyze_side_effects_free && let Some(name) = identifier_expression_name(ast, callee) {
     match resolve_explicit_side_effects_free_callee(
       parser,
-      &name,
+      name,
       callee.span(ast),
       callees.is_none(),
     ) {
@@ -844,7 +848,7 @@ fn is_pure_call_expression(
         let Some(callees) = callees else {
           return false;
         };
-        callees.push((name, callee.span(ast)));
+        callees.push((Atom::from(name), callee.span(ast)));
         return arguments_are_pure(
           parser,
           analyze_side_effects_free,
@@ -858,7 +862,7 @@ fn is_pure_call_expression(
     }
 
     if let Some(callees) = callees {
-      callees.push((name, callee.span(ast)));
+      callees.push((Atom::from(name), callee.span(ast)));
       return arguments_are_pure(
         parser,
         analyze_side_effects_free,
@@ -1239,7 +1243,7 @@ fn is_common_js_export_assignment(
   let Some(identifier) = member.object(ast).as_identifier_reference(ast) else {
     return false;
   };
-  let name = Atom::from(ast.get_utf8(identifier.name(ast)));
+  let name = ast.get_utf8(identifier.name(ast));
 
   let property_name = match ast.property_key_data(member.property(ast)) {
     PropertyKeyData::IdentifierName(property) if !member.computed(ast) => {
@@ -1251,7 +1255,7 @@ fn is_common_js_export_assignment(
     _ => None,
   };
 
-  let property_is_side_effect_free = match name.as_str() {
+  let property_is_side_effect_free = match name {
     "exports" => property_name.is_some_and(|property| property != "__proto__"),
     "module" => property_name == Some("exports"),
     _ => false,
@@ -1259,7 +1263,7 @@ fn is_common_js_export_assignment(
 
   property_is_side_effect_free
     && parser
-      .get_variable_info(&name)
+      .get_variable_info(name)
       .is_none_or(|info| info.is_free())
 }
 

--- a/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/trait.rs
@@ -525,7 +525,7 @@ Please annotate your `impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for ...` block
   fn meta_property(
     &self,
     _parser: &mut JavascriptParser<'p>,
-    _root_name: &Atom,
+    _root_name: &str,
     _span: Span,
   ) -> Option<bool> {
     None

--- a/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/url_plugin.rs
@@ -4,7 +4,6 @@ use rspack_core::{
   BoxDependency, ContextDependency, ContextMode, ContextOptions, DependencyCategory,
   JavascriptParserUrl, RuntimeGlobals, RuntimeRequirementsDependency, get_context,
 };
-use rspack_intern::Atom;
 use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{
   ArgumentData, Ast, Expr, GetSpan, MemberExpression, NewExpression, Visit, VisitWith,
@@ -229,7 +228,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for URLPlugin {
     let expr = expr.as_new_expression(ast)?;
     let callee = expr.callee(ast).as_identifier_reference(ast)?;
     if parser
-      .get_free_info_from_variable(&Atom::from(ast.get_utf8(callee.name(ast))))
+      .get_free_info_from_variable(ast.get_utf8(callee.name(ast)))
       .is_none()
       || ast.get_utf8(callee.name(ast)) != "URL"
     {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
@@ -1,4 +1,3 @@
-use rspack_intern::Atom;
 use swc_next_ecma_ast::{CallExpression, PropertyKeyData};
 
 use super::BasicEvaluatedExpression;
@@ -19,9 +18,9 @@ pub fn eval_call_expression<'parser>(
   let drive = parser.plugin_drive.clone();
   let callee = expression.callee(ast);
   if let Some(identifier) = callee.as_identifier_reference(ast) {
-    let name = Atom::from(ast.get_utf8(identifier.name(ast)));
+    let name = ast.get_utf8(identifier.name(ast));
     let is_create_require = parser.javascript_options.is_create_require_enabled()
-      && is_create_require_specifier(parser, &name);
+      && is_create_require_specifier(parser, name);
     let evaluated = if is_create_require {
       name.call_hooks_name(parser, |parser, for_name| {
         drive.evaluate_call_expression(parser, for_name, expression)
@@ -31,10 +30,10 @@ pub fn eval_call_expression<'parser>(
       if evaluated.is_identifier() && evaluated.identifier() == CREATE_REQUIRE_EVALUATED_TAG {
         drive.evaluate_call_expression(parser, CREATE_REQUIRE_EVALUATED_TAG, expression)
       } else {
-        drive.evaluate_call_expression(parser, &name, expression)
+        drive.evaluate_call_expression(parser, name, expression)
       }
     } else {
-      drive.evaluate_call_expression(parser, &name, expression)
+      drive.evaluate_call_expression(parser, name, expression)
     };
     if evaluated.is_some() {
       return evaluated;

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -1,4 +1,3 @@
-use rspack_intern::Atom;
 use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use swc_next_ecma_ast::{ArgumentData, GetSpan, NewExpression};
 
@@ -19,8 +18,8 @@ pub fn eval_new_expression<'parser>(
   let identifier = callee.as_identifier_reference(ast);
   if parser.javascript_options.is_create_require_enabled() {
     if let Some(identifier) = identifier {
-      let name = Atom::from(ast.get_utf8(identifier.name(ast)));
-      if is_create_require_specifier(parser, &name) {
+      let name = ast.get_utf8(identifier.name(ast));
+      if is_create_require_specifier(parser, name) {
         let evaluated = name.call_hooks_name(parser, |parser, for_name| {
           evaluate_create_require_new_expression(parser, for_name, Some(callee), expression)
         });
@@ -36,8 +35,7 @@ pub fn eval_new_expression<'parser>(
     }
   }
   let identifier = identifier?;
-  if ast.get_utf8(identifier.name(ast)) != "RegExp"
-    || parser.get_variable_info(&Atom::from("RegExp")).is_some()
+  if ast.get_utf8(identifier.name(ast)) != "RegExp" || parser.get_variable_info("RegExp").is_some()
   {
     return None;
   }

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -1,4 +1,3 @@
-use rspack_intern::Atom;
 use rspack_util::SpanExt;
 use swc_next_ecma_ast::{ExprData, GetSpan, UnaryExpression, UnaryOperator};
 
@@ -16,7 +15,8 @@ fn eval_typeof<'parser>(
   debug_assert_eq!(expression.operator(ast), UnaryOperator::Typeof);
   let argument = expression.argument(ast);
   let hook_result = match ast.expr_data(argument) {
-    ExprData::IdentifierReference(identifier) => Atom::from(ast.get_utf8(identifier.name(ast)))
+    ExprData::IdentifierReference(identifier) => ast
+      .get_utf8(identifier.name(ast))
       .call_hooks_name(parser, |parser, name| {
         parser
           .plugin_drive

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -273,13 +273,13 @@ fn object_and_members_to_name(object: &str, members_reversed: &[impl AsRef<str>]
 }
 
 pub trait RootName {
-  fn get_root_name(&self, _ast: &Ast<'_>) -> Option<Atom> {
+  fn get_root_name<'ast>(&self, _ast: &'ast Ast<'_>) -> Option<&'ast str> {
     None
   }
 }
 
 impl RootName for Expr {
-  fn get_root_name(&self, ast: &Ast<'_>) -> Option<Atom> {
+  fn get_root_name<'ast>(&self, ast: &'ast Ast<'_>) -> Option<&'ast str> {
     match ast.expr_data(*self) {
       ExprData::IdentifierReference(ident) => ident.get_root_name(ast),
       ExprData::ThisExpression(this) => this.get_root_name(ast),
@@ -290,7 +290,7 @@ impl RootName for Expr {
 }
 
 impl RootName for ExprRef {
-  fn get_root_name(&self, ast: &Ast<'_>) -> Option<Atom> {
+  fn get_root_name<'ast>(&self, ast: &'ast Ast<'_>) -> Option<&'ast str> {
     match self {
       ExprRef::Ident(ident) => ident.get_root_name(ast),
       ExprRef::This(this) => this.get_root_name(ast),
@@ -301,25 +301,25 @@ impl RootName for ExprRef {
 }
 
 impl RootName for ThisExpression {
-  fn get_root_name(&self, _ast: &Ast<'_>) -> Option<Atom> {
-    Some("this".into())
+  fn get_root_name<'ast>(&self, _ast: &'ast Ast<'_>) -> Option<&'ast str> {
+    Some("this")
   }
 }
 
 impl RootName for IdentifierReference {
-  fn get_root_name(&self, ast: &Ast<'_>) -> Option<Atom> {
-    Some(Atom::from(ast.get_utf8(self.name(ast))))
+  fn get_root_name<'ast>(&self, ast: &'ast Ast<'_>) -> Option<&'ast str> {
+    Some(ast.get_utf8(self.name(ast)))
   }
 }
 
 impl RootName for MetaProperty {
-  fn get_root_name(&self, ast: &Ast<'_>) -> Option<Atom> {
+  fn get_root_name<'ast>(&self, ast: &'ast Ast<'_>) -> Option<&'ast str> {
     match (
       ast.get_utf8(self.meta(ast).name(ast)),
       ast.get_utf8(self.property(ast).name(ast)),
     ) {
-      ("new", "target") => Some("new.target".into()),
-      ("import", "meta") => Some("import.meta".into()),
+      ("new", "target") => Some("new.target"),
+      ("import", "meta") => Some("import.meta"),
       _ => None,
     }
   }
@@ -1057,7 +1057,7 @@ impl<'parser> JavascriptParser<'parser> {
 
   pub fn get_all_variables_from_current_scope(
     &self,
-  ) -> impl Iterator<Item = (&str, VariableInfoId)> {
+  ) -> impl Iterator<Item = (&Atom, VariableInfoId)> {
     self.definitions_db.scope_variables(self.definitions)
   }
 
@@ -1205,7 +1205,7 @@ impl<'parser> JavascriptParser<'parser> {
         };
         let NameInfo {
           info: root_info, ..
-        } = self.get_name_info_from_variable(&root_name)?;
+        } = self.get_name_info_from_variable(root_name)?;
 
         let mut root_members = materialize_member_atoms(ast, root_members);
         let mut members = materialize_member_atoms(ast, members);
@@ -1213,11 +1213,10 @@ impl<'parser> JavascriptParser<'parser> {
         members.reverse();
         members_optionals.reverse();
         member_ranges.reverse();
-        let root_name_for_info = root_name.clone();
         Some(MemberExpressionInfo::Call(CallExpressionInfo {
           call: expr,
           root_info: root_info.map_or_else(
-            || ExportedVariableInfo::Name(root_name_for_info),
+            || ExportedVariableInfo::Name(Atom::from(root_name)),
             |i| ExportedVariableInfo::VariableInfo(i.id()),
           ),
           callee_members: root_members,
@@ -1235,18 +1234,17 @@ impl<'parser> JavascriptParser<'parser> {
         let NameInfo {
           name: resolved_root,
           info: root_info,
-        } = self.get_name_info_from_variable(&root_name)?;
+        } = self.get_name_info_from_variable(root_name)?;
 
         let mut members = materialize_member_atoms(ast, members);
         let name = object_and_members_to_name(resolved_root, &members);
         members.reverse();
         members_optionals.reverse();
         member_ranges.reverse();
-        let root_name_for_info = root_name.clone();
         Some(MemberExpressionInfo::Expression(ExpressionExpressionInfo {
           name,
           root_info: root_info.map_or_else(
-            || ExportedVariableInfo::Name(root_name_for_info),
+            || ExportedVariableInfo::Name(Atom::from(root_name)),
             |i| ExportedVariableInfo::VariableInfo(i.id()),
           ),
           members,
@@ -1709,7 +1707,7 @@ impl<'parser> JavascriptParser<'parser> {
       ExprData::MemberExpression(member) => eval::eval_member_expression(self, member, expr),
       ExprData::IdentifierReference(ident) => {
         let span = ident.span(ast);
-        let name = Atom::from(ast.get_utf8(ident.name(ast)));
+        let name = ast.get_utf8(ident.name(ast));
         if name == "undefined" {
           let mut eval = BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi());
           eval.set_undefined();
@@ -1721,7 +1719,7 @@ impl<'parser> JavascriptParser<'parser> {
             drive.evaluate_identifier(parser, name, None, span.real_lo(), span.real_hi())
           })
           .or_else(|| {
-            let info = self.get_variable_info(&name);
+            let info = self.get_variable_info(name);
             if let Some(info) = info {
               if let Some(name) = &info.name
                 && (info.is_free() || info.is_tagged())
@@ -1739,10 +1737,11 @@ impl<'parser> JavascriptParser<'parser> {
                 None
               }
             } else {
+              let name = Atom::from(name);
               let mut eval = BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi());
               eval.set_identifier(
                 name.clone(),
-                ExportedVariableInfo::Name(name.clone()),
+                ExportedVariableInfo::Name(name),
                 None,
                 None,
                 None,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1201,7 +1201,7 @@ impl JavascriptParser<'_> {
     self
       .plugin_drive
       .clone()
-      .meta_property(self, &root_name, expr.span(ast));
+      .meta_property(self, root_name, expr.span(ast));
   }
 
   fn walk_conditional_expression(&mut self, expr: ConditionalExpression) {
@@ -1341,7 +1341,7 @@ impl JavascriptParser<'_> {
     if object.is_meta_property(ast)
       && let Some(root_name) = object.get_root_name(ast)
     {
-      let root_info = ExportedVariableInfo::Name(root_name);
+      let root_info = ExportedVariableInfo::Name(Atom::from(root_name));
       if drive
         .unhandled_expression_member_chain(self, &root_info, expr.into())
         .unwrap_or_default()

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -229,7 +229,7 @@ impl ScopeInfoDB {
 
   /// The variables bound in scope `id` itself (not in enclosing scopes).
   /// `id` must be an active scope.
-  pub fn scope_variables(&self, id: ScopeInfoId) -> impl Iterator<Item = (&str, VariableInfoId)> {
+  pub fn scope_variables(&self, id: ScopeInfoId) -> impl Iterator<Item = (&Atom, VariableInfoId)> {
     let scope = self.expect_get_scope(id);
     scope.defined.iter().filter_map(move |name| {
       let binding = self
@@ -238,7 +238,7 @@ impl ScopeInfoDB {
         .iter()
         .rev()
         .find(|binding| binding.scope == id)?;
-      (binding.value != VariableInfoId::tombstone()).then_some((name.as_str(), binding.value))
+      (binding.value != VariableInfoId::tombstone()).then_some((name, binding.value))
     })
   }
 }
@@ -434,7 +434,10 @@ mod tests {
     db.set(root, "b".into(), b);
     db.delete(root, &"b".into());
 
-    let variables: Vec<_> = db.scope_variables(root).collect();
+    let variables: Vec<_> = db
+      .scope_variables(root)
+      .map(|(name, id)| (name.as_str(), id))
+      .collect();
     assert_eq!(variables, vec![("a", a)]);
   }
 }


### PR DESCRIPTION
## Summary

Stacked on #15544. This is the Atom-materialization portion of the SWC Next follow-up work.

- Borrow identifier/root names in evaluator, member-root and meta-property hooks, and use borrowed lookups in CommonJS/createRequire, dynamic import, ESM export, compatibility and URL plugins.
- Borrow configuration/property names for comparisons. Keep side-effects binding names borrowed during temporary duplicate-name counting, and create owned Atoms only for names that must be retained.
- Defer Atom creation until a purity or inner-graph result is accepted, or an evaluated/deferred result needs to own its name.
- Reuse existing Atoms from scope enumeration, accepted configured names and default exports instead of converting them back to strings and interning them again.

These paths scale with identifier occurrences and bindings during dependency scanning. Avoiding eager interning, atom cloning/dropping and temporary owned keys reduces per-node work without adding a cache or changing Atom hashing/collection internals. Existing owned-Atom queries retain their fast path.

Scope metadata lookup elimination, semantic/SymbolId reuse, concatenation identifier changes, comment storage and general AST decoding changes are deliberately excluded. The existing name-based duplicate counting, local-binding snapshot, shadowing, hook ordering, WTF-8 conversion and deferred-purity decisions are preserved.

### Local performance

`rust@scan_dependencies@three_module`, native ARM64 Docker + standard Valgrind Callgrind:

| Version | Instructions |
| --- | ---: |
| #15544 (`15fc2a7212`) | 39,318,142 |
| This PR (`c65664b063`) | 38,669,201 |
| Change relative to #15544 | **-648,941 (-1.65%)** |

The candidate was measured once. The baseline reuses the previously measured #15544 source: its patch checksum was verified against the parent commit, and the same image, native architecture, fixture, compiler flags and measurement boundary were retained. No performance reruns or cloud comparison were used.

Environment: `linux/arm64`, Rust `1.97.0-nightly (e8e4541ff)`, Valgrind `3.19.0`, `three@0.183.2/build/three.module.js`. Image ID: `sha256:ad4bf3d1931a328cfebd58092b5a9af81c2fcf9fb04b06c33882126246275b52`. This is the instruction-count change for dependency scanning, not wall-clock build time; parsing and semantic construction are outside the measured boundary.

### Local checks

- Full dev build, Rust/JavaScript formatting and JavaScript-plugin Clippy with `-D warnings` passed.
- Rust library tests: 48 passed.
- `test:unit` passed; rspack-test: 47 files, 9,221 passed and 4 skipped.
- No snapshots or test expectations changed. One existing scope test converts the newly returned `&Atom` to `&str` to keep its original assertion.
- The additional workspace `--all-features` Clippy check still fails in the unchanged `rspack_cacheable` crate with the same `noop`/`PortablePath: Archive` incompatibility recorded on #15544. No unrelated fix is included.

## Related links

- #15544
- Original migration plan: #15331

## Checklist

- [x] Tests updated (only an API type adaptation; assertions unchanged).
- [x] Documentation updated (not required).
