### PR TITLE
refactor(javascript): use dense ids for scope metadata storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,7 +5046,6 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
- "slotmap",
  "smallvec",
  "sugar_path",
  "swc_next_allocator",
@@ -6110,15 +6109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "slotmap"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
-dependencies = [
- "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,6 @@ simd-json           = { version = "0.17.3", default-features = false, features =
 simd-utf16-len      = { version = "0.1.0", default-features = false }
 simdutf8            = { version = "0.1.5", default-features = false }
 similar-asserts     = { version = "1.5.0", default-features = false }
-slotmap             = { version = "1.1.1", default-features = false }
 smallvec            = { version = "1.15.2", default-features = false }
 smol_str            = { version = "0.3.6", default-features = false }
 stacker             = { version = "0.1.24", default-features = false }

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -38,7 +38,6 @@ rspack_regex           = { workspace = true }
 rspack_util            = { workspace = true }
 rustc-hash             = { workspace = true }
 serde_json             = { workspace = true }
-slotmap                = { workspace = true }
 smallvec               = { workspace = true }
 sugar_path             = { workspace = true }
 swc_next_allocator     = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info.rs
@@ -1,48 +1,65 @@
+use std::num::NonZeroU32;
+
 use bitflags::bitflags;
 use rspack_intern::{AtomMap, AtomRef};
-use slotmap::{KeyData, SlotMap, new_key_type};
 use smallvec::SmallVec;
 
 use crate::Atom;
 
-new_key_type! {
-  pub struct ScopeInfoId;
-  pub struct VariableInfoId;
-  pub struct TagInfoId;
+macro_rules! dense_id {
+  ($name:ident) => {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct $name(NonZeroU32);
+
+    impl $name {
+      fn from_index(index: usize) -> Self {
+        let value = u32::try_from(index)
+          .ok()
+          .and_then(|index| index.checked_add(1))
+          .filter(|value| *value < u32::MAX - 1)
+          .unwrap_or_else(|| panic!("too many {} entries", stringify!($name)));
+        Self(NonZeroU32::new(value).expect("dense ids start at one"))
+      }
+
+      fn index(self) -> usize {
+        (self.0.get() - 1) as usize
+      }
+    }
+  };
 }
+
+dense_id!(ScopeInfoId);
+dense_id!(VariableInfoId);
+dense_id!(TagInfoId);
 
 impl VariableInfoId {
   pub fn tombstone() -> Self {
-    Self::from(KeyData::from_ffi(u64::MAX))
+    Self(NonZeroU32::new(u32::MAX).expect("u32::MAX is non-zero"))
   }
   pub fn undefined() -> Self {
-    Self::from(KeyData::from_ffi(u64::MAX - 1))
+    Self(NonZeroU32::new(u32::MAX - 1).expect("u32::MAX - 1 is non-zero"))
   }
 }
 
 #[derive(Debug, Default)]
 pub struct VariableInfoDB {
-  map: SlotMap<VariableInfoId, VariableInfo>,
+  map: Vec<VariableInfo>,
 }
 
 impl VariableInfoDB {
   fn new() -> Self {
-    Self {
-      map: SlotMap::with_key(),
-    }
+    Self { map: Vec::new() }
   }
 }
 
 #[derive(Debug, Default)]
 pub struct TagInfoDB {
-  pub map: SlotMap<TagInfoId, TagInfo>,
+  pub map: Vec<TagInfo>,
 }
 
 impl TagInfoDB {
   fn new() -> Self {
-    Self {
-      map: SlotMap::with_key(),
-    }
+    Self { map: Vec::new() }
   }
 }
 
@@ -67,7 +84,9 @@ struct Binding {
 /// before its parent receives further operations.
 #[derive(Debug)]
 pub struct ScopeInfoDB {
-  map: SlotMap<ScopeInfoId, ScopeInfo>,
+  // Entries are append-only for this parser's lifetime. IDs are local to
+  // each database and never need generations or slot reuse.
+  map: Vec<ScopeInfo>,
   /// For each name, the stack of active bindings, innermost last.
   bindings: AtomMap<SmallVec<[Binding; 2]>>,
   /// The innermost active scope, used to validate the stack discipline.
@@ -85,7 +104,7 @@ impl Default for ScopeInfoDB {
 impl ScopeInfoDB {
   pub fn new() -> Self {
     Self {
-      map: SlotMap::with_key(),
+      map: Vec::new(),
       bindings: AtomMap::default(),
       current: None,
       variable_info_db: VariableInfoDB::new(),
@@ -103,7 +122,8 @@ impl ScopeInfoDB {
       parent,
       defined: Vec::new(),
     };
-    let id = self.map.insert(info);
+    let id = ScopeInfoId::from_index(self.map.len());
+    self.map.push(info);
     self.current = Some(id);
     id
   }
@@ -148,14 +168,14 @@ impl ScopeInfoDB {
   pub fn expect_get_scope(&self, id: ScopeInfoId) -> &ScopeInfo {
     self
       .map
-      .get(id)
+      .get(id.index())
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
   pub fn expect_get_mut_scope(&mut self, id: ScopeInfoId) -> &mut ScopeInfo {
     self
       .map
-      .get_mut(id)
+      .get_mut(id.index())
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
@@ -163,7 +183,7 @@ impl ScopeInfoDB {
     self
       .variable_info_db
       .map
-      .get(id)
+      .get(id.index())
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
@@ -171,7 +191,7 @@ impl ScopeInfoDB {
     self
       .tag_info_db
       .map
-      .get(id)
+      .get(id.index())
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
@@ -179,7 +199,7 @@ impl ScopeInfoDB {
     self
       .tag_info_db
       .map
-      .get_mut(id)
+      .get_mut(id.index())
       .unwrap_or_else(|| panic!("{id:#?} should exist"))
   }
 
@@ -258,7 +278,9 @@ impl TagInfo {
     next: Option<TagInfoId>,
   ) -> TagInfoId {
     let tag_info = TagInfo { tag, data, next };
-    definitions_db.tag_info_db.map.insert(tag_info)
+    let id = TagInfoId::from_index(definitions_db.tag_info_db.map.len());
+    definitions_db.tag_info_db.map.push(tag_info);
+    id
   }
 }
 
@@ -344,16 +366,15 @@ impl VariableInfo {
     flags: VariableInfoFlags,
     tag_info: Option<TagInfoId>,
   ) -> VariableInfoId {
-    definitions_db
-      .variable_info_db
-      .map
-      .insert_with_key(|id| VariableInfo {
-        id,
-        declared_scope,
-        name,
-        flags,
-        tag_info,
-      })
+    let id = VariableInfoId::from_index(definitions_db.variable_info_db.map.len());
+    definitions_db.variable_info_db.map.push(VariableInfo {
+      id,
+      declared_scope,
+      name,
+      flags,
+      tag_info,
+    });
+    id
   }
 
   pub fn id(&self) -> VariableInfoId {


### PR DESCRIPTION
## Summary

Replace the append-only SlotMaps used by JavaScript scope metadata with Vec-backed storage:

- Store scopes, variable information and tags in Vecs with module-local `NonZeroU32` IDs.
- Preserve the existing name-based binding environment, variable metadata, scope entry/exit behavior, and undefined/tombstone states.
- Keep checked ID allocation and checked indexing; generations and slot reuse are unnecessary because these entries are never removed or reused during a parser's lifetime.
- Remove the now-unused `slotmap` dependency from the crate, workspace and lockfile.

This PR now contains only the dense ID/storage layer: four files, 55 insertions and 46 deletions. Semantic resolution, binding-state/metadata separation, declaration initialization, side-effects changes and walker/evaluator optimizations have been removed for separate follow-up PRs. No tests or snapshots are changed.

An initial test run alongside Clippy hit the startup deadlines in two CLI serve tests. Both tests passed unchanged in isolation, and the complete test:unit command passed after Clippy finished. No assertions, snapshots or timeouts were changed.

### Local performance

Previously measured `scan_dependencies / three_module` instruction counts using native Linux ARM64 Docker + Valgrind:

| Version | Instructions |
| --- | ---: |
| Release base / merged #15544 | 38,669,201 |
| Dense ID/storage layer only | 37,857,255 |
| Difference | -811,946 (-2.10%) |

The extracted source tree is identical to the previously measured dense-only tree (`43a6ed535b`), so these existing measurements are reused rather than rerun. This is one dependency-scan fixture, not an end-to-end wall-clock result. The earlier combined semantic-integration figures no longer describe this PR.

## Related links

- Base: `release/2.3.0`, including merged #15544.
- Original work: #15331.
- #15561 was closed and removed from the stack while the combined changes are being split by responsibility.

## Checklist

- [x] Tests updated (not required; storage-only refactor, existing coverage retained).
- [x] Documentation updated (not required; no public API changes).
