### PR TITLE
docs: align target-dependent globals and loading defaults

### DIFF
--- a/website/docs/en/config/node.mdx
+++ b/website/docs/en/config/node.mdx
@@ -15,9 +15,11 @@ Set `node` to `false` to disable all Node.js global polyfills and mocks. Otherwi
 ## node.global
 
 - **Type:** `boolean | 'warn'`
-- **Default:** `'warn'`
+- **Default:** `false` when the [target](/config/target) provides `global` natively, otherwise `'warn'`.
 
 Controls whether Rspack should provide a polyfill for the Node.js `global` object when bundling for non-Node environments.
+
+For example, `target: 'node'` defaults to `false`, while `target: 'web'` defaults to `'warn'`.
 
 See [the Node.js documentation](https://nodejs.org/api/globals.html#globals_global) for the exact behavior of this object.
 

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -370,7 +370,7 @@ If multiple modules would result in the same name, [`output.devtoolFallbackModul
 ## output.devtoolNamespace
 
 - **Type:** `string`
-- **Default:** `undefined`
+- **Default:** [`output.uniqueName`](#outputuniquename)
 
 This option determines the module's namespace used with the [`output.devtoolModuleFilenameTemplate`](#outputdevtoolmodulefilenametemplate). When not specified, it will default to the value of: [`output.uniqueName`](#outputuniquename). It's used to prevent source file path collisions in sourcemaps when loading multiple libraries built with Rspack.
 
@@ -591,9 +591,17 @@ Note this option does not affect output files for on-demand-loaded chunks. It on
 ## output.globalObject
 
 - **Type:** `string`
-- **Default:** `'self'`
+- **Default:** Derived from [`target`](/config/target): `'global'` when the target provides `global`, otherwise `'globalThis'` when it supports `globalThis`, otherwise `'self'`.
 
-When targeting a library, especially when `library.type` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` option to `'this'`. Defaults to `self` for Web-like targets.
+When targeting a library, especially when `library.type` is `'umd'`, this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set `output.globalObject` to `'this'`.
+
+For example, when `output.globalObject` is omitted:
+
+| `target`            | Default `output.globalObject` |
+| ------------------- | ----------------------------- |
+| `'web'`             | `'self'`                      |
+| `['web', 'es2020']` | `'globalThis'`                |
+| `'node'`            | `'global'`                    |
 
 The return value of your entry point will be assigned to the global object using the value of `output.library.name`. Depending on the value of the `type` option, the global object could change respectively, e.g., `self`, `global`, or `globalThis`.
 
@@ -1647,9 +1655,11 @@ The generated bundle will contain comments like:
 ## output.publicPath
 
 - **Type:** `'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
-- **Default:** `'auto'` when [target](/config/target) is `'web'` or `'webworker'`, `undefined` otherwise
+- **Default:** `'auto'` when the [target](/config/target) supports `document` or `importScripts`, otherwise `''`.
 
 Set the base URL path prefix for bundled static assets (such as JS, CSS, images, etc.).
+
+For example, `'web'` and `'webworker'` targets default to `'auto'`, while `'node'` defaults to an empty string. With an empty string, asset URLs have no additional prefix.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1794,14 +1804,23 @@ export default {
 ## output.wasmLoading
 
 - **Type:** `false | 'fetch' | 'async-node' | 'universal'`
-- **Default:** `'fetch'`
+- **Default:** Derived from [`target`](/config/target), [`output.module`](#outputmodule), and [`output.environment`](#outputenvironment).
 
-Option to set the method of loading WebAssembly Modules. Supported methods are `'fetch'` (web/webworker), `'async-node'` (Node.js), and `'universal'`.
+Selects the method used to load WebAssembly modules. Set it to `false` to disable WebAssembly loading.
 
-The default value can be affected by different [`target`](/config/target):
+Rspack chooses `'fetch'` when the target supports fetching WebAssembly, or `'async-node'` when it provides Node.js built-ins. For mixed targets where these capabilities differ, ESM output with dynamic import support can use `'universal'`. If no method can be selected, the default is `false`.
 
-- Defaults to `'fetch'` if [`target`](/config/target) is set to `'web'`, `'webworker'`, `'electron-renderer'` or `'node-webkit'`.
-- Defaults to `'async-node'` if [`target`](/config/target) is set to `'node'`, `'async-node'`, `'electron-main'` or `'electron-preload'`.
+Examples with otherwise default output settings:
+
+| `target`                                                    | `output.module` | Default `output.wasmLoading` |
+| ----------------------------------------------------------- | --------------- | ---------------------------- |
+| `'web'` or `'webworker'`                                    | `false`         | `'fetch'`                    |
+| `'electron-renderer'`                                       | `false`         | `'fetch'`                    |
+| `'node'` or `'async-node'`                                  | `false`         | `'async-node'`               |
+| `'electron-main'`, `'electron-preload'`, or `'node-webkit'` | `false`         | `'async-node'`               |
+| `['web', 'node']`                                           | `true`          | `'universal'`                |
+
+To override the inferred method:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1849,14 +1868,23 @@ See [Filename placeholders](/config/filename-placeholders) for more information.
 
 ## output.workerChunkLoading
 
-- **Type:** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string`
-- **Default:** `false`
+- **Type:** `false | 'import-scripts' | 'require' | 'async-node' | 'import' | 'universal' | string`
+- **Default:** Derived from [`target`](/config/target), [`output.chunkFormat`](#outputchunkformat), and [`output.environment`](#outputenvironment).
 
-The new option `workerChunkLoading` controls the chunk loading of workers.
+Controls how workers load additional JavaScript chunks. This is separate from [`output.chunkLoading`](#outputchunkloading), which controls chunk loading outside workers.
 
-:::tip
-The default value of this option depends on the [`target`](/config/target) setting. For more details, search for `"workerChunkLoading"` [in the Rspack defaults](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts).
-:::
+For example, with otherwise default output settings:
+
+| `target`                 | `output.module` | Default `output.workerChunkLoading` |
+| ------------------------ | --------------- | ----------------------------------- |
+| `'web'` or `'webworker'` | `false`         | `'import-scripts'`                  |
+| `'node'`                 | `false`         | `'require'`                         |
+| `'async-node'`           | `false`         | `'async-node'`                      |
+| `'web'`                  | `true`          | `'import'`                          |
+
+For module-format chunks, Rspack uses `'import'` when `output.environment.dynamicImportInWorker` is enabled. Mixed targets can use `'universal'` with ESM output and dynamic import support. If no loading method can be selected, the default is `false`.
+
+To disable worker chunk loading explicitly:
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1884,14 +1912,16 @@ export default {
 ## output.workerWasmLoading
 
 - **Type:** `false | 'fetch' | 'async-node' | 'universal'`
-- **Default:** `false`
+- **Default:** [`output.wasmLoading`](#outputwasmloading)
 
-Option to set the method of loading WebAssembly Modules in workers, defaults to the value of [output.wasmLoading](#outputwasmloading).
+Selects the method used to load WebAssembly modules inside workers. When omitted, it inherits `output.wasmLoading`, including an explicitly configured value of `false`.
+
+For example, the default is `'fetch'` for a web target and `'async-node'` for a Node.js target. To disable WebAssembly loading only inside workers:
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
-    workerWasmLoading: 'fetch',
+    workerWasmLoading: false,
   },
 };
 ```

--- a/website/docs/zh/config/node.mdx
+++ b/website/docs/zh/config/node.mdx
@@ -15,9 +15,11 @@ import Attribution from '@components/Attribution';
 ## node.global
 
 - **类型：** `boolean | 'warn'`
-- **默认值：** `'warn'`
+- **默认值：** 当 [target](/config/target) 原生提供 `global` 时为 `false`，否则为 `'warn'`。
 
 控制 Rspack 在为非 Node 环境打包时，是否需要为 Node.js 的 `global` 对象提供 polyfill。
+
+例如，`target: 'node'` 时默认为 `false`，`target: 'web'` 时默认为 `'warn'`。
 
 关于该对象的具体行为，请参考 [Node.js 文档](https://nodejs.org/api/globals.html#globals_global)。
 

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -366,7 +366,7 @@ export default {
 ## output.devtoolNamespace
 
 - **类型：** `string`
-- **默认值：** `undefined`
+- **默认值：** [`output.uniqueName`](#outputuniquename)
 
 此选项确定 [`output.devtoolModuleFilenameTemplate`](/config/output#outputdevtoolmodulefilenametemplate) 使用的模块名称空间。未指定时的默认值为：[`output.uniqueName`](/config/output#outputuniquename)。在加载多个通过 Rspack 构建的 library 时，用于防止 source map 中源文件路径冲突。
 
@@ -584,9 +584,17 @@ export default {
 ## output.globalObject
 
 - **类型：** `string`
-- **默认值：** `'self'`
+- **默认值：** 根据 [`target`](/config/target) 推断：目标环境提供 `global` 时为 `'global'`，否则在支持 `globalThis` 时为 `'globalThis'`，其余情况为 `'self'`。
 
-当输出为 library 时，尤其是当 `library.type` 为 `'umd'`时，此选项将决定使用哪个全局对象来挂载 library。为了使 UMD 构建在浏览器和 Node.js 上均可用，应将 `output.globalObject` 选项设置为 `'this'`。对于类似 web 的目标，默认为 `self`。
+当输出为 library 时，尤其是当 `library.type` 为 `'umd'` 时，此选项将决定使用哪个全局对象来挂载 library。为了使 UMD 构建在浏览器和 Node.js 上均可用，应将 `output.globalObject` 设置为 `'this'`。
+
+例如，未配置 `output.globalObject` 时：
+
+| `target`            | 默认的 `output.globalObject` |
+| ------------------- | ---------------------------- |
+| `'web'`             | `'self'`                     |
+| `['web', 'es2020']` | `'globalThis'`               |
+| `'node'`            | `'global'`                   |
 
 入口点的返回值将会使用 `output.library.name` 赋值给全局对象。依赖于 `target` 配置项，全局对象将会发生对应的改变，例如：`self`, `global` 或者 `globalThis`。
 
@@ -1638,9 +1646,11 @@ pathinfo 主要用于开发调试。这些注释会增加 bundle 体积，同时
 ## output.publicPath
 
 - **类型：** `'auto' | string | ((pathData: PathData, assetInfo?: AssetInfo) => string)`
-- **默认值：** [target](/config/target) 为 `'web'` 或 `'webworker'` 时为 `'auto'`，否则为 `undefined`
+- **默认值：** 当 [target](/config/target) 支持 `document` 或 `importScripts` 时为 `'auto'`，否则为 `''`。
 
 用于设置打包后的静态资源文件（如 JS、CSS、图片等）的 URL 路径前缀。
+
+例如，`'web'` 和 `'webworker'` 目标默认为 `'auto'`，而 `'node'` 默认为空字符串。使用空字符串时，资源 URL 不会添加额外前缀。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1785,14 +1795,23 @@ export default {
 ## output.wasmLoading
 
 - **类型：** `false | 'fetch' | 'async-node' | 'universal'`
-- **默认值：** `'fetch'`
+- **默认值：** 根据 [`target`](/config/target)、[`output.module`](#outputmodule) 和 [`output.environment`](#outputenvironment) 推断。
 
-用于设置加载 WebAssembly 模块的方式。支持的方式包括 `'fetch'`（web/webworker）、`'async-node'`（Node.js）和 `'universal'`。
+用于设置加载 WebAssembly 模块的方式。设为 `false` 可以禁用 WebAssembly 加载。
 
-默认值会受不同 [`target`](/config/target) 的影响：
+目标环境支持通过 fetch 加载 WebAssembly 时，Rspack 选择 `'fetch'`；否则，提供 Node.js 内置模块时选择 `'async-node'`。当混合目标对这些能力的支持不一致时，支持动态导入的 ESM 输出可以使用 `'universal'`。如果无法选择加载方式，则默认为 `false`。
 
-- 如果目标设置为 `'web'`、`'webworker'`、`'electron-renderer'` 或 `'node-webkit'`，默认值为 `'fetch'`。
-- 如果目标设置为 `'node'`、`'async-node'`、`'electron-main'` 或 `'electron-preload'`，则默认为 `'async-node'`。
+其他输出配置保持默认时，示例如下：
+
+| `target`                                                   | `output.module` | 默认的 `output.wasmLoading` |
+| ---------------------------------------------------------- | --------------- | --------------------------- |
+| `'web'` 或 `'webworker'`                                   | `false`         | `'fetch'`                   |
+| `'electron-renderer'`                                      | `false`         | `'fetch'`                   |
+| `'node'` 或 `'async-node'`                                 | `false`         | `'async-node'`              |
+| `'electron-main'`、`'electron-preload'` 或 `'node-webkit'` | `false`         | `'async-node'`              |
+| `['web', 'node']`                                          | `true`          | `'universal'`               |
+
+你也可以覆盖推断出的加载方式：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1840,14 +1859,23 @@ export default {
 
 ## output.workerChunkLoading
 
-- **类型：** `false | 'jsonp' | 'import-scripts' | 'require' | 'async-node' | 'import' | string`
-- **默认值：** `false`
+- **类型：** `false | 'import-scripts' | 'require' | 'async-node' | 'import' | 'universal' | string`
+- **默认值：** 根据 [`target`](/config/target)、[`output.chunkFormat`](#outputchunkformat) 和 [`output.environment`](#outputenvironment) 推断。
 
-`workerChunkLoading` 控制 chunk 加载方式。
+控制 Worker 加载其他 JavaScript chunk 的方式，与控制 Worker 外部 chunk 加载方式的 [`output.chunkLoading`](#outputchunkloading) 分开配置。
 
-:::tip
-此选项的默认值取决于目标设置。要获取更多信息，请在 Rspack [默认设置中](https://github.com/web-infra-dev/rspack/blob/main/packages/rspack/src/config/defaults.ts)搜索 `"workerChunkLoading"`。
-:::
+例如，其他输出配置保持默认时：
+
+| `target`                 | `output.module` | 默认的 `output.workerChunkLoading` |
+| ------------------------ | --------------- | ---------------------------------- |
+| `'web'` 或 `'webworker'` | `false`         | `'import-scripts'`                 |
+| `'node'`                 | `false`         | `'require'`                        |
+| `'async-node'`           | `false`         | `'async-node'`                     |
+| `'web'`                  | `true`          | `'import'`                         |
+
+对于 module 格式的 chunk，启用 `output.environment.dynamicImportInWorker` 时，Rspack 使用 `'import'`。支持动态导入的 ESM 输出可以为混合目标选择 `'universal'`。如果无法选择加载方式，则默认为 `false`。
+
+可以显式禁用 Worker 的 chunk 加载：
 
 ```js title="rspack.config.mjs"
 export default {
@@ -1875,14 +1903,16 @@ export default {
 ## output.workerWasmLoading
 
 - **类型：** `false | 'fetch' | 'async-node' | 'universal'`
-- **默认值：** `false`
+- **默认值：** [`output.wasmLoading`](#outputwasmloading)
 
-用来设置在 Worker 中加载 WebAssembly 模块的方式，默认为 [`output.wasmLoading`](#outputwasmloading) 的值。
+用于设置 Worker 内部加载 WebAssembly 模块的方式。未配置时继承 `output.wasmLoading`，包括显式设置的 `false`。
+
+例如，web 目标下默认为 `'fetch'`，Node.js 目标下默认为 `'async-node'`。如需仅禁用 Worker 内部的 WebAssembly 加载：
 
 ```js title="rspack.config.mjs"
 export default {
   output: {
-    workerWasmLoading: 'fetch',
+    workerWasmLoading: false,
   },
 };
 ```


### PR DESCRIPTION
## Summary

Align the English and Chinese configuration references with how Rspack derives globals and loading defaults.

- Describe target-dependent `node.global`, `output.globalObject`, and `output.publicPath`, including the empty-string public path on Node.js targets. Correct `devtoolNamespace` to inherit `output.uniqueName`.
- Document WebAssembly loading across browser, Node.js, Electron, Node-Webkit, and mixed ESM targets. Node-Webkit uses `async-node`, not `fetch`.
- Explain worker chunk-loading inference and `workerWasmLoading` inheritance, including explicit disabling. Add target/output tables so the defaults can be compared directly.

## Validation

- Verified 17 relevant configuration-default scenarios with published `@rspack/core@2.2.3` and cross-checked the corresponding source on the base commit. Coverage includes browser/Node/Electron/Node-Webkit targets, modern global objects, ESM worker loading, mixed-target Wasm loading, explicit disabling, and namespace inheritance.
- Loaded both modified `.mjs` examples with Node.js 24.10.0.
- Prettier 3.9.6 and `git diff --check` passed for the changed files. New internal links and anchors were checked where applicable.
- Verified all 6 merge orders of the three split PRs: no conflicts, and the combined tree exactly reproduces the original documentation changes on the updated base.
- The full documentation site build was not run; website dependencies are not installed. Validation tooling is separate and is not included in the PR.

## Related links

- [Configuration defaults](https://github.com/web-infra-dev/rspack/blob/bba0032cb676be776dc8a09eb65c1d197c930db3/packages/rspack/src/config/defaults.ts)
- Extracted from #15565. This PR targets `main` independently; no other split PR is required first.

## Checklist

- [x] Tests updated (or not required; documentation only).
- [x] Documentation updated (English and Chinese).
