### PR TITLE
perf(binding): share JS tap registration across hook types

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -50,7 +50,7 @@ use rspack_core::{
 };
 use rspack_error::Diagnostic;
 use rspack_hash::RspackHasher;
-use rspack_hook::{Hook, HookCommon, Interceptor};
+use rspack_hook::{Hook, Interceptor};
 use rspack_napi::threadsafe_function::DynThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_html::{
@@ -288,7 +288,7 @@ impl RegisterJsTapsInner {
 
   pub async fn call_register(
     &self,
-    hook: &HookCommon,
+    stages: &[i32],
   ) -> rspack_error::Result<RegisterFunctionOutput> {
     if let RegisterJsTapsCache::Cache(rw) = &self.cache {
       let cache = {
@@ -298,7 +298,7 @@ impl RegisterJsTapsInner {
       Ok(match cache {
         Some(js_taps) => js_taps,
         None => {
-          let js_taps = self.call_register_impl(hook).await?;
+          let js_taps = self.call_register_impl(stages).await?;
           {
             #[allow(clippy::unwrap_used)]
             let mut cache = rw.write().unwrap();
@@ -308,16 +308,19 @@ impl RegisterJsTapsInner {
         }
       })
     } else {
-      let js_taps = self.call_register_impl(hook).await?;
+      let js_taps = self.call_register_impl(stages).await?;
       Ok(js_taps)
     }
   }
 
   async fn call_register_impl(
     &self,
-    hook: &HookCommon,
+    stages: &[i32],
   ) -> rspack_error::Result<RegisterFunctionOutput> {
-    self.register.call_with_sync(hook.used_stages()).await
+    let mut used_stages = stages.to_vec();
+    // Hook tap stages are already sorted, so duplicate stages are adjacent.
+    used_stages.dedup();
+    self.register.call_with_sync(used_stages).await
   }
 
   fn clear_cache(&self) {
@@ -423,7 +426,7 @@ macro_rules! define_register {
         if let Some(non_skippable_registers) = &self.inner.non_skippable_registers && !non_skippable_registers.is_non_skippable(&$kind) {
           return Ok(Vec::new());
         }
-        let js_taps = self.inner.call_register(hook.common()).await?;
+        let js_taps = self.inner.call_register(hook.tap_stages()).await?;
         let js_taps = js_taps
           .iter()
           .map(|t| Box::new($tap_name::new(t.clone())) as <$tap_hook as Hook>::Tap)

--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -50,7 +50,7 @@ use rspack_core::{
 };
 use rspack_error::Diagnostic;
 use rspack_hash::RspackHasher;
-use rspack_hook::{Hook, Interceptor};
+use rspack_hook::{Hook, HookCommon, Interceptor};
 use rspack_napi::threadsafe_function::DynThreadsafeFunction;
 use rspack_paths::Utf8PathBuf;
 use rspack_plugin_html::{
@@ -209,7 +209,7 @@ impl<T, R> ThreadsafeJsTapFunction<T, R> {
 impl<T, R> ThreadsafeJsTapFunction<T, R>
 where
   T: 'static + JsValuesTupleIntoVec,
-  R: 'static + FromNapiValue,
+  R: 'static + FromNapiValue + Send,
 {
   async fn call_with_sync(&self, value: T) -> rspack_error::Result<R> {
     self.inner.call_with_sync::<T, R>(value).await
@@ -219,7 +219,7 @@ where
 impl<T, R> ThreadsafeJsTapFunction<T, Promise<R>>
 where
   T: 'static + JsValuesTupleIntoVec,
-  R: 'static + FromNapiValue,
+  R: 'static + FromNapiValue + Send,
 {
   async fn call_with_promise(&self, value: T) -> rspack_error::Result<R> {
     self.inner.call_with_promise::<T, R>(value).await
@@ -288,7 +288,7 @@ impl RegisterJsTapsInner {
 
   pub async fn call_register(
     &self,
-    hook: &impl Hook,
+    hook: &HookCommon,
   ) -> rspack_error::Result<RegisterFunctionOutput> {
     if let RegisterJsTapsCache::Cache(rw) = &self.cache {
       let cache = {
@@ -315,11 +315,9 @@ impl RegisterJsTapsInner {
 
   async fn call_register_impl(
     &self,
-    hook: &impl Hook,
+    hook: &HookCommon,
   ) -> rspack_error::Result<RegisterFunctionOutput> {
-    let mut used_stages = Vec::from_iter(hook.used_stages());
-    used_stages.sort_unstable();
-    self.register.call_with_sync(used_stages).await
+    self.register.call_with_sync(hook.used_stages()).await
   }
 
   fn clear_cache(&self) {
@@ -425,7 +423,7 @@ macro_rules! define_register {
         if let Some(non_skippable_registers) = &self.inner.non_skippable_registers && !non_skippable_registers.is_non_skippable(&$kind) {
           return Ok(Vec::new());
         }
-        let js_taps = self.inner.call_register(hook).await?;
+        let js_taps = self.inner.call_register(hook.common()).await?;
         let js_taps = js_taps
           .iter()
           .map(|t| Box::new($tap_name::new(t.clone())) as <$tap_hook as Hook>::Tap)

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -183,7 +183,8 @@ pub trait Interceptor<H: Hook> {
 pub trait Hook {
   type Tap;
 
-  fn common(&self) -> &HookCommon;
+  /// Returns tap stages in ascending order, including duplicates.
+  fn tap_stages(&self) -> &[i32];
 
   fn used_stages(&self) -> Vec<i32>;
 

--- a/crates/rspack_hook/src/lib.rs
+++ b/crates/rspack_hook/src/lib.rs
@@ -183,6 +183,8 @@ pub trait Interceptor<H: Hook> {
 pub trait Hook {
   type Tap;
 
+  fn common(&self) -> &HookCommon;
+
   fn used_stages(&self) -> Vec<i32>;
 
   fn intercept(&mut self, interceptor: impl Interceptor<Self> + Send + Sync + 'static)

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -180,8 +180,8 @@ impl DefineHookInput {
       impl ::rspack_hook::Hook for #hook_name {
         type Tap = Box<dyn #trait_name + Send + Sync>;
 
-        fn common(&self) -> &::rspack_hook::HookCommon {
-          &self.common
+        fn tap_stages(&self) -> &[i32] {
+          self.common.tap_stages()
         }
 
         fn used_stages(&self) -> Vec<i32> {

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -180,6 +180,10 @@ impl DefineHookInput {
       impl ::rspack_hook::Hook for #hook_name {
         type Tap = Box<dyn #trait_name + Send + Sync>;
 
+        fn common(&self) -> &::rspack_hook::HookCommon {
+          &self.common
+        }
+
         fn used_stages(&self) -> Vec<i32> {
           self.common.used_stages()
         }

--- a/crates/rspack_napi/src/threadsafe_function.rs
+++ b/crates/rspack_napi/src/threadsafe_function.rs
@@ -1,18 +1,12 @@
 use std::{
-  any::Any,
-  cell::Cell,
   fmt::Debug,
   marker::PhantomData,
-  rc::Rc,
   sync::{Arc, OnceLock},
 };
 
 use napi::{
   Env, JsValue, Status, Unknown, ValueType,
-  bindgen_prelude::{
-    CallbackContext, FromNapiValue, JsValuesTupleIntoVec, Promise, PromiseRaw, TypeName,
-    ValidateNapiValue,
-  },
+  bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue},
   sys::{self, napi_env, napi_value},
   threadsafe_function::{ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
@@ -33,6 +27,7 @@ pub struct ThreadsafeFunction<T: 'static + JsValuesTupleIntoVec, R> {
 
 pub struct DynThreadsafeFunction {
   inner: Arc<RawThreadsafeFunction<DynJsArgs, Unknown<'static>, DynJsArgs, Status, false, true>>,
+  env: napi_env,
 }
 
 struct DynJsArgs(Box<dyn DynJsArgsToVec>);
@@ -80,6 +75,7 @@ impl Clone for DynThreadsafeFunction {
   fn clone(&self) -> Self {
     Self {
       inner: self.inner.clone(),
+      env: self.env,
     }
   }
 }
@@ -117,6 +113,7 @@ impl FromNapiValue for DynThreadsafeFunction {
       .get_or_init(|| unsafe { JsCallback::new(env).expect("should initialize error resolver") });
     Ok(Self {
       inner: Arc::new(inner),
+      env,
     })
   }
 }
@@ -164,129 +161,82 @@ impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
   }
 }
 
-// Only converted Rust values cross back to the caller. The decoder always runs on
-// the JS thread; no napi_value or Unknown is stored in the completion channel.
-type DynJsValue = Box<dyn Any + Send>;
-type DynJsDecoder = fn(Env, Unknown<'_>) -> napi::Result<DynJsValue>;
-type DynJsCompletion = Rc<Cell<Option<oneshot::Sender<Result<DynJsValue>>>>>;
-
-fn decode_js_value<R: 'static + FromNapiValue + Send>(
-  env: Env,
-  value: Unknown<'_>,
-) -> napi::Result<DynJsValue> {
-  // SAFETY: The decoder is invoked by the TSFN or Promise callback on the JS thread.
-  unsafe { R::from_napi_value(env.raw(), value.raw()) }.map(|value| Box::new(value) as DynJsValue)
-}
-
-fn take_js_value<R: 'static + Send>(value: DynJsValue) -> R {
-  *value
-    .downcast::<R>()
-    .expect("TSFN decoder must match its caller's return type")
-}
-
-fn complete_js_call(completion: &DynJsCompletion, result: Result<DynJsValue>) {
-  if let Some(sender) = completion.take() {
-    // A caller may drop its future while a Promise is still pending.
-    let _ = sender.send(result);
-  }
-}
-
-fn resolve_js_promise(
-  env: Env,
-  value: Unknown<'_>,
-  decode: DynJsDecoder,
-  sender: oneshot::Sender<Result<DynJsValue>>,
-) {
-  let completion = Rc::new(Cell::new(Some(sender)));
-  let on_resolve = completion.clone();
-  let on_reject = completion.clone();
-  // Use one PromiseRaw<Unknown> implementation for every hook return type. Both
-  // conversion and rejection handling stay on the JS thread.
-  // SAFETY: `value` belongs to the active TSFN callback's environment.
-  let result = unsafe { PromiseRaw::<Unknown>::from_napi_value(env.raw(), value.raw()) }
-    .and_then(|promise| {
-      promise.then(move |ctx| {
-        // Propagate conversion errors through the chained catch, just like
-        // napi::Promise<R>, to preserve JS error conversion and stack handling.
-        let value = decode(ctx.env, ctx.value)?;
-        complete_js_call(&on_resolve, Ok(value));
-        Ok(())
-      })
-    })
-    .and_then(|promise| {
-      promise.catch(move |ctx: CallbackContext<Unknown>| {
-        let err = napi::Error::from(ctx.value).to_rspack_error(&ctx.env);
-        complete_js_call(&on_reject, Err(err));
-        Ok(())
-      })
-    });
-  if let Err(err) = result {
-    complete_js_call(&completion, Err(pretty_type_error(value, err)));
-  }
-}
-
 impl DynThreadsafeFunction {
-  fn call_with_return(
-    &self,
-    value: DynJsArgs,
-    decode: DynJsDecoder,
-    promise: bool,
-  ) -> Receiver<Result<DynJsValue>> {
-    let (tx, rx) = channel();
+  async fn resolve_error(&self, err: napi::Error) -> Error {
+    let (tx, rx) = tokio::sync::oneshot::channel::<rspack_error::Error>();
+    ERROR_RESOLVER
+      .get()
+      // SAFETY: The error resolver is initialized in `FromNapiValue::from_napi_value` and it's the only way to create a tsfn.
+      .expect("should have error resolver initialized")
+      .call(Box::new(move |env| {
+        let err = err.to_rspack_error(&env);
+        tx.send(err).expect("failed to resolve js error");
+      }));
+    rx.await.expect("failed to resolve js error")
+  }
+
+  fn call_with_return<T, D>(&self, value: T) -> Receiver<Result<D>>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    D: 'static + FromNapiValue,
+  {
+    let (tx, rx) = channel::<Result<D>>();
     self.inner.call_with_return_value(
-      value,
+      DynJsArgs(Box::new(value)),
       ThreadsafeFunctionCallMode::NonBlocking,
-      move |result: napi::Result<Unknown>, env| {
-        let result = match result {
-          Err(err) => Err(err.to_rspack_error(&env)),
-          Ok(value) if promise => {
-            resolve_js_promise(env, value, decode, tx);
-            return Ok(());
-          }
-          Ok(value) => decode(env, value).map_err(|err| pretty_type_error(value, err)),
-        };
-        tx.send(result)
-          .unwrap_or_else(|_| panic!("failed to send tsfn value"));
-        Ok(())
+      {
+        move |r: napi::Result<Unknown>, env| {
+          let r = match r {
+            Err(err) => Err(err.to_rspack_error(&env)),
+            Ok(o) => {
+              let raw_env = env.raw();
+              let return_value = o.raw();
+              unsafe { D::from_napi_value(raw_env, return_value) }
+                .map_err(|e| pretty_type_error(o, e))
+            }
+          };
+          tx.send(r)
+            .unwrap_or_else(|_| panic!("failed to send tsfn value"));
+          Ok(())
+        }
       },
     );
     rx
   }
 
-  // Dispatch before constructing the future so it only owns the Send completion
-  // receiver, not the JS-thread argument conversion payload.
-  fn call_async(
-    &self,
-    value: DynJsArgs,
-    decode: DynJsDecoder,
-    promise: bool,
-  ) -> impl std::future::Future<Output = Result<DynJsValue>> + Send + use<> {
-    let rx = self.call_with_return(value, decode, promise);
-    async move { rx.await.expect("failed to receive tsfn value") }
+  async fn call_async<T, D>(&self, value: T) -> Result<D>
+  where
+    T: 'static + JsValuesTupleIntoVec,
+    D: 'static + FromNapiValue,
+  {
+    let rx = self.call_with_return(value);
+    rx.await.expect("failed to receive tsfn value")
   }
 
   /// Call the JS function.
   pub async fn call_with_sync<T, R>(&self, value: T) -> Result<R>
   where
     T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue + Send,
+    R: 'static + FromNapiValue,
   {
-    self
-      .call_async(DynJsArgs(Box::new(value)), decode_js_value::<R>, false)
-      .await
-      .map(take_js_value::<R>)
+    self.call_async::<T, R>(value).await
   }
 
-  /// Call the JS function and await its returned Promise.
+  /// Call the JS function.
+  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
+  /// Otherwise, an [napi::Error] is returned.
   pub async fn call_with_promise<T, R>(&self, value: T) -> Result<R>
   where
     T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue + Send,
+    R: 'static + FromNapiValue,
   {
-    self
-      .call_async(DynJsArgs(Box::new(value)), decode_js_value::<R>, true)
-      .await
-      .map(take_js_value::<R>)
+    match self.call_async::<T, Promise<R>>(value).await {
+      Ok(r) => match r.await {
+        Ok(r) => Ok(r),
+        Err(err) => Err(self.resolve_error(err).await),
+      },
+      Err(err) => Err(err),
+    }
   }
 }
 

--- a/crates/rspack_napi/src/threadsafe_function.rs
+++ b/crates/rspack_napi/src/threadsafe_function.rs
@@ -1,12 +1,18 @@
 use std::{
+  any::Any,
+  cell::Cell,
   fmt::Debug,
   marker::PhantomData,
+  rc::Rc,
   sync::{Arc, OnceLock},
 };
 
 use napi::{
   Env, JsValue, Status, Unknown, ValueType,
-  bindgen_prelude::{FromNapiValue, JsValuesTupleIntoVec, Promise, TypeName, ValidateNapiValue},
+  bindgen_prelude::{
+    CallbackContext, FromNapiValue, JsValuesTupleIntoVec, Promise, PromiseRaw, TypeName,
+    ValidateNapiValue,
+  },
   sys::{self, napi_env, napi_value},
   threadsafe_function::{ThreadsafeFunction as RawThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
@@ -27,7 +33,6 @@ pub struct ThreadsafeFunction<T: 'static + JsValuesTupleIntoVec, R> {
 
 pub struct DynThreadsafeFunction {
   inner: Arc<RawThreadsafeFunction<DynJsArgs, Unknown<'static>, DynJsArgs, Status, false, true>>,
-  env: napi_env,
 }
 
 struct DynJsArgs(Box<dyn DynJsArgsToVec>);
@@ -75,7 +80,6 @@ impl Clone for DynThreadsafeFunction {
   fn clone(&self) -> Self {
     Self {
       inner: self.inner.clone(),
-      env: self.env,
     }
   }
 }
@@ -113,7 +117,6 @@ impl FromNapiValue for DynThreadsafeFunction {
       .get_or_init(|| unsafe { JsCallback::new(env).expect("should initialize error resolver") });
     Ok(Self {
       inner: Arc::new(inner),
-      env,
     })
   }
 }
@@ -161,82 +164,129 @@ impl<T: 'static + JsValuesTupleIntoVec, R> ThreadsafeFunction<T, R> {
   }
 }
 
-impl DynThreadsafeFunction {
-  async fn resolve_error(&self, err: napi::Error) -> Error {
-    let (tx, rx) = tokio::sync::oneshot::channel::<rspack_error::Error>();
-    ERROR_RESOLVER
-      .get()
-      // SAFETY: The error resolver is initialized in `FromNapiValue::from_napi_value` and it's the only way to create a tsfn.
-      .expect("should have error resolver initialized")
-      .call(Box::new(move |env| {
-        let err = err.to_rspack_error(&env);
-        tx.send(err).expect("failed to resolve js error");
-      }));
-    rx.await.expect("failed to resolve js error")
-  }
+// Only converted Rust values cross back to the caller. The decoder always runs on
+// the JS thread; no napi_value or Unknown is stored in the completion channel.
+type DynJsValue = Box<dyn Any + Send>;
+type DynJsDecoder = fn(Env, Unknown<'_>) -> napi::Result<DynJsValue>;
+type DynJsCompletion = Rc<Cell<Option<oneshot::Sender<Result<DynJsValue>>>>>;
 
-  fn call_with_return<T, D>(&self, value: T) -> Receiver<Result<D>>
-  where
-    T: 'static + JsValuesTupleIntoVec,
-    D: 'static + FromNapiValue,
-  {
-    let (tx, rx) = channel::<Result<D>>();
+fn decode_js_value<R: 'static + FromNapiValue + Send>(
+  env: Env,
+  value: Unknown<'_>,
+) -> napi::Result<DynJsValue> {
+  // SAFETY: The decoder is invoked by the TSFN or Promise callback on the JS thread.
+  unsafe { R::from_napi_value(env.raw(), value.raw()) }.map(|value| Box::new(value) as DynJsValue)
+}
+
+fn take_js_value<R: 'static + Send>(value: DynJsValue) -> R {
+  *value
+    .downcast::<R>()
+    .expect("TSFN decoder must match its caller's return type")
+}
+
+fn complete_js_call(completion: &DynJsCompletion, result: Result<DynJsValue>) {
+  if let Some(sender) = completion.take() {
+    // A caller may drop its future while a Promise is still pending.
+    let _ = sender.send(result);
+  }
+}
+
+fn resolve_js_promise(
+  env: Env,
+  value: Unknown<'_>,
+  decode: DynJsDecoder,
+  sender: oneshot::Sender<Result<DynJsValue>>,
+) {
+  let completion = Rc::new(Cell::new(Some(sender)));
+  let on_resolve = completion.clone();
+  let on_reject = completion.clone();
+  // Use one PromiseRaw<Unknown> implementation for every hook return type. Both
+  // conversion and rejection handling stay on the JS thread.
+  // SAFETY: `value` belongs to the active TSFN callback's environment.
+  let result = unsafe { PromiseRaw::<Unknown>::from_napi_value(env.raw(), value.raw()) }
+    .and_then(|promise| {
+      promise.then(move |ctx| {
+        // Propagate conversion errors through the chained catch, just like
+        // napi::Promise<R>, to preserve JS error conversion and stack handling.
+        let value = decode(ctx.env, ctx.value)?;
+        complete_js_call(&on_resolve, Ok(value));
+        Ok(())
+      })
+    })
+    .and_then(|promise| {
+      promise.catch(move |ctx: CallbackContext<Unknown>| {
+        let err = napi::Error::from(ctx.value).to_rspack_error(&ctx.env);
+        complete_js_call(&on_reject, Err(err));
+        Ok(())
+      })
+    });
+  if let Err(err) = result {
+    complete_js_call(&completion, Err(pretty_type_error(value, err)));
+  }
+}
+
+impl DynThreadsafeFunction {
+  fn call_with_return(
+    &self,
+    value: DynJsArgs,
+    decode: DynJsDecoder,
+    promise: bool,
+  ) -> Receiver<Result<DynJsValue>> {
+    let (tx, rx) = channel();
     self.inner.call_with_return_value(
-      DynJsArgs(Box::new(value)),
+      value,
       ThreadsafeFunctionCallMode::NonBlocking,
-      {
-        move |r: napi::Result<Unknown>, env| {
-          let r = match r {
-            Err(err) => Err(err.to_rspack_error(&env)),
-            Ok(o) => {
-              let raw_env = env.raw();
-              let return_value = o.raw();
-              unsafe { D::from_napi_value(raw_env, return_value) }
-                .map_err(|e| pretty_type_error(o, e))
-            }
-          };
-          tx.send(r)
-            .unwrap_or_else(|_| panic!("failed to send tsfn value"));
-          Ok(())
-        }
+      move |result: napi::Result<Unknown>, env| {
+        let result = match result {
+          Err(err) => Err(err.to_rspack_error(&env)),
+          Ok(value) if promise => {
+            resolve_js_promise(env, value, decode, tx);
+            return Ok(());
+          }
+          Ok(value) => decode(env, value).map_err(|err| pretty_type_error(value, err)),
+        };
+        tx.send(result)
+          .unwrap_or_else(|_| panic!("failed to send tsfn value"));
+        Ok(())
       },
     );
     rx
   }
 
-  async fn call_async<T, D>(&self, value: T) -> Result<D>
-  where
-    T: 'static + JsValuesTupleIntoVec,
-    D: 'static + FromNapiValue,
-  {
-    let rx = self.call_with_return(value);
-    rx.await.expect("failed to receive tsfn value")
+  // Dispatch before constructing the future so it only owns the Send completion
+  // receiver, not the JS-thread argument conversion payload.
+  fn call_async(
+    &self,
+    value: DynJsArgs,
+    decode: DynJsDecoder,
+    promise: bool,
+  ) -> impl std::future::Future<Output = Result<DynJsValue>> + Send + use<> {
+    let rx = self.call_with_return(value, decode, promise);
+    async move { rx.await.expect("failed to receive tsfn value") }
   }
 
   /// Call the JS function.
   pub async fn call_with_sync<T, R>(&self, value: T) -> Result<R>
   where
     T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue,
+    R: 'static + FromNapiValue + Send,
   {
-    self.call_async::<T, R>(value).await
+    self
+      .call_async(DynJsArgs(Box::new(value)), decode_js_value::<R>, false)
+      .await
+      .map(take_js_value::<R>)
   }
 
-  /// Call the JS function.
-  /// If `Promise<T>` is returned, it will be awaited and its value `T` will be returned.
-  /// Otherwise, an [napi::Error] is returned.
+  /// Call the JS function and await its returned Promise.
   pub async fn call_with_promise<T, R>(&self, value: T) -> Result<R>
   where
     T: 'static + JsValuesTupleIntoVec,
-    R: 'static + FromNapiValue,
+    R: 'static + FromNapiValue + Send,
   {
-    match self.call_async::<T, Promise<R>>(value).await {
-      Ok(r) => match r.await {
-        Ok(r) => Ok(r),
-        Err(err) => Err(self.resolve_error(err).await),
-      },
-      Err(err) => Err(err),
-    }
+    self
+      .call_async(DynJsArgs(Box::new(value)), decode_js_value::<R>, true)
+      .await
+      .map(take_js_value::<R>)
   }
 }
 

--- a/tests/rspack-test/compilerCases/js-tap-results.js
+++ b/tests/rspack-test/compilerCases/js-tap-results.js
@@ -1,0 +1,97 @@
+/** @type {import('@rspack/test-tools').TCompilerCaseConfig[]} */
+module.exports = [
+  "success",
+  "sync exception",
+  "promise rejection",
+  "callback error",
+  "invalid result",
+  "invalid promise result",
+].map((mode) => {
+  let completedPromises;
+  let resolvedModules;
+  return {
+    description: `preserves JS tap ${mode}`,
+    options() {
+      return {
+        entry: "./d",
+        incremental: false,
+        plugins: [
+          (compiler) => {
+            compiler.hooks.compilation.tap(
+              "JsTapResults",
+              (_compilation, params) => {
+                params.normalModuleFactory.hooks.beforeResolve.tapPromise(
+                  "JsTapResults",
+                  async () => {
+                    await Promise.resolve();
+                    resolvedModules++;
+                    if (mode === "invalid promise result") {
+                      return "not a boolean";
+                    }
+                  },
+                );
+              },
+            );
+            compiler.hooks.make.tapPromise("JsTapResults", async () => {
+              await new Promise((resolve) => setImmediate(resolve));
+              if (mode === "promise rejection") {
+                throw new Error("JS tap promise rejection");
+              }
+              completedPromises++;
+            });
+            compiler.hooks.make.tapAsync(
+              "JsTapResultsCallback",
+              (_compilation, callback) => {
+                setImmediate(() =>
+                  callback(
+                    mode === "callback error"
+                      ? new Error("JS tap callback error")
+                      : undefined,
+                  ),
+                );
+              },
+            );
+            compiler.hooks.shouldEmit.tap("JsTapResults", () => {
+              if (mode === "sync exception") {
+                throw new Error("JS tap sync exception");
+              }
+              if (mode === "invalid result") {
+                return "not a boolean";
+              }
+              return true;
+            });
+          },
+        ],
+      };
+    },
+    async build(_context, compiler) {
+      // Successful builds exercise fresh compilation closures and cached taps.
+      // Fatal-error cases use separate compilers rather than restarting while the
+      // native completion callback is still being finalized.
+      for (let run = 0; run < (mode === "success" ? 3 : 1); run++) {
+        completedPromises = 0;
+        resolvedModules = 0;
+        const { err, stats } = await new Promise((resolve) => {
+          compiler.run((err, stats) => resolve({ err, stats }));
+        });
+        if (mode === "success") {
+          expect(err).toBeFalsy();
+          expect(stats.hasErrors()).toBe(false);
+          expect(completedPromises).toBe(1);
+          expect(resolvedModules).toBeGreaterThan(0);
+        } else if (mode === "invalid promise result") {
+          expect(err).toBeFalsy();
+          expect(stats.hasErrors()).toBe(true);
+          expect(stats.toString({ all: false, errors: true })).toContain(
+            "bool",
+          );
+        } else {
+          expect(err).toBeTruthy();
+          expect(err.message).toContain(
+            mode === "invalid result" ? "boolean" : `JS tap ${mode}`,
+          );
+        }
+      }
+    },
+  };
+});


### PR DESCRIPTION
## Motivation

JS tap registration specializes the same cache lookup and registration code for each concrete hook type because it takes `&impl Hook`, although it only needs stage data. For example, two hooks with the same registration types but different Rust hook types generate separate implementations of this logic.

## Changes

- Expose sorted tap stages as `&[i32]` through `Hook::tap_stages()` and generated hook implementations.
- Pass the borrowed stage slice to JS tap registration so hooks with the same registration types share the cache lookup and registration implementation.
- Copy and deduplicate stages only when registration is needed. A cache hit does not allocate a stage vector; a cache miss converts a slice such as `[-10, 0, 0, 10]` to `[-10, 0, 10]` before calling JavaScript.
- Add JS tap regression coverage for synchronous results and exceptions, Promise results and rejections, callback errors, invalid results, and repeated successful builds.

No release binary size measurement is included.

Validation on the current revision:
- `cargo clippy -p rspack_binding_api -p rspack_hook -p rspack_macros --all-targets --offline -- --deny warnings`
- `cargo test -p rspack_macros_test --test hook --offline` — 4 passed, after rebuilding the test artifact.
- `cargo fmt --all -- --check`
- `git diff --check`

The hook, TSFN lifecycle, and JS tap result suites passed on an earlier revision (113 JavaScript tests). JavaScript integration tests have not been rerun after restoring the original TSFN implementation and switching registration to stage slices.

---
_by OpenAI Codex_