### PR TITLE
chore: document persistent cache format policy

### DIFF
--- a/.agents/CACHE_AND_INCREMENTAL.md
+++ b/.agents/CACHE_AND_INCREMENTAL.md
@@ -112,6 +112,20 @@ unselected one. Code should depend on their Cache responsibility rather than use
 the owner of Incremental state. The two implementations do not need identical cache coverage or
 storage formats while the migration is in progress.
 
+## Persistent cache format policy
+
+Persistent cache files are disposable implementation details, and their serialized format may change
+without support for older data. This applies to both cache backends and shared serialization code.
+
+- Do not add legacy decoders, fallback readers, dual-format writes, or migration code for old caches.
+- Keep existing cache namespaces, keys, and storage locations when changing a serialized payload.
+  Do not introduce another namespace or a format-version suffix (such as `owned-v1` or `owned-v2`)
+  to isolate old cache data.
+- Do not add format-version guards or other compatibility-only invalidation mechanisms.
+
+Use the existing cache validation and miss handling. Clear stale local cache files and rebuild when
+a format change makes them unusable.
+
 ## Ownership and data flow
 
 Ownership is the architectural boundary:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Rspack is a high-performance JavaScript bundler written in Rust that offers stro
 ## Cache architecture
 
 - **Backend boundary**: `crates/rspack_core/src/new_cache/` and `crates/rspack_core/src/legacy_cache/` may depend on shared code in `crates/rspack_core/src/cache/`, but must not reference each other.
+- **Persistent cache format**: Do not add compatibility code for old persistent cache formats or introduce new/versioned cache namespaces to isolate format changes. Keep existing namespaces; clear stale cache files and rebuild when needed.
 - Read [Cache and Incremental](.agents/CACHE_AND_INCREMENTAL.md) before modifying either cache backend or their shared dependencies.
 
 ## Setup


### PR DESCRIPTION
## Summary

Document that persistent cache changes must not add old-format compatibility or new/versioned namespaces for format isolation. Add the rule to `AGENTS.md` and the cache architecture guide.