### PR TITLE
refactor: let modules own dependencies and async blocks

### DIFF
--- a/crates/rspack_cacheable_macros/src/cacheable/impl.rs
+++ b/crates/rspack_cacheable_macros/src/cacheable/impl.rs
@@ -63,14 +63,14 @@ pub fn impl_cacheable(tokens: TokenStream, args: CacheableArgs) -> TokenStream {
   let bounds = if visitor.omit_bounds {
     quote! {
         #[rkyv(serialize_bounds(
-            __S: #crate_path::__private::rkyv::ser::Writer + #crate_path::__private::rkyv::ser::Allocator + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
+            __S: #crate_path::__private::rkyv::ser::Writer + #crate_path::__private::rkyv::ser::Allocator + #crate_path::__private::rkyv::ser::Sharing + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
         ))]
         #[rkyv(deserialize_bounds(
-            __D: #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>
+            __D: #crate_path::__private::rkyv::de::Pooling + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>
         ))]
         #[rkyv(bytecheck(
             bounds(
-                __C: #crate_path::__private::rkyv::validation::ArchiveContext + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
+                __C: #crate_path::__private::rkyv::validation::ArchiveContext + #crate_path::__private::rkyv::validation::SharedContext + #crate_path::__private::rkyv::rancor::Fallible<Error = #crate_path::Error>,
             )
         ))]
     }

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/add.rs
@@ -29,7 +29,7 @@ impl Task<TaskContext> for AddTask {
   async fn main_run(self: Box<Self>, context: &mut TaskContext) -> TaskResult<TaskContext> {
     let Self {
       original_module_identifier,
-      module,
+      mut module,
       module_graph_module,
       dependencies,
       from_unlazy,
@@ -109,7 +109,7 @@ impl Task<TaskContext> for AddTask {
       return Ok(vec![]);
     }
 
-    let cached_build_result = if let Some(module_build_cache) = &context.module_build_cache {
+    let cached_module_state = if let Some(module_build_cache) = &context.module_build_cache {
       module_build_cache
         .restore(
           &module,
@@ -142,9 +142,13 @@ impl Task<TaskContext> for AddTask {
       .affected_modules
       .mark_as_add(&module_identifier);
 
-    if let Some(cached_build_result) = cached_build_result {
+    if let Some(module_state) = cached_module_state {
+      module
+        .as_normal_module_mut()
+        .expect("module cache entries are only restored for normal modules")
+        .restore_module_state(module_state);
       return Ok(vec![Box::new(BuildResultTask {
-        build_result: Box::new(cached_build_result.into_build_result(module)),
+        module,
         plugin_driver: context.plugin_driver.clone(),
         forwarded_ids,
       })]);

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -8,9 +8,9 @@ use super::{
   TaskContext, lazy::process_unlazy_dependencies, process_dependencies::ProcessDependenciesTask,
 };
 use crate::{
-  AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockRef, BoxModule, BuildContext,
-  BuildResult, CacheFacade, CompilationId, CompilerId, CompilerOptions, DependencyParents,
-  DependencyRef, FileSystemInfo, ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
+  AsyncDependenciesBlockRef, BoxModule, BuildContext, CacheFacade, CompilationId, CompilerId,
+  CompilerOptions, DependenciesBlock, DependencyParents, DependencyRef, FileSystemInfo,
+  ModuleCodeTemplate, ResolverFactory, SharedPluginDriver,
   compilation::build_module_graph::{
     ForwardedIdSet, HasLazyDependencies, LazyDependencies, module_build_cache::ModuleBuildCache,
   },
@@ -85,11 +85,11 @@ impl Task<TaskContext> for BuildTask {
     if let (Some(module_build_cache), Some(build_start_time)) =
       (module_build_cache, build_start_time)
     {
-      module_build_cache.mark_pending(result.module.identifier(), build_start_time);
+      module_build_cache.mark_pending(result.identifier(), build_start_time);
     }
 
     Ok(vec![Box::new(BuildResultTask {
-      build_result: Box::new(result),
+      module: result,
       plugin_driver,
       forwarded_ids,
     })])
@@ -98,7 +98,7 @@ impl Task<TaskContext> for BuildTask {
 
 #[derive(Debug)]
 pub(super) struct BuildResultTask {
-  pub build_result: Box<BuildResult>,
+  pub module: BoxModule,
   pub plugin_driver: SharedPluginDriver,
   pub forwarded_ids: ForwardedIdSet,
 }
@@ -110,12 +110,10 @@ impl Task<TaskContext> for BuildResultTask {
   }
   async fn main_run(self: Box<Self>, context: &mut TaskContext) -> TaskResult<TaskContext> {
     let BuildResultTask {
-      build_result,
+      mut module,
       plugin_driver,
       mut forwarded_ids,
     } = *self;
-    let mut module = build_result.module;
-
     plugin_driver
       .compilation_hooks
       .succeed_module
@@ -159,46 +157,34 @@ impl Task<TaskContext> for BuildResultTask {
     let mut lazy_dependencies = LazyDependencies::default();
     let mut queue = VecDeque::new();
     let mut all_dependencies = vec![];
-    let mut handle_block = |dependencies: Vec<DependencyRef>,
-                            blocks: Vec<AsyncDependenciesBlockBuildResult>,
-                            current_block: Option<AsyncDependenciesBlockRef>|
-     -> Vec<AsyncDependenciesBlockBuildResult> {
-      for (index_in_block, dependency) in dependencies.into_iter().enumerate() {
-        let dependency_id = *dependency.id();
-        if let Some(until) = dependency.lazy() {
-          lazy_dependencies.insert(&dependency, until);
+    let mut handle_block =
+      |dependencies: &[DependencyRef], current_block: Option<&AsyncDependenciesBlockRef>| {
+        for (index_in_block, dependency) in dependencies.iter().enumerate() {
+          let dependency_id = *dependency.id();
+          if let Some(until) = dependency.lazy() {
+            lazy_dependencies.insert(dependency, until);
+          }
+          all_dependencies.push(dependency_id);
+          module_graph.set_parents(
+            dependency_id,
+            DependencyParents {
+              block: current_block.map(|block| block.identifier()),
+              module: module.identifier(),
+              index_in_block,
+            },
+          );
+          module_graph.add_dependency_ref(dependency.clone());
         }
-        if current_block.is_none() {
-          module.add_dependency_id(dependency_id);
+        if let Some(current_block) = current_block {
+          module_graph.add_block(current_block.clone());
         }
-        all_dependencies.push(dependency_id);
-        module_graph.set_parents(
-          dependency_id,
-          DependencyParents {
-            block: current_block.as_ref().map(|block| block.identifier()),
-            module: module.identifier(),
-            index_in_block,
-          },
-        );
-        module_graph.add_dependency_ref(dependency);
-      }
-      if let Some(current_block) = current_block {
-        module.add_block_id(current_block.identifier());
-        module_graph.add_block(current_block);
-      }
-      blocks
-    };
-    let blocks = handle_block(build_result.dependencies, build_result.blocks, None);
-    queue.extend(blocks);
+      };
+    handle_block(module.get_dependency_refs(), None);
+    queue.extend(module.get_block_refs().iter().cloned());
 
-    while let Some(AsyncDependenciesBlockBuildResult {
-      block,
-      dependencies,
-      blocks,
-    }) = queue.pop_front()
-    {
-      let blocks = handle_block(dependencies, blocks, Some(block));
-      queue.extend(blocks);
+    while let Some(block) = queue.pop_front() {
+      handle_block(block.get_dependency_refs(), Some(&block));
+      queue.extend(block.get_block_refs().iter().cloned());
     }
 
     {

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -1,58 +1,28 @@
 use std::sync::Arc;
 
-use rspack_cacheable::cacheable;
 use rspack_collections::{Identifiable, IdentifierDashMap};
 use rspack_error::{Result, ToStringResultToRspackResultExt};
 
 use crate::{
-  AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockIdentifier, BoxModule,
-  BuildModuleGraphArtifact, BuildResult, DependenciesBlock, DependencyRef, FileSystemInfo,
-  ModuleGraph, ModuleIdentifier, NormalModuleState, ValueCacheVersions,
+  BoxModule, BuildModuleGraphArtifact, FileSystemInfo, ModuleGraph, ModuleIdentifier,
+  NormalModuleState, ValueCacheVersions,
   new_cache::{CacheFacade, CacheValue},
 };
 
 /// Cache for completed normal module builds.
 ///
-/// Cache entries store only [`NormalModuleState`] plus the graph-owned build
-/// output. Factory-owned module data is always supplied by the fresh module.
+/// Cache entries store [`NormalModuleState`], including its dependency and block
+/// objects. Factory-owned module data is supplied by the fresh module.
 #[derive(Debug, Clone)]
 pub(crate) struct ModuleBuildCache {
   cache: CacheFacade,
   pending: Arc<IdentifierDashMap<u64>>,
 }
 
-#[cacheable]
-#[derive(Debug, Clone)]
-pub(crate) struct ModuleBuildCacheEntry {
-  module_state: NormalModuleState,
-  graph_result: ModuleGraphBuildResult,
-}
-
-#[cacheable]
-#[derive(Debug, Clone)]
-struct ModuleGraphBuildResult {
-  dependencies: Vec<DependencyRef>,
-  blocks: Vec<AsyncDependenciesBlockBuildResult>,
-}
-
-impl ModuleBuildCacheEntry {
-  pub(crate) fn into_build_result(self, mut module: BoxModule) -> BuildResult {
-    module
-      .as_normal_module_mut()
-      .expect("module cache entries are only restored for normal modules")
-      .restore_module_state(self.module_state);
-    BuildResult {
-      module,
-      dependencies: self.graph_result.dependencies,
-      blocks: self.graph_result.blocks,
-    }
-  }
-}
-
 impl ModuleBuildCache {
   pub(crate) fn new(cache: CacheFacade) -> Self {
     Self {
-      cache,
+      cache: cache.get_child_cache("module-owned-dependencies"),
       pending: Default::default(),
     }
   }
@@ -68,7 +38,7 @@ impl ModuleBuildCache {
     module: &BoxModule,
     file_system_info: &FileSystemInfo,
     value_cache_versions: &ValueCacheVersions,
-  ) -> Result<Option<ModuleBuildCacheEntry>> {
+  ) -> Result<Option<NormalModuleState>> {
     if module.as_normal_module().is_none() {
       return Ok(None);
     }
@@ -76,12 +46,11 @@ impl ModuleBuildCache {
     let identifier = module.identifier();
     let Some(result) = self
       .cache
-      .get::<ModuleBuildCacheEntry>(identifier.as_str(), None)
+      .get::<NormalModuleState>(identifier.as_str(), None)
     else {
       return Ok(None);
     };
     if result
-      .module_state
       .need_build_with_context(file_system_info, value_cache_versions)
       .await?
     {
@@ -93,8 +62,8 @@ impl ModuleBuildCache {
 
   /// Stores modules built during this phase from the final module graph.
   ///
-  /// Snapshot creation and cache-entry construction are parallel. Module state
-  /// and graph containers are cloned, while blocks and dependencies retain shared identity.
+  /// Snapshot creation and cache-entry construction are parallel. The module's
+  /// state is cloned, while dependency and block objects retain shared identity.
   pub(crate) async fn store_pending(
     &self,
     artifact: &mut BuildModuleGraphArtifact,
@@ -162,9 +131,6 @@ impl ModuleBuildCache {
     .collect::<Result<Vec<_>>>()?;
 
     for (module_identifier, entry) in cache_entries {
-      let Some(entry) = entry else {
-        continue;
-      };
       self
         .cache
         .store(module_identifier.as_str(), None, CacheValue::new(entry));
@@ -176,54 +142,13 @@ impl ModuleBuildCache {
 fn create_cache_entry(
   module_graph: &ModuleGraph,
   module_identifier: ModuleIdentifier,
-) -> Option<ModuleBuildCacheEntry> {
+) -> NormalModuleState {
   let source_module = module_graph
     .module_by_identifier(&module_identifier)
     .expect("pending module should exist in the final module graph");
-  let normal_module = source_module
+  source_module
     .as_normal_module()
-    .expect("only normal modules are marked pending for the module build cache");
-  let dependencies = clone_dependencies(module_graph, source_module.get_dependencies())?;
-  let blocks = source_module
-    .get_blocks()
-    .iter()
-    .map(|block_id| clone_block(module_graph, block_id))
-    .collect::<Option<Vec<_>>>()?;
-  Some(ModuleBuildCacheEntry {
-    module_state: normal_module.module_state().clone(),
-    graph_result: ModuleGraphBuildResult {
-      dependencies,
-      blocks,
-    },
-  })
-}
-
-fn clone_dependencies(
-  module_graph: &ModuleGraph,
-  dependency_ids: &[crate::DependencyId],
-) -> Option<Vec<DependencyRef>> {
-  dependency_ids
-    .iter()
-    .map(|dependency_id| {
-      crate::module_graph::internal::try_dependency_ref_by_id(module_graph, dependency_id)
-    })
-    .collect()
-}
-
-fn clone_block(
-  module_graph: &ModuleGraph,
-  block_id: &AsyncDependenciesBlockIdentifier,
-) -> Option<AsyncDependenciesBlockBuildResult> {
-  let block = module_graph.block_ref_by_id(block_id)?.clone();
-  let dependencies = clone_dependencies(module_graph, block.get_dependencies())?;
-  let blocks = block
-    .get_blocks()
-    .iter()
-    .map(|block_id| clone_block(module_graph, block_id))
-    .collect::<Option<Vec<_>>>()?;
-  Some(AsyncDependenciesBlockBuildResult {
-    block,
-    dependencies,
-    blocks,
-  })
+    .expect("only normal modules are marked pending for the module build cache")
+    .module_state()
+    .clone()
 }

--- a/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_build_cache.rs
@@ -22,7 +22,7 @@ pub(crate) struct ModuleBuildCache {
 impl ModuleBuildCache {
   pub(crate) fn new(cache: CacheFacade) -> Self {
     Self {
-      cache: cache.get_child_cache("module-owned-dependencies"),
+      cache,
       pending: Default::default(),
     }
   }

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -36,23 +36,23 @@ use swc_experimental_ecma_ast::{ClassExpr, Ident, ObjectPatProp, Program, Prop, 
 use swc_experimental_ecma_semantic::resolver::Semantic;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkGraph, ChunkInitFragments, CodeGenerationDataChunkInitFragments,
-  CodeGenerationDataTopLevelDeclarations, CodeGenerationPublicPathAutoReplace,
-  CodeGenerationResultBuilder, CodeGenerationRuntimeRequirementsWrite, Compilation,
-  ConcatenatedModuleIdent, ConcatenationBindingPlan, ConcatenationBindingResolver,
-  ConcatenationBindingTarget, ConcatenationContext, ConcatenationInterop,
-  ConcatenationNameAllocator, ConcatenationScope, ConditionalInitFragment, ConnectionState,
-  Context, DEFAULT_EXPORT, DEFAULT_EXPORT_ATOM, DependenciesBlock, Dependency,
-  DependencyCodeGenerationRef, DependencyId, DependencyType, ExportProvided, ExportsArgument,
-  ExportsInfoArtifact, FactoryMeta, ImportedByDeferModulesArtifact, InitFragment,
-  InitFragmentStage, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleGraph, ModuleGraphCacheArtifact, ModuleGraphConnection, ModuleIdentifier, ModuleLayer,
-  ModuleStaticCache, ModuleType, NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition,
-  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState,
-  UsedName, UsedNameItem, analyze_module_scope, escape_identifier, fast_set, filter_runtime,
-  get_runtime_key, impl_source_map_config, merge_runtime_condition,
-  merge_runtime_condition_non_false, module_update_hash, property_access, property_name,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph, ChunkInitFragments,
+  CodeGenerationDataChunkInitFragments, CodeGenerationDataTopLevelDeclarations,
+  CodeGenerationPublicPathAutoReplace, CodeGenerationResultBuilder,
+  CodeGenerationRuntimeRequirementsWrite, Compilation, ConcatenatedModuleIdent,
+  ConcatenationBindingPlan, ConcatenationBindingResolver, ConcatenationBindingTarget,
+  ConcatenationContext, ConcatenationInterop, ConcatenationNameAllocator, ConcatenationScope,
+  ConditionalInitFragment, ConnectionState, Context, DEFAULT_EXPORT, DEFAULT_EXPORT_ATOM,
+  DependenciesBlock, DependenciesBlockData, Dependency, DependencyCodeGenerationRef, DependencyId,
+  DependencyType, ExportProvided, ExportsArgument, ExportsInfoArtifact, FactoryMeta,
+  ImportedByDeferModulesArtifact, InitFragment, InitFragmentStage, LibIdentOptions, Module,
+  ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact,
+  ModuleGraphConnection, ModuleIdentifier, ModuleLayer, ModuleStaticCache, ModuleType,
+  NAMESPACE_OBJECT_EXPORT, ParserOptions, Resolve, RuntimeCondition, RuntimeGlobals, RuntimeSpec,
+  SideEffectsStateArtifact, SourceType, URLStaticMode, UsageState, UsedName, UsedNameItem,
+  analyze_module_scope, escape_identifier, fast_set, filter_runtime, get_runtime_key,
+  impl_source_map_config, merge_runtime_condition, merge_runtime_condition_non_false,
+  module_update_hash, property_access, property_name,
   render_make_deferred_namespace_mode_from_exports_type,
   reserved_names::RESERVED_NAMES_ATOM_SET,
   subtract_runtime_condition, to_normal_comment,
@@ -522,8 +522,7 @@ pub struct ConcatenatedModule {
   modules: Vec<ConcatenatedInnerModule>,
   runtime: Option<RuntimeSpec>,
 
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   #[cacheable(with=As<SourceSizeCacheSerde>)]
   cached_source_sizes: SourceSizeCache,
   diagnostics: Vec<Diagnostic>,
@@ -548,8 +547,7 @@ impl ConcatenatedModule {
       root_module_ctxt,
       modules,
       runtime,
-      dependencies: vec![],
-      blocks: vec![],
+      dependencies_block: Default::default(),
       cached_source_sizes: SourceSizeCache::default(),
       diagnostics: vec![],
       build_info: BuildInfo {
@@ -645,24 +643,12 @@ impl Identifiable for ConcatenatedModule {
 }
 
 impl DependenciesBlock for ConcatenatedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -804,7 +790,7 @@ impl Module for ConcatenatedModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let compilation = compilation.expect("should pass compilation");
 
     let module_graph = compilation.get_module_graph();
@@ -826,20 +812,21 @@ impl Module for ConcatenatedModule {
           .expect("should have module");
 
         module
-          .get_dependencies()
+          .get_dependency_refs()
           .iter()
-          .copied()
-          .filter(|dep_id| {
-            let dep = module_graph.dependency_by_id(dep_id);
-            let module_id_of_dep = module_graph.module_identifier_by_dependency_id(dep_id);
-            !is_esm_dep_like(dep)
+          .filter(|dep| {
+            let module_id_of_dep = module_graph.module_identifier_by_dependency_id(dep.id());
+            !is_esm_dep_like(dep.as_ref())
               || module_id_of_dep.is_none_or(|module_id| !modules.contains(module_id))
           })
+          .cloned()
           .collect::<Vec<_>>()
       })
       .collect::<Vec<_>>();
     for part in dependency_parts {
-      self.dependencies.extend(part);
+      for dependency in part {
+        self.add_dependency(dependency);
+      }
     }
 
     for m in self.modules.iter() {
@@ -854,8 +841,8 @@ impl Module for ConcatenatedModule {
       }
 
       // populate blocks
-      for b in module.get_blocks() {
-        self.blocks.push(*b);
+      for block in module.get_block_refs() {
+        self.dependencies_block.add_block(block.clone());
       }
       // populate diagnostic
       self.diagnostics.extend(module.diagnostics().into_owned());
@@ -882,12 +869,7 @@ impl Module for ConcatenatedModule {
           .map(|(name, asset)| (name.clone(), asset.clone())),
       );
     }
-    // return a dummy result is enough, since we don't build the ConcatenatedModule in make phase
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![],
-      blocks: vec![],
-    })
+    Ok(BoxModule::new(self))
   }
 
   // #[tracing::instrument("ConcatenatedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -27,15 +27,15 @@ use rustc_hash::FxHashMap as HashMap;
 
 use crate::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, BuildResult, ChunkGraph,
+  BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph,
   ChunkGroupOptions, CodeGenerationResultBuilder, Compilation, Context, ContextElementDependency,
-  DependenciesBlock, DependencyCategory, DependencyId, DependencyLocation, DynamicImportMode,
-  ExportsType, FactoryMeta, FakeNamespaceObjectMode, GroupOptions, ImportAttributes, ImportPhase,
-  LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate,
-  ModuleGraph, ModuleId, ModuleIdsArtifact, ModuleLayer, ModuleType, RealDependencyLocation,
-  ReferencedSpecifier, Resolve, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeSpec, SourceType,
-  contextify, get_exports_type_with_strict, get_outgoing_async_modules, impl_module_meta_info,
-  module_update_hash, property_access, to_path,
+  DependenciesBlock, DependenciesBlockData, DependencyCategory, DependencyId, DependencyLocation,
+  DynamicImportMode, ExportsType, FactoryMeta, FakeNamespaceObjectMode, GroupOptions,
+  ImportAttributes, ImportPhase, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleId, ModuleIdsArtifact,
+  ModuleLayer, ModuleType, RealDependencyLocation, ReferencedSpecifier, Resolve, RuntimeGlobals,
+  RuntimeGlobalsRenderMode, RuntimeSpec, SourceType, contextify, get_exports_type_with_strict,
+  get_outgoing_async_modules, impl_module_meta_info, module_update_hash, property_access, to_path,
 };
 
 static CHUNK_NAME_INDEX_PLACEHOLDER: &str = "[index]";
@@ -269,8 +269,7 @@ pub type ResolveContextModuleDependencies = Arc<
 #[cacheable]
 #[derive(Debug)]
 pub struct ContextModule {
-  dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  dependencies_block: DependenciesBlockData,
   identifier: Identifier,
   options: ContextModuleOptions,
   factory_meta: Option<FactoryMeta>,
@@ -293,8 +292,7 @@ impl ContextModule {
     }
 
     Self {
-      dependencies: Vec::new(),
-      blocks: Vec::new(),
+      dependencies_block: Default::default(),
       identifier: create_identifier(&options, None),
       options,
       factory_meta: None,
@@ -1303,24 +1301,12 @@ impl ContextModule {
 }
 
 impl DependenciesBlock for ContextModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -1431,7 +1417,7 @@ impl Module for ContextModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let resolve_dependencies = &self.resolve_dependencies;
     let context_element_dependencies = resolve_dependencies(self.options.clone()).await?;
 
@@ -1522,11 +1508,10 @@ impl Module for ContextModule {
       self.build_info.dependencies.context = context_dependencies;
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("ContextModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -10,15 +10,90 @@ use crate::{
 };
 
 pub trait DependenciesBlock {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier);
+  fn dependencies_block(&self) -> &DependenciesBlockData;
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier];
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData;
 
-  fn add_dependency_id(&mut self, dependency: DependencyId);
+  fn add_block(&mut self, block: AsyncDependenciesBlockRef) {
+    self.dependencies_block_mut().add_block(block);
+  }
 
-  fn remove_dependency_id(&mut self, _dependency: DependencyId);
+  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
+    &self.dependencies_block().block_ids
+  }
 
-  fn get_dependencies(&self) -> &[DependencyId];
+  fn get_block_refs(&self) -> &[AsyncDependenciesBlockRef] {
+    &self.dependencies_block().blocks
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyRef) {
+    self.dependencies_block_mut().add_dependency(dependency);
+  }
+
+  fn remove_dependency_id(&mut self, dependency: DependencyId) {
+    self.dependencies_block_mut().remove_dependency(dependency);
+  }
+
+  fn get_dependencies(&self) -> &[DependencyId] {
+    &self.dependencies_block().dependency_ids
+  }
+
+  fn get_dependency_refs(&self) -> &[DependencyRef] {
+    &self.dependencies_block().dependencies
+  }
+}
+
+/// Build-owned dependency objects and blocks. The graph indexes the same shared objects.
+/// ID slices are read indexes maintained together with their owning references, so existing
+/// graph algorithms can keep borrowing contiguous IDs without collecting them on every read.
+/// Cloning copies these containers for normal-module state cache entries; the dependency
+/// and block objects themselves remain shared.
+#[cacheable]
+#[derive(Debug, Default, Clone)]
+pub struct DependenciesBlockData {
+  dependencies: Vec<DependencyRef>,
+  #[cacheable(omit_bounds)]
+  blocks: Vec<AsyncDependenciesBlockRef>,
+  dependency_ids: Vec<DependencyId>,
+  block_ids: Vec<AsyncDependenciesBlockIdentifier>,
+}
+
+impl DependenciesBlockData {
+  pub fn new(dependencies: Vec<DependencyRef>, blocks: Vec<AsyncDependenciesBlockRef>) -> Self {
+    Self {
+      dependency_ids: dependencies
+        .iter()
+        .map(|dependency| *dependency.id())
+        .collect(),
+      block_ids: blocks.iter().map(|block| block.identifier()).collect(),
+      dependencies,
+      blocks,
+    }
+  }
+
+  fn add_dependency(&mut self, dependency: DependencyRef) {
+    self.dependency_ids.push(*dependency.id());
+    self.dependencies.push(dependency);
+  }
+
+  fn remove_dependency(&mut self, dependency: DependencyId) {
+    self.dependency_ids.retain(|id| *id != dependency);
+    self.dependencies.retain(|value| *value.id() != dependency);
+  }
+
+  pub(crate) fn add_block(&mut self, block: AsyncDependenciesBlockRef) {
+    self.block_ids.push(block.identifier());
+    self.blocks.push(block);
+  }
+
+  pub(crate) fn replace_block(&mut self, block: AsyncDependenciesBlockRef) {
+    let existing = self
+      .blocks
+      .iter_mut()
+      .find(|existing| existing.identifier() == block.identifier())
+      .expect("the parent module should own the block being replaced");
+    *existing = block;
+  }
 }
 
 pub type AsyncDependenciesBlockIdentifierMap<V> = std::collections::HashMap<
@@ -76,11 +151,7 @@ impl From<Identifier> for AsyncDependenciesBlockIdentifier {
 pub struct AsyncDependenciesBlock {
   id: AsyncDependenciesBlockIdentifier,
   group_options: Option<GroupOptions>,
-  block_ids: Vec<AsyncDependenciesBlockIdentifier>,
-  dependency_ids: Vec<DependencyId>,
-  /// Construction-only dependencies, drained before publishing the block.
-  #[cacheable(with=rspack_cacheable::with::Skip)]
-  dependencies: Vec<BoxDependency>,
+  dependencies_block: DependenciesBlockData,
   loc: Option<DependencyLocation>,
   parent: ModuleIdentifier,
   request: Option<String>,
@@ -107,12 +178,10 @@ impl AsyncDependenciesBlock {
     id.push_str(parent.as_str());
     id.push_str("|dep=");
 
-    let mut dependency_ids = Vec::with_capacity(dependencies.len());
     for dep in &dependencies {
       if let Some(resource_identifier) = dep.resource_identifier() {
         id.push_str(resource_identifier);
       }
-      dependency_ids.push(*dep.id());
     }
 
     if let Some(loc) = loc.as_ref() {
@@ -126,70 +195,54 @@ impl AsyncDependenciesBlock {
     Self {
       id: id.into(),
       group_options: Default::default(),
-      block_ids: Default::default(),
-      dependency_ids,
+      dependencies_block: DependenciesBlockData::new(
+        dependencies.into_iter().map(Into::into).collect(),
+        Vec::new(),
+      ),
       loc,
       parent,
       request,
-      dependencies,
     }
   }
 
   pub fn get_dependency_mut(&mut self, idx: usize) -> Option<&mut (dyn Dependency + 'static)> {
     self
+      .dependencies_block
       .dependencies
       .get_mut(idx)
-      .map(|dependency| dependency.as_mut())
+      .and_then(DependencyRef::get_mut)
   }
 
   pub fn dependencies_mut(&mut self) -> impl Iterator<Item = &mut (dyn Dependency + 'static)> {
     self
+      .dependencies_block
       .dependencies
       .iter_mut()
-      .map(|dependency| dependency.as_mut())
+      .map(|dependency| {
+        dependency
+          .get_mut()
+          .expect("parser dependencies must not be published")
+      })
   }
 }
 
-/// An immutable block shared by the module graph and build cache.
+/// A block and its dependency objects, shared by its owning module and graph indexes.
 pub type AsyncDependenciesBlockRef = Arc<AsyncDependenciesBlock>;
-
-/// Graph objects produced by an async block, kept separate from its immutable metadata.
-#[cacheable]
-#[derive(Debug, Clone)]
-pub struct AsyncDependenciesBlockBuildResult {
-  pub block: AsyncDependenciesBlockRef,
-  pub dependencies: Vec<DependencyRef>,
-  #[cacheable(omit_bounds)]
-  pub blocks: Vec<AsyncDependenciesBlockBuildResult>,
-}
-
-impl From<Box<AsyncDependenciesBlock>> for AsyncDependenciesBlockBuildResult {
-  fn from(mut block: Box<AsyncDependenciesBlock>) -> Self {
-    let dependencies = std::mem::take(&mut block.dependencies)
-      .into_iter()
-      .map(Into::into)
-      .collect();
-    Self {
-      block: Arc::from(block),
-      dependencies,
-      blocks: Vec::new(),
-    }
-  }
-}
 
 impl AsyncDependenciesBlock {
   pub(crate) fn without_dependency(&self, dependency: DependencyId) -> Self {
     Self {
       id: self.id,
       group_options: self.group_options.clone(),
-      block_ids: self.block_ids.clone(),
-      dependency_ids: self
-        .dependency_ids
-        .iter()
-        .copied()
-        .filter(|id| *id != dependency)
-        .collect(),
-      dependencies: Vec::new(),
+      dependencies_block: DependenciesBlockData::new(
+        self
+          .get_dependency_refs()
+          .iter()
+          .filter(|value| *value.id() != dependency)
+          .cloned()
+          .collect(),
+        self.get_block_refs().to_vec(),
+      ),
       loc: self.loc.clone(),
       parent: self.parent,
       request: self.request.clone(),
@@ -248,25 +301,16 @@ impl AsyncDependenciesBlock {
 }
 
 impl DependenciesBlock for AsyncDependenciesBlock {
-  fn add_block_id(&mut self, _block: AsyncDependenciesBlockIdentifier) {
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
+  }
+
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
+  }
+
+  fn add_block(&mut self, _block: AsyncDependenciesBlockRef) {
     unimplemented!("Nested block are not implemented");
-    // self.block_ids.push(block);
-  }
-
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.block_ids
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependency_ids.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependency_ids.retain(|dep| dep != &dependency);
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependency_ids
   }
 }
 

--- a/crates/rspack_core/src/dependency/dependency_trait.rs
+++ b/crates/rspack_core/src/dependency/dependency_trait.rs
@@ -309,6 +309,11 @@ pub type BoxDependency = UniqueDependency;
 pub struct DependencyRef(TriompheArc<dyn Dependency>);
 
 impl DependencyRef {
+  /// Parser construction may mutate a dependency until its reference is published.
+  pub(crate) fn get_mut(&mut self) -> Option<&mut (dyn Dependency + 'static)> {
+    TriompheArc::get_mut(&mut self.0)
+  }
+
   pub fn new<D: Dependency + 'static>(dependency: D) -> Self {
     UniqueDependency::new(dependency).shareable()
   }

--- a/crates/rspack_core/src/external_module.rs
+++ b/crates/rspack_core/src/external_module.rs
@@ -11,13 +11,13 @@ use rustc_hash::FxHashMap as HashMap;
 use serde::Serialize;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildMetaExportsType, BuildResult, ChunkGraph, ChunkInitFragments, ChunkUkey,
-  CodeGenerationDataChunkInitFragments, CodeGenerationDataUrl, CodeGenerationResultBuilder,
-  Compilation, ConcatenationScope, Context, CssLayer, CssModuleRenderCondition, DependenciesBlock,
-  DependencyId, DependencyRef, ExportProvided, ExternalType, FactoryMeta, ImportAttributes,
-  ImportPhase, InitFragmentExt, InitFragmentKey, InitFragmentStage, LibIdentOptions, Module,
-  ModuleArgument, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, BuildMetaExportsType, ChunkGraph,
+  ChunkInitFragments, ChunkUkey, CodeGenerationDataChunkInitFragments, CodeGenerationDataUrl,
+  CodeGenerationResultBuilder, Compilation, ConcatenationScope, Context, CssLayer,
+  CssModuleRenderCondition, DependenciesBlock, DependenciesBlockData, DependencyRef,
+  ExportProvided, ExternalType, FactoryMeta, ImportAttributes, ImportPhase, InitFragmentExt,
+  InitFragmentKey, InitFragmentStage, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleType,
   NAMESPACE_OBJECT_EXPORT, NormalInitFragment, RuntimeGlobals, RuntimeSpec, SourceType,
   StaticExportsDependency, StaticExportsSpec, UsageState, UsedExports, UsedNameItem,
   css_module_render_conditions_identifier, extract_url_and_global, impl_module_meta_info,
@@ -450,8 +450,7 @@ fn resolve_external_type<'a>(
 #[cacheable]
 #[derive(Debug)]
 pub struct ExternalModule {
-  dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  dependencies_block: DependenciesBlockData,
   pub id: Identifier,
   pub request: ExternalRequest,
   pub external_type: ExternalType,
@@ -493,8 +492,7 @@ impl ExternalModule {
     place_in_initial: bool,
   ) -> Self {
     Self {
-      dependencies: Vec::new(),
-      blocks: Vec::new(),
+      dependencies_block: Default::default(),
       id: Identifier::from({
         let resolved_type = resolve_external_type(external_type.as_str(), &dependency_meta);
         let request_str = simd_json::to_string(&request).expect("invalid json to_string");
@@ -1069,24 +1067,12 @@ impl Identifiable for ExternalModule {
 }
 
 impl DependenciesBlock for ExternalModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -1166,7 +1152,7 @@ impl Module for ExternalModule {
     mut self: Box<Self>,
     build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     self.build_info.module = build_context.compiler_options.output.module;
     let resolved_external_type = self.resolve_external_type();
     let request = match &self.request {
@@ -1210,14 +1196,13 @@ impl Module for ExternalModule {
       _ => {}
     }
     self.build_meta.set_exports_type(exports_type);
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![DependencyRef::new(StaticExportsDependency::new(
+    Ok(BoxModule::new(self).with_dependencies(
+      vec![DependencyRef::new(StaticExportsDependency::new(
         StaticExportsSpec::True,
         can_mangle,
       ))],
-      blocks: Vec::new(),
-    })
+      Vec::new(),
+    ))
   }
 
   // #[tracing::instrument("ExternalModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -8,10 +8,9 @@ use rspack_sources::BoxSource;
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId, FactoryMeta,
-  Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec,
-  SourceType, ValueCacheVersions,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder, Compilation, Context,
+  DependenciesBlock, DependenciesBlockData, FactoryMeta, Module, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, ValueCacheVersions,
 };
 
 #[cacheable]
@@ -20,8 +19,7 @@ pub struct TempModule {
   id: ModuleIdentifier,
   build_info: BuildInfo,
   build_meta: BuildMeta,
-  dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  dependencies_block: DependenciesBlockData,
 }
 
 impl TempModule {
@@ -34,9 +32,13 @@ impl TempModule {
         ..Default::default()
       },
       build_meta: m.build_meta().clone(),
-      dependencies: m.get_dependencies().to_vec(),
-      // clean all of blocks
-      blocks: vec![],
+      dependencies_block: DependenciesBlockData::new(
+        m.get_dependency_refs()
+          .iter()
+          .map(|dependency| super::TempDependency::transform_from(dependency.into()).into_owned())
+          .collect(),
+        Vec::new(),
+      ),
     })))
   }
 }
@@ -124,12 +126,8 @@ impl Module for TempModule {
     self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![],
-      blocks: vec![],
-    })
+  ) -> Result<BoxModule> {
+    Ok(BoxModule::new(self))
   }
 }
 
@@ -140,19 +138,11 @@ impl Identifiable for TempModule {
 }
 
 impl DependenciesBlock for TempModule {
-  fn add_block_id(&mut self, _block: AsyncDependenciesBlockIdentifier) {
-    unreachable!()
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-  fn add_dependency_id(&mut self, _dependency: DependencyId) {
-    unreachable!()
-  }
-  fn remove_dependency_id(&mut self, _dependency: DependencyId) {
-    unreachable!()
-  }
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -27,9 +27,9 @@ pub use concatenation_backend::*;
 pub mod diagnostics;
 pub mod incremental;
 pub use dependencies_block::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockBuildResult, AsyncDependenciesBlockIdentifier,
-  AsyncDependenciesBlockIdentifierMap, AsyncDependenciesBlockIdentifierSet,
-  AsyncDependenciesBlockRef, DependenciesBlock,
+  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierMap,
+  AsyncDependenciesBlockIdentifierSet, AsyncDependenciesBlockRef, DependenciesBlock,
+  DependenciesBlockData,
 };
 mod fake_namespace_object;
 pub use fake_namespace_object::*;

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -28,17 +28,17 @@ use smol_str::SmolStr;
 use swc_core::atoms::Wtf8Atom;
 
 use crate::{
-  AsyncDependenciesBlockBuildResult, BindingCell, CacheFacade, ChunkGraph, ChunkUkey,
+  AsyncDependenciesBlockRef, BindingCell, CacheFacade, ChunkGraph, ChunkUkey,
   CodeGenerationResultBuilder, CollectedTypeScriptInfo, Compilation, CompilationAsset,
   CompilationId, CompilerId, CompilerOptions, ConcatenationScope, ConnectionState, Context,
-  ContextModule, CssExportType, DependenciesBlock, DependencyCodeGenerationRef, DependencyId,
-  DependencyRef, ExportProvided, ExportsInfoArtifact, ExternalModule, FileSystemInfo, Filename,
-  GetTargetResult, ImportPhase, ModuleCodeTemplate, ModuleGraph, ModuleGraphCacheArtifact,
-  ModuleLayer, ModuleType, NormalModule, OptimizationBailoutItem, RawModule, Resolve,
-  ResolverFactory, RuntimeSpec, SelfModule, SharedPluginDriver, SideEffectsStateArtifact, Snapshot,
-  SourceType, concatenated_module::ConcatenatedModule,
-  dependencies_block::dependencies_block_update_hash, get_target,
-  value_cache_versions::ValueCacheVersions,
+  ContextModule, CssExportType, DependenciesBlock, DependenciesBlockData,
+  DependencyCodeGenerationRef, DependencyId, DependencyRef, ExportProvided, ExportsInfoArtifact,
+  ExternalModule, FileSystemInfo, Filename, GetTargetResult, ImportPhase, ModuleCodeTemplate,
+  ModuleGraph, ModuleGraphCacheArtifact, ModuleLayer, ModuleType, NormalModule,
+  OptimizationBailoutItem, RawModule, Resolve, ResolverFactory, RuntimeSpec, SelfModule,
+  SharedPluginDriver, SideEffectsStateArtifact, Snapshot, SourceType,
+  concatenated_module::ConcatenatedModule, dependencies_block::dependencies_block_update_hash,
+  get_target, value_cache_versions::ValueCacheVersions,
 };
 
 pub struct BuildContext {
@@ -660,16 +660,6 @@ impl RspackHash for ExportsArgument {
   }
 }
 
-// webpack build info
-#[cacheable]
-#[derive(Debug)]
-pub struct BuildResult {
-  pub module: BoxModule,
-  /// Dependencies are shared after the module build finishes.
-  pub dependencies: Vec<DependencyRef>,
-  pub blocks: Vec<AsyncDependenciesBlockBuildResult>,
-}
-
 #[cacheable]
 #[derive(Debug, Default, Clone)]
 pub struct FactoryMeta {
@@ -723,7 +713,7 @@ pub trait Module:
     self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult>;
+  ) -> Result<BoxModule>;
 
   fn factory_meta(&self) -> Option<&FactoryMeta>;
 
@@ -1028,6 +1018,16 @@ impl<T: Module> ModuleExt for T {
 pub struct BoxModule(Box<dyn Module>);
 
 impl BoxModule {
+  /// Installs a module's complete build output before it is published into the graph.
+  pub fn with_dependencies(
+    mut self,
+    dependencies: Vec<DependencyRef>,
+    blocks: Vec<AsyncDependenciesBlockRef>,
+  ) -> Self {
+    *self.dependencies_block_mut() = DependenciesBlockData::new(dependencies, blocks);
+    self
+  }
+
   /// Create a new BoxModule from a boxed Module trait object.
   pub fn new(module: Box<dyn Module>) -> Self {
     BoxModule(module)
@@ -1037,7 +1037,7 @@ impl BoxModule {
     self,
     build_context: BuildContext,
     compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     self.0.build(build_context, compilation).await
   }
 }
@@ -1197,9 +1197,8 @@ mod test {
 
   use super::{BoxModule, Module};
   use crate::{
-    AsyncDependenciesBlockIdentifier, BuildContext, BuildResult, CodeGenerationResultBuilder,
-    Compilation, Context, DependenciesBlock, DependencyId, ModuleCodeGenerationContext, ModuleExt,
-    ModuleGraph, ModuleType, RuntimeSpec, SourceType,
+    BuildContext, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
+    ModuleCodeGenerationContext, ModuleExt, ModuleGraph, ModuleType, RuntimeSpec, SourceType,
   };
 
   #[cacheable]
@@ -1221,23 +1220,10 @@ mod test {
       impl_empty_diagnosable_trait!($ident);
 
       impl DependenciesBlock for $ident {
-        fn add_block_id(&mut self, _: AsyncDependenciesBlockIdentifier) {
+        fn dependencies_block(&self) -> &$crate::DependenciesBlockData {
           unreachable!()
         }
-
-        fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-          unreachable!()
-        }
-
-        fn add_dependency_id(&mut self, _: DependencyId) {
-          unreachable!()
-        }
-
-        fn remove_dependency_id(&mut self, _: DependencyId) {
-          unreachable!()
-        }
-
-        fn get_dependencies(&self) -> &[DependencyId] {
+        fn dependencies_block_mut(&mut self) -> &mut $crate::DependenciesBlockData {
           unreachable!()
         }
       }
@@ -1273,7 +1259,7 @@ mod test {
           self: Box<Self>,
           _build_context: BuildContext,
           _compilation: Option<&Compilation>,
-        ) -> Result<BuildResult> {
+        ) -> Result<BoxModule> {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -301,11 +301,16 @@ impl ModuleGraph {
       if let Some(b_id) = parent_block
         && let Some(block) = self.inner.blocks.get_mut(&b_id)
       {
-        // Keep cache snapshots unchanged when revoking a published dependency.
+        // Shared blocks may also be retained by another module or a rollback entry.
         if let Some(block) = Arc::get_mut(block) {
           block.remove_dependency_id(*dep_id);
         } else {
           *block = Arc::new(block.without_dependency(*dep_id));
+        }
+        if let Some(module_id) = original_module_identifier
+          && let Some(module) = self.inner.modules.get_mut(&module_id)
+        {
+          module.dependencies_block_mut().replace_block(block.clone());
         }
       }
     }

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -28,9 +28,9 @@ use serde_json::json;
 use tracing::{Instrument, info_span};
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxLoader, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, ConnectionState, Context,
-  DependenciesBlock, DependencyCodeGenerationRef, DependencyId, FactoryMeta, GenerateContext,
+  BoxLoader, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph,
+  CodeGenerationResultBuilder, Compilation, ConnectionState, Context, DependenciesBlock,
+  DependenciesBlockData, DependencyCodeGenerationRef, DependencyId, FactoryMeta, GenerateContext,
   GeneratorOptions, ImportPhase, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
   ModuleGraphCacheArtifact, ModuleIdentifier, ModuleLayer, ModuleType, NeedBuildContext,
   OptimizationBailoutItem, OutputOptions, ParseContext, ParseResult, ParserAndGenerator,
@@ -106,6 +106,7 @@ pub struct NormalModuleHooks {
 #[cacheable]
 #[derive(Debug, Clone)]
 pub(crate) struct NormalModuleState {
+  dependencies_block: DependenciesBlockData,
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
   diagnostics: Vec<Diagnostic>,
@@ -121,9 +122,6 @@ pub(crate) struct NormalModuleState {
 #[cacheable]
 #[derive(Debug)]
 pub struct NormalModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
-
   id: ModuleIdentifier,
   /// Context of this module
   context: Box<Context>,
@@ -215,8 +213,6 @@ impl NormalModule {
       ..Default::default()
     };
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
       id: ModuleIdentifier::from(id.as_ref()),
       context: Box::new(context.unwrap_or_else(|| get_context(&resource_data))),
       request,
@@ -237,6 +233,7 @@ impl NormalModule {
       cached_source_sizes: SourceSizeCache::default(),
       factory_meta: None,
       state: NormalModuleState {
+        dependencies_block: Default::default(),
         source: None,
         diagnostics: Default::default(),
         code_generation_dependencies: None,
@@ -423,24 +420,12 @@ impl Identifiable for NormalModule {
 }
 
 impl DependenciesBlock for NormalModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.state.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.state.dependencies_block
   }
 }
 
@@ -494,7 +479,8 @@ impl Module for NormalModule {
     mut self: Box<Self>,
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
+    self.state.dependencies_block = Default::default();
     self.state.force_build = false;
     self.state.build_info.snapshot = None;
     self.state.build_info.optimization_bailouts.clear();
@@ -569,11 +555,7 @@ impl Module for NormalModule {
         &build_context.compiler_options.output,
         &self.state.build_meta,
       ));
-      return Ok(BuildResult {
-        module: BoxModule::new(self),
-        dependencies: Vec::new(),
-        blocks: Vec::new(),
-      });
+      return Ok(BoxModule::new(self));
     };
 
     build_context
@@ -618,11 +600,7 @@ impl Module for NormalModule {
         &self.state.build_meta,
       ));
 
-      return Ok(BuildResult {
-        module: BoxModule::new(self),
-        dependencies: vec![],
-        blocks: vec![],
-      });
+      return Ok(BoxModule::new(self));
     }
 
     let (
@@ -691,11 +669,10 @@ impl Module for NormalModule {
       &self.state.build_meta,
     ));
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("NormalModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_core/src/raw_module.rs
+++ b/crates/rspack_core/src/raw_module.rs
@@ -12,11 +12,10 @@ use rspack_sources::{BoxSource, OriginalSource, RawStringSource, SourceExt};
 use rspack_util::source_map::{ModuleSourceMapConfig, SourceMapKind};
 
 use crate::{
-  BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder,
-  Compilation, ConnectionState, Context, DependenciesBlock, DependencyId, FactoryMeta, Module,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder, Compilation,
+  ConnectionState, Context, DependenciesBlock, DependenciesBlockData, FactoryMeta, Module,
   ModuleCodeGenerationContext, ModuleGraph, ModuleGraphCacheArtifact, ModuleIdentifier, ModuleType,
-  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType,
-  dependencies_block::AsyncDependenciesBlockIdentifier, impl_module_meta_info,
+  RuntimeGlobals, RuntimeSpec, SideEffectsStateArtifact, SourceType, impl_module_meta_info,
   module_declared_side_effect_free, module_update_hash,
 };
 
@@ -24,8 +23,7 @@ use crate::{
 #[cacheable]
 #[derive(Debug)]
 pub struct RawModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   source_str: String,
   #[cacheable(with=AsOption<AsPreset>)]
   source: Option<BoxSource>,
@@ -47,8 +45,7 @@ impl RawModule {
     runtime_requirements: RuntimeGlobals,
   ) -> Self {
     Self {
-      blocks: Default::default(),
-      dependencies: Default::default(),
+      dependencies_block: Default::default(),
       source_str,
       source: None,
       identifier,
@@ -73,24 +70,12 @@ impl Identifiable for RawModule {
 }
 
 impl DependenciesBlock for RawModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -172,12 +157,8 @@ impl Module for RawModule {
     self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![],
-      blocks: vec![],
-    })
+  ) -> Result<BoxModule> {
+    Ok(BoxModule::new(self))
   }
 }
 

--- a/crates/rspack_core/src/self_module.rs
+++ b/crates/rspack_core/src/self_module.rs
@@ -10,10 +10,10 @@ use rspack_sources::BoxSource;
 use rspack_util::source_map::SourceMapKind;
 
 use crate::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  ChunkUkey, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier,
-  ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkUkey, CodeGenerationResultBuilder,
+  Compilation, Context, DependenciesBlock, DependenciesBlockData, FactoryMeta, LibIdentOptions,
+  Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec,
+  SourceType, impl_module_meta_info,
 };
 
 #[impl_source_map_config]
@@ -22,8 +22,7 @@ use crate::{
 pub struct SelfModule {
   identifier: ModuleIdentifier,
   readable_identifier: String,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   factory_meta: Option<FactoryMeta>,
   build_info: BuildInfo,
   build_meta: BuildMeta,
@@ -35,8 +34,7 @@ impl SelfModule {
     Self {
       identifier: ModuleIdentifier::from(identifier.as_str()),
       readable_identifier: identifier,
-      blocks: Default::default(),
-      dependencies: Default::default(),
+      dependencies_block: Default::default(),
       factory_meta: None,
       build_info: BuildInfo {
         strict: true,
@@ -55,24 +53,12 @@ impl Identifiable for SelfModule {
 }
 
 impl DependenciesBlock for SelfModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -133,12 +119,8 @@ impl Module for SelfModule {
     self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![],
-      blocks: vec![],
-    })
+  ) -> Result<BoxModule> {
+    Ok(BoxModule::new(self))
   }
 }
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -110,23 +110,11 @@ pub fn impl_runtime_module(
     }
 
     impl #impl_generics ::rspack_core::DependenciesBlock for #name #ty_generics #where_clause {
-      fn add_block_id(&mut self, _: ::rspack_core::AsyncDependenciesBlockIdentifier) {
+      fn dependencies_block(&self) -> &::rspack_core::DependenciesBlockData {
         unreachable!()
       }
 
-      fn get_blocks(&self) -> &[::rspack_core::AsyncDependenciesBlockIdentifier] {
-        unreachable!()
-      }
-
-      fn add_dependency_id(&mut self, _: ::rspack_core::DependencyId) {
-        unreachable!()
-      }
-
-      fn remove_dependency_id(&mut self, _: ::rspack_core::DependencyId) {
-        unreachable!()
-      }
-
-      fn get_dependencies(&self) -> &[::rspack_core::DependencyId] {
+      fn dependencies_block_mut(&mut self) -> &mut ::rspack_core::DependenciesBlockData {
         unreachable!()
       }
     }
@@ -202,12 +190,8 @@ pub fn impl_runtime_module(
         self: Box<Self>,
         _build_context: ::rspack_core::BuildContext,
         _compilation: Option<&::rspack_core::Compilation>,
-      ) -> ::rspack_error::Result<::rspack_core::BuildResult> {
-        Ok(::rspack_core::BuildResult {
-          module: ::rspack_core::BoxModule::new(self),
-          dependencies: vec![],
-          blocks: vec![],
-        })
+      ) -> ::rspack_error::Result<::rspack_core::BoxModule> {
+        Ok(::rspack_core::BoxModule::new(self))
       }
     }
 

--- a/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_entry/dll_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
-  EntryDependency, FactoryMeta, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
-  ModuleType, NeedBuildContext, RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions,
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
+  BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder,
+  Compilation, Context, DependenciesBlock, DependenciesBlockData, EntryDependency, FactoryMeta,
+  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph, ModuleType, NeedBuildContext,
+  RuntimeGlobals, RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -29,13 +29,11 @@ pub struct DllModule {
 
   build_meta: BuildMeta,
 
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  dependencies_block: DependenciesBlockData,
 
   entries: Vec<String>,
 
   context: Context,
-
-  dependencies: Vec<DependencyId>,
 }
 
 impl DllModule {
@@ -81,7 +79,7 @@ impl Module for DllModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let dependencies = self
       .entries
       .clone()
@@ -90,11 +88,10 @@ impl Module for DllModule {
       .map(BoxDependency::new)
       .collect::<Vec<_>>();
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: vec![],
-    })
+    Ok(
+      BoxModule::new(self)
+        .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
+    )
   }
 
   async fn code_generation(
@@ -152,24 +149,11 @@ impl Identifiable for DllModule {
 }
 
 impl DependenciesBlock for DllModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block);
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
-
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency);
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -4,12 +4,12 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependencyId,
-  FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext,
-  ModuleDependency, ModuleGraph, ModuleId, ModuleType, NeedBuildContext, RuntimeSpec, SourceType,
-  StaticExportsDependency, StaticExportsSpec, ValueCacheVersions, impl_module_meta_info,
-  impl_source_map_config, module_update_hash,
+  BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder,
+  Compilation, Context, DependenciesBlock, DependenciesBlockData, FactoryMeta, LibIdentOptions,
+  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleDependency, ModuleGraph, ModuleId,
+  ModuleType, NeedBuildContext, RuntimeSpec, SourceType, StaticExportsDependency,
+  StaticExportsSpec, ValueCacheVersions, impl_module_meta_info, impl_source_map_config,
+  module_update_hash,
   rspack_sources::{BoxSource, OriginalSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -31,8 +31,7 @@ pub struct DelegatedModule {
   user_request: String,
   original_request: Option<String>,
   delegate_data: DllManifestContentItem,
-  dependencies: Vec<DependencyId>,
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
+  dependencies_block: DependenciesBlockData,
   factory_meta: Option<FactoryMeta>,
   build_info: BuildInfo,
   build_meta: BuildMeta,
@@ -95,7 +94,7 @@ impl Module for DelegatedModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let dependencies = vec![
       BoxDependency::new(DelegatedSourceDependency::new(self.source_request.clone())),
       BoxDependency::new(StaticExportsDependency::new(
@@ -110,11 +109,10 @@ impl Module for DelegatedModule {
       )),
     ];
     self.build_meta = self.delegate_data.build_meta.clone();
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: vec![],
-    })
+    Ok(
+      BoxModule::new(self)
+        .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
+    )
   }
 
   async fn code_generation(
@@ -129,7 +127,7 @@ impl Module for DelegatedModule {
 
     let mut code_generation_result = CodeGenerationResultBuilder::default();
 
-    let dep = self.dependencies[0];
+    let dep = self.get_dependencies()[0];
     let mg = compilation.get_module_graph();
     let source_module = mg.get_module_by_dependency_id(&dep);
     let dependency = mg
@@ -221,24 +219,12 @@ impl Identifiable for DelegatedModule {
 }
 
 impl DependenciesBlock for DelegatedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block);
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency);
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 

--- a/crates/rspack_plugin_extract_css/src/css_module.rs
+++ b/crates/rspack_plugin_extract_css/src/css_module.rs
@@ -1,11 +1,11 @@
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxModule, BuildContext, BuildInfo, BuildMeta, BuildResult,
-  CodeGenerationResultBuilder, Compilation, CompilerOptions, DependenciesBlock, DependencyId,
-  FactoryMeta, Module, ModuleCodeGenerationContext, ModuleExt, ModuleFactory,
-  ModuleFactoryCreateData, ModuleFactoryResult, ModuleGraph, ModuleLayer, RuntimeSpec, SourceType,
-  impl_module_meta_info, impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
+  BoxModule, BuildContext, BuildInfo, BuildMeta, CodeGenerationResultBuilder, Compilation,
+  CompilerOptions, DependenciesBlock, DependenciesBlockData, FactoryMeta, Module,
+  ModuleCodeGenerationContext, ModuleExt, ModuleFactory, ModuleFactoryCreateData,
+  ModuleFactoryResult, ModuleGraph, ModuleLayer, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -34,8 +34,7 @@ pub(crate) struct CssModule {
   build_info: BuildInfo,
   build_meta: BuildMeta,
 
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
 
   identifier__: Identifier,
 }
@@ -64,8 +63,7 @@ impl CssModule {
       supports: dep.supports.clone(),
       source_map: dep.source_map.clone(),
       identifier_index: dep.identifier_index,
-      blocks: vec![],
-      dependencies: vec![],
+      dependencies_block: Default::default(),
       factory_meta: None,
       build_info: BuildInfo {
         cacheable: dep.cacheable,
@@ -165,13 +163,9 @@ impl Module for CssModule {
     mut self: Box<Self>,
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     self.build_info.hash = Some(self.compute_hash(&build_context.compiler_options));
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: vec![],
-      blocks: vec![],
-    })
+    Ok(BoxModule::new(self))
   }
 
   // #[tracing::instrument("ExtractCssModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
@@ -205,24 +199,12 @@ impl Identifiable for CssModule {
 }
 
 impl DependenciesBlock for CssModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1795,7 +1795,7 @@ async fn create_concatenated_module(
       Some(compilation),
     )
     .await?;
-  new_module = build_result.module;
+  new_module = build_result;
 
   Ok(new_module)
 }

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -3,12 +3,12 @@ use std::{borrow::Cow, sync::Arc};
 use rspack_cacheable::{cacheable, cacheable_dyn, with::AsVec};
 use rspack_collections::Identifiable;
 use rspack_core::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, DependencyRange, FactoryMeta, ImportPhase, LibIdentOptions,
-  Module, ModuleArgument, ModuleCodeGenerationContext, ModuleFactoryCreateData, ModuleGraph,
-  ModuleIdentifier, ModuleLayer, ModuleType, NeedBuildContext, OutputOptions, RuntimeGlobals,
-  RuntimeSpec, SourceType, ValueCacheVersions, impl_module_meta_info, module_update_hash,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  DependencyRange, FactoryMeta, ImportPhase, LibIdentOptions, Module, ModuleArgument,
+  ModuleCodeGenerationContext, ModuleFactoryCreateData, ModuleGraph, ModuleIdentifier, ModuleLayer,
+  ModuleType, NeedBuildContext, OutputOptions, RuntimeGlobals, RuntimeSpec, SourceType,
+  ValueCacheVersions, impl_module_meta_info, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource},
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
@@ -55,8 +55,7 @@ pub(crate) struct LazyCompilationProxyModule {
   identifier: ModuleIdentifier,
   lib_ident: Option<String>,
 
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
 
   source_map_kind: SourceMapKind,
 
@@ -113,8 +112,7 @@ impl LazyCompilationProxyModule {
       lib_ident,
       identifier,
       source_map_kind: SourceMapKind::empty(),
-      blocks: vec![],
-      dependencies: vec![],
+      dependencies_block: Default::default(),
       context: Box::new(create_data.context.clone()),
       layer: create_data.issuer_layer.clone(),
       dep_options,
@@ -193,7 +191,7 @@ impl Module for LazyCompilationProxyModule {
     mut self: Box<Self>,
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let client_dep = CommonJsRequireDependency::new(
       self.client.clone(),
       DependencyRange::new(0, 0),
@@ -232,11 +230,10 @@ impl Module for LazyCompilationProxyModule {
       }
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("LazyCompilationProxyModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
@@ -250,14 +247,14 @@ impl Module for LazyCompilationProxyModule {
       ..
     } = code_generation_context;
 
-    let client_dep_id = self.dependencies[0];
+    let client_dep_id = self.get_dependencies()[0];
     let module_graph = &compilation.get_module_graph();
 
     let client_module = module_graph
       .module_identifier_by_dependency_id(&client_dep_id)
       .expect("should have module");
 
-    let block = self.blocks.first();
+    let block = self.get_blocks().first();
 
     let client = format!(
       "var client = {}(\"{}\");\nvar data = {};",
@@ -350,23 +347,11 @@ impl Identifiable for LazyCompilationProxyModule {
 }
 
 impl DependenciesBlock for LazyCompilationProxyModule {
-  fn add_block_id(&mut self, block: rspack_core::AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block);
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[rspack_core::AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: rspack_core::DependencyId) {
-    self.dependencies.push(dependency);
-  }
-
-  fn remove_dependency_id(&mut self, dependency: rspack_core::DependencyId) {
-    self.dependencies.retain(|d| d != &dependency);
-  }
-
-  fn get_dependencies(&self) -> &[rspack_core::DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -4,14 +4,14 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, ChunkGroupOptions,
-  CodeGenerationDataItem, CodeGenerationResultBuilder, CodeGenerationRuntimeRequirementsWrite,
-  Compilation, Context, DependenciesBlock, Dependency, DependencyId, DependencyType,
-  ExportsArgument, FactoryMeta, GroupOptions, LibIdentOptions, Module, ModuleCodeGenerationContext,
-  ModuleCodeTemplate, ModuleDependency, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeGlobalsRenderMode, RuntimeSpec, SourceType, StaticExportsDependency, StaticExportsSpec,
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
+  BuildMetaExportsType, ChunkGroupOptions, CodeGenerationDataItem, CodeGenerationResultBuilder,
+  CodeGenerationRuntimeRequirementsWrite, Compilation, Context, DependenciesBlock,
+  DependenciesBlockData, Dependency, DependencyType, ExportsArgument, FactoryMeta, GroupOptions,
+  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleDependency,
+  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeSpec,
+  SourceType, StaticExportsDependency, StaticExportsSpec, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
 };
@@ -31,8 +31,7 @@ use crate::{
 #[cacheable]
 #[derive(Debug)]
 pub struct ContainerEntryModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   lib_ident: String,
   exposes: Vec<(String, ExposeOptions)>,
@@ -58,8 +57,7 @@ impl ContainerEntryModule {
     let namespace = module_identifier_namespace(runtime_mode);
     let lib_ident = format!("{namespace}/container/entry/{name}");
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(format!(
         "container entry ({}) {}",
         share_scope.key(),
@@ -93,8 +91,7 @@ impl ContainerEntryModule {
     let namespace = module_identifier_namespace(runtime_mode);
     let lib_ident = format!("{namespace}/share/container/{name}");
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(format!("share container entry {}@{}", &name, &version,)),
       lib_ident,
       exposes: vec![],
@@ -131,24 +128,12 @@ impl Identifiable for ContainerEntryModule {
 }
 
 impl DependenciesBlock for ContainerEntryModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -193,7 +178,7 @@ impl Module for ContainerEntryModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let mut blocks = vec![];
     let mut dependencies: Vec<BoxDependency> = vec![];
 
@@ -240,11 +225,10 @@ impl Module for ContainerEntryModule {
     // I need `name` for SharedContainer logic.
     // I will add `name` field to struct.
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("ContainerEntryModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, ChunkUkey, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module, ModuleArgument,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
+  BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph, ChunkUkey,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  FactoryMeta, LibIdentOptions, Module, ModuleArgument, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
 };
@@ -23,8 +23,7 @@ use crate::utils::{json_stringify, module_identifier_namespace};
 #[cacheable]
 #[derive(Debug)]
 pub struct FallbackModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   readable_identifier: String,
   lib_ident: String,
@@ -48,8 +47,7 @@ impl FallbackModule {
       requests_len_minus_one
     );
     Self {
-      blocks: Default::default(),
-      dependencies: Default::default(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(identifier.as_str()),
       readable_identifier: identifier,
       lib_ident,
@@ -72,24 +70,12 @@ impl Identifiable for FallbackModule {
 }
 
 impl DependenciesBlock for FallbackModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -136,7 +122,7 @@ impl Module for FallbackModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let mut dependencies: Vec<BoxDependency> = Vec::new();
     for request in &self.requests {
       dependencies.push(BoxDependency::new(FallbackItemDependency::new(
@@ -144,11 +130,10 @@ impl Module for FallbackModule {
       )))
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: vec![],
-    })
+    Ok(
+      BoxModule::new(self)
+        .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
+    )
   }
 
   // #[tracing::instrument("FallbackModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -4,11 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
-  BuildResult, ChunkGraph, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
-  Dependency, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType,
-  impl_module_meta_info, impl_source_map_config, module_update_hash,
+  BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta, ChunkGraph,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  Dependency, ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext,
+  ModuleGraph, ModuleIdentifier, ModuleType, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
   runtime_mode::RuntimeMode,
 };
@@ -29,8 +29,7 @@ use crate::{
 #[cacheable]
 #[derive(Debug)]
 pub struct RemoteModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   readable_identifier: String,
   lib_ident: String,
@@ -57,8 +56,7 @@ impl RemoteModule {
     let namespace = module_identifier_namespace(runtime_mode);
     let lib_ident = format!("{namespace}/container/remote/{request}");
     Self {
-      blocks: Default::default(),
-      dependencies: Default::default(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(format!(
         "remote ({}) {} {}",
         share_scope.key(),
@@ -90,24 +88,12 @@ impl Identifiable for RemoteModule {
 }
 
 impl DependenciesBlock for RemoteModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -158,7 +144,7 @@ impl Module for RemoteModule {
     mut self: Box<Self>,
     build_context: BuildContext,
     _compilation: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let mut dependencies: Vec<BoxDependency> = Vec::new();
 
     if self.external_requests.len() == 1 {
@@ -191,11 +177,10 @@ impl Module for RemoteModule {
       dependencies.push(BoxDependency::new(dep));
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: vec![],
-    })
+    Ok(
+      BoxModule::new(self)
+        .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
+    )
   }
 
   // #[tracing::instrument("RemoteModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]
@@ -205,7 +190,7 @@ impl Module for RemoteModule {
   ) -> Result<CodeGenerationResultBuilder> {
     let mut codegen = CodeGenerationResultBuilder::default();
     let module_graph = code_generation_context.compilation.get_module_graph();
-    let module = module_graph.get_module_by_dependency_id(&self.dependencies[0]);
+    let module = module_graph.get_module_by_dependency_id(&self.get_dependencies()[0]);
     let id = module.and_then(|m| {
       ChunkGraph::get_module_id(
         &code_generation_context.compilation.module_ids_artifact,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -4,12 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn, with::Unsupported};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, ExportsType, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::BoxSource, runtime_mode::RuntimeMode,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  ExportsType, FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph,
+  ModuleIdentifier, ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHash, RspackHashDigest, RspackHasher};
@@ -26,8 +25,7 @@ use crate::{ConsumeOptions, ShareScope, utils::module_identifier_namespace};
 #[derive(Debug)]
 pub struct ConsumeSharedModule {
   #[cacheable(with=Unsupported)]
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   lib_ident: String,
   readable_identifier: String,
@@ -76,8 +74,7 @@ impl ConsumeSharedModule {
       },
     );
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
       lib_ident: format!(
         "{namespace}/sharing/consume/{}/{}{}",
@@ -107,24 +104,12 @@ impl Identifiable for ConsumeSharedModule {
 }
 
 impl DependenciesBlock for ConsumeSharedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -175,7 +160,7 @@ impl Module for ConsumeSharedModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let mut blocks = vec![];
     let mut dependencies = vec![];
     if let Some(fallback) = &self.options.import {
@@ -188,11 +173,10 @@ impl Module for ConsumeSharedModule {
       }
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("ConsumeSharedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -4,12 +4,11 @@ use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildResult, CodeGenerationResultBuilder, Compilation, Context,
-  DependenciesBlock, DependencyId, FactoryMeta, LibIdentOptions, Module,
-  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleType, RuntimeGlobals,
-  RuntimeSpec, SourceType, impl_module_meta_info, impl_source_map_config, module_update_hash,
-  rspack_sources::BoxSource, runtime_mode::RuntimeMode,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
+  CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock, DependenciesBlockData,
+  FactoryMeta, LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier,
+  ModuleType, RuntimeGlobals, RuntimeSpec, SourceType, impl_module_meta_info,
+  impl_source_map_config, module_update_hash, rspack_sources::BoxSource, runtime_mode::RuntimeMode,
 };
 use rspack_error::{Result, impl_empty_diagnosable_trait};
 use rspack_hash::{RspackHashDigest, RspackHasher};
@@ -28,8 +27,7 @@ use crate::{ConsumeVersion, ShareScope, utils::module_identifier_namespace};
 #[cacheable]
 #[derive(Debug)]
 pub struct ProvideSharedModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   lib_ident: String,
   readable_identifier: String,
@@ -68,8 +66,7 @@ impl ProvideSharedModule {
       &scopes_key, &name, &version, &request
     );
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
+      dependencies_block: Default::default(),
       identifier: ModuleIdentifier::from(identifier.as_ref()),
       lib_ident: format!("{namespace}/sharing/provide/{scopes_key}/{name}"),
       readable_identifier: identifier,
@@ -115,24 +112,12 @@ impl Identifiable for ProvideSharedModule {
 }
 
 impl DependenciesBlock for ProvideSharedModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -169,7 +154,7 @@ impl Module for ProvideSharedModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     let mut blocks = vec![];
     let mut dependencies = vec![];
     let dep = BoxDependency::new(ProvideForSharedDependency::new(self.request.clone()));
@@ -180,11 +165,10 @@ impl Module for ProvideSharedModule {
       blocks.push(Box::new(block));
     }
 
-    Ok(BuildResult {
-      module: BoxModule::new(self),
-      dependencies: dependencies.into_iter().map(Into::into).collect(),
-      blocks: blocks.into_iter().map(Into::into).collect(),
-    })
+    Ok(BoxModule::new(self).with_dependencies(
+      dependencies.into_iter().map(Into::into).collect(),
+      blocks.into_iter().map(Into::into).collect(),
+    ))
   }
 
   // #[tracing::instrument("ProvideSharedModule::code_generation", skip_all, fields(identifier = ?self.identifier()))]

--- a/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
+++ b/crates/rspack_plugin_rsc/src/rsc_entry_module.rs
@@ -8,11 +8,11 @@ use rspack_cacheable::{
 };
 use rspack_collections::{Identifiable, Identifier};
 use rspack_core::{
-  AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, CodeGenerationResultBuilder,
-  Compilation, Context, DependenciesBlock, DependencyId, DependencyRange, FactoryMeta, ImportPhase,
-  LibIdentOptions, Module, ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleLayer,
-  ModuleType, ReferencedSpecifier, RuntimeSpec, SourceType, contextify, impl_module_meta_info,
+  AsyncDependenciesBlock, BoxDependency, BoxModule, BuildContext, BuildInfo, BuildMeta,
+  BuildMetaExportsType, CodeGenerationResultBuilder, Compilation, Context, DependenciesBlock,
+  DependenciesBlockData, DependencyRange, FactoryMeta, ImportPhase, LibIdentOptions, Module,
+  ModuleCodeGenerationContext, ModuleGraph, ModuleIdentifier, ModuleLayer, ModuleType,
+  ReferencedSpecifier, RuntimeSpec, SourceType, contextify, impl_module_meta_info,
   impl_source_map_config, module_update_hash,
   rspack_sources::{BoxSource, RawStringSource, SourceExt},
 };
@@ -32,8 +32,7 @@ use crate::{
 #[cacheable]
 #[derive(Debug)]
 pub struct RscEntryModule {
-  blocks: Vec<AsyncDependenciesBlockIdentifier>,
-  dependencies: Vec<DependencyId>,
+  dependencies_block: DependenciesBlockData,
   identifier: ModuleIdentifier,
   lib_ident: String,
   client_modules: Vec<ClientModuleImport>,
@@ -76,8 +75,7 @@ impl RscEntryModule {
     };
 
     Self {
-      blocks: Vec::new(),
-      dependencies: Vec::new(),
+      dependencies_block: Default::default(),
       identifier,
       lib_ident,
       client_modules,
@@ -192,24 +190,12 @@ impl Identifiable for RscEntryModule {
 }
 
 impl DependenciesBlock for RscEntryModule {
-  fn add_block_id(&mut self, block: AsyncDependenciesBlockIdentifier) {
-    self.blocks.push(block)
+  fn dependencies_block(&self) -> &DependenciesBlockData {
+    &self.dependencies_block
   }
 
-  fn get_blocks(&self) -> &[AsyncDependenciesBlockIdentifier] {
-    &self.blocks
-  }
-
-  fn add_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.push(dependency)
-  }
-
-  fn remove_dependency_id(&mut self, dependency: DependencyId) {
-    self.dependencies.retain(|d| d != &dependency)
-  }
-
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies
+  fn dependencies_block_mut(&mut self) -> &mut DependenciesBlockData {
+    &mut self.dependencies_block
   }
 }
 
@@ -250,7 +236,7 @@ impl Module for RscEntryModule {
     mut self: Box<Self>,
     _build_context: BuildContext,
     _: Option<&Compilation>,
-  ) -> Result<BuildResult> {
+  ) -> Result<BoxModule> {
     if self.is_server_side_rendering {
       // Eager: no code-split points; use ImportEagerDependency (CSS filtering done at call site).
       let all_client_modules = self.all_client_modules();
@@ -268,11 +254,10 @@ impl Module for RscEntryModule {
         }
         dependencies.push(BoxDependency::new(dep));
       }
-      Ok(BuildResult {
-        module: BoxModule::new(self),
-        dependencies: dependencies.into_iter().map(Into::into).collect(),
-        blocks: vec![],
-      })
+      Ok(
+        BoxModule::new(self)
+          .with_dependencies(dependencies.into_iter().map(Into::into).collect(), vec![]),
+      )
     } else {
       // Non-eager: code-split points; use AsyncDependenciesBlock + ClientReferenceDependency.
       let mut blocks = Vec::with_capacity(
@@ -372,11 +357,10 @@ impl Module for RscEntryModule {
         blocks.push(Box::new(block));
       }
 
-      Ok(BuildResult {
-        module: BoxModule::new(self),
-        dependencies: dependencies.into_iter().map(Into::into).collect(),
-        blocks: blocks.into_iter().map(Into::into).collect(),
-      })
+      Ok(BoxModule::new(self).with_dependencies(
+        dependencies.into_iter().map(Into::into).collect(),
+        blocks.into_iter().map(Into::into).collect(),
+      ))
     }
   }
 

--- a/tests/rspack-test/compilerCases/module-owned-dependencies.js
+++ b/tests/rspack-test/compilerCases/module-owned-dependencies.js
@@ -97,7 +97,11 @@ module.exports = [
 				if (iteration === 3) write("b-async.js", 'export default "updated";');
 				const stats = await manager.build();
 				expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
-				if (!legacy) expect(built).toBe(cache === false || iteration % 2 === 0 ? 1 : 0);
+				if (!legacy) {
+					// Consecutive run() calls use rebuild(), which bypasses the module cache.
+					const cacheHit = reopen && iteration % 2 === 1;
+					expect(built).toBe(cacheHit ? 0 : 1);
+				}
 				const filename = path.join(root, "dist/main.js");
 				const source = fs.readFileSync(filename, "utf8");
 				expect(source).toContain(`CONCATENATED MODULE: ./${selected}.js`);

--- a/tests/rspack-test/compilerCases/module-owned-dependencies.js
+++ b/tests/rspack-test/compilerCases/module-owned-dependencies.js
@@ -1,0 +1,117 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { createRequire } = require("node:module");
+
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+	{ name: "memory", cache: true },
+	{ name: "persistent-reopen", cache: "persistent", reopen: true },
+	{ name: "legacy-persistent-reopen", cache: "persistent", reopen: true, legacy: true },
+	{ name: "disabled", cache: false }
+].map(({ name, cache, reopen, legacy }) => {
+	let root;
+	let timestamp;
+	let selected = "a";
+	let built;
+
+	function write(file, source) {
+		const filename = path.join(root, file);
+		fs.writeFileSync(filename, source);
+		fs.utimesSync(filename, timestamp, timestamp);
+	}
+
+	function writeEntry() {
+		write("index.js", `
+			import { value } from "./${selected}.js";
+			export const sync = value;
+			export const async = () => import("./${selected}-async.js").then(m => m.default);
+		`);
+	}
+
+	return {
+		description: `should retain dependency and block objects across graph replacement with ${name}`,
+		options(context) {
+			root = context.getDist(name);
+			fs.rmSync(root, { recursive: true, force: true });
+			fs.mkdirSync(root, { recursive: true });
+			timestamp = new Date(Date.now() - 20000);
+			writeEntry();
+			for (const value of ["a", "b"]) {
+				write(`${value}.js`, `export const value = "${value}";`);
+				write(`${value}-async.js`, `export default "${value}";`);
+			}
+			return {
+				context: root,
+				entry: "./index.js",
+				target: "node",
+				mode: "production",
+				devtool: false,
+				incremental: false,
+				output: {
+					path: path.join(root, "dist"),
+					filename: "main.js",
+					chunkFilename: "[id].[contenthash].js",
+					library: { type: "commonjs2" }
+				},
+				optimization: { concatenateModules: true, inlineExports: false, minimize: false },
+				cache: cache === "persistent" ? {
+					type: "persistent",
+					storage: { type: "filesystem", location: path.join(root, "cache") }
+				} : cache,
+				experiments: legacy ? {} : {
+					newCache: { module: true, loader: false, codeGeneration: false, devtool: false, minimize: false }
+				},
+				plugins: [{
+					apply(compiler) {
+						compiler.hooks.compilation.tap("ModuleOwnedDependenciesTest", compilation => {
+							compilation.hooks.buildModule.tap("ModuleOwnedDependenciesTest", module => {
+								if (module.resource === path.join(root, "index.js")) built++;
+							});
+							compilation.hooks.finishModules.tap("ModuleOwnedDependenciesTest", modules => {
+								const entry = [...modules].find(module => module.resource === path.join(root, "index.js"));
+								const dependency = entry.dependencies.find(dep => dep.request === `./${selected}.js`);
+								expect(dependency).toBeDefined();
+								expect(compilation.moduleGraph.getModule(dependency).resource).toBe(path.join(root, `${selected}.js`));
+								expect(entry.blocks).toHaveLength(1);
+								const asyncDependency = entry.blocks[0].dependencies[0];
+								expect(asyncDependency.request).toBe(`./${selected}-async.js`);
+								expect(compilation.moduleGraph.getModule(asyncDependency).resource).toBe(path.join(root, `${selected}-async.js`));
+							});
+						});
+					}
+				}]
+			};
+		},
+		compiler(_, compiler) {
+			compiler.outputFileSystem = fs;
+		},
+		async build(context) {
+			const manager = context.getCompiler();
+			for (let iteration = 0; iteration < 5; iteration++) {
+				built = 0;
+				timestamp = new Date(timestamp.getTime() + 1000);
+				if (iteration === 2 || iteration === 4) {
+					selected = iteration === 2 ? "b" : "a";
+					writeEntry();
+				}
+				if (iteration === 3) write("b-async.js", 'export default "updated";');
+				const stats = await manager.build();
+				expect(stats.toJson({ all: false, errors: true }).errors).toEqual([]);
+				if (!legacy) expect(built).toBe(cache === false || iteration % 2 === 0 ? 1 : 0);
+				const filename = path.join(root, "dist/main.js");
+				const source = fs.readFileSync(filename, "utf8");
+				expect(source).toContain(`CONCATENATED MODULE: ./${selected}.js`);
+				const output = { exports: {} };
+				new Function("require", "module", "exports", source)(
+					createRequire(filename), output, output.exports
+				);
+				expect(output.exports.sync).toBe(selected);
+				expect(await output.exports.async()).toBe(iteration === 3 ? "updated" : selected);
+				if (reopen && iteration < 4) {
+					await manager.close();
+					manager.createCompiler().outputFileSystem = fs;
+				}
+			}
+		}
+	};
+});


### PR DESCRIPTION
## Summary

Keep dependency and async block objects on modules, with ModuleGraph indexing shared references. Remove `BuildResult` and `ModuleGraphBuildResult`.

The existing normal-module state cache clones the owning containers while sharing their dependency and block objects.