### PR TITLE
docs: clarify package resolution defaults and condition priority

### DIFF
--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -89,9 +89,11 @@ export default {
 ## resolve.aliasFields
 
 - **Type:** `string[]`
-- **Default:** `['browser']`
+- **Default:** Depends on [target](/config/target) and [dependency type](#resolvebydependency).
 
 Define a field, such as `browser`, that should be parsed in accordance with [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+
+For typical JavaScript requests, the default is `['browser']` when targeting the web, web workers, or Electron renderers. For Node.js, Electron main and preload scripts, and NW.js, it is `[]`. CSS `@import` and URL requests use `[]` by default.
 
 ## resolve.byDependency
 
@@ -184,28 +186,34 @@ export default {
 
 ### Default value
 
-Rspack's default `conditionNames` are determined by [mode](/config/mode), [target](/config/target) and module type.
+Rspack's default `conditionNames` are determined by [mode](/config/mode), [target](/config/target), and [dependency type](#resolvebydependency). Typical defaults are:
 
 ```js
-// For ES modules
-['import', 'module', 'webpack', mode, target];
+// ES module requests
+['import', 'module', 'webpack', modeCondition, ...targetConditions];
 
-// For CommonJS
-['require', 'module', 'webpack', mode, target];
+// CommonJS requests
+['require', 'module', 'webpack', modeCondition, ...targetConditions];
 
-// For CSS module
-[mode, 'style'];
+// CSS @import requests
+[modeCondition, 'style'];
 ```
 
-In the above example:
+Here, `modeCondition` is `'development'` in development mode and `'production'` otherwise, including when `mode` is `'none'`.
 
-- `mode` is determined by [mode](/config/mode) config, which is `development` in development mode and `production` in other modes.
-- `target` is determined by [target](/config/target) config:
-  - If `target` includes `web`, it will be `browser`.
-  - If `target` includes `node`, it will be `node`.
-  - If `target` includes `webworker`, it will be `worker`.
-  - If `target` includes `electron`, it will be `electron`.
-  - If `target` includes `nwjs`, it will be `nwjs`.
+`targetConditions` are derived from the target's platform capabilities. A target can enable several conditions:
+
+| Target                                      | `targetConditions`                |
+| ------------------------------------------- | --------------------------------- |
+| `'web'`                                     | `['browser']`                     |
+| `'webworker'`                               | `['worker', 'browser']`           |
+| `'node'`                                    | `['node']`                        |
+| `'electron-main'`                           | `['node', 'electron']`            |
+| `'electron-preload'`, `'electron-renderer'` | `['node', 'browser', 'electron']` |
+| `'nwjs'`                                    | `['node', 'browser', 'nwjs']`     |
+| `false`, `'es2022'`                         | `[]`                              |
+
+CSS `@import` requests use their own condition names and do not include these platform conditions by default.
 
 ### Example
 
@@ -262,7 +270,7 @@ export default {
 };
 ```
 
-Alternatively, to prioritize the default value first and then add your custom condition names:
+You can also place `'...'` before the custom condition. Both configurations enable the same conditions; changing their order does not change resolution priority. Priority is determined by the key order in the package's `exports` object.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -520,11 +528,11 @@ When this configuration is `["testImports", "imports"]`, the result of `import v
 ## resolve.mainFields
 
 - **Type:** `string[]`
-- **Default:** Based on the [target](/config/target) option
+- **Default:** Depends on [target](/config/target) and [dependency type](#resolvebydependency).
 
 Controls the priority of fields in a package.json used to locate a package's entry file. It is the ordered list of package.json fields Rspack will try when resolving an npm package's entry point.
 
-If `target` is `'web'`, `'webworker'`, or not specified, the default value is `["browser", "module", "main"]`.
+For typical JavaScript requests, the default is `["browser", "module", "main"]` when targeting the web, web workers, or Electron renderers.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -534,7 +542,7 @@ export default {
 };
 ```
 
-For any other `target` (including `'node'`), the default value is `["module", "main"]`.
+For Node.js, Electron main and preload scripts, and NW.js, the default for JavaScript requests is `["module", "main"]`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -543,6 +551,8 @@ export default {
   },
 };
 ```
+
+CSS `@import` requests use `["style", "main"]` by default. URL requests use the top-level default, `["main"]`. Rspack combines top-level resolve options with the matching [resolve.byDependency](#resolvebydependency) options for each request.
 
 For example, consider an arbitrary library called `foo` with a `package.json` that contains the following fields:
 
@@ -554,7 +564,7 @@ For example, consider an arbitrary library called `foo` with a `package.json` th
 }
 ```
 
-When `import foo from 'foo'`, Rspack resolves to the module in the `browser` field, because the `browser` field has the highest priority in `mainFields` array.
+With `mainFields: ['browser', 'module', 'main']`, `import foo from 'foo'` resolves to the module in the `browser` field, because that field has the highest priority in the array.
 
 Note that the [`exports` field](https://nodejs.org/api/packages.html#packages_exports) takes precedence over `mainFields`. If an entry is resolved via `exports`, Rspack ignores the `browser`, `module`, and `main` fields.
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -89,9 +89,11 @@ export default {
 ## resolve.aliasFields
 
 - **类型：** `string[]`
-- **默认值：**`['browser']`
+- **默认值：** 取决于 [target](/config/target) 和[依赖类型](#resolvebydependency)。
 
 定义一个字段，例如 `browser`，以依照[此规范](https://github.com/defunctzombie/package-browser-field-spec)进行解析。
+
+对于常见的 JavaScript 请求，以 Web、Web Worker 或 Electron 渲染进程为目标时，默认值为 `['browser']`。以 Node.js、Electron 主进程和预加载脚本、NW.js 为目标时，默认值为 `[]`。CSS `@import` 和 URL 请求的默认值为 `[]`。
 
 ## resolve.byDependency
 
@@ -184,28 +186,34 @@ export default {
 
 ### 默认值
 
-Rspack 默认的 `conditionNames` 由 [mode](/config/mode)、[target](/config/target) 和模块类型共同决定。
+Rspack 默认的 `conditionNames` 由 [mode](/config/mode)、[target](/config/target) 和[依赖类型](#resolvebydependency)共同决定。常见请求的默认值如下：
 
 ```js
-// 针对 ES modules
-['import', 'module', 'webpack', mode, target];
+// ES 模块请求
+['import', 'module', 'webpack', modeCondition, ...targetConditions];
 
-// 针对 CommonJS
-['require', 'module', 'webpack', mode, target];
+// CommonJS 请求
+['require', 'module', 'webpack', modeCondition, ...targetConditions];
 
-// 针对 CSS 模块
-[mode, 'style'];
+// CSS @import 请求
+[modeCondition, 'style'];
 ```
 
-在上述示例中：
+其中，`modeCondition` 在开发模式下为 `'development'`，其他情况下为 `'production'`，包括 `mode` 为 `'none'` 时。
 
-- `mode` 由 [mode](/config/mode) 配置决定，开发模式下为 `development`，其他模式为 `production`。
-- `target` 由 [target](/config/target) 配置决定：
-  - 如果 `target` 包含 `web`，则为 `browser`。
-  - 如果 `target` 包含 `node`，则为 `node`。
-  - 如果 `target` 包含 `webworker`，则为 `worker`。
-  - 如果 `target` 包含 `electron`，则为 `electron`。
-  - 如果 `target` 包含 `nwjs`，则为 `nwjs`。
+`targetConditions` 由目标平台的能力决定，一个目标可以启用多个条件：
+
+| Target                                      | `targetConditions`                |
+| ------------------------------------------- | --------------------------------- |
+| `'web'`                                     | `['browser']`                     |
+| `'webworker'`                               | `['worker', 'browser']`           |
+| `'node'`                                    | `['node']`                        |
+| `'electron-main'`                           | `['node', 'electron']`            |
+| `'electron-preload'`, `'electron-renderer'` | `['node', 'browser', 'electron']` |
+| `'nwjs'`                                    | `['node', 'browser', 'nwjs']`     |
+| `false`, `'es2022'`                         | `[]`                              |
+
+CSS `@import` 请求使用独立的条件名称，默认不包含这些平台条件。
 
 ### 示例
 
@@ -262,7 +270,7 @@ export default {
 };
 ```
 
-或者，如果你想让默认值优先，再追加自定义 condition names：
+也可以将 `'...'` 放在自定义条件之前。两种配置启用的条件相同，调整它们的顺序不会改变解析优先级。优先级由包的 `exports` 对象中键的顺序决定。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -520,11 +528,11 @@ export default {
 ## resolve.mainFields
 
 - **类型：** `string[]`
-- **默认值：** 根据 [target](/config/target) 选项确定
+- **默认值：** 取决于 [target](/config/target) 和[依赖类型](#resolvebydependency)。
 
 控制用于定位包入口文件的 package.json 字段优先级。Rspack 在解析 npm 包入口时，会按该列表的顺序依次尝试这些字段。
 
-当 `target` 配置为 `'web'`, `'webworker'`, 或未指定时，默认值为 `["browser", "module", "main"]`。
+对于常见的 JavaScript 请求，以 Web、Web Worker 或 Electron 渲染进程为目标时，默认值为 `["browser", "module", "main"]`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -534,7 +542,7 @@ export default {
 };
 ```
 
-对于任何其他 `target`（包括 `'node'`）, 默认值为 `["module", "main"]`。
+以 Node.js、Electron 主进程和预加载脚本、NW.js 为目标时，JavaScript 请求的默认值为 `["module", "main"]`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -543,6 +551,8 @@ export default {
   },
 };
 ```
+
+CSS `@import` 请求的默认值为 `["style", "main"]`，URL 请求使用顶层默认值 `["main"]`。Rspack 会为每个请求合并顶层 resolve 选项和匹配的 [resolve.byDependency](#resolvebydependency) 选项。
 
 例如，对于一个名为 `foo` 的库，它的 `package.json` 包含以下字段：
 
@@ -554,7 +564,7 @@ export default {
 }
 ```
 
-当 `import foo from 'foo'` 时，Rspack 会解析到 `browser` 字段中的模块，因为 `browser` 字段在 `mainFields` 数组中优先级最高。
+配置 `mainFields: ['browser', 'module', 'main']` 时，`import foo from 'foo'` 会解析到 `browser` 字段中的模块，因为该字段在数组中的优先级最高。
 
 注意 [`exports` 字段](https://nodejs.org/api/packages.html#packages_exports) 的优先级高于 `mainFields`。如果入口通过 `exports` 解析成功，Rspack 会忽略 `browser`、`module` 和 `main` 字段。
 


### PR DESCRIPTION
## Summary

Correct the English and Chinese package resolution reference to match the defaults selected for each target and dependency type:

- Document all platform conditions enabled by Worker, Electron, and NW.js targets, including that `mode: 'none'` uses the `production` condition.
- Clarify that rearranging `resolve.conditionNames` or the `'...'` placeholder does not change conditional export priority; the package's `exports` key order controls matching.
- Correct `aliasFields` and `mainFields` defaults for Node.js, Electron, CSS `@import`, and URL requests, and state the configuration used by the package entry example.

## Validation

- Executed the current source's `getResolveDefaults`, target handling, and `cleverMerge` functions for 144 combinations: nine targets, four modes, and four dependency types. Checked `conditionNames`, `aliasFields`, and `mainFields` against the documented values.
- Ran 38 builds with `@rspack/core@2.2.3`, then checked 2,020 native resolver results covering package entry fields, browser aliases, conditional exports, CSS, and URL requests. Both positions of `'...'` resolve to the same files; reversing the package's matching `exports` keys changes the selected file.
- Prettier with the repository's `singleQuote` and `heading-case` settings: passed for both changed files.
- CSpell with the website configuration: passed for both changed files.
- `git diff --check`: passed.
- MDX compilation and internal route checks passed for both pages; headings are unchanged.
- The full documentation site build and runtime test suites were not run locally. Verification fixtures are separate and are not included in the PR.

## Related links

- [Resolve defaults](https://github.com/web-infra-dev/rspack/blob/4ebbe71d42/packages/rspack/src/config/defaults.ts#L1268-L1363)
- [Target platform capabilities](https://github.com/web-infra-dev/rspack/blob/4ebbe71d42/packages/rspack/src/config/target.ts#L198-L445)
- [Conditional export matching](https://github.com/web-infra-dev/rspack/blob/4ebbe71d42/crates/rspack_resolver/src/lib.rs#L2163-L2187)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
