### PR TITLE
fix(mf): infer shared module exports from fallback

### DIFF
--- a/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
+++ b/crates/rspack_plugin_mf/src/sharing/consume_shared_module.rs
@@ -148,12 +148,36 @@ impl Module for ConsumeSharedModule {
 
   fn get_exports_type(
     &self,
-    _module_graph: &ModuleGraph,
-    _module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
-    _exports_info_artifact: &rspack_core::ExportsInfoArtifact,
-    _strict: bool,
+    module_graph: &ModuleGraph,
+    module_graph_cache: &rspack_core::ModuleGraphCacheArtifact,
+    exports_info_artifact: &rspack_core::ExportsInfoArtifact,
+    strict: bool,
   ) -> ExportsType {
-    ExportsType::Dynamic
+    if self.options.import.is_none() {
+      return ExportsType::Dynamic;
+    }
+
+    let fallback_dependency = if self.options.eager {
+      self.get_dependency_ids().next()
+    } else {
+      self
+        .get_blocks()
+        .first()
+        .and_then(|block_id| module_graph.block_by_id(block_id))
+        .and_then(|block| block.get_dependency_ids().next())
+    };
+    let Some(fallback_module) =
+      fallback_dependency.and_then(|dep_id| module_graph.get_module_by_dependency_id(dep_id))
+    else {
+      return ExportsType::Dynamic;
+    };
+
+    fallback_module.get_exports_type(
+      module_graph,
+      module_graph_cache,
+      exports_info_artifact,
+      strict,
+    )
   }
 
   async fn build(

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/plugin-with-params.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-params/plugin-with-params.js
@@ -9,7 +9,10 @@ module.exports = function(params) {
 				const { shareScopeMap, scope, pkgName, version, GlobalFederation } = args;
         args.resolver = function () {
           shareScopeMap[scope][pkgName][version] = {
-						lib: ()=>()=> 'This is react 0.2.1'
+						lib: () => ({
+							__esModule: true,
+							default: () => 'This is react 0.2.1'
+						})
 					};
           return {
             shared: shareScopeMap[scope][pkgName][version],

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin-esm.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin-esm.js
@@ -5,7 +5,10 @@ export default function MyRuntimePlugin() {
 			const { shareScopeMap, scope, pkgName, version } = args;
 			args.resolver = function () {
 				shareScopeMap[scope][pkgName][version] = {
-					lib: ()=>()=> 'This is react 0.2.1'
+					lib: () => ({
+						__esModule: true,
+						default: () => 'This is react 0.2.1'
+					})
 				};
 				return {
           shared:shareScopeMap[scope][pkgName][version],

--- a/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin.js
+++ b/tests/rspack-test/configCases/container-1-5/runtime-plugin-with-used-exports/runtime-plugin.js
@@ -5,7 +5,10 @@ module.exports = function MyRuntimePlugin() {
 			const { shareScopeMap, scope, pkgName, version,  } = args;
 			args.resolver = function () {
 				shareScopeMap[scope][pkgName][version] = {
-					lib: ()=>()=> 'This is react 0.2.1'
+					lib: () => ({
+						__esModule: true,
+						default: () => 'This is react 0.2.1'
+					})
 				};
 				return {
           shared: shareScopeMap[scope][pkgName][version],

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/cjs.js
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/cjs.js
@@ -1,0 +1,3 @@
+exports.greet = function greet() {
+	return "hello";
+};

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/consumer.js
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/consumer.js
@@ -1,0 +1,13 @@
+import cjsDefault, { greet } from "./cjs.js";
+import * as cjsNamespace from "./cjs.js";
+import esmDefault, { named } from "./esm.mjs";
+import * as esmNamespace from "./esm.mjs";
+
+export const values = {
+	cjsDefault,
+	cjsNamespace,
+	greet,
+	esmDefault,
+	esmNamespace,
+	named
+};

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/consumer.mjs
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/consumer.mjs
@@ -1,0 +1,13 @@
+import cjsDefault, { greet } from "./cjs.js";
+import * as cjsNamespace from "./cjs.js";
+import esmDefault, { named } from "./esm.mjs";
+import * as esmNamespace from "./esm.mjs";
+
+export const values = {
+	cjsDefault,
+	cjsNamespace,
+	greet,
+	esmDefault,
+	esmNamespace,
+	named
+};

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/esm.mjs
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/esm.mjs
@@ -1,0 +1,5 @@
+export default function greet() {
+	return "esm default";
+}
+
+export const named = "esm named";

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/index.js
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/index.js
@@ -1,0 +1,23 @@
+function checkNamespaces({ values }) {
+	const { cjsDefault, cjsNamespace, greet, esmDefault, esmNamespace, named } = values;
+	expect(cjsDefault.greet()).toBe("hello");
+	expect(greet()).toBe("hello");
+	expect(cjsNamespace.default).toBe(cjsDefault);
+	expect(cjsNamespace.default.greet()).toBe("hello");
+	expect(cjsNamespace.greet).toBe(greet);
+	expect(cjsNamespace.__esModule).toBe(true);
+
+	expect(esmDefault()).toBe("esm default");
+	expect(named).toBe("esm named");
+	expect(esmNamespace.default).toBe(esmDefault);
+	expect(esmNamespace.named).toBe(named);
+	expect(esmNamespace.__esModule).toBe(true);
+}
+
+it("should preserve shared module namespaces in .js consumers", async () => {
+	checkNamespaces(await import("./consumer.js"));
+});
+
+it("should preserve shared module namespaces in .mjs consumers", async () => {
+	checkNamespaces(await import("./consumer.mjs"));
+});

--- a/tests/rspack-test/configCases/sharing/consume-module-namespace/rspack.config.js
+++ b/tests/rspack-test/configCases/sharing/consume-module-namespace/rspack.config.js
@@ -1,0 +1,19 @@
+const { sharing } = require('@rspack/core');
+
+module.exports = [false, true].flatMap((eager) =>
+  [false, true].map((concatenateModules) => ({
+    mode: 'production',
+    optimization: {
+      concatenateModules,
+      minimize: false,
+    },
+    plugins: [
+      new sharing.SharePlugin({
+        shared: {
+          './cjs.js': { eager, singleton: true, requiredVersion: false },
+          './esm.mjs': { eager, singleton: true, requiredVersion: false },
+        },
+      }),
+    ],
+  })),
+);

--- a/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
+++ b/tests/rspack-test/hotCases/sharing/share-plugin/__snapshots__/web/1.snap.txt
@@ -7,7 +7,7 @@
 - Bundle: bundle.js
 - Bundle: common_js_2.chunk.CURRENT_HASH.js
 - Manifest: main.LAST_HASH.hot-update.json, size: 28
-- Update: main.LAST_HASH.hot-update.js, size: 42679
+- Update: main.LAST_HASH.hot-update.js, size: 40979
 
 ## Manifest
 
@@ -27,9 +27,7 @@
 - ./module.js
 
 #### Changed Runtime Modules
-- webpack/runtime/compat_get_default_export
 - webpack/runtime/consumes_loading
-- webpack/runtime/create_fake_namespace_object
 - webpack/runtime/get_full_hash
 - webpack/runtime/jsonp_chunk_loading
 
@@ -40,60 +38,18 @@ self["rspackHotUpdate"]("main", {
 "./module.js"(__unused_rspack_module, __webpack_exports__, __webpack_require__) {
 __webpack_require__.r(__webpack_exports__);
 __webpack_require__.d(__webpack_exports__, {
-  "default": () => (/* reexport default from dynamic */ common__rspack_import_0_default.a),
+  "default": () => (/* reexport safe */ common__rspack_import_0["default"]),
   getValue: () => (getValue)
 });
 /* import */ var common__rspack_import_0 = __webpack_require__("webpack/sharing/consume/default/common/./common?1");
-/* import */ var common__rspack_import_0_default = /*#__PURE__*/__webpack_require__.n(common__rspack_import_0);
 
 
-const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.t.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2", 23));
+const getValue = () => __webpack_require__.e(/* import() */ "webpack_sharing_consume_default_common2_common_2").then(__webpack_require__.bind(__webpack_require__, "webpack/sharing/consume/default/common2/./common?2"));
 
 
 },
 
 },function(__webpack_require__) {
-// webpack/runtime/compat_get_default_export
-(() => {
-// getDefaultExport function for compatibility with non-ESM modules
-__webpack_require__.n = (module) => {
-	var getter = module && module.__esModule ?
-		() => (module['default']) :
-		() => (module);
-	__webpack_require__.d(getter, { a: getter });
-	return getter;
-};
-
-})();
-// webpack/runtime/create_fake_namespace_object
-(() => {
-var getProto = Object.getPrototypeOf ? (obj) => (Object.getPrototypeOf(obj)) : (obj) => (obj.__proto__);
-var leafPrototypes;
-// create a fake namespace object
-// mode & 1: value is a module id, require it
-// mode & 2: merge all properties of value into the ns
-// mode & 4: return value when already ns object
-// mode & 16: return value when it's Promise-like
-// mode & 8|1: behave like require
-__webpack_require__.t = function(value, mode) {
-	if(mode & 1) value = this(value);
-	if(mode & 8) return value;
-	if(typeof value === 'object' && value) {
-		if((mode & 4) && value.__esModule) return value;
-		if((mode & 16) && typeof value.then === 'function') return value;
-	}
-	var ns = Object.create(null);
-  __webpack_require__.r(ns);
-	var def = {};
-	leafPrototypes = leafPrototypes || [null, getProto({}), getProto([]), getProto(getProto)];
-	for(var current = mode & 2 && value; (typeof current == 'object' || typeof current == 'function') && !~leafPrototypes.indexOf(current); current = getProto(current)) {
-		Object.getOwnPropertyNames(current).forEach((key) => { def[key] = () => (value[key]) });
-	}
-	def['default'] = () => (value);
-	__webpack_require__.d(ns, def);
-	return ns;
-};
-})();
 // webpack/runtime/get_full_hash
 (() => {
 __webpack_require__.h = () => ("CURRENT_HASH")


### PR DESCRIPTION
## Summary

Namespace imports of shared CommonJS modules currently expose raw exports, so passing the namespace to another runtime loses `.default`. Match webpack 5.110.2 by deriving `ConsumeSharedModule`'s export type from its eager or asynchronous local fallback. Keep `Dynamic` when no fallback is available, including `import: false`.

Add regression coverage for CommonJS and ESM namespace, default, and named imports across `.js`/`.mjs` consumers, eager/lazy sharing, module concatenation, and both runtime modes. The new case fails before the fix with an undefined namespace default and passes with the rebuilt binding; the same fixtures also pass with webpack 5.110.2.

As with webpack, runtime replacements must preserve the fallback's module format. Update the existing runtime-plugin fixtures to return ESM namespaces matching their ESM fallbacks, preserving their parameter and worker assertions.

Refresh the shared-module HMR snapshot to reflect direct ESM imports and removal of the now-unneeded interop helpers.


## Related links

Fixes #15581.

Reference: [webpack 5.110.2 ConsumeSharedModule](https://github.com/webpack/webpack/blob/v5.110.2/lib/sharing/ConsumeSharedModule.js#L199-L246).

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

