### PR TITLE
docs: clarify descriptionData matching conditions

### DIFF
--- a/website/docs/en/config/module-rules.mdx
+++ b/website/docs/en/config/module-rules.mdx
@@ -417,23 +417,51 @@ export default {
 - **Type:** `{ [key: string]: Condition }`
 - **Default:** `undefined`
 
-`descriptionData` option allows you to match values of properties in the description file, typically `package.json`, to determine which modules a rule should apply to. This is a useful way to apply rules to specific modules based on metadata found in their `package.json`.
+`descriptionData` matches property values in a module's description file, typically `package.json`, to determine which modules a rule applies to. This lets you configure rules for modules in specific packages based on metadata such as the package name or version.
 
-The object keys in `descriptionData` correspond to keys in the module's `package.json`, such as `name`, `version`, etc. Each key should be associated with a [`Condition`](#condition) for matching the `package.json` data.
+Each key in the `descriptionData` object specifies a property to match, such as `name` or `version`, and the corresponding value is a [`Condition`](#condition) used to check that property's value. If you specify multiple properties, all must satisfy their conditions for the module to match `descriptionData`.
 
-For example, below we are applying the rule only to JavaScript resources with `'rspack'` string included in their `package.json` `name`.
+A string condition matches property values that start with the given string, so this example matches modules in packages such as `react` and `react-dom`:
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: /node_modules/,
+        descriptionData: { name: 'react' },
+        // Other rule options...
+      },
+    ],
+  },
+};
+```
+
+A regular expression condition tests the property value against a pattern; this example uses `^` and `$` to match only modules in the package named `react`:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        descriptionData: { name: /^react$/ },
+        // Other rule options...
+      },
+    ],
+  },
+};
+```
+
+A function condition provides custom matching logic; this example matches modules in packages whose names contain `rspack`:
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
         descriptionData: {
-          name: (packageJsonName) => packageJsonName.includes('rspack'),
+          name: (name) => name.includes('rspack'),
         },
-        // additional rule options...
+        // Other rule options...
       },
     ],
   },

--- a/website/docs/zh/config/module-rules.mdx
+++ b/website/docs/zh/config/module-rules.mdx
@@ -417,23 +417,51 @@ export default {
 - **类型：** `{ [key: string]: Condition }`
 - **默认值：** `undefined`
 
-`descriptionData` 选项允许你通过匹配描述文件（通常是 `package.json`）中的属性值，来决定某个 rule 应该应用于哪些模块。这是一个基于 `package.json` 来应用 rule 的实用方法。
+`descriptionData` 用于匹配模块描述文件（通常是 `package.json`）中的属性值，从而决定规则适用于哪些模块。你可以根据包名、版本等信息，为特定包中的模块配置规则。
 
-`descriptionData` 对象中的 key 对应模块的 `package.json` 中的键，例如 `name`、`version` 等。每个 key 与一个用于匹配 `package.json` 数据的 [`Condition`](#condition) 进行关联。
+`descriptionData` 对象的每个键指定要匹配的属性（如 `name`、`version`），对应的值则是用于检查该属性值的 [`Condition`](#condition)。如果指定了多个属性，它们必须同时满足各自的条件，模块才能通过 `descriptionData` 的匹配。
 
-例如，下面的配置会将 rule 应用于 `package.json` 的 `name` 中包含 `'rspack'` 字符串的 JavaScript 资源。
+字符串条件检查属性值是否以给定字符串开头，下面会匹配 `react`、`react-dom` 等包中的模块：
 
 ```js title="rspack.config.mjs"
 export default {
   module: {
     rules: [
       {
-        test: /\.js$/,
-        include: /node_modules/,
+        descriptionData: { name: 'react' },
+        // 其他规则选项...
+      },
+    ],
+  },
+};
+```
+
+正则表达式条件检查属性值是否符合给定模式，下面使用 `^` 和 `$` 仅匹配包名为 `react` 的模块：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
+        descriptionData: { name: /^react$/ },
+        // 其他规则选项...
+      },
+    ],
+  },
+};
+```
+
+函数条件可自定义匹配逻辑，下面匹配包名中包含 `rspack` 的模块：
+
+```js title="rspack.config.mjs"
+export default {
+  module: {
+    rules: [
+      {
         descriptionData: {
-          name: (packageJsonName) => packageJsonName.includes('rspack'),
+          name: (name) => name.includes('rspack'),
         },
-        // 其他 rule options...
+        // 其他规则选项...
       },
     ],
   },


### PR DESCRIPTION
## Summary

Clarify how `descriptionData` matches package metadata in the English and Chinese docs, including the requirement that all specified property conditions match. Add examples distinguishing string prefix matching from anchored regular expressions, and simplify the function condition example.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).