### PR TITLE
chore(docs): fix standalone configuration examples and type declarations

### DIFF
--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -52,6 +52,9 @@ You can also use the [path module](https://nodejs.org/api/path.html) in Node.js 
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   entry: path.join(__dirname, './src/index.js'),
@@ -176,7 +179,7 @@ Whether to create a load-on-demand asynchronous chunk for this entry.
 #### EntryDescription.publicPath
 
 <PropertyType
-  type="'auto' | string | (pathData: PathData, assetInfo?: AssetInfo) => string"
+  type="'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -83,6 +83,11 @@ You should commit the files at `lockfileLocation` and `cacheLocation` to the ver
 For example:
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   experiments: {
     buildHttp: {

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -58,9 +58,9 @@ export default {
 
   ```ts
   type BundlerInfo = {
-    version?: string,
-    bundler?: string,
-    force?: ('version' | 'uniqueId')[] ｜ boolean;
+    version?: string;
+    bundler?: string;
+    force?: boolean | ('version' | 'uniqueId')[];
   };
   ```
 
@@ -194,29 +194,44 @@ export default {
 - **Type:** `boolean | { keep?: string | RegExp | ((path: string) => boolean) }`
 - **Default:** `false`
 
-Before generating the products, delete all files in the output directory.
+Remove files from the output directory before emitting assets. Set `clean` to `true` to enable cleaning:
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
     clean: true, // Clean the output directory before emit.
   },
+};
+```
 
-  // or
+To preserve a path, use `clean.keep`:
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: 'ignored/dir', // keep these assets under 'dist/ignored/dir'.
     },
   },
+};
+```
 
-  // or
+Alternatively, match paths with a regular expression:
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: /ignored\/dir/, // keep these assets under 'dist/ignored/dir'.
     },
   },
+};
+```
 
-  // or
+For custom matching, return `true` from a function to keep a file:
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: (path) => path.includes('ignored/dir'), // keep these assets under 'dist/ignored/dir'.

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -422,6 +422,11 @@ type ResolveFallback =
 Redirect module requests when normal resolving fails.
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     fallback: {
@@ -694,6 +699,11 @@ The replacement of [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package
 - string:
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     // string
@@ -705,6 +715,11 @@ export default {
 - object:
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     tsConfig: {

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -52,6 +52,9 @@ export default {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   entry: path.join(__dirname, './src/index.js'),
@@ -176,7 +179,7 @@ export default {
 #### EntryDescription.publicPath
 
 <PropertyType
-  type="'auto' | string | (pathData: PathData, assetInfo?: AssetInfo) => string"
+  type="'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)"
   defaultValueList={[{ defaultValue: 'undefined' }]}
 />
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -84,6 +84,11 @@ type HttpUriOptions = {
 示例：
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   experiments: {
     buildHttp: {

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -58,9 +58,9 @@ export default {
 
   ```ts
   type BundlerInfo = {
-    version?: string,
-    bundler?: string,
-    force?: ('version' | 'uniqueId')[] ｜ boolean;
+    version?: string;
+    bundler?: string;
+    force?: boolean | ('version' | 'uniqueId')[];
   };
   ```
 
@@ -190,29 +190,44 @@ export default {
 - **类型：** `boolean | { keep?: string | RegExp | ((path: string) => boolean) }`
 - **默认值：** `false`
 
-在生成产物前，删除输出目录下的所有文件。
+在输出产物之前清理输出目录中的文件。将 `clean` 设为 `true` 可启用清理：
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
     clean: true, // Clean the output directory before emit.
   },
+};
+```
 
-  // or
+通过 `clean.keep` 保留指定路径：
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: 'ignored/dir', // keep these assets under 'dist/ignored/dir'.
     },
   },
+};
+```
 
-  // or
+也可以使用正则表达式匹配要保留的路径：
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: /ignored\/dir/, // keep these assets under 'dist/ignored/dir'.
     },
   },
+};
+```
 
-  // or
+如需自定义匹配逻辑，可以通过函数返回 `true` 来保留文件：
+
+```js title="rspack.config.mjs"
+export default {
   output: {
     clean: {
       keep: (path) => path.includes('ignored/dir'), // keep these assets under 'dist/ignored/dir'.

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -422,6 +422,11 @@ type ResolveFallback =
 当常规解析失败时重定向模块请求。
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     fallback: {
@@ -692,6 +697,11 @@ Rspack 中用来替代 [tsconfig-paths-webpack-plugin](https://www.npmjs.com/pac
 - string:
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     tsConfig: path.resolve(__dirname, './tsconfig.json'),
@@ -702,6 +712,11 @@ export default {
 - object:
 
 ```js title="rspack.config.mjs"
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export default {
   resolve: {
     tsConfig: {


### PR DESCRIPTION
## Summary

Make configuration examples usable as written in both English and Chinese documentation.

- Initialize `__dirname` from `import.meta.url` and add missing Node.js imports in the entry, HTTP build, and resolver examples. The previous `.mjs` snippets throw `ReferenceError` when loaded.
- Separate the four `output.clean` alternatives into standalone configurations. In the previous example, repeated `output` keys silently overwrite the preceding alternatives.
- Fix the full-width union operator in `BundlerInfo` and parenthesize the callback union in `EntryDescription.publicPath` so the documented declarations parse as TypeScript.

## Validation

- Loaded all 18 added or modified `.mjs` examples with Node.js 24.10.0; checked for duplicate object keys.
- Checked the 4 changed TypeScript declarations with TypeScript 6.0.3; callback declarations were also checked against the exported Rspack types.
- Reproduced the original missing-variable, duplicate-key, and type-syntax problems.
- Prettier 3.9.6 and `git diff --check` passed for the changed files. New internal links and anchors were checked where applicable.
- Verified all 6 merge orders of the three split PRs: no conflicts, and the combined tree exactly reproduces the original documentation changes on the updated base.
- The full documentation site build was not run; website dependencies are not installed. Validation tooling is separate and is not included in the PR.

## Related links

- [Configuration types](https://github.com/web-infra-dev/rspack/blob/bba0032cb676be776dc8a09eb65c1d197c930db3/packages/rspack/src/config/types.ts)
- Extracted from #15565. This PR targets `main` independently; no other split PR is required first.

## Checklist

- [x] Tests updated (or not required; documentation only).
- [x] Documentation updated (English and Chinese).
