### PR TITLE
refactor: clarify dependency accessors

### DIFF
--- a/crates/rspack_binding_api/src/async_dependency_block.rs
+++ b/crates/rspack_binding_api/src/async_dependency_block.rs
@@ -68,9 +68,10 @@ impl AsyncDependenciesBlock {
   pub fn dependencies(&self) -> napi::Result<Vec<DependencyWrapper>> {
     self.with_ref(|compilation, block| {
       let module_graph = compilation.get_module_graph();
+      // Only expose dependencies that are still present in the current graph.
       Ok(
         block
-          .get_dependencies()
+          .get_dependency_ids()
           .filter_map(|dependency_id| {
             internal::try_dependency_by_id(module_graph, dependency_id)
               .map(|dep| DependencyWrapper::new(dep, compilation.id(), Some(compilation)))

--- a/crates/rspack_binding_api/src/module.rs
+++ b/crates/rspack_binding_api/src/module.rs
@@ -502,7 +502,8 @@ impl Module {
           "Module.dependencies is unavailable while the module graph is under construction (e.g. inside a loader during compilation.rebuildModule)",
         ));
       };
-      let dependencies = module.get_dependencies();
+      // Only expose dependencies that are still present in the current graph.
+      let dependencies = module.get_dependency_ids();
       Ok(
         dependencies
           .filter_map(|dependency_id| {

--- a/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
+++ b/crates/rspack_core/src/compilation/build_chunk_graph/code_splitter.rs
@@ -1235,7 +1235,7 @@ Or do you want to use the entrypoints '{name}' and '{runtime}' independently on 
           continue;
         };
         let root_modules = block
-          .get_dependencies()
+          .get_dependency_ids()
           .filter_map(|dep| module_graph.module_identifier_by_dependency_id(dep))
           .copied()
           .collect::<Vec<_>>();

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/build.rs
@@ -179,11 +179,11 @@ impl Task<TaskContext> for BuildResultTask {
           module_graph.add_block(current_block.clone());
         }
       };
-    handle_block(module.get_dependency_refs(), None);
+    handle_block(module.get_dependencies(), None);
     queue.extend(module.get_block_refs().iter().cloned());
 
     while let Some(block) = queue.pop_front() {
-      handle_block(block.get_dependency_refs(), Some(&block));
+      handle_block(block.get_dependencies(), Some(&block));
       queue.extend(block.get_block_refs().iter().cloned());
     }
 

--- a/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/module_executor/execute.rs
@@ -282,7 +282,7 @@ impl Task<ExecutorTaskContext> for ExecuteTask {
           execute_result.errors.extend(diagnostics);
         }
       }
-      for dep_id in module.get_dependencies() {
+      for dep_id in module.get_dependency_ids() {
         if !has_error && make_failed_dependencies.contains(dep_id) {
           let diagnostics = origin_context
             .artifact

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -812,7 +812,7 @@ impl Module for ConcatenatedModule {
           .expect("should have module");
 
         module
-          .get_dependency_refs()
+          .get_dependencies()
           .iter()
           .filter(|dep| {
             let module_id_of_dep = module_graph.module_identifier_by_dependency_id(dep.id());

--- a/crates/rspack_core/src/context_module.rs
+++ b/crates/rspack_core/src/context_module.rs
@@ -30,8 +30,8 @@ use crate::{
   BuildInfo, BuildMeta, BuildMetaDefaultObject, BuildMetaExportsType, ChunkGraph,
   ChunkGroupOptions, CodeGenerationResultBuilder, Compilation, Context, ContextElementDependency,
   DependenciesBlock, DependenciesBlockData, DependencyCategory, DependencyId, DependencyLocation,
-  DynamicImportMode, ExportsType, FactoryMeta, FakeNamespaceObjectMode, GroupOptions,
-  ImportAttributes, ImportPhase, LibIdentOptions, Module, ModuleArgument,
+  DependencyRef, DynamicImportMode, ExportsType, FactoryMeta, FakeNamespaceObjectMode,
+  GroupOptions, ImportAttributes, ImportPhase, LibIdentOptions, Module, ModuleArgument,
   ModuleCodeGenerationContext, ModuleCodeTemplate, ModuleGraph, ModuleId, ModuleIdsArtifact,
   ModuleLayer, ModuleType, RealDependencyLocation, ReferencedSpecifier, Resolve, RuntimeGlobals,
   RuntimeGlobalsRenderMode, RuntimeSpec, SourceType, contextify, get_exports_type_with_strict,
@@ -480,16 +480,15 @@ impl ContextModule {
     }
   }
 
-  fn get_user_request_map<'a>(
+  fn get_user_request_map(
     &self,
-    dependencies: impl IntoIterator<Item = &'a DependencyId>,
+    dependencies: &[DependencyRef],
     compilation: &Compilation,
   ) -> FxIndexMap<String, Option<String>> {
     let module_graph = compilation.get_module_graph();
-    let dependencies = dependencies.into_iter();
     dependencies
-      .filter_map(|dep_id| {
-        let dependency = module_graph.dependency_by_id(dep_id);
+      .iter()
+      .filter_map(|dependency| {
         let dep = if let Some(d) = dependency.as_module_dependency() {
           Some(d.user_request().to_string())
         } else {
@@ -498,7 +497,7 @@ impl ContextModule {
             .map(|d| d.request().to_string())
         };
         let module_id = module_graph
-          .module_identifier_by_dependency_id(dep_id)
+          .module_identifier_by_dependency_id(dependency.id())
           .and_then(|module| ChunkGraph::get_module_id(&compilation.module_ids_artifact, *module))
           .map(|s| s.to_string());
         // module_id could be None in weak mode
@@ -605,8 +604,7 @@ impl ContextModule {
       .iter()
       .filter_map(|b| {
         let block = module_graph.block_by_id(b)?;
-        let dep = block.get_dependencies().next()?;
-        let dependency = module_graph.dependency_by_id(dep);
+        let dependency = block.get_dependencies().first()?;
         let user_request = dependency
           .as_module_dependency()
           .map(|d| d.user_request().to_string())
@@ -617,7 +615,7 @@ impl ContextModule {
           })?;
         Some(ContextBlockInfo {
           user_request,
-          dep_id: *dep,
+          dep_id: *dependency.id(),
           block_id: block.identifier(),
         })
       })
@@ -669,11 +667,11 @@ impl ContextModule {
         self.get_glob_object_export_source(runtime_template, entries)
       }
       _ => {
-        if self.get_dependency_refs().is_empty() {
+        if self.get_dependencies().is_empty() {
           return self.get_empty_object_export_source(runtime_template);
         }
         let map = self.get_user_request_map(self.get_dependencies(), compilation);
-        let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
+        let fake_map = self.get_fake_map(self.get_dependency_ids(), compilation);
         let return_module_object = self.get_return_module_object_source(
           &fake_map,
           false,
@@ -732,7 +730,7 @@ impl ContextModule {
         }
       }
       ContextMode::Eager => {
-        if !self.get_dependency_refs().is_empty() {
+        if !self.get_dependencies().is_empty() {
           self.get_eager_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
@@ -746,21 +744,21 @@ impl ContextModule {
         }
       }
       ContextMode::AsyncWeak => {
-        if !self.get_dependency_refs().is_empty() {
+        if !self.get_dependencies().is_empty() {
           self.get_async_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_async_context(compilation, runtime_template)
         }
       }
       ContextMode::Weak => {
-        if !self.get_dependency_refs().is_empty() {
+        if !self.get_dependencies().is_empty() {
           self.get_sync_weak_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
         }
       }
       ContextMode::Sync => {
-        if !self.get_dependency_refs().is_empty() {
+        if !self.get_dependencies().is_empty() {
           self.get_sync_source(compilation, runtime_template)
         } else {
           self.get_source_for_empty_context(compilation, runtime_template)
@@ -781,8 +779,8 @@ impl ContextModule {
       .filter_map(|b| module_graph.block_by_id(b));
     let block_and_first_dependency_list = blocks
       .clone()
-      .filter_map(|b| b.get_dependencies().next().map(|d| (b, d)));
-    let first_dependencies = block_and_first_dependency_list.clone().map(|(_, d)| d);
+      .filter_map(|b| b.get_dependencies().first().map(|d| (b, d)));
+    let first_dependencies = block_and_first_dependency_list.clone().map(|(_, d)| d.id());
     let mut has_multiple_or_no_chunks = false;
     let mut has_no_chunk = true;
     let mut has_no_module_deferred = true;
@@ -790,7 +788,7 @@ impl ContextModule {
     let has_fake_map = matches!(fake_map, FakeMapValue::Map(_));
 
     let mut items = block_and_first_dependency_list
-      .filter_map(|(b, d)| {
+      .filter_map(|(b, dependency)| {
         let chunks: Vec<_> = compilation
           .build_chunk_graph_artifact
           .chunk_graph
@@ -816,7 +814,6 @@ impl ContextModule {
         if chunks.len() != 1 {
           has_multiple_or_no_chunks = true;
         }
-        let dependency = compilation.get_module_graph().dependency_by_id(d);
         let user_request = dependency
           .as_module_dependency()
           .map(|d| d.user_request().to_string())
@@ -825,7 +822,7 @@ impl ContextModule {
               .as_context_dependency()
               .map(|d| d.request().to_string())
           })?;
-        let module = module_graph.get_module_by_dependency_id(d)?;
+        let module = module_graph.get_module_by_dependency_id(dependency.id())?;
         let module_id =
           ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())?;
         let async_deps = (self
@@ -990,14 +987,14 @@ impl ContextModule {
     let block = mg.block_by_id_expect(block_id);
     let promise = runtime_template.block_promise(Some(block_id), compilation, "lazy-once context");
     let map = self.get_user_request_map(block.get_dependencies(), compilation);
-    let fake_map = self.get_fake_map(block.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(block.get_dependency_ids(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(block.get_dependencies(), compilation));
+      .then(|| self.get_module_deferred_async_deps_map(block.get_dependency_ids(), compilation));
 
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
@@ -1055,14 +1052,14 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     let map = self.get_user_request_map(self.get_dependencies(), compilation);
-    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependency_ids(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependency_ids(), compilation));
 
     let return_module_object = self.get_return_module_object_source(
       &fake_map,
@@ -1133,7 +1130,7 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     let map = self.get_user_request_map(self.get_dependencies(), compilation);
-    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependency_ids(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, true, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"
@@ -1178,14 +1175,14 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     let map = self.get_user_request_map(self.get_dependencies(), compilation);
-    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependency_ids(), compilation);
     let async_deps_map = self
       .options
       .context_options
       .phase
       .unwrap_or_default()
       .is_defer()
-      .then(|| self.get_module_deferred_async_deps_map(self.get_dependencies(), compilation));
+      .then(|| self.get_module_deferred_async_deps_map(self.get_dependency_ids(), compilation));
     let return_module_object_source = self.get_return_module_object_source(
       &fake_map,
       true,
@@ -1243,7 +1240,7 @@ impl ContextModule {
     runtime_template: &mut ModuleCodeTemplate,
   ) -> String {
     let map = self.get_user_request_map(self.get_dependencies(), compilation);
-    let fake_map = self.get_fake_map(self.get_dependencies(), compilation);
+    let fake_map = self.get_fake_map(self.get_dependency_ids(), compilation);
     let return_module_object =
       self.get_return_module_object_source(&fake_map, false, None, "fakeMap[id]", runtime_template);
     formatdoc! {r#"

--- a/crates/rspack_core/src/dependencies_block.rs
+++ b/crates/rspack_core/src/dependencies_block.rs
@@ -34,11 +34,13 @@ pub trait DependenciesBlock {
     self.dependencies_block_mut().remove_dependency(dependency);
   }
 
-  fn get_dependencies(&self) -> DependencyIds<'_> {
-    DependencyIds(self.get_dependency_refs().iter())
+  /// Returns dependency IDs in insertion order for graph lookups.
+  fn get_dependency_ids(&self) -> DependencyIds<'_> {
+    DependencyIds(self.get_dependencies().iter())
   }
 
-  fn get_dependency_refs(&self) -> &[DependencyRef] {
+  /// Returns the dependency objects owned by this block in insertion order.
+  fn get_dependencies(&self) -> &[DependencyRef] {
     &self.dependencies_block().dependencies
   }
 }
@@ -118,15 +120,14 @@ pub type AsyncDependenciesBlockIdentifierSet =
   std::collections::HashSet<AsyncDependenciesBlockIdentifier, BuildHasherDefault<IdentifierHasher>>;
 
 pub fn dependencies_block_update_hash(
-  deps: DependencyIds<'_>,
+  deps: &[DependencyRef],
   blocks: &[AsyncDependenciesBlockIdentifier],
   hasher: &mut RspackHasher,
   compilation: &Compilation,
   runtime: Option<&RuntimeSpec>,
 ) {
   let mg = compilation.get_module_graph();
-  for dep_id in deps {
-    let dep = mg.dependency_by_id(dep_id);
+  for dep in deps {
     if let Some(dep) = dep.as_dependency_code_generation() {
       dep.update_hash(hasher, compilation, runtime);
     }
@@ -249,7 +250,7 @@ impl AsyncDependenciesBlock {
       group_options: self.group_options.clone(),
       dependencies_block: DependenciesBlockData::new(
         self
-          .get_dependency_refs()
+          .get_dependencies()
           .iter()
           .filter(|value| *value.id() != dependency)
           .cloned()

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -33,7 +33,7 @@ impl TempModule {
       },
       build_meta: m.build_meta().clone(),
       dependencies_block: DependenciesBlockData::new(
-        m.get_dependency_refs()
+        m.get_dependencies()
           .iter()
           .map(|dependency| super::TempDependency::transform_from(dependency.into()).into_owned())
           .collect(),

--- a/crates/rspack_core/src/module_graph/mod.rs
+++ b/crates/rspack_core/src/module_graph/mod.rs
@@ -109,7 +109,7 @@ pub(crate) struct ModuleGraphData {
   /// ```ignore
   /// let parent_module_id = parent_module.identifier();
   /// parent_module
-  ///   .get_dependencies()
+  ///   .get_dependency_ids()
   ///   .map(|dependency_id| {
   ///     let parents_info = module_graph_partial
   ///       .dependency_id_to_parents
@@ -598,7 +598,10 @@ impl ModuleGraph {
 
   /// Get a dependency by ID, panicking if not found.
   ///
-  /// **PREFERRED METHOD**: Use this for ALL internal Rust code including:
+  /// When a module or block is available, prefer [`DependenciesBlock::get_dependencies`]
+  /// to access its dependency objects directly.
+  ///
+  /// **PREFERRED METHOD** when only an ID is available in internal Rust code, including:
   /// - Core compilation logic
   /// - All plugins (`rspack_plugin_*`)
   /// - Stats generation, code generation, runtime templates

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -848,8 +848,7 @@ impl Module for NormalModule {
         }
         module_chain.insert(self.identifier());
         let mut current = ConnectionState::Active(false);
-        for dependency_id in self.get_dependencies() {
-          let dependency = module_graph.dependency_by_id(dependency_id);
+        for dependency in self.get_dependencies() {
           let state = dependency.get_module_evaluation_side_effects_state(
             module_graph,
             module_graph_cache,

--- a/crates/rspack_core/src/runtime_template.rs
+++ b/crates/rspack_core/src/runtime_template.rs
@@ -1805,7 +1805,7 @@ return {}
       .block_by_id(block_id)
       .expect("should have block");
     let dep = block
-      .get_dependencies()
+      .get_dependency_ids()
       .next()
       .expect("should have dependency");
     let ensure_chunk = self.block_promise(Some(block_id), compilation, "");

--- a/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
+++ b/crates/rspack_plugin_css/src/dependency/icss_symbol.rs
@@ -122,14 +122,13 @@ fn resolve_icss_import(
   request: &str,
 ) -> Option<String> {
   let module_graph = compilation.get_module_graph();
-  let imported_module = module.get_dependencies().find_map(|id| {
-    let dependency = module_graph.dependency_by_id(id);
+  let imported_module = module.get_dependencies().iter().find_map(|dependency| {
     let dependency_request = dependency
       .as_module_dependency()
       .map(|d| d.request())
       .or_else(|| dependency.as_context_dependency().map(|d| d.request()));
     if dependency_request == Some(request) {
-      module_graph.module_graph_module_by_dependency_id(id)
+      module_graph.module_graph_module_by_dependency_id(dependency.id())
     } else {
       None
     }

--- a/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/generator.rs
@@ -295,10 +295,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       runtime_template: self.generate_context.runtime_template,
     };
 
-    let module_graph = compilation.get_module_graph();
-    self.module.get_dependencies().for_each(|id| {
-      let dep = module_graph.dependency_by_id(id);
-
+    self.module.get_dependencies().iter().for_each(|dep| {
       if let Some(dependency) = dep.as_dependency_code_generation() {
         render_dependency_template(dependency, &mut source, &mut context);
       }
@@ -316,11 +313,11 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
   }
 
   fn css_text_expr_with_imports(&mut self) -> String {
-    let module_graph = self.generate_context.compilation.get_module_graph();
-    let has_css_imports = self.module.get_dependencies().any(|dependency_id| {
-      let dependency = module_graph.dependency_by_id(dependency_id);
-      matches!(dependency.dependency_type(), DependencyType::CssImport)
-    });
+    let has_css_imports = self
+      .module
+      .get_dependencies()
+      .iter()
+      .any(|dependency| matches!(dependency.dependency_type(), DependencyType::CssImport));
     if !has_css_imports {
       let css_source = self.render_css_module_source();
       return self.css_text_expr(css_source, &[]);
@@ -392,8 +389,8 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     self
       .module
       .get_dependencies()
-      .filter_map(move |dependency_id| {
-        let dependency = module_graph.dependency_by_id(dependency_id);
+      .iter()
+      .filter_map(move |dependency| {
         if !matches!(dependency.dependency_type(), DependencyType::CssImport) {
           return None;
         }
@@ -402,7 +399,7 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
             "dependency with type DependencyType::CssImport should only be CssImportDependency"
           );
         };
-        let imported_module = module_graph.module_graph_module_by_dependency_id(dependency_id)?;
+        let imported_module = module_graph.module_graph_module_by_dependency_id(dependency.id())?;
 
         Some(CssImportedModule {
           module_identifier: imported_module.module_identifier,
@@ -790,13 +787,12 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
     let from = id
       .and_then(find_target_module)
       .or_else(|| {
-        self.module.get_dependencies().find_map(|id| {
-          let dependency = module_graph.dependency_by_id(id);
-          let request = dependency_request(dependency);
+        self.module.get_dependencies().iter().find_map(|dependency| {
+          let request = dependency_request(dependency.as_ref());
           if let Some(request) = request
             && request == from_name
           {
-            return find_target_module(id);
+            return find_target_module(dependency.id());
           }
           None
         })
@@ -805,10 +801,8 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
         let dependency_requests = self
           .module
           .get_dependencies()
-          .filter_map(|id| {
-            let dependency = module_graph.dependency_by_id(id);
-            dependency_request(dependency)
-          })
+          .iter()
+          .filter_map(|dependency| dependency_request(dependency.as_ref()))
           .collect::<Vec<_>>();
         panic!(
           "should have css from module: ident={ident}, from={from_name}, id={id:?}, dependency_requests={dependency_requests:?}"
@@ -897,11 +891,9 @@ impl<'a, 'g> CssModuleGenerator<'a, 'g> {
       .or_else(|| {
         module
           .get_dependencies()
-          .filter(|dep_id| {
-            let dependency = module_graph.dependency_by_id(dep_id);
-            dependency_request(dependency) == Some(from_name)
-          })
-          .filter_map(find_target_module)
+          .iter()
+          .filter(|dependency| dependency_request(dependency.as_ref()) == Some(from_name))
+          .filter_map(|dependency| find_target_module(dependency.id()))
           .max_by_key(|(_, priority)| *priority)
       })
       .map(|(target, _)| target)
@@ -1164,12 +1156,11 @@ fn find_static_export_target(
       .map(|module| module.identifier())
   })
   .or_else(|| {
-    module.get_dependencies().find_map(|id| {
-      let dependency = module_graph.dependency_by_id(id);
-      let request = dependency_request(dependency);
+    module.get_dependencies().iter().find_map(|dependency| {
+      let request = dependency_request(dependency.as_ref());
       (request == Some(from_request)).then(|| {
         module_graph
-          .get_module_by_dependency_id(id)
+          .get_module_by_dependency_id(dependency.id())
           .map(|module| module.identifier())
       })?
     })

--- a/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
+++ b/crates/rspack_plugin_dll/src/dll_reference/delegated_module.rs
@@ -129,12 +129,11 @@ impl Module for DelegatedModule {
 
     let dep = self
       .get_dependencies()
-      .next()
+      .first()
       .expect("should have source dependency");
     let mg = compilation.get_module_graph();
-    let source_module = mg.get_module_by_dependency_id(dep);
-    let dependency = mg
-      .dependency_by_id(dep)
+    let source_module = mg.get_module_by_dependency_id(dep.id());
+    let dependency = dep
       .downcast_ref::<DelegatedSourceDependency>()
       .expect("Should be module dependency");
 
@@ -143,7 +142,7 @@ impl Module for DelegatedModule {
         let mut s = format!(
           "{}.exports = ({})",
           runtime_template.render_module_argument(ModuleArgument::Module),
-          runtime_template.module_raw(compilation, dep, dependency.request(), false,)
+          runtime_template.module_raw(compilation, dep.id(), dependency.request(), false,)
         );
 
         let request = json_stringify(

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -1574,7 +1574,7 @@ var {} = {{}};
     };
 
     for dep in module.get_dependencies() {
-      let Some(conn) = module_graph.connection_by_dependency_id(dep) else {
+      let Some(conn) = module_graph.connection_by_dependency_id(dep.id()) else {
         continue;
       };
 
@@ -1588,7 +1588,6 @@ var {} = {{}};
         continue;
       }
 
-      let dep = module_graph.dependency_by_id(dep);
       if let Some(dep) = dep.downcast_ref::<ESMExportImportedSpecifierDependency>()
         && dep.name.is_none()
       {
@@ -2546,10 +2545,8 @@ var {} = {{}};
         // eg.
         // import './foo.cjs'
         // should be rendered as __rspack_require('./foo.cjs')
-        for dep_id in module.get_dependencies() {
-          let dep = module_graph.dependency_by_id(dep_id);
-
-          let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
+        for dep in module.get_dependencies() {
+          let Some(conn) = module_graph.connection_by_dependency_id(dep.id()) else {
             continue;
           };
 
@@ -2747,7 +2744,7 @@ var {} = {{}};
         let module = module_graph
           .module_by_identifier(m)
           .expect("should have module");
-        for dep_id in module.get_dependencies() {
+        for dep_id in module.get_dependency_ids() {
           let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
             continue;
           };

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -48,12 +48,11 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
       let Some(block) = module_graph.block_by_id(block_id) else {
         continue;
       };
-      for dep_id in block.get_dependencies() {
-        let dep = module_graph.dependency_by_id(dep_id);
+      for dep in block.get_dependencies() {
         if dep.dependency_type() != &DependencyType::DynamicImport {
           continue;
         }
-        let Some(target) = module_graph.module_identifier_by_dependency_id(dep_id) else {
+        let Some(target) = module_graph.module_identifier_by_dependency_id(dep.id()) else {
           continue;
         };
         if target == module_id {
@@ -574,19 +573,18 @@ pub(crate) fn analyze_dyn_import_targets(
     if !concatenated_modules.contains(module_id) {
       continue;
     }
-    for dep_id in module
+    for dep in module
       .get_blocks()
       .iter()
       .filter_map(|block| module_graph.block_by_id(block))
       .flat_map(|block| block.get_dependencies())
     {
-      let dep = module_graph.dependency_by_id(dep_id);
       if dep.dependency_type() != &DependencyType::DynamicImport {
         continue;
       }
       let exports_info_artifact = &compilation.exports_info_artifact;
 
-      let Some(conn) = module_graph.connection_by_dependency_id(dep_id) else {
+      let Some(conn) = module_graph.connection_by_dependency_id(dep.id()) else {
         continue;
       };
       if !conn.is_target_active(

--- a/crates/rspack_plugin_esm_library/src/split_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/split_chunks.rs
@@ -127,7 +127,7 @@ fn get_module_deps(module: ModuleIdentifier, module_graph: &ModuleGraph) -> Vec<
   module_graph
     .module_by_identifier(&module)
     .expect("should have module")
-    .get_dependencies()
+    .get_dependency_ids()
     .filter_map(|dep_id| module_graph.module_identifier_by_dependency_id(dep_id))
     .copied()
     .collect()

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -11,7 +11,7 @@ use rspack_cacheable::{
 use rspack_core::{
   ArcComputed, AsyncDependenciesBlockIdentifier, BuildMetaExportsType,
   COLLECTED_TYPESCRIPT_INFO_PARSE_META_KEY, ChunkGraph, CollectedTypeScriptInfo, Compilation,
-  DependenciesBlock, DependencyId, GenerateContext, ImportMeta, Module, ModuleArgument,
+  DependenciesBlock, Dependency, GenerateContext, ImportMeta, Module, ModuleArgument,
   ModuleCodeTemplate, ModuleGraph, ModuleType, ParseContext, ParseResult, ParserAndGenerator,
   ResolvedModuleOptions, RuntimeGlobals, RuntimeGlobalsRenderMode, RuntimeVariable,
   SideEffectsBailoutItem, SourceType, TemplateContext, TemplateReplaceSource,
@@ -184,8 +184,8 @@ impl JavaScriptParserAndGenerator {
       .block_by_id(block_id)
       .expect("should have block");
     //    let block = block_id.expect_get(compilation);
-    block.get_dependencies().for_each(|dependency_id| {
-      self.source_dependency(compilation, dependency_id, source, context)
+    block.get_dependencies().iter().for_each(|dependency| {
+      self.source_dependency(compilation, dependency.as_ref(), source, context)
     });
     block
       .get_blocks()
@@ -196,15 +196,11 @@ impl JavaScriptParserAndGenerator {
   fn source_dependency(
     &self,
     compilation: &Compilation,
-    dependency_id: &DependencyId,
+    dependency: &dyn Dependency,
     source: &mut TemplateReplaceSource,
     context: &mut TemplateContext,
   ) {
-    if let Some(dependency) = compilation
-      .get_module_graph()
-      .dependency_by_id(dependency_id)
-      .as_dependency_code_generation()
-    {
+    if let Some(dependency) = dependency.as_dependency_code_generation() {
       if let Some(template) = dependency
         .dependency_template()
         .and_then(|template_type| compilation.get_dependency_template(template_type))
@@ -439,8 +435,8 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
         runtime_template: generate_context.runtime_template,
       };
 
-      module.get_dependencies().for_each(|dependency_id| {
-        self.source_dependency(compilation, dependency_id, &mut source, &mut context)
+      module.get_dependencies().iter().for_each(|dependency| {
+        self.source_dependency(compilation, dependency.as_ref(), &mut source, &mut context)
       });
 
       if let Some(dependencies) = module.get_presentational_dependencies() {

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -689,13 +689,13 @@ fn collect_active_dependencies(
         let block = module_graph
           .module_by_identifier(&module)
           .expect("should have module");
-        (block.get_blocks(), block.get_dependencies())
+        (block.get_blocks(), block.get_dependency_ids())
       }
       ModuleOrAsyncDependenciesBlock::AsyncDependenciesBlock(async_dependencies_block_id) => {
         let block = module_graph
           .block_by_id(&async_dependencies_block_id)
           .expect("should have module");
-        (block.get_blocks(), block.get_dependencies())
+        (block.get_blocks(), block.get_dependency_ids())
       }
     };
     for &dep_id in block_dependencies {

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -1151,12 +1151,12 @@ impl ModuleConcatenationPlugin {
 
         let connections = module
           .get_dependencies()
-          .filter_map(|d| {
-            let dep = module_graph.dependency_by_id(d);
-            if !is_esm_dep_like(dep) {
+          .iter()
+          .filter_map(|dep| {
+            if !is_esm_dep_like(dep.as_ref()) {
               return None;
             }
-            let con = module_graph.connection_by_dependency_id(d)?;
+            let con = module_graph.connection_by_dependency_id(dep.id())?;
             let module_dep = dep.as_module_dependency().expect("should be module dep");
             let imported_names = module_dep.get_referenced_exports(
               module_graph,

--- a/crates/rspack_plugin_lazy_compilation/src/module.rs
+++ b/crates/rspack_plugin_lazy_compilation/src/module.rs
@@ -248,7 +248,7 @@ impl Module for LazyCompilationProxyModule {
     } = code_generation_context;
 
     let client_dep_id = self
-      .get_dependencies()
+      .get_dependency_ids()
       .next()
       .expect("should have client dependency");
     let module_graph = &compilation.get_module_graph();
@@ -280,7 +280,7 @@ impl Module for LazyCompilationProxyModule {
         .expect("should have block");
 
       let dep_id = block
-        .get_dependencies()
+        .get_dependency_ids()
         .next()
         .expect("should have dependency");
       let module = module_graph

--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -247,17 +247,16 @@ impl Module for ContainerEntryModule {
     let runtime_argument = require_name.clone();
 
     if self.dependency_type == DependencyType::ShareContainerEntry {
-      let module_graph = compilation.get_module_graph();
       let mut factory = String::new();
-      for dependency_id in self.get_dependencies() {
-        let dependency = module_graph.dependency_by_id(dependency_id);
+      for dependency in self.get_dependencies() {
         if let Some(dependency) = dependency
           .as_any()
           .downcast_ref::<ContainerExposedDependency>()
           && *dependency.dependency_type() == DependencyType::ShareContainerFallback
         {
           let request: &str = dependency.user_request();
-          let module_expr = runtime_template.module_raw(compilation, dependency_id, request, false);
+          let module_expr =
+            runtime_template.module_raw(compilation, dependency.id(), request, false);
           factory = runtime_template.returning_function(&module_expr, "");
         }
       }
@@ -468,15 +467,14 @@ impl ExposeModuleMap {
       let block = module_graph
         .block_by_id(block_id)
         .expect("should have block");
-      let modules_iter = block.get_dependencies().map(|dependency_id| {
-        let dep = module_graph.dependency_by_id(dependency_id);
+      let modules_iter = block.get_dependencies().iter().map(|dep| {
         let dep = dep
           .downcast_ref::<ContainerExposedDependency>()
           .expect("dependencies of ContainerEntryModule should be ContainerExposedDependency");
         let name = dep.exposed_name.as_str();
-        let module = module_graph.get_module_by_dependency_id(dependency_id);
+        let module = module_graph.get_module_by_dependency_id(dep.id());
         let user_request = dep.user_request();
-        (name, module, user_request, dependency_id)
+        (name, module, user_request, dep.id())
       });
       let name = modules_iter.clone().next().expect("should have item").0;
       let str = if modules_iter

--- a/crates/rspack_plugin_mf/src/container/fallback_module.rs
+++ b/crates/rspack_plugin_mf/src/container/fallback_module.rs
@@ -149,7 +149,7 @@ impl Module for FallbackModule {
     let mut codegen = CodeGenerationResultBuilder::default();
     let module_graph = compilation.get_module_graph();
     let ids: Vec<_> = self
-      .get_dependencies()
+      .get_dependency_ids()
       .filter_map(|dep| module_graph.get_module_by_dependency_id(dep))
       .filter_map(|module| {
         ChunkGraph::get_module_id(&compilation.module_ids_artifact, module.identifier())

--- a/crates/rspack_plugin_mf/src/container/remote_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_module.rs
@@ -192,7 +192,7 @@ impl Module for RemoteModule {
     let module_graph = code_generation_context.compilation.get_module_graph();
     let module = module_graph.get_module_by_dependency_id(
       self
-        .get_dependencies()
+        .get_dependency_ids()
         .next()
         .expect("should have external dependency"),
     );

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -99,7 +99,7 @@ impl RuntimeModule for RemoteRuntimeModule {
           ShareScope::Multiple(v) => ShareScopeField::Multiple(v.as_slice()),
         };
         let dep = m
-          .get_dependencies()
+          .get_dependency_ids()
           .next()
           .expect("should have external dependency");
         let external_module = module_graph

--- a/crates/rspack_plugin_mf/src/sharing/collect_shared_entry_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/collect_shared_entry_plugin.rs
@@ -140,7 +140,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
         (
           key,
           consume.share_scope().clone(),
-          consume.get_dependencies(),
+          consume.get_dependency_ids(),
           consume.get_blocks(),
           None,
         )
@@ -155,7 +155,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
         (
           provide.share_key().to_string(),
           provide.share_scope().clone(),
-          provide.get_dependencies(),
+          provide.get_dependency_ids(),
           provide.get_blocks(),
           provide.version().map(str::to_string),
         )
@@ -177,7 +177,7 @@ async fn finish_make(&self, compilation: &mut Compilation) -> Result<()> {
     }
     for block_id in blocks {
       if let Some(block) = module_graph.block_by_id(block_id) {
-        for dep_id in block.get_dependencies() {
+        for dep_id in block.get_dependency_ids() {
           if let Some(target_id) = module_graph.module_identifier_by_dependency_id(dep_id) {
             target_modules.push(*target_id);
           }

--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -217,7 +217,7 @@ impl Module for ConsumeSharedModule {
       if self.options.eager {
         runtime_template.sync_module_factory(
           self
-            .get_dependencies()
+            .get_dependency_ids()
             .next()
             .expect("should have fallback dependency"),
           fallback,

--- a/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/provide_shared_module.rs
@@ -189,7 +189,7 @@ impl Module for ProvideSharedModule {
     let factory = if self.eager {
       runtime_template.sync_module_factory(
         self
-          .get_dependencies()
+          .get_dependency_ids()
           .next()
           .expect("should have shared dependency"),
         &self.request,

--- a/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
+++ b/crates/rspack_plugin_mf/src/sharing/shared_used_exports_optimizer_plugin.rs
@@ -113,7 +113,7 @@ fn collect_processed_modules<'a>(
 
   for block_id in module_blocks {
     if let Some(block) = module_graph.block_by_id(block_id) {
-      for dep_id in block.get_dependencies() {
+      for dep_id in block.get_dependency_ids() {
         if let Some(target_id) = module_graph.module_identifier_by_dependency_id(dep_id) {
           out.push(*target_id);
         }
@@ -176,7 +176,7 @@ async fn optimize_dependencies(
             collect_processed_modules(
               module_graph,
               consume_shared_module.get_blocks(),
-              consume_shared_module.get_dependencies(),
+              consume_shared_module.get_dependency_ids(),
               &mut modules_to_process,
             );
             sk
@@ -187,7 +187,7 @@ async fn optimize_dependencies(
             collect_processed_modules(
               module_graph,
               provide_shared_module.get_blocks(),
-              provide_shared_module.get_dependencies(),
+              provide_shared_module.get_dependency_ids(),
               &mut modules_to_process,
             );
             sk
@@ -199,7 +199,7 @@ async fn optimize_dependencies(
             collect_processed_modules(
               module_graph,
               share_container_entry_module.get_blocks(),
-              share_container_entry_module.get_dependencies(),
+              share_container_entry_module.get_dependency_ids(),
               &mut modules_to_process,
             );
             sk

--- a/crates/rspack_plugin_rsc/src/client_plugin.rs
+++ b/crates/rspack_plugin_rsc/src/client_plugin.rs
@@ -163,7 +163,7 @@ fn collect_css_files_from_block_modules(
   };
 
   block
-    .get_dependencies()
+    .get_dependency_ids()
     .filter_map(|dependency_id| module_graph.connection_by_dependency_id(dependency_id))
     .filter_map(|connection| chunk_graph.try_get_module_chunks(connection.module_identifier()))
     .flat_map(|chunk_ukeys| collect_css_files_from_chunks(module_loading, chunk_ukeys, compilation))
@@ -539,7 +539,7 @@ impl RscClientPlugin {
           let Some(block) = module_graph.block_by_id(block_id) else {
             continue;
           };
-          for dep_id in block.get_dependencies() {
+          for dep_id in block.get_dependency_ids() {
             if let Some(conn) = module_graph.connection_by_dependency_id(dep_id) {
               client_entry_modules.insert(*conn.module_identifier());
             }

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -33,8 +33,8 @@ pub fn cutout_star_re_export_externals(
     let mut side_effects_deps_by_module = IdentifierMap::<Vec<DependencyId>>::default();
     let mut star_export_deps_by_module = IdentifierMap::default();
 
-    for dep_id in module.get_dependencies() {
-      let dep = mg.dependency_by_id(dep_id);
+    for dep in module.get_dependencies() {
+      let dep_id = dep.id();
       let Some(module) = mg
         .module_identifier_by_dependency_id(dep_id)
         .and_then(|module_id| mg.module_by_identifier(module_id))
@@ -101,12 +101,11 @@ pub fn cutout_star_re_export_externals(
       exports_info.other_exports_info().provided(),
       Some(rspack_core::ExportProvided::Unknown)
     ) {
-      let has_unknown_exports = module.get_dependencies().any(|dep_id| {
-        if connections_to_disable.contains(dep_id) {
+      let has_unknown_exports = module.get_dependencies().iter().any(|dep| {
+        if connections_to_disable.contains(dep.id()) {
           return false;
         }
 
-        let dep = mg.dependency_by_id(dep_id);
         let Some(exports) = dep.get_exports(
           mg,
           &compilation.module_graph_cache_artifact,
@@ -144,8 +143,8 @@ pub fn cutout_dyn_import_externals(
       let Some(block) = mg.block_by_id(block_id) else {
         continue;
       };
-      for block_dep_id in block.get_dependencies() {
-        let block_dep = mg.dependency_by_id(block_dep_id);
+      for block_dep in block.get_dependencies() {
+        let block_dep_id = block_dep.id();
         if block_dep.as_any().is::<ImportDependency>() {
           let import_dep_connection = mg.connection_by_dependency_id(block_dep_id);
           if let Some(import_dep_connection) = import_dep_connection {

--- a/crates/rspack_plugin_rslib/src/worker_external.rs
+++ b/crates/rspack_plugin_rslib/src/worker_external.rs
@@ -36,13 +36,12 @@ pub fn cutout_worker_externals(
       let Some(block) = mg.block_by_id(block_id) else {
         continue;
       };
-      for block_dep_id in block.get_dependencies() {
-        let dependency = mg.dependency_by_id(block_dep_id);
+      for dependency in block.get_dependencies() {
         if !dependency.as_any().is::<WorkerDependency>() {
           continue;
         }
 
-        let Some(connection) = mg.connection_by_dependency_id(block_dep_id) else {
+        let Some(connection) = mg.connection_by_dependency_id(dependency.id()) else {
           continue;
         };
         let Some(module) = mg.module_by_identifier(connection.module_identifier()) else {
@@ -53,7 +52,7 @@ pub fn cutout_worker_externals(
         };
 
         if should_cutout_worker_external(cutout_all_externals, output_module, external_module) {
-          connections_to_disable.push(*block_dep_id);
+          connections_to_disable.push(*dependency.id());
         }
       }
     }

--- a/crates/rspack_plugin_wasm/src/parser_and_generator.rs
+++ b/crates/rspack_plugin_wasm/src/parser_and_generator.rs
@@ -236,7 +236,7 @@ impl ParserAndGenerator for AsyncWasmParserAndGenerator {
 
         module
           .get_dependencies()
-          .map(|id| module_graph.dependency_by_id(id))
+          .iter()
           .filter(|dep| dep.dependency_type() == &DependencyType::WasmImport)
           .map(|dep| {
             (

--- a/crates/rspack_tools/src/compare/occasion/make.rs
+++ b/crates/rspack_tools/src/compare/occasion/make.rs
@@ -198,11 +198,8 @@ impl<'a> ArtifactComparator<'a> {
     }
 
     // Compare each dependency by type in order and build mapping
-    for (i, (dep_id1, dep_id2)) in deps1.zip(deps2).enumerate() {
+    for (i, (dep1, dep2)) in deps1.iter().zip(deps2).enumerate() {
       let dep_debug_info = debug_info.with_field("dependency_index", &i.to_string());
-
-      let dep1 = self.mg1.dependency_by_id(dep_id1);
-      let dep2 = self.mg2.dependency_by_id(dep_id2);
 
       // Compare dependency types
       let type1 = dep1.dependency_type();
@@ -219,7 +216,7 @@ impl<'a> ArtifactComparator<'a> {
       }
 
       // Build mapping: dep_id1 -> dep_id2
-      dep_id_map.insert(*dep_id1, *dep_id2);
+      dep_id_map.insert(*dep1.id(), *dep2.id());
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

Rename `get_dependencies` to `get_dependency_ids` and `get_dependency_refs` to `get_dependencies`. Use dependency objects directly for data reads, and IDs for graph lookups and binding filtering.