### PR TITLE
docs: simplify agent instructions

### DIFF
--- a/.agents/ARCHITECTURE.md
+++ b/.agents/ARCHITECTURE.md
@@ -273,6 +273,9 @@ Unified error system.
 
 ### Parallel processing
 
+- Prefer `rayon` for synchronous CPU-bound parallel work and `rspack_parallel` for async orchestration instead of raw Tokio tasks.
+- Do not use Tokio to parallelize synchronous CPU work. Mix thread pools only across a necessary, explicit boundary.
+
 - Module building parallelized
 - Asset processing parallelized
 - Code generation uses parallel workers

--- a/.agents/CACHE_AND_INCREMENTAL.md
+++ b/.agents/CACHE_AND_INCREMENTAL.md
@@ -103,6 +103,9 @@ Rspack currently carries two implementations of the same Cache responsibility:
 | `legacy_cache` | `crates/rspack_core/src/legacy_cache/` |
 | `new_cache`    | `crates/rspack_core/src/new_cache/`    |
 
+Both backends may depend on shared code in `crates/rspack_core/src/cache/`, but must not reference
+each other.
+
 The backend selector is not another Incremental mode. Switching between `legacy_cache` and
 `new_cache` may change how cache entries are keyed, retained, serialized, or flushed, but it must not
 change which Incremental passes are enabled or whether Incremental artifacts can be recovered.

--- a/.agents/CODE_STYLE.md
+++ b/.agents/CODE_STYLE.md
@@ -48,6 +48,12 @@ use rspack_error::Result;
 7. Hook implementations
 8. Trait implementations
 
+### Cloning
+
+- Add `Clone` only for a concrete need, whether derived or manually implemented.
+- If it copies underlying data, explain why in the type's documentation and PR description.
+  Implementations that only clone `Arc` handles are exempt from this explanation.
+
 ### Error handling
 
 - Use `rspack_error::Result<T>` for fallible operations

--- a/.agents/DEVELOPMENT.md
+++ b/.agents/DEVELOPMENT.md
@@ -2,13 +2,26 @@
 
 Run commands from the repository root unless shown otherwise. Command definitions live in [root package scripts](../package.json), [test package scripts](../tests/rspack-test/package.json), and [Cargo aliases](../.cargo/config.toml).
 
-## Setup and build variants
+## Setup
 
-- Initial setup: `pnpm run setup` installs dependencies and builds the development binding and JS packages.
+Use the Rust toolchain in `rust-toolchain.toml`, the pnpm version in `package.json`, and the latest Node.js LTS.
+
+`pnpm run setup` installs dependencies and builds the development binding and JS packages.
+
+## Build
+
+Build the changed code before running tests that consume it:
+
+| Changed code | Build                        |
+| ------------ | ---------------------------- |
+| JavaScript   | `pnpm run build:js`          |
+| Rust         | `pnpm run build:binding:dev` |
+| Both         | `pnpm run build:cli:dev`     |
+
+Other build variants:
+
 - Native binding variants: `pnpm run build:binding:debug` or `pnpm run build:binding:release`.
 - WASM: `pnpm run build:cli:dev:wasm`; browser: `pnpm run build:cli:dev:browser`.
-
-For ordinary changes, use the language-specific build commands in [AGENTS.md](../AGENTS.md#build-and-validation).
 
 ## Tests
 

--- a/.agents/DEVELOPMENT.md
+++ b/.agents/DEVELOPMENT.md
@@ -1,0 +1,37 @@
+# Development commands
+
+Run commands from the repository root unless shown otherwise. Command definitions live in [root package scripts](../package.json), [test package scripts](../tests/rspack-test/package.json), and [Cargo aliases](../.cargo/config.toml).
+
+## Setup and build variants
+
+- Initial setup: `pnpm run setup` installs dependencies and builds the development binding and JS packages.
+- Native binding variants: `pnpm run build:binding:debug` or `pnpm run build:binding:release`.
+- WASM: `pnpm run build:cli:dev:wasm`; browser: `pnpm run build:cli:dev:browser`.
+
+For ordinary changes, use the language-specific build commands in [AGENTS.md](../AGENTS.md#build-and-validation).
+
+## Tests
+
+- Focused integration cases: `pnpm --dir tests/rspack-test run test -t "configCases/asset"`.
+- Base integration suite: `pnpm --dir tests/rspack-test run test:base` (there is no root `test:base` script).
+- JavaScript suites: `pnpm run test:unit`; Rust suites: `pnpm run test:rs`.
+- HMR: `pnpm run test:hot`; E2E: `pnpm run test:e2e`; API types: `pnpm run test:type`.
+
+See the [testing guide](../website/docs/en/contribute/development/testing.mdx) for harness details. New tests must follow the [repository's test restrictions](../AGENTS.md#adding-tests).
+
+## Lint and formatting
+
+- JavaScript lint: `pnpm run lint:js`.
+- Rust check: `pnpm run lint:rs`; clippy: `cargo lint`.
+- Rust format check: `cargo fmt --all --check`.
+- Format Rust: `pnpm run format:rs`; JS/TS: `pnpm run format:js`.
+
+The root lint and formatting commands cover the whole workspace.
+
+## Performance and debugging
+
+Rust benchmarks live in `xtask/benchmark/`. Build them with `pnpm run build:bench`, then run `pnpm run bench:ci` to prepare fixtures and execute benchmarks. `pnpm run bench:prepare` prepares fixtures separately.
+
+Use `pnpm run build:binding:profiling` for a profiling binding. Tracing support lives in `crates/rspack_tracing/`.
+
+See the [debugging guide](../website/docs/en/contribute/development/debugging.mdx) for VS Code configurations, JavaScript inspection, and `rust-lldb`. See [project layout](../website/docs/en/contribute/development/project.md) for core, plugin, API, CLI, and binding paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,7 @@ Rspack is a Rust-based JavaScript bundler with a webpack-compatible API.
 
 ## Build and validation
 
-Use the Rust toolchain in `rust-toolchain.toml`, the pnpm version in `package.json`, and the latest Node.js LTS.
-
-Before testing changed code, build the artifacts those tests consume:
-
-| Changed code | Build                        |
-| ------------ | ---------------------------- |
-| JavaScript   | `pnpm run build:js`          |
-| Rust         | `pnpm run build:binding:dev` |
-| Both         | `pnpm run build:cli:dev`     |
-
-See [Development commands](.agents/DEVELOPMENT.md) for setup, focused tests, linting, profiling, and build variants.
+Before testing changed code, build the artifacts those tests consume using the [development commands](.agents/DEVELOPMENT.md#build).
 
 ## Adding tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,168 +1,39 @@
 # Rspack
 
-## Project overview
+Rspack is a Rust-based JavaScript bundler with a webpack-compatible API.
 
-Rspack is a high-performance JavaScript bundler written in Rust that offers strong compatibility with the webpack ecosystem.
+## Build and validation
 
-## Project architecture
+Use the Rust toolchain in `rust-toolchain.toml`, the pnpm version in `package.json`, and the latest Node.js LTS.
 
-- **Monorepo** with Rust crates (`crates/`) and JavaScript packages (`packages/`)
-- See [Project Architecture](website/docs/en/contribute/development/project.md) for details
+Before testing changed code, build the artifacts those tests consume:
 
-## Concurrency architecture
+| Changed code | Build                        |
+| ------------ | ---------------------------- |
+| JavaScript   | `pnpm run build:js`          |
+| Rust         | `pnpm run build:binding:dev` |
+| Both         | `pnpm run build:cli:dev`     |
 
-- **Synchronous concurrency**: Prefer `rayon` for CPU-bound parallel work and data-parallel iteration
-- **Asynchronous concurrency**: Prefer the abstractions provided by `rspack_parallel` instead of using raw `tokio` task orchestration directly
-- **Thread pool boundaries**: Avoid mixing `rayon` and `tokio` thread pools for the same workflow unless there is a clear boundary that cannot be avoided
-- **Rule of thumb**: Do not use `tokio` to parallelize synchronous CPU-heavy work, and do not introduce `rayon` inside async orchestration that should stay within `rspack_parallel`
+See [Development commands](.agents/DEVELOPMENT.md) for setup, focused tests, linting, profiling, and build variants.
 
-## Cache architecture
+## Adding tests
 
-- **Backend boundary**: `crates/rspack_core/src/new_cache/` and `crates/rspack_core/src/legacy_cache/` may depend on shared code in `crates/rspack_core/src/cache/`, but must not reference each other.
-- **Persistent cache format**: Do not add compatibility code for old persistent cache formats or introduce new/versioned cache namespaces to isolate format changes. Keep existing namespaces; clear stale cache files and rebuild when needed.
-- Read [Cache and Incremental](.agents/CACHE_AND_INCREMENTAL.md) before modifying either cache backend or their shared dependencies.
+- **Rust:** Do not add new Rust tests in ordinary changes. New cases belong in dedicated test crates; do not add inline `#[test]` functions or crate-local unit tests.
+- **JavaScript:** Reuse existing runners and add cases under `tests/rspack-test/{type}Cases/`. Do not add top-level or suite-level `test.js` runners. Harness-required files inside a case, such as `hookCases/**/test.js`, are allowed.
 
-## Setup
+## Pull requests
 
-- **Rust**: Use the toolchain pinned by `rust-toolchain.toml`
-- **Node.js**: Latest LTS
-- **pnpm**: Version in `package.json`
-- Run `pnpm run setup` to install and build
+- Follow [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md).
+- Update relevant English and Chinese docs when public behavior or APIs change.
 
-## Building
+## References
 
-- `pnpm run build:js` - Build JavaScript/TypeScript packages
-- `pnpm run build:binding:dev` - Build Rust crates (dev)
-- `pnpm run build:cli:dev` - Full build (dev)
-- `pnpm run build:binding:debug` - Debug build
-- `pnpm run build:binding:release` - Release build
-- `pnpm run build:cli:dev:wasm` - WASM build
-- `pnpm run build:cli:dev:browser` - Browser build
-
-## Testing
-
-- `pnpm run test:rs` - Rust unit tests
-- `pnpm run test:unit` - JavaScript unit tests
-- `pnpm run test:e2e` - E2E tests
-- `pnpm run test:base` - Integration tests (in `tests/rspack-test`)
-- `pnpm run test:hot` - HMR tests
-- `cd tests/rspack-test && pnpm run test -t "configCases/asset"` - Run filtered tests
-
-Before running tests after code changes:
-
-- If you modified JavaScript/TypeScript code, run `pnpm run build:js` first
-- If you modified Rust code, run `pnpm run build:binding:dev` first
-- If your change spans both JS and Rust, run `pnpm run build:cli:dev` first
-
-## Debugging
-
-- **VS Code**: `.vscode/launch.json` with `Debug Rspack` and `Attach` options
-- **Rust**: Set breakpoints, use `Debug Rspack` or `Attach Rust`
-- **JavaScript**: Use `--inspect` flag, attach with `Attach JavaScript`
-- **rust-lldb**: `rust-lldb -- node /path/to/rspack build` for panic debugging
-
-## Code quality
-
-- **Linting**: `pnpm run lint:js` (Rslint), `pnpm run lint:rs` (cargo check), `cargo lint` (Rust)
-- **Formatting**: `pnpm run format:rs` (cargo fmt), `pnpm run format:js` (rs fmt), `cargo fmt --all --check` (Rust)
-- **Style**: snake_case for Rust, camelCase for JS/TS
-
-## Common tasks
-
-### Adding a new feature
-
-1. Create feature branch from `main`
-2. Implement in appropriate crate/package
-3. Add test coverage when needed, following the restrictions in [Adding tests](#adding-tests)
-4. Update docs if APIs change
-5. Run checks and tests: `pnpm run lint:js && pnpm run lint:rs && cargo lint && pnpm run test:unit && pnpm run test:rs`
-6. Format: `pnpm run format:rs && pnpm run format:js`
-7. Create PR
-
-### Modifying code
-
-- **Rust**: Core in `crates/rspack_core/`, plugins in `crates/rspack_plugin_*/`, rebuild with `pnpm run build:binding:dev`, test with `pnpm run test:rs`, avoid linting and formatting for fast local development
-- **Rust `Clone`**: Do not derive or manually implement `Clone` for data structures without a concrete need. When adding an implementation that copies underlying data, explain why it is necessary in both the type's documentation comment and the PR description. Cloning `Arc` handles, including wrappers that only clone those handles, is exempt.
-- **JS/TS**: API in `packages/rspack/src/`, CLI in `packages/rspack-cli/src/`, rebuild with `pnpm run build:js`, test with `pnpm run test:unit`
-
-### Adding tests
-
-- **Rust**: Do not add new Rust tests in ordinary changes, especially unit tests for small functions. Only add Rust test cases when they belong in a dedicated test crate; do not add inline `#[test]` functions or crate-local unit tests.
-- **JavaScript**: Do not create new top-level or suite-level `test.js` runner entry files. Reuse an existing runner and add coverage only by adding a case under the appropriate cases directory, such as `tests/rspack-test/{type}Cases/` (Normal, Config, Hot, Watch, StatsOutput, StatsAPI, Diagnostic, Hash, Compiler, Defaults, Error, Hook, TreeShaking, Builtin). Files required inside an individual case by an existing harness, such as `hookCases/**/test.js`, are allowed and are not new runner entry points.
-
-## Dependency management
-
-- **Package manager**: pnpm (workspaces for monorepo)
-- **Rust**: `Cargo.toml` in each crate
-- **JavaScript**: `package.json` files
-
-## Performance
-
-- **Benchmarks**: Rust CodSpeed benchmarks in `xtask/benchmark/`, run with `pnpm run bench:ci` (setup: `pnpm run bench:prepare`)
-- **Profiling**: `pnpm run build:binding:profiling`
-- **Tracing**: See `crates/rspack_tracing/`
-
-## Documentation
-
-- **Site**: `website/` directory
-- **Docs**: `website/docs/en/` (English), `website/docs/zh/` (Chinese)
-- **API**: `website/docs/en/api/`
-
-## Pull request guidelines
-
-- **Template**: Use `.github/PULL_REQUEST_TEMPLATE.md`
-- **Title prefix**: `test:`, `fix:`, `feat:`, `refactor:`, `chore:`
-- **Semver alignment**:
-  - `fix:` -> PATCH bump
-  - `feat:` -> MINOR bump
-  - Any breaking change -> MAJOR bump (`type(scope)!:` and/or `BREAKING CHANGE:` in commit body)
-- **CI**: All checks must pass
-
-## Contributing
-
-- Follow existing code patterns
-- Add test coverage for new features only under the restrictions in [Adding tests](#adding-tests)
-- Update docs when APIs change
-- Run linters before submitting
-- Use Conventional Commits in semver style: `type(scope): subject`
-- Prefer these types for release impact: `fix`, `feat`; use `!` or `BREAKING CHANGE:` only for incompatible changes
-- Keep PRs focused (one feature/fix per PR)
-
-## Finding code
-
-- **Rust core**: `crates/rspack_core/`
-- **Plugins**: `crates/rspack_plugin_*/`
-- **JavaScript API**: `packages/rspack/src/`
-- **JavaScript binding API**: `crates/rspack_binding_api/`
-- **Node-API support**: `crates/rspack_napi/`
-- **Generated binding package**: `crates/node_binding/`
-- **CLI**: `packages/rspack-cli/src/`
-- **Tests**: `tests/rspack-test/`
-
-## Error handling
-
-- Use `rspack_error` crate for Rust errors
-- Provide clear, actionable error messages
-- Include context (file paths, line numbers)
-
-## AI-Friendly Documentation
-
-This project includes comprehensive documentation designed for AI assistants and large language models. All AI-friendly documentation is located in the `.agents/` directory:
-
-- **[Architecture Guide](.agents/ARCHITECTURE.md)** - High-level architecture overview, core components, compilation pipeline, and system design
-- **[`rspack_sources` Architecture](.agents/RSPACK_SOURCES.md)** - Source composition, source-map streaming, UTF-8/UTF-16 position invariants, ownership, caching, and performance rules; read before changing or heavily using `crates/rspack_sources`
-- **[JavaScript Binding Guide](.agents/BINDING.md)** - Binding ownership, lifetimes, hook bridging, performance rules, file map, and validation
-- **[API Design](.agents/API_DESIGN.md)** - API design principles, patterns, versioning strategy, and compatibility guidelines
-- **[Code Style](.agents/CODE_STYLE.md)** - Coding standards and conventions for Rust and TypeScript/JavaScript
-- **[Common Patterns](.agents/COMMON_PATTERNS.md)** - Common code patterns, templates, and best practices for plugin/loader development
-- **[Glossary](.agents/GLOSSARY.md)** - Comprehensive glossary of terms and concepts used throughout the codebase
-- **[Skills](.agents/SKILLS.md)** - Required skills and knowledge areas for contributing to Rspack
-
-These documents provide detailed context about the project structure, coding standards, common patterns, and domain-specific knowledge to help AI assistants better understand and contribute to the codebase.
-
-## Resources
-
-- [Project Architecture](website/docs/en/contribute/development/project.md)
-- [Testing Guide](website/docs/en/contribute/development/testing.mdx)
-- [Debugging Guide](website/docs/en/contribute/development/debugging.mdx)
-- [API Docs](website/docs/en/api/index.mdx)
+- [Concurrency](.agents/ARCHITECTURE.md#parallel-processing): read before changing parallel execution or task scheduling.
+- [Cache and Incremental](.agents/CACHE_AND_INCREMENTAL.md): read before changing either cache backend or shared cache dependencies.
+- [Rspack Sources](.agents/RSPACK_SOURCES.md): read before changing or heavily using `crates/rspack_sources`.
+- [Binding](.agents/BINDING.md): read when changing Rust/JavaScript ownership, lifetimes, or hook bridging.
+- [Rust cloning](.agents/CODE_STYLE.md#cloning) and [error handling](.agents/CODE_STYLE.md#error-handling): read the relevant rules before adding `Clone` implementations or changing Rust error handling.
+- [Architecture](.agents/ARCHITECTURE.md) and [project layout](website/docs/en/contribute/development/project.md): compilation flow and subsystem locations.
+- [API design](.agents/API_DESIGN.md): public contracts and webpack compatibility.
+- [Code style](.agents/CODE_STYLE.md), [common patterns](.agents/COMMON_PATTERNS.md), and [glossary](.agents/GLOSSARY.md): conventions and terminology.
+- [Testing](website/docs/en/contribute/development/testing.mdx) and [debugging](website/docs/en/contribute/development/debugging.mdx): harness and debugger details.


### PR DESCRIPTION
## Summary

Reduce always-loaded repository instructions by removing generic workflow guidance and moving detailed commands and architecture rules into task-specific references. Keep build prerequisites and test restrictions in `AGENTS.md`, with explicit conditions for reading the relevant guides.

## Related links

[Discussion on auditing skills and AGENTS.md](https://x.com/lonely__mh/status/2096146061597241503?s=46)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).