### PR TITLE
docs: simplify ESM configuration examples and output descriptions

### DIFF
--- a/website/docs/en/config/cache.mdx
+++ b/website/docs/en/config/cache.mdx
@@ -124,16 +124,15 @@ export default {
 `cache.buildDependencies` is an array of file or directory paths treated as build dependencies. Rspack tracks these paths and invalidates the persistent cache when any tracked build dependency changes.
 
 ```js title="rspack.config.mjs"
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { join } from 'node:path';
 
 export default {
   cache: {
     type: 'persistent',
-    buildDependencies: [__filename, join(__dirname, './tsconfig.json')],
+    buildDependencies: [
+      import.meta.filename,
+      join(import.meta.dirname, './tsconfig.json'),
+    ],
   },
 };
 ```

--- a/website/docs/en/config/context.mdx
+++ b/website/docs/en/config/context.mdx
@@ -21,19 +21,14 @@ By default, Rspack uses the current working directory of the Node.js process as 
 
 ## Example
 
-For example, you can use [`__dirname`](https://nodejs.org/docs/latest/api/modules.html#__dirname) as the base directory:
+For example, you can use the configuration file's directory as the base directory:
 
 <Tabs>
   <Tab label="ESM">
 
 ```js title="rspack.config.mjs"
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
 export default {
-  context: __dirname,
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },
@@ -55,6 +50,6 @@ module.exports = {
   </Tab>
 </Tabs>
 
-In the above example, the `main` entry will be resolved based on the `path.join(__dirname, './src/index.js')` path.
+In the above example, the `main` entry resolves to `src/index.js` relative to the configuration file's directory.
 
 <Attribution url="https://webpack.js.org/configuration/entry-context/#context" />

--- a/website/docs/en/config/dev-server.mdx
+++ b/website/docs/en/config/dev-server.mdx
@@ -836,9 +836,6 @@ It also allows you to set additional [TLS options](https://nodejs.org/api/tls.ht
 ```js title="rspack.config.mjs"
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   devServer: {
@@ -846,10 +843,10 @@ export default {
       type: 'https',
       options: {
         minVersion: 'TLSv1.1',
-        key: fs.readFileSync(path.join(__dirname, './server.key')),
-        pfx: fs.readFileSync(path.join(__dirname, './server.pfx')),
-        cert: fs.readFileSync(path.join(__dirname, './server.crt')),
-        ca: fs.readFileSync(path.join(__dirname, './ca.pem')),
+        key: fs.readFileSync(path.join(import.meta.dirname, './server.key')),
+        pfx: fs.readFileSync(path.join(import.meta.dirname, './server.pfx')),
+        cert: fs.readFileSync(path.join(import.meta.dirname, './server.crt')),
+        ca: fs.readFileSync(path.join(import.meta.dirname, './ca.pem')),
         passphrase: '@rspack/dev-server',
         requestCert: true,
       },

--- a/website/docs/en/config/entry.mdx
+++ b/website/docs/en/config/entry.mdx
@@ -52,12 +52,9 @@ You can also use the [path module](https://nodejs.org/api/path.html) in Node.js 
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
-  entry: path.join(__dirname, './src/index.js'),
+  entry: path.join(import.meta.dirname, './src/index.js'),
 };
 ```
 

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -84,16 +84,13 @@ For example:
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   experiments: {
     buildHttp: {
       allowedUris: ['https://'],
-      lockfileLocation: path.join(__dirname, 'my_project.lock'),
-      cacheLocation: path.join(__dirname, 'my_project.lock.data'),
+      lockfileLocation: path.join(import.meta.dirname, 'my_project.lock'),
+      cacheLocation: path.join(import.meta.dirname, 'my_project.lock.data'),
     },
   },
 };

--- a/website/docs/en/config/output.mdx
+++ b/website/docs/en/config/output.mdx
@@ -1610,8 +1610,6 @@ Output JavaScript files as module type.
 
 When enabled, [`output.iife`](#outputiife) defaults to `false` and [`output.scriptType`](#outputscripttype) defaults to `'module'`. Explicit values for these options take precedence over the defaults.
 
-The built-in [SwcJsMinimizerRspackPlugin](/plugins/swc-js-minimizer-rspack-plugin#minimizeroptions) detects ESM assets from their metadata unless `minimizerOptions.module` is explicitly configured.
-
 If you set [`output.library.type`](#outputlibrarytype) to 'module' or 'modern-module', Rspack will set `output.module` to `true` for you automatically.
 
 ```js title="rspack.config.mjs"
@@ -1634,13 +1632,10 @@ The output directory as an **absolute** path.
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   output: {
-    path: path.resolve(__dirname, 'dist/assets'),
+    path: path.resolve(import.meta.dirname, 'dist/assets'),
   },
 };
 ```
@@ -1965,9 +1960,9 @@ export default {
 - **Type:** `false | 'fetch' | 'async-node' | 'universal'`
 - **Default:** [`output.wasmLoading`](#outputwasmloading)
 
-Selects the method used to load WebAssembly modules inside workers. When omitted, it inherits `output.wasmLoading`, including an explicitly configured value of `false`.
+Sets how workers load WebAssembly modules. Defaults to `output.wasmLoading`.
 
-For example, the default is `'fetch'` for a web target and `'async-node'` for a Node.js target. To disable WebAssembly loading only inside workers:
+Set to `false` to disable WebAssembly loading inside workers:
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -423,15 +423,12 @@ Redirect module requests when normal resolving fails.
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
     fallback: {
       abc: false, // do not include a polyfill for abc
-      xyz: path.resolve(__dirname, 'path/to/file.js'), // include a polyfill for xyz
+      xyz: path.resolve(import.meta.dirname, 'path/to/file.js'), // include a polyfill for xyz
     },
   },
 };
@@ -668,14 +665,9 @@ A list of directories where server-relative URLs (beginning with '/') are resolv
 For example, importing `'/static/app.js'` and expecting it to resolve relative to the project root:
 
 ```js title="rspack.config.mjs"
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 export default {
   resolve: {
-    roots: [__dirname],
+    roots: [import.meta.dirname],
   },
 };
 ```
@@ -700,14 +692,11 @@ The replacement of [tsconfig-paths-webpack-plugin](https://www.npmjs.com/package
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
     // string
-    tsConfig: path.resolve(__dirname, './tsconfig.json'),
+    tsConfig: path.resolve(import.meta.dirname, './tsconfig.json'),
   },
 };
 ```
@@ -716,14 +705,11 @@ export default {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
     tsConfig: {
-      configFile: path.resolve(__dirname, './tsconfig.json'),
+      configFile: path.resolve(import.meta.dirname, './tsconfig.json'),
       references: 'auto',
     },
   },

--- a/website/docs/en/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/en/guide/features/builtin-swc-loader.mdx
@@ -311,9 +311,6 @@ When you use SWC's Wasm plugin, SWC will generate cache files in the `.swc` dire
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   module: {
@@ -325,7 +322,10 @@ export default {
           options: {
             jsc: {
               experimental: {
-                cacheRoot: path.join(__dirname, './node_modules/.cache/swc'),
+                cacheRoot: path.join(
+                  import.meta.dirname,
+                  './node_modules/.cache/swc',
+                ),
               },
             },
           },

--- a/website/docs/en/plugins/copy-rspack-plugin.mdx
+++ b/website/docs/en/plugins/copy-rspack-plugin.mdx
@@ -68,9 +68,6 @@ export default {
 ```ts title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   entry: './src/index.js',
@@ -81,7 +78,7 @@ export default {
       patterns: [
         {
           from: '*.json',
-          context: path.join(__dirname, 'src'),
+          context: path.join(import.meta.dirname, 'src'),
         },
       ],
     }),
@@ -120,9 +117,6 @@ It can refer to a file or a directory. If a relative path is passed, it is relat
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   plugins: [
@@ -132,15 +126,15 @@ export default {
         { from: 'relative/path/to/file.js' },
         { from: 'relative/path/to/dir' },
         // absolute path
-        { from: path.resolve(__dirname, 'src', 'file.js') },
-        { from: path.resolve(__dirname, 'src', 'dir') },
+        { from: path.resolve(import.meta.dirname, 'src', 'file.js') },
+        { from: path.resolve(import.meta.dirname, 'src', 'dir') },
         // glob
         { from: 'dir/**/*' },
         // If absolute path is a `glob` we replace backslashes with forward slashes,
         // because only forward slashes can be used in the `glob`
         {
           from: path.posix.join(
-            path.resolve(__dirname, 'src').replace(/\\/g, '/'),
+            path.resolve(import.meta.dirname, 'src').replace(/\\/g, '/'),
             '*.txt',
           ),
         },
@@ -197,15 +191,14 @@ export default {
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       // `./src/*.json` -> `./dist/*.json`
-      patterns: [{ from: '*.json', context: path.join(__dirname, 'src') }],
+      patterns: [
+        { from: '*.json', context: path.join(import.meta.dirname, 'src') },
+      ],
     }),
   ],
 };
@@ -295,12 +288,15 @@ export default {
 Whether to ignore the error if there are missing files or directories.
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+
 export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       patterns: [
         {
-          from: path.resolve(__dirname, 'missing-file.txt'),
+          from: path.resolve(import.meta.dirname, 'missing-file.txt'),
           noErrorOnMissing: true,
         },
       ],

--- a/website/docs/en/plugins/dll-plugin.mdx
+++ b/website/docs/en/plugins/dll-plugin.mdx
@@ -11,8 +11,11 @@ The `DllPlugin` is used in a separate rspack configuration exclusively to create
 ## Examples
 
 ```js
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+
 new rspack.DllPlugin({
-  path: path.resolve(__dirname, 'manifest.json'),
+  path: path.resolve(import.meta.dirname, 'manifest.json'),
   name: '[name]_dll_lib',
 });
 ```

--- a/website/docs/en/plugins/provide-plugin.mdx
+++ b/website/docs/en/plugins/provide-plugin.mdx
@@ -32,12 +32,9 @@ It is also possible to specify full path:
 
 ```js
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 new rspack.ProvidePlugin({
-  identifier: path.resolve(path.join(__dirname, 'src/module1')),
+  identifier: path.resolve(path.join(import.meta.dirname, 'src/module1')),
   // ...
 });
 ```

--- a/website/docs/zh/config/cache.mdx
+++ b/website/docs/zh/config/cache.mdx
@@ -121,16 +121,15 @@ export default {
 `cache.buildDependencies` 是构建依赖的文件或目录路径数组。Rspack 会追踪这些路径，并在任意被追踪的构建依赖发生变化时使持久化缓存失效。
 
 ```js title="rspack.config.mjs"
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { join } from 'node:path';
 
 export default {
   cache: {
     type: 'persistent',
-    buildDependencies: [__filename, join(__dirname, './tsconfig.json')],
+    buildDependencies: [
+      import.meta.filename,
+      join(import.meta.dirname, './tsconfig.json'),
+    ],
   },
 };
 ```

--- a/website/docs/zh/config/context.mdx
+++ b/website/docs/zh/config/context.mdx
@@ -21,19 +21,14 @@ import { Tabs, Tab } from '@theme';
 
 ## 示例
 
-比如，你可以使用 [`__dirname`](https://nodejs.org/docs/latest/api/modules.html#__dirname) 作为基础目录：
+比如，你可以使用配置文件所在的目录作为基础目录：
 
 <Tabs>
   <Tab label="ESM">
 
 ```js title="rspack.config.mjs"
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
 export default {
-  context: __dirname,
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },
@@ -55,6 +50,6 @@ module.exports = {
   </Tab>
 </Tabs>
 
-在上述例子中，`main` 入口会基于 `path.join(__dirname, './src/index.js')` 路径进行解析。
+在上述例子中，`main` 入口会解析为配置文件所在目录下的 `src/index.js`。
 
 <Attribution url="https://webpack.docschina.org/configuration/entry-context/#context" />

--- a/website/docs/zh/config/dev-server.mdx
+++ b/website/docs/zh/config/dev-server.mdx
@@ -826,9 +826,6 @@ export default {
 ```js title="rspack.config.mjs"
 import fs from 'node:fs';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   devServer: {
@@ -836,10 +833,10 @@ export default {
       type: 'https',
       options: {
         minVersion: 'TLSv1.1',
-        key: fs.readFileSync(path.join(__dirname, './server.key')),
-        pfx: fs.readFileSync(path.join(__dirname, './server.pfx')),
-        cert: fs.readFileSync(path.join(__dirname, './server.crt')),
-        ca: fs.readFileSync(path.join(__dirname, './ca.pem')),
+        key: fs.readFileSync(path.join(import.meta.dirname, './server.key')),
+        pfx: fs.readFileSync(path.join(import.meta.dirname, './server.pfx')),
+        cert: fs.readFileSync(path.join(import.meta.dirname, './server.crt')),
+        ca: fs.readFileSync(path.join(import.meta.dirname, './ca.pem')),
         passphrase: '@rspack/dev-server',
         requestCert: true,
       },

--- a/website/docs/zh/config/entry.mdx
+++ b/website/docs/zh/config/entry.mdx
@@ -52,12 +52,9 @@ export default {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
-  entry: path.join(__dirname, './src/index.js'),
+  entry: path.join(import.meta.dirname, './src/index.js'),
 };
 ```
 

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -85,16 +85,13 @@ type HttpUriOptions = {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   experiments: {
     buildHttp: {
       allowedUris: ['https://'],
-      lockfileLocation: path.join(__dirname, 'my_project.lock'),
-      cacheLocation: path.join(__dirname, 'my_project.lock.data'),
+      lockfileLocation: path.join(import.meta.dirname, 'my_project.lock'),
+      cacheLocation: path.join(import.meta.dirname, 'my_project.lock.data'),
     },
   },
 };

--- a/website/docs/zh/config/output.mdx
+++ b/website/docs/zh/config/output.mdx
@@ -1601,8 +1601,6 @@ export default {
 
 当启用时，[`output.iife`](#outputiife) 默认为 `false`，[`output.scriptType`](#outputscripttype) 默认为 `'module'`。显式配置的值优先于这些默认值。
 
-内置的 [SwcJsMinimizerRspackPlugin](/plugins/swc-js-minimizer-rspack-plugin#minimizeroptions) 根据产物元数据识别 ESM，除非显式配置了 `minimizerOptions.module`。
-
 配置 [`output.library.type`](#outputlibrarytype) 为 'module' 或 'modern-module' 会自动将 `output.module` 设为 `true`。
 
 ```js title="rspack.config.mjs"
@@ -1625,13 +1623,10 @@ export default {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   output: {
-    path: path.resolve(__dirname, 'dist/assets'),
+    path: path.resolve(import.meta.dirname, 'dist/assets'),
   },
 };
 ```
@@ -1956,9 +1951,9 @@ export default {
 - **类型：** `false | 'fetch' | 'async-node' | 'universal'`
 - **默认值：** [`output.wasmLoading`](#outputwasmloading)
 
-用于设置 Worker 内部加载 WebAssembly 模块的方式。未配置时继承 `output.wasmLoading`，包括显式设置的 `false`。
+设置 Worker 内部的 WebAssembly 加载方式，默认继承 `output.wasmLoading`。
 
-例如，web 目标下默认为 `'fetch'`，Node.js 目标下默认为 `'async-node'`。如需仅禁用 Worker 内部的 WebAssembly 加载：
+设为 `false` 可禁用 Worker 内部的 WebAssembly 加载：
 
 ```js title="rspack.config.mjs"
 export default {

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -423,15 +423,12 @@ type ResolveFallback =
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
     fallback: {
       abc: false, // 不为 abc 引入 polyfill
-      xyz: path.resolve(__dirname, 'path/to/file.js'), // 为 xyz 引入 polyfill
+      xyz: path.resolve(import.meta.dirname, 'path/to/file.js'), // 为 xyz 引入 polyfill
     },
   },
 };
@@ -666,14 +663,9 @@ export default {
 例如，导入 `'/static/app.js'` 时，期望其相对于项目根目录进行解析：
 
 ```js title="rspack.config.mjs"
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 export default {
   resolve: {
-    roots: [__dirname],
+    roots: [import.meta.dirname],
   },
 };
 ```
@@ -698,13 +690,10 @@ Rspack 中用来替代 [tsconfig-paths-webpack-plugin](https://www.npmjs.com/pac
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
-    tsConfig: path.resolve(__dirname, './tsconfig.json'),
+    tsConfig: path.resolve(import.meta.dirname, './tsconfig.json'),
   },
 };
 ```
@@ -713,14 +702,11 @@ export default {
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   resolve: {
     tsConfig: {
-      configFile: path.resolve(__dirname, './tsconfig.json'),
+      configFile: path.resolve(import.meta.dirname, './tsconfig.json'),
       references: 'auto',
     },
   },

--- a/website/docs/zh/guide/features/builtin-swc-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-swc-loader.mdx
@@ -311,9 +311,6 @@ Rspack 支持在 `builtin:swc-loader` 里加载 SWC 的 Wasm 插件, 你可以�
 
 ```js title="rspack.config.mjs"
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   module: {
@@ -325,7 +322,10 @@ export default {
           options: {
             jsc: {
               experimental: {
-                cacheRoot: path.join(__dirname, './node_modules/.cache/swc'),
+                cacheRoot: path.join(
+                  import.meta.dirname,
+                  './node_modules/.cache/swc',
+                ),
               },
             },
           },

--- a/website/docs/zh/plugins/copy-rspack-plugin.mdx
+++ b/website/docs/zh/plugins/copy-rspack-plugin.mdx
@@ -68,9 +68,6 @@ export default {
 ```ts title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   entry: './src/index.js',
@@ -81,7 +78,7 @@ export default {
       patterns: [
         {
           from: '*.json',
-          context: path.join(__dirname, 'src'),
+          context: path.join(import.meta.dirname, 'src'),
         },
       ],
     }),
@@ -118,10 +115,8 @@ export default {
 若传入相对路径，则是相对于 [context](#context) 选项。
 
 ```js title="rspack.config.mjs"
+import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   plugins: [
@@ -131,15 +126,15 @@ export default {
         { from: 'relative/path/to/file.js' },
         { from: 'relative/path/to/dir' },
         // 绝对路径
-        { from: path.resolve(__dirname, 'src', 'file.js') },
-        { from: path.resolve(__dirname, 'src', 'dir') },
+        { from: path.resolve(import.meta.dirname, 'src', 'file.js') },
+        { from: path.resolve(import.meta.dirname, 'src', 'dir') },
         // glob
         { from: 'dir/**/*' },
         // 如果绝对路径是 `glob`，我们用 forward slashes 替换 backslashes，
         // 因为只有 forward slashes 可以用于 `glob`
         {
           from: path.posix.join(
-            path.resolve(__dirname, 'src').replace(/\\/g, '/'),
+            path.resolve(import.meta.dirname, 'src').replace(/\\/g, '/'),
             '*.txt',
           ),
         },
@@ -196,15 +191,14 @@ export default {
 ```js title="rspack.config.mjs"
 import { rspack } from '@rspack/core';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       // `./src/*.json` -> `./dist/*.json`
-      patterns: [{ from: '*.json', context: path.join(__dirname, 'src') }],
+      patterns: [
+        { from: '*.json', context: path.join(import.meta.dirname, 'src') },
+      ],
     }),
   ],
 };
@@ -294,17 +288,15 @@ export default {
 当没有找到对应的文件或目录时，是否忽略错误。
 
 ```js title="rspack.config.mjs"
-import { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { rspack } from '@rspack/core';
+import path from 'node:path';
 
 export default {
   plugins: [
     new rspack.CopyRspackPlugin({
       patterns: [
         {
-          from: path.resolve(__dirname, 'missing-file.txt'),
+          from: path.resolve(import.meta.dirname, 'missing-file.txt'),
           noErrorOnMissing: true,
         },
       ],

--- a/website/docs/zh/plugins/dll-plugin.mdx
+++ b/website/docs/zh/plugins/dll-plugin.mdx
@@ -11,8 +11,11 @@ Dll 插件用于在一个单独的 rspack 配置中生成一个 dll 库，DllRef
 ## 示例
 
 ```js
+import { rspack } from '@rspack/core';
+import path from 'node:path';
+
 new rspack.DllPlugin({
-  path: path.resolve(__dirname, 'manifest.json'),
+  path: path.resolve(import.meta.dirname, 'manifest.json'),
   name: '[name]_dll_lib',
 });
 ```

--- a/website/docs/zh/plugins/provide-plugin.mdx
+++ b/website/docs/zh/plugins/provide-plugin.mdx
@@ -32,12 +32,9 @@ new rspack.ProvidePlugin({
 
 ```js
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 new rspack.ProvidePlugin({
-  identifier: path.resolve(path.join(__dirname, 'src/module1')),
+  identifier: path.resolve(path.join(import.meta.dirname, 'src/module1')),
   // ...
 });
 ```


### PR DESCRIPTION
## Summary

Rspack 2 supports Node.js versions that provide `import.meta.dirname` and `import.meta.filename`, so ESM documentation examples no longer need to recreate the CommonJS globals. Simplify the English and Chinese examples and add missing plugin imports. Remove the minimizer implementation detail from `output.module` and shorten the `output.workerWasmLoading` description.

## Related links

- Follow-up to #15566, #15567, and #15568.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).