### PR TITLE
docs: clarify resolve and performance configuration examples

### DIFF
--- a/website/docs/en/config/performance.mdx
+++ b/website/docs/en/config/performance.mdx
@@ -17,15 +17,15 @@ You can define budget thresholds with `maxAssetSize` and `maxEntrypointSize`, an
 
 <PropertyType type="false | object" />
 
-By default, performance hints are enabled in production mode for browser targets, such as `'web'` and `'webworker'`, including mixed browser and Node.js targets. They are disabled when targeting only Node.js, Electron, or NW.js, and in development and none modes.
+By default, performance hints are enabled only in production mode for browser targets.
 
 For example, when `performance` is omitted:
 
-| `mode`                      | `target`                                     | Default `performance`             |
-| --------------------------- | -------------------------------------------- | --------------------------------- |
-| `'production'`              | `'web'` or `'webworker'`                     | An object with `hints: 'warning'` |
-| `'production'`              | `'node'`, `'electron-renderer'`, or `'nwjs'` | `false`                           |
-| `'development'` or `'none'` | `'web'`                                      | `false`                           |
+| `mode`                      | `target`                 | Default `performance`  |
+| --------------------------- | ------------------------ | ---------------------- |
+| `'production'`              | `'web'` or `'webworker'` | `{ hints: 'warning' }` |
+| `'production'`              | `'node'`                 | `false`                |
+| `'development'` or `'none'` | `'web'`                  | `false`                |
 
 To enable performance hints for a Node.js production build, set `performance: {}`. To enable them in development or none mode, also set `performance.hints` to `'warning'` or `'error'`.
 

--- a/website/docs/en/config/resolve.mdx
+++ b/website/docs/en/config/resolve.mdx
@@ -89,11 +89,39 @@ export default {
 ## resolve.aliasFields
 
 - **Type:** `string[]`
-- **Default:** Depends on [target](/config/target) and [dependency type](#resolvebydependency).
+- **Default:** Depends on [target](/config/target) and [how modules are referenced](#resolvebydependency).
 
-Define a field, such as `browser`, that should be parsed in accordance with [this specification](https://github.com/defunctzombie/package-browser-field-spec).
+Specifies which `package.json` fields provide module aliases for replacing modules with alternative implementations.
 
-For typical JavaScript requests, the default is `['browser']` when targeting the web, web workers, or Electron renderers. For Node.js, Electron main and preload scripts, and NW.js, it is `[]`. CSS `@import` and URL requests use `[]` by default.
+Common defaults are:
+
+| Scenario                                          | Default       |
+| ------------------------------------------------- | ------------- |
+| Module imports targeting `'web'` or `'webworker'` | `['browser']` |
+| Module imports targeting Node.js                  | `[]`          |
+| CSS `@import` or URL references                   | `[]`          |
+
+For example, this configuration uses the alias mappings in the `browser` field to replace modules with browser implementations provided by the package. The mappings follow the [browser field specification](https://github.com/defunctzombie/package-browser-field-spec).
+
+```js title="rspack.config.mjs"
+export default {
+  resolve: {
+    aliasFields: ['browser'],
+  },
+};
+```
+
+For example, a package's `package.json` contains this mapping:
+
+```json title="package.json"
+{
+  "browser": {
+    "./storage.js": "./storage.browser.js"
+  }
+}
+```
+
+With the configuration above, `import './storage.js'` in the package's root-level `index.js` resolves to `storage.browser.js` in the same directory.
 
 ## resolve.byDependency
 
@@ -201,7 +229,7 @@ Rspack's default `conditionNames` are determined by [mode](/config/mode), [targe
 
 Here, `modeCondition` is `'development'` in development mode and `'production'` otherwise, including when `mode` is `'none'`.
 
-`targetConditions` are derived from the target's platform capabilities. A target can enable several conditions:
+`targetConditions` depend on the target:
 
 | Target                                      | `targetConditions`                |
 | ------------------------------------------- | --------------------------------- |
@@ -270,15 +298,7 @@ export default {
 };
 ```
 
-You can also place `'...'` before the custom condition. Both configurations enable the same conditions; changing their order does not change resolution priority. Priority is determined by the key order in the package's `exports` object.
-
-```js title="rspack.config.mjs"
-export default {
-  resolve: {
-    conditionNames: ['...', 'my-custom-condition'],
-  },
-};
-```
+The order of `conditionNames`, including the position of `'...'`, does not affect priority; the package's `exports` key order determines matching priority.
 
 ## resolve.descriptionFiles
 
@@ -532,7 +552,7 @@ When this configuration is `["testImports", "imports"]`, the result of `import v
 
 Controls the priority of fields in a package.json used to locate a package's entry file. It is the ordered list of package.json fields Rspack will try when resolving an npm package's entry point.
 
-For typical JavaScript requests, the default is `["browser", "module", "main"]` when targeting the web, web workers, or Electron renderers.
+For JavaScript requests targeting `'web'` or `'webworker'`, the default is `["browser", "module", "main"]`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -542,7 +562,7 @@ export default {
 };
 ```
 
-For Node.js, Electron main and preload scripts, and NW.js, the default for JavaScript requests is `["module", "main"]`.
+For Node.js, the default for JavaScript requests is `["module", "main"]`.
 
 ```js title="rspack.config.mjs"
 export default {
@@ -552,7 +572,7 @@ export default {
 };
 ```
 
-CSS `@import` requests use `["style", "main"]` by default. URL requests use the top-level default, `["main"]`. Rspack combines top-level resolve options with the matching [resolve.byDependency](#resolvebydependency) options for each request.
+CSS `@import` requests default to `["style", "main"]`; URL requests default to `["main"]`. Use [resolve.byDependency](#resolvebydependency) to configure these separately.
 
 For example, consider an arbitrary library called `foo` with a `package.json` that contains the following fields:
 

--- a/website/docs/zh/config/performance.mdx
+++ b/website/docs/zh/config/performance.mdx
@@ -17,15 +17,15 @@ import Attribution from '@components/Attribution';
 
 <PropertyType type="false | object" />
 
-默认情况下，性能提示在 production 模式下为 `'web'`、`'webworker'` 等浏览器目标启用，包括混合浏览器和 Node.js 的目标。目标仅包含 Node.js、Electron 或 NW.js 时，以及 development 和 none 模式下，性能提示默认禁用。
+默认情况下，性能提示仅在 production 模式下为浏览器目标启用。
 
 例如，未配置 `performance` 时：
 
-| `mode`                      | `target`                                    | 默认的 `performance`           |
-| --------------------------- | ------------------------------------------- | ------------------------------ |
-| `'production'`              | `'web'` 或 `'webworker'`                    | 包含 `hints: 'warning'` 的对象 |
-| `'production'`              | `'node'`、`'electron-renderer'` 或 `'nwjs'` | `false`                        |
-| `'development'` 或 `'none'` | `'web'`                                     | `false`                        |
+| `mode`                      | `target`                 | 默认的 `performance`   |
+| --------------------------- | ------------------------ | ---------------------- |
+| `'production'`              | `'web'` 或 `'webworker'` | `{ hints: 'warning' }` |
+| `'production'`              | `'node'`                 | `false`                |
+| `'development'` 或 `'none'` | `'web'`                  | `false`                |
 
 如需在 Node.js 的 production 构建中启用性能提示，可设置 `performance: {}`。如需在 development 或 none 模式下启用，还需要将 `performance.hints` 设为 `'warning'` 或 `'error'`。
 

--- a/website/docs/zh/config/resolve.mdx
+++ b/website/docs/zh/config/resolve.mdx
@@ -89,11 +89,39 @@ export default {
 ## resolve.aliasFields
 
 - **类型：** `string[]`
-- **默认值：** 取决于 [target](/config/target) 和[依赖类型](#resolvebydependency)。
+- **默认值：** 取决于 [target](/config/target) 和[模块引用方式](#resolvebydependency)。
 
-定义一个字段，例如 `browser`，以依照[此规范](https://github.com/defunctzombie/package-browser-field-spec)进行解析。
+指定从 `package.json` 的哪些字段读取模块别名，用于将模块替换为其他实现。
 
-对于常见的 JavaScript 请求，以 Web、Web Worker 或 Electron 渲染进程为目标时，默认值为 `['browser']`。以 Node.js、Electron 主进程和预加载脚本、NW.js 为目标时，默认值为 `[]`。CSS `@import` 和 URL 请求的默认值为 `[]`。
+常见默认值如下：
+
+| 场景                                      | 默认值        |
+| ----------------------------------------- | ------------- |
+| 模块导入，目标为 `'web'` 或 `'webworker'` | `['browser']` |
+| 模块导入，目标为 Node.js                  | `[]`          |
+| CSS `@import` 或 URL 引用                 | `[]`          |
+
+例如，下面的配置会使用 `browser` 字段中的别名映射，将模块替换为包提供的浏览器版本。映射规则遵循 [browser 字段规范](https://github.com/defunctzombie/package-browser-field-spec)。
+
+```js title="rspack.config.mjs"
+export default {
+  resolve: {
+    aliasFields: ['browser'],
+  },
+};
+```
+
+例如，某个包的 `package.json` 包含以下映射：
+
+```json title="package.json"
+{
+  "browser": {
+    "./storage.js": "./storage.browser.js"
+  }
+}
+```
+
+使用上述配置时，该包根目录下的 `index.js` 中的 `import './storage.js'` 会解析到同一目录下的 `storage.browser.js`。
 
 ## resolve.byDependency
 
@@ -201,7 +229,7 @@ Rspack 默认的 `conditionNames` 由 [mode](/config/mode)、[target](/config/ta
 
 其中，`modeCondition` 在开发模式下为 `'development'`，其他情况下为 `'production'`，包括 `mode` 为 `'none'` 时。
 
-`targetConditions` 由目标平台的能力决定，一个目标可以启用多个条件：
+`targetConditions` 取决于目标：
 
 | Target                                      | `targetConditions`                |
 | ------------------------------------------- | --------------------------------- |
@@ -270,15 +298,7 @@ export default {
 };
 ```
 
-也可以将 `'...'` 放在自定义条件之前。两种配置启用的条件相同，调整它们的顺序不会改变解析优先级。优先级由包的 `exports` 对象中键的顺序决定。
-
-```js title="rspack.config.mjs"
-export default {
-  resolve: {
-    conditionNames: ['...', 'my-custom-condition'],
-  },
-};
-```
+`conditionNames` 的顺序（包括 `'...'` 的位置）不影响解析优先级；优先级由包的 `exports` 对象中键的顺序决定。
 
 ## resolve.descriptionFiles
 
@@ -532,7 +552,7 @@ export default {
 
 控制用于定位包入口文件的 package.json 字段优先级。Rspack 在解析 npm 包入口时，会按该列表的顺序依次尝试这些字段。
 
-对于常见的 JavaScript 请求，以 Web、Web Worker 或 Electron 渲染进程为目标时，默认值为 `["browser", "module", "main"]`。
+对于以 `'web'` 或 `'webworker'` 为目标的 JavaScript 请求，默认值为 `["browser", "module", "main"]`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -542,7 +562,7 @@ export default {
 };
 ```
 
-以 Node.js、Electron 主进程和预加载脚本、NW.js 为目标时，JavaScript 请求的默认值为 `["module", "main"]`。
+以 Node.js 为目标时，JavaScript 请求的默认值为 `["module", "main"]`。
 
 ```js title="rspack.config.mjs"
 export default {
@@ -552,7 +572,7 @@ export default {
 };
 ```
 
-CSS `@import` 请求的默认值为 `["style", "main"]`，URL 请求使用顶层默认值 `["main"]`。Rspack 会为每个请求合并顶层 resolve 选项和匹配的 [resolve.byDependency](#resolvebydependency) 选项。
+CSS `@import` 请求的默认值为 `["style", "main"]`，URL 请求的默认值为 `["main"]`。可通过 [resolve.byDependency](#resolvebydependency) 分别配置。
 
 例如，对于一个名为 `foo` 的库，它的 `package.json` 包含以下字段：
 


### PR DESCRIPTION
## Summary

Make the English and Chinese resolve and performance references easier to configure from. Add a complete `aliasFields` example showing the configuration, `package.json` mapping, and resolved file, and present common defaults in tables. Simplify target descriptions and replace the equivalent `conditionNames` example with a concise explanation of ordering.

## Related links

- https://github.com/web-infra-dev/rspack/pull/15571
- https://github.com/web-infra-dev/rspack/pull/15572

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).