### PR TITLE
refactor: use SIMD UTF-16 length for dependency locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4541,6 +4541,7 @@ dependencies = [
  "itoa",
  "memchr",
  "rspack_cacheable",
+ "simd-utf16-len",
 ]
 
 [[package]]
@@ -5007,6 +5008,7 @@ dependencies = [
  "rspack_util",
  "rustc-hash",
  "serde_json",
+ "simd-utf16-len",
  "slotmap",
  "smallvec",
  "sugar_path",

--- a/crates/rspack_location/Cargo.toml
+++ b/crates/rspack_location/Cargo.toml
@@ -10,6 +10,7 @@ version.workspace = true
 itoa             = { workspace = true }
 memchr           = { workspace = true }
 rspack_cacheable = { workspace = true }
+simd-utf16-len   = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/rspack_location/src/lib.rs
+++ b/crates/rspack_location/src/lib.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Debug};
 
 pub use itoa::Buffer;
 use rspack_cacheable::cacheable;
+use simd_utf16_len::utf16_len;
 
 /// Represents a position within a source file (line and column).
 /// Semantics match V8 Error stack positions:
@@ -80,9 +81,8 @@ impl RealDependencyLocation {
     }
 
     // 3. Calculate the UTF-16 length of the start column.
-    // This avoids the overhead of constructing the surrogate pair iterator and only performs numerical accumulation.
     let start_line_slice = source.get(line_start_offset..start_byte)?;
-    let start_utf16_col = start_line_slice.encode_utf16().count() + 1; // 1-based
+    let start_utf16_col = utf16_len(start_line_slice) + 1; // 1-based
 
     let start = SourcePosition {
       line,
@@ -106,12 +106,12 @@ impl RealDependencyLocation {
       let end_line = line.checked_add(newlines_in_span as u32)?;
 
       let end_column = if newlines_in_span == 0 {
-        start_utf16_col + span_slice.encode_utf16().count()
+        start_utf16_col + utf16_len(span_slice)
       } else {
         #[allow(clippy::unwrap_used)]
         let last_newline_pos = span_slice.rfind('\n').unwrap();
         let text_after_last_newline = &span_slice[last_newline_pos + 1..];
-        text_after_last_newline.encode_utf16().count() + 1 // 1-based
+        utf16_len(text_after_last_newline) + 1 // 1-based
       };
 
       Some(SourcePosition {

--- a/crates/rspack_plugin_javascript/Cargo.toml
+++ b/crates/rspack_plugin_javascript/Cargo.toml
@@ -38,6 +38,7 @@ rspack_regex                          = { workspace = true }
 rspack_util                           = { workspace = true }
 rustc-hash                            = { workspace = true }
 serde_json                            = { workspace = true }
+simd-utf16-len                        = { workspace = true }
 slotmap                               = { workspace = true }
 smallvec                              = { workspace = true }
 sugar_path                            = { workspace = true }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/location_advancer.rs
@@ -1,17 +1,6 @@
 use memchr;
 use rspack_core::{DependencyLocation, DependencyRange, RealDependencyLocation, SourcePosition};
-
-/// For pure-ASCII slices (the common case, e.g. minified vendor sources) the
-/// UTF-16 code-unit count equals the byte length, and `is_ascii` is a
-/// SIMD-accelerated byte scan — much cheaper than decoding every char.
-#[inline]
-fn utf16_len(s: &str) -> usize {
-  if s.is_ascii() {
-    s.len()
-  } else {
-    s.encode_utf16().count()
-  }
-}
+use simd_utf16_len::utf16_len;
 
 /// Advances source positions incrementally to compute dependency locations efficiently.
 /// This optimization reduces repeated source scans when processing dependencies
@@ -29,7 +18,7 @@ impl DependencyLocationAdvancer {
   }
 
   /// Advance a source position from one byte offset to another, counting newlines and UTF-16 columns.
-  /// Optimized with ASCII fast-paths and SIMD reverse searching.
+  /// Uses SIMD-accelerated UTF-16 length calculation and newline searching.
   fn advance_pos(
     source: &str,
     from_off: usize,


### PR DESCRIPTION
## Summary

Replace all four `encode_utf16().count()` calls in dependency location calculation with `simd_utf16_len::utf16_len`, preserving UTF-16 column semantics for ASCII, Unicode, and surrogate pairs.

Reuse the workspace's `simd-utf16-len` dependency and remove the parser's redundant ASCII fast path, which the library already provides.

## Validation

- `pnpm run build:binding:dev`
- `cargo test --locked -p rspack_location -p rspack_plugin_javascript --lib location -- --nocapture` — 26 tests passed.
- `cargo clippy --locked -p rspack_location -p rspack_plugin_javascript --all-targets -- -D warnings`
- `cargo fmt -p rspack_location -p rspack_plugin_javascript --check`
- Repository search confirms no remaining `encode_utf16().count()` calls.

## Related links

#15562

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
