### PR TITLE
refactor: derive module dependency IDs from references

### DIFF
--- a/crates/rspack_binding_api/src/async_dependency_block.rs
+++ b/crates/rspack_binding_api/src/async_dependency_block.rs
@@ -71,7 +71,6 @@ impl AsyncDependenciesBlock {
       Ok(
         block
           .get_dependencies()
-          .iter()
           .filter_map(|dependency_id| {
             internal::try_dependency_by_id(module_graph, dependency_id)
               .map(|dep| DependencyWrapper::new(dep, compilation.id(), Some(compilation)))

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -505,7 +505,6 @@ impl Module {
       let dependencies = module.get_dependencies();
       Ok(
         dependencies
-          .iter()
           .filter_map(|dependency_id| {
             internal::try_dependency_by_id(module_graph, dependency_id).map(|dep| {
               DependencyWrapper::new(

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1236,7 +1236,6 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
         };
         let root_modules = block
           .get_dependencies()
-          .iter()
           .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
           .copied()
           .collect::<Vec<_>>();

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -605,7 +605,7 @@ impl ContextModule {
       .iter()
       .filter_map(|b| {
         let block = module_graph.block_by_id(b)?;
-        let dep = block.get_dependencies().first()?;
+        let dep = block.get_dependencies().next()?;
         let dependency = module_graph.dependency_by_id(dep);
         let user_request = dependency
           .as_module_dependency()
@@ -669,12 +669,11 @@ impl ContextModule {
         self.get_glob_object_export_source(runtime_template, entries)
       }
       _ => {
-        if self.get_dependencies().is_empty() {
+        if self.get_dependency_refs().is_empty() {
           return self.get_empty_object_export_source(runtime_template);
         }
-        let dependencies = self.get_dependencies();
-        let map = self.get_user_request_map(dependencies, compilation);
-        let fake_map = self.get_fake_map(dependencies, compilation);
+        let map = self.get_user_request_map(self.get_dependencies(), compilation);
+        let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
         let return_module_object = self.get_return_module_object_source(
           &fake_map,
           false,
@@ -733,7 +732,7 @@ impl ContextModule {
         }
       }
       ContextMode::Eager => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_eager_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
@@ -747,21 +746,21 @@ impl ContextModule {
         }
       }
       ContextMode::AsyncWeak => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_async_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
         }
       }
       ContextMode::Weak => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_sync_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
         }
       }
       ContextMode::Sync => {
-        if !self.get_dependencies().is_empty() {
+        if !self.get_dependency_refs().is_empty() {
           self.get_sync_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
@@ -782,7 +781,7 @@ impl ContextModule {
       .filter_map(|b| module_graph.block_by_id(b));
     let block_and_first_dependency_list = blocks
       .clone()
-      .filter_map(|b| b.get_dependencies().first().map(|d| (b, d)));
+      .filter_map(|b| b.get_dependencies().next().map(|d| (b, d)));
     let first_dependencies = block_and_first_dependency_list.clone().map(|(_, d)| d);
     let mut has_multiple_or_no_chunks = false;
     let mut has_no_chunk = true;
@@ -989,17 +988,16 @@ impl ContextModule {
   ) -> String {
     let mg = compilation.get_module_graph();
     let block = mg.block_by_id_expect(block_id);
-    let dependencies = block.get_dependencies();
     let promise = runtime_template.block_promise(Some(block_id), compilation, "lazy-once context");
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(block.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(block.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(block.get_dependencies(), compilation));
 
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
@@ -1056,16 +1054,15 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
 
     let return_module_object = self.get_return_module_object_source(
       &fake_map,
@@ -1135,9 +1132,8 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, true, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"
@@ -1181,16 +1177,15 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(dependencies, compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
       true,
@@ -1247,9 +1242,8 @@ impl ContextModule {
     compilation: &Compilation,
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
-    let dependencies = self.get_dependencies();
-    let map = self.get_user_request_map(dependencies, compilation);
-    let fake_map = self.get_fake_map(dependencies, compilation);
+    let map = self.get_user_request_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, false, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"
@@ -1530,14 +1524,6 @@ impl Module for ContextModule {
       compilation,
     );
     code_generation_result.add(SourceType::JavaScript, source);
-    let mut all_deps = self.get_dependencies().to_vec();
-    let module_graph = compilation.get_module_graph();
-    for block in self.get_blocks() {
-      let block = module_graph
-        .block_by_id(block)
-        .expect("should have block in ContextModule code_generation");
-      all_deps.extend(block.get_dependencies());
-    }
 
     Ok(code_generation_result)
   }

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -34,8 +34,8 @@ pub trait DependenciesBlock {
     self.dependencies_block_mut().remove_dependency(dependency);
   }
 
-  fn get_dependencies(&self) -> &[DependencyId] {
-    &self.dependencies_block().dependency_ids
+  fn get_dependencies(&self) -> DependencyIds<'_> {
+    DependencyIds(self.get_dependency_refs().iter())
   }
 
   fn get_dependency_refs(&self) -> &[DependencyRef] {
@@ -43,9 +43,29 @@ pub trait DependenciesBlock {
   }
 }
 
+/// Iterates dependency IDs directly from their owning references without allocating an ID list.
+/// Cloning only copies the cursor so code generation can traverse the same dependencies multiple times.
+#[derive(Clone)]
+pub struct DependencyIds<'a>(std::slice::Iter<'a, DependencyRef>);
+
+impl<'a> Iterator for DependencyIds<'a> {
+  type Item = &'a DependencyId;
+
+  #[inline]
+  fn next(&mut self) -> Option<Self::Item> {
+    self.0.next().map(|dependency| dependency.id())
+  }
+
+  #[inline]
+  fn size_hint(&self) -> (usize, Option<usize>) {
+    self.0.size_hint()
+  }
+}
+
+impl ExactSizeIterator for DependencyIds<'_> {}
+
 /// Build-owned dependency objects and blocks. The graph indexes the same shared objects.
-/// ID slices are read indexes maintained together with their owning references, so existing
-/// graph algorithms can keep borrowing contiguous IDs without collecting them on every read.
+/// Dependency IDs are read from the objects; block IDs remain a contiguous read index.
 /// Cloning copies these containers for normal-module state cache entries; the dependency
 /// and block objects themselves remain shared.
 #[cacheable]
@@ -54,17 +74,12 @@ pub struct DependenciesBlockData {
   dependencies: Vec<DependencyRef>,
   #[cacheable(omit_bounds)]
   blocks: Vec<AsyncDependenciesBlockRef>,
-  dependency_ids: Vec<DependencyId>,
   block_ids: Vec<AsyncDependenciesBlockIdentifier>,
 }
 
 impl DependenciesBlockData {
   pub fn new(dependencies: Vec<DependencyRef>, blocks: Vec<AsyncDependenciesBlockRef>) -> Self {
     Self {
-      dependency_ids: dependencies
-        .iter()
-        .map(|dependency| *dependency.id())
-        .collect(),
       block_ids: blocks.iter().map(|block| block.identifier()).collect(),
       dependencies,
       blocks,
@@ -72,12 +87,10 @@ impl DependenciesBlockData {
   }
 
   fn add_dependency(&mut self, dependency: DependencyRef) {
-    self.dependency_ids.push(*dependency.id());
     self.dependencies.push(dependency);
   }
 
   fn remove_dependency(&mut self, dependency: DependencyId) {
-    self.dependency_ids.retain(|id| *id != dependency);
     self.dependencies.retain(|value| *value.id() != dependency);
   }
 
@@ -105,7 +118,7 @@ pub type AsyncDependenciesBlockIdentifierSet =
   std::collections::HashSet<AsyncDependenciesBlockIdentifier, BuildHasherDefault<IdentifierHasher>>;
 
 pub fn dependencies_block_update_hash(
-  deps: &[DependencyId],
+  deps: DependencyIds<'_>,
   blocks: &[AsyncDependenciesBlockIdentifier],
   hasher: &mut RspackHasher,
   compilation: &Compilation,

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -29,7 +29,7 @@ pub mod incremental;
 pub use dependencies_block::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, AsyncDependenciesBlockIdentifierMap,
   AsyncDependenciesBlockIdentifierSet, AsyncDependenciesBlockRef, DependenciesBlock,
-  DependenciesBlockData,
+  DependenciesBlockData, DependencyIds,
 };
 mod fake_namespace_object;
 pub use fake_namespace_object::*;

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -110,7 +110,6 @@ pub(crate) struct ModuleGraphData {
   /// let parent_module_id = parent_module.identifier();
   /// parent_module
   ///   .get_dependencies()
-  ///   .iter()
   ///   .map(|dependency_id| {
   ///     let parents_info = module_graph_partial
   ///       .dependency_id_to_parents

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -848,7 +848,7 @@ impl Module for NormalModule {
         }
         module_chain.insert(self.identifier());
         let mut current = ConnectionState::Active(false);
-        for dependency_id in self.get_dependencies().iter() {
+        for dependency_id in self.get_dependencies() {
           let dependency = module_graph.dependency_by_id(dependency_id);
           let state = dependency.get_module_evaluation_side_effects_state(
             module_graph,

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1804,9 +1804,12 @@ return {}
     let block = module_graph
       .block_by_id(block_id)
       .expect("should have block");
-    let dep = block.get_dependencies()[0];
+    let dep = block
+      .get_dependencies()
+      .next()
+      .expect("should have dependency");
     let ensure_chunk = self.block_promise(Some(block_id), compilation, "");
-    let return_value = self.module_raw(compilation, &dep, request, false);
+    let return_value = self.module_raw(compilation, dep, request, false);
     let factory = self.returning_function(&return_value, "");
     self.returning_function(
       &if ensure_chunk.starts_with("Promise.resolve(") {

--- a/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
+++ b/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
@@ -122,7 +122,7 @@ fn resolve_icss_import(
   request: &str,
 ) -> Option<String> {
   let module_graph = compilation.get_module_graph();
-  let imported_module = module.get_dependencies().iter().find_map(|id| {
+  let imported_module = module.get_dependencies().find_map(|id| {
     let dependency = module_graph.dependency_by_id(id);
     let dependency_request = dependency
       .as_module_dependency()

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -296,7 +296,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     };
 
     let module_graph = compilation.get_module_graph();
-    self.module.get_dependencies().iter().for_each(|id| {
+    self.module.get_dependencies().for_each(|id| {
       let dep = module_graph.dependency_by_id(id);
 
       if let Some(dependency) = dep.as_dependency_code_generation() {
@@ -317,7 +317,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
 
   fn css_text_expr_with_imports(&mut self) -> String {
     let module_graph = self.generate_context.compilation.get_module_graph();
-    let has_css_imports = self.module.get_dependencies().iter().any(|dependency_id| {
+    let has_css_imports = self.module.get_dependencies().any(|dependency_id| {
       let dependency = module_graph.dependency_by_id(dependency_id);
       matches!(dependency.dependency_type(), DependencyType::CssImport)
     });
@@ -392,7 +392,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     self
       .module
       .get_dependencies()
-      .iter()
       .filter_map(move |dependency_id| {
         let dependency = module_graph.dependency_by_id(dependency_id);
         if !matches!(dependency.dependency_type(), DependencyType::CssImport) {
@@ -791,7 +790,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     let from = id
       .and_then(find_target_module)
       .or_else(|| {
-        self.module.get_dependencies().iter().find_map(|id| {
+        self.module.get_dependencies().find_map(|id| {
           let dependency = module_graph.dependency_by_id(id);
           let request = dependency_request(dependency);
           if let Some(request) = request
@@ -806,7 +805,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
         let dependency_requests = self
           .module
           .get_dependencies()
-          .iter()
           .filter_map(|id| {
             let dependency = module_graph.dependency_by_id(id);
             dependency_request(dependency)
@@ -899,7 +897,6 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       .or_else(|| {
         module
           .get_dependencies()
-          .iter()
           .filter(|dep_id| {
             let dependency = module_graph.dependency_by_id(dep_id);
             dependency_request(dependency) == Some(from_name)
@@ -1167,7 +1164,7 @@ fn find_static_export_target(
       .map(|module| module.identifier())
   })
   .or_else(|| {
-    module.get_dependencies().iter().find_map(|id| {
+    module.get_dependencies().find_map(|id| {
       let dependency = module_graph.dependency_by_id(id);
       let request = dependency_request(dependency);
       (request == Some(from_request)).then(|| {

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -127,11 +127,14 @@ impl Module for DelegatedModule {
 
     let mut code_generation_result = CodeGenerationResultBuilder::default();
 
-    let dep = self.get_dependencies()[0];
+    let dep = self
+      .get_dependencies()
+      .next()
+      .expect("should have source dependency");
     let mg = compilation.get_module_graph();
-    let source_module = mg.get_module_by_dependency_id(&dep);
+    let source_module = mg.get_module_by_dependency_id(dep);
     let dependency = mg
-      .dependency_by_id(&dep)
+      .dependency_by_id(dep)
       .downcast_ref::<DelegatedSourceDependency>()
       .expect("Should be module dependency");
 
@@ -140,7 +143,7 @@ impl Module for DelegatedModule {
         let mut s = format!(
           "{}.exports = ({})",
           runtime_template.render_module_argument(ModuleArgument::Module),
-          runtime_template.module_raw(compilation, &dep, dependency.request(), false,)
+          runtime_template.module_raw(compilation, dep, dependency.request(), false,)
         );
 
         let request = json_stringify(

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -128,7 +128,6 @@ fn get_module_deps(module: ModuleIdentifier, module_graph: &ModuleGraph) -> Vec<
     .module_by_identifier(&module)
     .expect("should have module")
     .get_dependencies()
-    .iter()
     .filter_map(|dep_id| module_graph.module_identifier_by_dependency_id(dep_id))
     .copied()
     .collect()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -184,7 +184,7 @@ impl JavaScriptParserAndGenerator {
       .block_by_id(block_id)
       .expect("should have block");
     //    let block = block_id.expect_get(compilation);
-    block.get_dependencies().iter().for_each(|dependency_id| {
+    block.get_dependencies().for_each(|dependency_id| {
       self.source_dependency(compilation, dependency_id, source, context)
     });
     block
@@ -439,7 +439,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         runtime_template: generate_context.runtime_template,
       };
 
-      module.get_dependencies().iter().for_each(|dependency_id| {
+      module.get_dependencies().for_each(|dependency_id| {
         self.source_dependency(compilation, dependency_id, &mut source, &mut context)
       });
 

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1151,7 +1151,6 @@ impl ModuleConcatenationPlugin {
 
         let connections = module
           .get_dependencies()
-          .iter()
           .filter_map(|d| {
             let dep = module_graph.dependency_by_id(d);
             if !is_esm_dep_like(dep) {

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -247,11 +247,14 @@ impl Module for LazyCompilationProxyModule {
       ..
     } = code_generation_context;
 
-    let client_dep_id = self.get_dependencies()[0];
+    let client_dep_id = self
+      .get_dependencies()
+      .next()
+      .expect("should have client dependency");
     let module_graph = &compilation.get_module_graph();
 
     let client_module = module_graph
-      .module_identifier_by_dependency_id(&client_dep_id)
+      .module_identifier_by_dependency_id(client_dep_id)
       .expect("should have module");
 
     let block = self.get_blocks().first();
@@ -276,9 +279,12 @@ impl Module for LazyCompilationProxyModule {
         .block_by_id(block_id)
         .expect("should have block");
 
-      let dep_id = block.get_dependencies()[0];
+      let dep_id = block
+        .get_dependencies()
+        .next()
+        .expect("should have dependency");
       let module = module_graph
-        .module_identifier_by_dependency_id(&dep_id)
+        .module_identifier_by_dependency_id(dep_id)
         .expect("should have module");
 
       RawStringSource::from(format!(
@@ -295,7 +301,7 @@ impl Module for LazyCompilationProxyModule {
         runtime_template.module_namespace_promise(
           compilation,
           *module,
-          &dep_id,
+          dep_id,
           Some(block_id),
           &self.resource,
           "import()",

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -468,7 +468,7 @@ impl ExposeModuleMap {
       let block = module_graph
         .block_by_id(block_id)
         .expect("should have block");
-      let modules_iter = block.get_dependencies().iter().map(|dependency_id| {
+      let modules_iter = block.get_dependencies().map(|dependency_id| {
         let dep = module_graph.dependency_by_id(dependency_id);
         let dep = dep
           .downcast_ref::<ContainerExposedDependency>()

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -150,7 +150,6 @@ impl Module for FallbackModule {
     let module_graph = compilation.get_module_graph();
     let ids: Vec<_> = self
       .get_dependencies()
-      .iter()
       .filter_map(|dep| module_graph.get_module_by_dependency_id(dep))
       .filter_map(|module| {
         ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -190,7 +190,12 @@ impl Module for RemoteModule {
   ) -> Result<CodeGenerationResultBuilder> {
     let mut codegen = CodeGenerationResultBuilder::default();
     let module_graph = code_generation_context.compilation.get_module_graph();
-    let module = module_graph.get_module_by_dependency_id(&self.get_dependencies()[0]);
+    let module = module_graph.get_module_by_dependency_id(
+      self
+        .get_dependencies()
+        .next()
+        .expect("should have external dependency"),
+    );
     let id = module.and_then(|m| {
       ChunkGraph::get_module_id(
         &code_generation_context.compilation.module_ids_artifact,

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -98,9 +98,12 @@ impl RuntimeModule for RemoteRuntimeModule {
           ShareScope::Single(s) => ShareScopeField::Single(s.as_str()),
           ShareScope::Multiple(v) => ShareScopeField::Multiple(v.as_slice()),
         };
-        let dep = m.get_dependencies()[0];
+        let dep = m
+          .get_dependencies()
+          .next()
+          .expect("should have external dependency");
         let external_module = module_graph
-          .get_module_by_dependency_id(&dep)
+          .get_module_by_dependency_id(dep)
           .expect("should have module");
         let external_module_id = ChunkGraph::get_module_id(
           &compilation.module_ids_artifact,

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -215,7 +215,14 @@ impl Module for ConsumeSharedModule {
     }
     let factory = self.options.import.as_ref().map(|fallback| {
       if self.options.eager {
-        runtime_template.sync_module_factory(&self.get_dependencies()[0], fallback, compilation)
+        runtime_template.sync_module_factory(
+          self
+            .get_dependencies()
+            .next()
+            .expect("should have fallback dependency"),
+          fallback,
+          compilation,
+        )
       } else {
         runtime_template.async_module_factory(&self.get_blocks()[0], fallback, compilation)
       }

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -187,7 +187,14 @@ impl Module for ProvideSharedModule {
       .runtime_requirements_mut()
       .insert(RuntimeGlobals::INITIALIZE_SHARING);
     let factory = if self.eager {
-      runtime_template.sync_module_factory(&self.get_dependencies()[0], &self.request, compilation)
+      runtime_template.sync_module_factory(
+        self
+          .get_dependencies()
+          .next()
+          .expect("should have shared dependency"),
+        &self.request,
+        compilation,
+      )
     } else {
       runtime_template.async_module_factory(&self.get_blocks()[0], &self.request, compilation)
     };

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -99,10 +99,10 @@ impl SharedUsedExportsOptimizerPlugin {
   }
 }
 
-fn collect_processed_modules(
+fn collect_processed_modules<'a>(
   module_graph: &ModuleGraph,
   module_blocks: &[AsyncDependenciesBlockIdentifier],
-  module_deps: &[DependencyId],
+  module_deps: impl IntoIterator<Item = &'a DependencyId>,
   out: &mut Vec<ModuleIdentifier>,
 ) {
   for dep_id in module_deps {

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -164,7 +164,6 @@ fn collect_css_files_from_block_modules(
 
   block
     .get_dependencies()
-    .iter()
     .filter_map(|dependency_id| module_graph.connection_by_dependency_id(dependency_id))
     .filter_map(|connection| chunk_graph.try_get_module_chunks(connection.module_identifier()))
     .flat_map(|chunk_ukeys| collect_css_files_from_chunks(module_loading, chunk_ukeys, compilation))

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -101,7 +101,7 @@ pub fn cutout_star_re_export_externals(
       exports_info.other_exports_info().provided(),
       Some(rspack_core::ExportProvided::Unknown)
     ) {
-      let has_unknown_exports = module.get_dependencies().iter().any(|dep_id| {
+      let has_unknown_exports = module.get_dependencies().any(|dep_id| {
         if connections_to_disable.contains(dep_id) {
           return false;
         }

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -236,7 +236,6 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 
         module
           .get_dependencies()
-          .iter()
           .map(|id| module_graph.dependency_by_id(id))
           .filter(|dep| dep.dependency_type() == &DependencyType::WasmImport)
           .map(|dep| {

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -198,7 +198,7 @@ impl<'a> ArtifactComparator<'a> {
     }
 
     // Compare each dependency by type in order and build mapping
-    for (i, (dep_id1, dep_id2)) in deps1.iter().zip(deps2.iter()).enumerate() {
+    for (i, (dep_id1, dep_id2)) in deps1.zip(deps2).enumerate() {
       let dep_debug_info = debug_info.with_field("dependency_index", &i.to_string());
 
       let dep1 = self.mg1.dependency_by_id(dep_id1);


### PR DESCRIPTION
## Summary

Remove the redundant `dependency_ids` vector from modules and async blocks. Read IDs from their owned dependency references through an allocation-free iterator and adapt the consumers. Cloning the iterator only copies its cursor for code generation that needs multiple passes.

Follow-up to #15550.