### PR TITLE
perf(sources): upgrade simd-utf16-len to 0.2.0

### DIFF
--- a/.agents/RSPACK_SOURCES.md
+++ b/.agents/RSPACK_SOURCES.md
@@ -187,8 +187,7 @@ calculation handle.
 `TextSpan` carries a borrowed `&str` plus an ASCII hint. Preserve the hint across transformations:
 
 - known ASCII uses byte length as UTF-16 length;
-- known non-ASCII uses `simd_utf16_len` directly;
-- unknown checks ASCII before using SIMD;
+- known non-ASCII and unknown use `simd_utf16_len` directly; its ASCII fast path avoids a separate scan;
 - a subspan of known non-ASCII becomes unknown because the slice may be ASCII-only.
 
 `WithUtf16` converts UTF-16 columns back to valid UTF-8 byte boundaries. It builds a pooled byte

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6024,8 +6024,7 @@ dependencies = [
 [[package]]
 name = "simd-utf16-len"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c17a83ac53a3ccce2d4fec2031c22b539d12dc95498e75935a6da589b7b4372"
+source = "git+https://github.com/SyMind/simd-utf16-len.git?rev=2f230d9c7c55bf3e103259bf58895de2040b297c#2f230d9c7c55bf3e103259bf58895de2040b297c"
 
 [[package]]
 name = "simdutf8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,8 +6023,9 @@ dependencies = [
 
 [[package]]
 name = "simd-utf16-len"
-version = "0.1.0"
-source = "git+https://github.com/SyMind/simd-utf16-len.git?rev=2f230d9c7c55bf3e103259bf58895de2040b297c#2f230d9c7c55bf3e103259bf58895de2040b297c"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08765f7253d069ccd9adbe45ae962652c1c662e6f274a7575e8c9701c6ab5afa"
 
 [[package]]
 name = "simdutf8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ sftrace-setup       = { version = "0.1.2", default-features = false }
 sha2                = { version = "0.10.9", default-features = false }
 signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
 simd-json           = { version = "0.17.3", default-features = false, features = ["runtime-detection", "serde_impl"] }
-simd-utf16-len      = { version = "0.1.0", default-features = false }
+simd-utf16-len      = { git = "https://github.com/SyMind/simd-utf16-len.git", rev = "2f230d9c7c55bf3e103259bf58895de2040b297c", default-features = false }
 simdutf8            = { version = "0.1.5", default-features = false }
 similar-asserts     = { version = "1.5.0", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ sftrace-setup       = { version = "0.1.2", default-features = false }
 sha2                = { version = "0.10.9", default-features = false }
 signal-hook         = { version = "0.3.18", default-features = false, features = ["iterator"] }
 simd-json           = { version = "0.17.3", default-features = false, features = ["runtime-detection", "serde_impl"] }
-simd-utf16-len      = { git = "https://github.com/SyMind/simd-utf16-len.git", rev = "2f230d9c7c55bf3e103259bf58895de2040b297c", default-features = false }
+simd-utf16-len      = { version = "0.2.0", default-features = false }
 simdutf8            = { version = "0.1.5", default-features = false }
 similar-asserts     = { version = "1.5.0", default-features = false }
 slotmap             = { version = "1.1.1", default-features = false }

--- a/crates/rspack_sources/src/helpers.rs
+++ b/crates/rspack_sources/src/helpers.rs
@@ -218,14 +218,7 @@ impl<'a> TextSpan<'a> {
   pub(crate) fn utf16_len_of(&self, text: &str) -> usize {
     match self.ascii_hit {
       AsciiHit::Ascii => text.len(),
-      AsciiHit::NotAscii => utf16_len(text),
-      AsciiHit::Unknown => {
-        if text.is_ascii() {
-          text.len()
-        } else {
-          utf16_len(text)
-        }
-      }
+      AsciiHit::NotAscii | AsciiHit::Unknown => utf16_len(text),
     }
   }
 


### PR DESCRIPTION
## Summary

Upgrade `simd-utf16-len` from 0.1.0 to 0.2.0 and use its built-in ASCII fast path in `rspack_sources`. When `TextSpan` has no ASCII hint, call `utf16_len` directly to avoid a redundant `is_ascii()` check. Known ASCII spans continue to return their byte length directly.

Update the lockfile and source architecture notes. Validation at `108917ae06`: the binding build and CI pass, along with all 77 `rspack_sources` unit tests and 11 documentation tests.

## Related links

- [simd-utf16-len 0.2.0](https://crates.io/crates/simd-utf16-len/0.2.0)
- [CI validation for 108917ae06](https://github.com/web-infra-dev/rspack/actions/runs/34312765927)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
