### PR TITLE
docs: clarify performance hint defaults and asset filtering

### DIFF
--- a/website/docs/en/config/performance.mdx
+++ b/website/docs/en/config/performance.mdx
@@ -17,6 +17,18 @@ You can define budget thresholds with `maxAssetSize` and `maxEntrypointSize`, an
 
 <PropertyType type="false | object" />
 
+By default, performance hints are enabled in production mode for browser targets, such as `'web'` and `'webworker'`, including mixed browser and Node.js targets. They are disabled when targeting only Node.js, Electron, or NW.js, and in development and none modes.
+
+For example, when `performance` is omitted:
+
+| `mode`                      | `target`                                     | Default `performance`             |
+| --------------------------- | -------------------------------------------- | --------------------------------- |
+| `'production'`              | `'web'` or `'webworker'`                     | An object with `hints: 'warning'` |
+| `'production'`              | `'node'`, `'electron-renderer'`, or `'nwjs'` | `false`                           |
+| `'development'` or `'none'` | `'web'`                                      | `false`                           |
+
+To enable performance hints for a Node.js production build, set `performance: {}`. To enable them in development or none mode, also set `performance.hints` to `'warning'` or `'error'`.
+
 Set `performance` to `false` to disable the performance hints:
 
 ```js title="rspack.config.mjs"
@@ -30,6 +42,8 @@ export default {
 <PropertyType type="(assetFilename: string) => boolean" />
 
 Used to filter which assets are included in performance hint calculations. Files returning `true` are included, and files returning `false` are ignored.
+
+By default, Rspack excludes assets marked as development assets, such as source maps. A custom `assetFilter` replaces this default filter and applies to both individual asset sizes and entrypoint total sizes.
 
 Ignore CSS files when calculating performance hints:
 
@@ -50,6 +64,8 @@ export default {
     { defaultValue: 'false', mode: 'development' },
   ]}
 />
+
+In none mode, `hints` also defaults to `false`. These defaults apply when `performance` is an object. When `performance` is `false`, performance hints are disabled regardless of the mode.
 
 Controls whether performance hints are enabled and which level to use:
 

--- a/website/docs/zh/config/performance.mdx
+++ b/website/docs/zh/config/performance.mdx
@@ -17,6 +17,18 @@ import Attribution from '@components/Attribution';
 
 <PropertyType type="false | object" />
 
+默认情况下，性能提示在 production 模式下为 `'web'`、`'webworker'` 等浏览器目标启用，包括混合浏览器和 Node.js 的目标。目标仅包含 Node.js、Electron 或 NW.js 时，以及 development 和 none 模式下，性能提示默认禁用。
+
+例如，未配置 `performance` 时：
+
+| `mode`                      | `target`                                    | 默认的 `performance`           |
+| --------------------------- | ------------------------------------------- | ------------------------------ |
+| `'production'`              | `'web'` 或 `'webworker'`                    | 包含 `hints: 'warning'` 的对象 |
+| `'production'`              | `'node'`、`'electron-renderer'` 或 `'nwjs'` | `false`                        |
+| `'development'` 或 `'none'` | `'web'`                                     | `false`                        |
+
+如需在 Node.js 的 production 构建中启用性能提示，可设置 `performance: {}`。如需在 development 或 none 模式下启用，还需要将 `performance.hints` 设为 `'warning'` 或 `'error'`。
+
 将 `performance` 设为 `false` 可禁用性能提示功能：
 
 ```js title="rspack.config.mjs"
@@ -30,6 +42,8 @@ export default {
 <PropertyType type="(assetFilename: string) => boolean" />
 
 用于筛选哪些资源会参与性能提示计算。返回 `true` 的文件会被纳入计算，返回 `false` 的文件会被忽略。
+
+默认情况下，Rspack 会排除被标记为开发资源的产物，例如 source map。自定义的 `assetFilter` 会替换默认筛选规则，并同时应用于单个资源体积和入口总体积的计算。
 
 例如在性能提示计算时忽略 CSS 文件：
 
@@ -50,6 +64,8 @@ export default {
     { defaultValue: 'false', mode: 'development' },
   ]}
 />
+
+在 none 模式下，`hints` 也默认为 `false`。这些默认值在 `performance` 为对象时生效。当 `performance` 为 `false` 时，无论使用哪种模式，性能提示都会被禁用。
 
 控制是否启用性能提示，以及提示级别：
 


### PR DESCRIPTION
## Summary

Clarify when Rspack enables performance hints and how assets are included in size calculations in the English and Chinese configuration reference.

- Document the mode and target defaults, including disabled hints for Node.js, Electron, and NW.js targets, and enabled hints for production builds with mixed browser targets.
- Explain how to enable hints explicitly and distinguish `performance: false` from the mode-dependent defaults of `performance.hints`, including `mode: 'none'`.
- Explain that the default asset filter excludes development assets such as source maps, and that a custom filter replaces it for both asset and entrypoint size calculations.

For example, a production Node.js build does not emit performance hints unless `performance` is configured. Setting `performance: {}` enables the default warning thresholds for that build.

## Validation

- Checked the current configuration defaults, target capabilities, and size-limit plugin implementation.
- Verified 72 mode/target/explicit-option combinations with `@rspack/core@2.2.3` on Node.js 24.16.0, including browser/Node/Electron/NW.js targets, mixed targets, omitted mode, and `performance: {}`.
- Ran 7 real compilations covering source maps and development asset metadata, custom filter replacement, asset and entrypoint filtering, explicit disabling, development-mode warnings, and error-level hints.
- Passed Prettier 3.9.6 with the repository's single-quote and heading-case settings, project-configured CSpell, MDX compilation, internal route checks, and `git diff --check` for both changed pages. Headings are unchanged.
- The full documentation site build and runtime test suites were not run locally. Verification fixtures are separate and are not included in the PR.

## Related links

- [Performance configuration defaults](https://github.com/web-infra-dev/rspack/blob/4ebbe71d4228b8b84b65e06e0266746ef1e99d65/packages/rspack/src/config/defaults.ts#L174-L183)
- [Hint defaults](https://github.com/web-infra-dev/rspack/blob/4ebbe71d4228b8b84b65e06e0266746ef1e99d65/packages/rspack/src/config/defaults.ts#L1166-L1174)
- [Asset and entrypoint filtering](https://github.com/web-infra-dev/rspack/blob/4ebbe71d4228b8b84b65e06e0266746ef1e99d65/crates/rspack_plugin_size_limits/src/lib.rs#L33-L65)

## Checklist

- [x] Tests updated (or not required; documentation only).
- [x] Documentation updated (English and Chinese).
