### PR TITLE
ci: run standalone crate checks only on main

### DIFF
--- a/.github/workflows/reusable-rust-test.yml
+++ b/.github/workflows/reusable-rust-test.yml
@@ -46,12 +46,16 @@ jobs:
         run: cargo codegen
 
       - name: Install cargo-binstall
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: cargo-bins/cargo-binstall@75b4bfae1b2c753a6806bbce6e6cb89b602de33c # v1.22.0
 
       - name: Install cargo-workspaces
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: cargo binstall --no-confirm cargo-workspaces@0.4.0 --force
 
+      # Check standalone published crates on main; Clippy checks the workspace on every branch.
       - name: Run Cargo Check (per crate)
+        if: ${{ github.ref == 'refs/heads/main' }}
         run: cargo workspaces exec --ignore-private cargo check --lib --locked
 
       - name: Run Clippy

--- a/scripts/x.mjs
+++ b/scripts/x.mjs
@@ -205,7 +205,7 @@ program
       'publish',
       '--publish-as-is', // Publish crates from the current commit without versioning
       '--no-remove-dev-deps', // Do not remove dev-dependencies from `Cargo.lock`, otherwise the `Cargo.toml` will be updated and dirty check will fail
-      '--no-verify', // Skip verification of the workspace. This was pre-checked by `release-crates.yml` with `cargo check` with `separated` strategy
+      '--no-verify', // Standalone crate checks run in CI on main.
       // Commented `--locked` flag
       // because some dev-deps refer to workspace members with versions rspack_swc_plugin_ts_collector
       // and these workspace members are to be removed in release. This would cause `Cargo.lock` to be updated.


### PR DESCRIPTION
## Summary

Run standalone per-crate checks and install their tools only on main. Other branches use the existing workspace Clippy check to reduce CI time.

## Related links

#15235

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).