### PR TITLE
refactor(javascript): reuse semantic and member analysis results

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/side_effects_parser_plugin.rs
@@ -8,17 +8,17 @@ use rspack_util::{
   SpanExt,
   swc::{AstSubRangeExt, RspackComments},
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 use swc_next_ecma_ast::{
   ArgumentData, ArrowFunctionBodyData, ArrowFunctionExpression, AssignmentExpression,
   AssignmentOperator, AssignmentTargetData, Ast, BindingPattern, BindingPatternData,
   CallExpression, Class, ClassElement, ClassElementData, CommentKind, Decl, DeclData,
   ExportDefaultDeclarationKindData, Expr, ExprData, ForStatementInitData, FormalParameterItemData,
-  FormalParameterPatternData, Function, GetSpan, ImportDeclarationSpecifierData,
-  MethodDefinitionKind, ModuleExportName, ModuleExportNameData, Program, PropertyKey,
-  PropertyKeyData, SimpleAssignmentTargetData, Span, Stmt, StmtData,
-  VariableDeclaration as AstVariableDeclaration, VariableKind,
+  FormalParameterPatternData, Function, GetSpan, MethodDefinitionKind, ModuleExportName,
+  ModuleExportNameData, Program, PropertyKey, PropertyKeyData, ScopeId, SimpleAssignmentTargetData,
+  SourceType, Span, Stmt, StmtData, VariableDeclaration as AstVariableDeclaration, VariableKind,
 };
+use swc_next_ecma_semantic::Semantic;
 
 use super::side_effects_analysis::{SideEffectsContext, may_have_side_effects};
 use crate::{
@@ -78,141 +78,48 @@ fn has_pure_comment(comments: &RspackComments<'_>, pos: u32) -> bool {
   })
 }
 
-fn visit_pattern_binding_names<'ast>(
-  ast: &'ast Ast<'_>,
-  pattern: BindingPattern,
-  f: &mut impl FnMut(&'ast str),
-) {
-  match ast.binding_pattern_data(pattern) {
-    BindingPatternData::BindingIdentifier(identifier) => f(ast.get_utf8(identifier.name(ast))),
-    BindingPatternData::ArrayPattern(array) => {
-      for element in ast.nodes(array.elements(ast)).flatten() {
-        visit_pattern_binding_names(ast, element, f);
-      }
-      if let Some(rest) = array.rest(ast) {
-        visit_pattern_binding_names(ast, rest.argument(ast), f);
-      }
-    }
-    BindingPatternData::ObjectPattern(object) => {
-      for property in ast.nodes(object.properties(ast)) {
-        visit_pattern_binding_names(ast, property.value(ast), f);
-      }
-      if let Some(rest) = object.rest(ast) {
-        visit_pattern_binding_names(ast, rest.argument(ast), f);
-      }
-    }
-    BindingPatternData::AssignmentPattern(assignment) => {
-      visit_pattern_binding_names(ast, assignment.left(ast), f);
-    }
-    BindingPatternData::BindingRestElement(rest) => {
-      visit_pattern_binding_names(ast, rest.argument(ast), f);
-    }
-    BindingPatternData::SimpleAssignmentTarget(_) => {}
+fn top_level_scope(ast: &Ast<'_>) -> ScopeId {
+  match ast.source_type() {
+    SourceType::Script => ScopeId::ROOT,
+    SourceType::Module | SourceType::CommonJs => ScopeId::MODULE,
+    SourceType::Unambiguous => unreachable!("parser should resolve unambiguous source type"),
   }
 }
 
-fn visit_decl_binding_names<'ast>(
-  ast: &'ast Ast<'_>,
-  declaration: Decl,
-  f: &mut impl FnMut(&'ast str),
-) {
-  match ast.decl_data(declaration) {
-    DeclData::Function(function) => {
-      if let Some(identifier) = function.id(ast) {
-        f(ast.get_utf8(identifier.name(ast)));
-      }
-    }
-    DeclData::Class(class) => {
-      if let Some(identifier) = class.id(ast) {
-        f(ast.get_utf8(identifier.name(ast)));
-      }
-    }
-    DeclData::VariableDeclaration(variable) => {
-      for declarator in ast.nodes(variable.declarators(ast)) {
-        visit_pattern_binding_names(ast, declarator.id(ast), f);
-      }
-    }
-    _ => {}
+fn collect_defined_configured_side_effects_free(
+  ast: &Ast<'_>,
+  program: Program,
+  configured: &[String],
+  semantic: &Semantic<'_>,
+) -> AtomSet {
+  let scope = top_level_scope(ast);
+  let configured_names = configured
+    .iter()
+    .map(String::as_str)
+    .collect::<FxHashSet<_>>();
+  let mut defined = configured
+    .iter()
+    .filter(|name| semantic.binding(scope, name.as_bytes()).is_some())
+    .map(|name| Atom::from(name.as_str()))
+    .collect::<AtomSet>();
+  if configured_names.is_empty() {
+    return defined;
   }
-}
-
-fn visit_stmt_defined_binding_names<'ast>(
-  ast: &'ast Ast<'_>,
-  statement: Stmt,
-  f: &mut impl FnMut(&'ast str),
-) {
-  match ast.stmt_data(statement) {
-    StmtData::Declaration(declaration) => visit_decl_binding_names(ast, declaration, f),
-    StmtData::ImportDeclaration(import) => {
-      for specifier in ast.nodes(import.specifiers(ast)) {
-        let local = match ast.import_declaration_specifier_data(specifier) {
-          ImportDeclarationSpecifierData::ImportSpecifier(specifier) => specifier.local(ast),
-          ImportDeclarationSpecifierData::ImportDefaultSpecifier(specifier) => specifier.local(ast),
-          ImportDeclarationSpecifierData::ImportNamespaceSpecifier(specifier) => {
-            specifier.local(ast)
-          }
-        };
-        f(ast.get_utf8(local.name(ast)));
-      }
-    }
-    StmtData::ExportNamedDeclaration(export) => {
-      if let Some(declaration) = export.declaration(ast) {
-        visit_decl_binding_names(ast, declaration, f);
-      }
-    }
-    StmtData::ExportDefaultDeclaration(export) => {
-      match ast.export_default_declaration_kind_data(export.declaration(ast)) {
-        ExportDefaultDeclarationKindData::Function(function) => {
-          if let Some(identifier) = function.id(ast) {
-            f(ast.get_utf8(identifier.name(ast)));
-          }
-        }
-        ExportDefaultDeclarationKindData::Class(class) => {
-          if let Some(identifier) = class.id(ast) {
-            f(ast.get_utf8(identifier.name(ast)));
-          }
-        }
-        ExportDefaultDeclarationKindData::Expr(expression) => match ast.expr_data(expression) {
-          ExprData::Function(function) => {
-            if let Some(identifier) = function.id(ast) {
-              f(ast.get_utf8(identifier.name(ast)));
-            }
-          }
-          ExprData::Class(class) => {
-            if let Some(identifier) = class.id(ast) {
-              f(ast.get_utf8(identifier.name(ast)));
-            }
-          }
-          _ => {}
-        },
-        _ => {}
-      }
-    }
-    _ => {}
-  }
-}
-
-fn collect_pure_function_acceptable_names(ast: &Ast<'_>, program: Program) -> AtomSet {
-  let statements = program.body(ast);
-  let mut names = AtomSet::default();
-  for statement in ast.nodes(statements) {
-    visit_stmt_defined_binding_names(ast, statement, &mut |name| {
-      names.insert(Atom::from(name));
-    });
-  }
-
-  let local_bindings = names.clone();
-  for statement in ast.nodes(statements) {
+  for statement in ast.nodes(program.body(ast)) {
     match ast.stmt_data(statement) {
       StmtData::ExportNamedDeclaration(export) if export.source(ast).is_none() => {
         for specifier in ast.nodes(export.specifiers(ast)) {
+          let exported = module_export_name(ast, specifier.exported(ast));
+          if !configured_names.contains(exported.as_ref()) {
+            continue;
+          }
           let local = module_export_name(ast, specifier.local(ast));
-          if local_bindings.contains(local.as_ref()) {
-            names.insert(Atom::from(module_export_name(ast, specifier.exported(ast))));
+          if semantic.binding(scope, local.as_bytes()).is_some() {
+            defined.insert(Atom::from(exported));
           }
         }
       }
-      StmtData::ExportDefaultDeclaration(export) => {
+      StmtData::ExportDefaultDeclaration(export) if configured_names.contains("default") => {
         let is_function = match ast.export_default_declaration_kind_data(export.declaration(ast)) {
           ExportDefaultDeclarationKindData::Function(_) => true,
           ExportDefaultDeclarationKindData::Expr(expression) => matches!(
@@ -222,39 +129,13 @@ fn collect_pure_function_acceptable_names(ast: &Ast<'_>, program: Program) -> At
           _ => false,
         };
         if is_function {
-          names.insert(Atom::from("default"));
+          defined.insert(Atom::from("default"));
         }
       }
       _ => {}
     }
   }
-  names
-}
-
-fn collect_defined_configured_side_effects_free(
-  ast: &Ast<'_>,
-  program: Program,
-  configured_side_effects_free: &[String],
-) -> AtomSet {
-  let acceptable = collect_pure_function_acceptable_names(ast, program);
-  configured_side_effects_free
-    .iter()
-    .filter_map(|name| acceptable.get(name).cloned())
-    .collect()
-}
-
-fn collect_duplicate_top_level_names(ast: &Ast<'_>, program: Program) -> AtomSet {
-  let mut counts = FxHashMap::<&str, usize>::default();
-  for statement in ast.nodes(program.body(ast)) {
-    visit_stmt_defined_binding_names(ast, statement, &mut |name| {
-      *counts.entry(name).or_default() += 1;
-    });
-  }
-  counts
-    .into_iter()
-    .filter(|(_, count)| *count > 1)
-    .map(|(name, _)| Atom::from(name))
-    .collect()
+  defined
 }
 
 fn collect_annotation_from_variable(
@@ -386,9 +267,13 @@ fn mark_side_effects_free(parser: &mut JavascriptParser, name: &str, export_name
 fn already_marked_or_duplicate(
   parser: &JavascriptParser,
   name: &str,
-  duplicate_names: &AtomSet,
+  identifier: swc_next_ecma_ast::BindingIdentifier,
 ) -> bool {
-  duplicate_names.contains(name)
+  parser
+    .ast
+    .semantic
+    .symbol_of(identifier.node_id())
+    .is_some_and(|symbol| parser.ast.semantic.declarations(symbol).len() > 1)
     || parser
       .build_info
       .side_effects_free
@@ -401,7 +286,6 @@ fn try_mark_auto_side_effects_free_variable(
   analyze_side_effects_free: bool,
   variable: AstVariableDeclaration,
   export_name: Option<&str>,
-  duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
   if variable.kind(ast) != VariableKind::Const {
@@ -414,7 +298,7 @@ fn try_mark_auto_side_effects_free_variable(
       continue;
     };
     let name = ast.get_utf8(identifier.name(ast));
-    if already_marked_or_duplicate(parser, name, duplicate_names) {
+    if already_marked_or_duplicate(parser, name, identifier) {
       continue;
     }
     let Some(initializer) = declarator.init(ast) else {
@@ -440,7 +324,6 @@ fn try_mark_auto_side_effects_free_decl(
   analyze_side_effects_free: bool,
   declaration: Decl,
   export_name: Option<&str>,
-  duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
   match ast.decl_data(declaration) {
@@ -449,7 +332,7 @@ fn try_mark_auto_side_effects_free_decl(
         return;
       };
       let name = ast.get_utf8(identifier.name(ast));
-      if !already_marked_or_duplicate(parser, name, duplicate_names)
+      if !already_marked_or_duplicate(parser, name, identifier)
         && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
       {
         mark_side_effects_free(parser, name, export_name);
@@ -460,7 +343,6 @@ fn try_mark_auto_side_effects_free_decl(
       analyze_side_effects_free,
       variable,
       export_name,
-      duplicate_names,
     ),
     _ => {}
   }
@@ -470,18 +352,13 @@ fn mark_auto_side_effects_free_program(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
   program: Program,
-  duplicate_names: &AtomSet,
 ) {
   let ast = parser.ast.ast;
   for statement in ast.nodes(program.body(ast)) {
     match ast.stmt_data(statement) {
-      StmtData::Declaration(declaration) => try_mark_auto_side_effects_free_decl(
-        parser,
-        analyze_side_effects_free,
-        declaration,
-        None,
-        duplicate_names,
-      ),
+      StmtData::Declaration(declaration) => {
+        try_mark_auto_side_effects_free_decl(parser, analyze_side_effects_free, declaration, None)
+      }
       StmtData::ExportNamedDeclaration(export) => {
         if let Some(declaration) = export.declaration(ast) {
           try_mark_auto_side_effects_free_decl(
@@ -489,7 +366,6 @@ fn mark_auto_side_effects_free_program(
             analyze_side_effects_free,
             declaration,
             None,
-            duplicate_names,
           );
         }
       }
@@ -500,7 +376,7 @@ fn mark_auto_side_effects_free_program(
               continue;
             };
             let name = ast.get_utf8(identifier.name(ast));
-            if !already_marked_or_duplicate(parser, name, duplicate_names)
+            if !already_marked_or_duplicate(parser, name, identifier)
               && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
             {
               mark_side_effects_free(parser, name, Some("default"));
@@ -511,7 +387,7 @@ fn mark_auto_side_effects_free_program(
               && let Some(identifier) = function.id(ast)
             {
               let name = ast.get_utf8(identifier.name(ast));
-              if !already_marked_or_duplicate(parser, name, duplicate_names)
+              if !already_marked_or_duplicate(parser, name, identifier)
                 && is_side_effects_free_function_body(parser, analyze_side_effects_free, function)
               {
                 mark_side_effects_free(parser, name, Some("default"));
@@ -544,7 +420,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
       }
 
       if let Some(configured) = &parser.javascript_options.side_effects_free {
-        let defined = collect_defined_configured_side_effects_free(ast, program, configured);
+        let defined = collect_defined_configured_side_effects_free(
+          ast,
+          program,
+          configured,
+          parser.ast.semantic,
+        );
         if !defined.is_empty() {
           parser
             .build_info
@@ -554,19 +435,13 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for SideEffectsParserPlugin {
         }
       }
 
-      let duplicate_names = collect_duplicate_top_level_names(ast, program);
       loop {
         let previous_len = parser
           .build_info
           .side_effects_free
           .as_ref()
           .map_or(0, |side_effects_free| side_effects_free.len());
-        mark_auto_side_effects_free_program(
-          parser,
-          self.analyze_side_effects_free,
-          program,
-          &duplicate_names,
-        );
+        mark_auto_side_effects_free_program(parser, self.analyze_side_effects_free, program);
         let next_len = parser
           .build_info
           .side_effects_free
@@ -701,6 +576,7 @@ enum ExplicitSideEffectsFreeCallee {
 
 fn resolve_explicit_side_effects_free_callee(
   parser: &mut JavascriptParser,
+  identifier: swc_next_ecma_ast::IdentifierReference,
   ident: &str,
   span: Span,
   allow_unresolved_marked: bool,
@@ -725,6 +601,29 @@ fn resolve_explicit_side_effects_free_callee(
     }
   }
 
+  if parser.active_synthetic_ast.is_none() {
+    let reference = parser
+      .ast
+      .semantic
+      .reference_of(identifier.node_id())
+      .map(|reference| parser.ast.semantic.reference(reference));
+    return match reference {
+      Some(reference) if reference.flags.is_dynamic() => ExplicitSideEffectsFreeCallee::Invalid,
+      Some(reference) if reference.symbol.is_some() => {
+        if reference.symbol.is_some_and(|symbol| {
+          parser.ast.semantic.scope_of(symbol) == top_level_scope(parser.ast.ast)
+        }) {
+          ExplicitSideEffectsFreeCallee::Direct
+        } else {
+          ExplicitSideEffectsFreeCallee::Invalid
+        }
+      }
+      _ if allow_unresolved_marked => ExplicitSideEffectsFreeCallee::Direct,
+      _ => ExplicitSideEffectsFreeCallee::Invalid,
+    };
+  }
+
+  // Separately parsed replacement expressions resolve names in the caller's environment.
   if let Some((declared_scope, is_free)) = parser
     .get_variable_info(ident)
     .map(|info| (info.declared_scope, info.is_free()))
@@ -799,13 +698,6 @@ fn arguments_are_pure(
   true
 }
 
-fn identifier_expression_name<'ast>(ast: &'ast Ast<'_>, expression: Expr) -> Option<&'ast str> {
-  let ExprData::IdentifierReference(identifier) = ast.expr_data(expression) else {
-    return None;
-  };
-  Some(ast.get_utf8(identifier.name(ast)))
-}
-
 fn is_pure_call_expression(
   parser: &mut JavascriptParser,
   analyze_side_effects_free: bool,
@@ -828,9 +720,11 @@ fn is_pure_call_expression(
     );
   }
 
-  if analyze_side_effects_free && let Some(name) = identifier_expression_name(ast, callee) {
+  if analyze_side_effects_free && let Some(identifier) = callee.as_identifier_reference(ast) {
+    let name = ast.get_utf8(identifier.name(ast));
     match resolve_explicit_side_effects_free_callee(
       parser,
+      identifier,
       name,
       callee.span(ast),
       callees.is_none(),

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_call_expr.rs
@@ -6,7 +6,7 @@ use crate::{
     CREATE_REQUIRE_EVALUATED_TAG, JavascriptParserPlugin, is_create_require_namespace_member,
     is_create_require_specifier,
   },
-  visitors::{CallHooksName, JavascriptParser},
+  visitors::JavascriptParser,
 };
 
 #[inline]
@@ -22,7 +22,7 @@ pub fn eval_call_expression<'parser>(
     let is_create_require = parser.javascript_options.is_create_require_enabled()
       && is_create_require_specifier(parser, name);
     let evaluated = if is_create_require {
-      name.call_hooks_name(parser, |parser, for_name| {
+      parser.call_hooks_name(name, |parser, for_name| {
         drive.evaluate_call_expression(parser, for_name, expression)
       })
     } else if parser.javascript_options.is_create_require_enabled() {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_member_expr.rs
@@ -5,7 +5,8 @@ use super::BasicEvaluatedExpression;
 use crate::{
   parser_plugin::{CREATED_REQUIRE_IDENTIFIER_TAG, CreatedRequireTagData, JavascriptParserPlugin},
   visitors::{
-    AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
+    AllowedMemberTypes, ExportedVariableInfo, ExprRef, ExpressionExpressionInfo, JavascriptParser,
+    MemberExpressionInfo,
   },
 };
 
@@ -14,12 +15,24 @@ pub fn eval_member_expression<'parser>(
   member: MemberExpression,
   expression: Expr,
 ) -> Option<BasicEvaluatedExpression<'parser>> {
-  let ast = parser.ast.ast;
-  let span = member.span(ast);
-  let drive = parser.plugin_drive.clone();
-  let result = if let Some(MemberExpressionInfo::Expression(info)) =
-    parser.get_member_expression_info(ExprRef::Member(member), AllowedMemberTypes::Expression)
+  let info = match parser
+    .get_member_expression_info(ExprRef::Member(member), AllowedMemberTypes::Expression)
   {
+    Some(MemberExpressionInfo::Expression(info)) => Some(info),
+    _ => None,
+  };
+  eval_member_expression_with_info(parser, member, expression, info)
+}
+
+pub fn eval_member_expression_with_info<'parser>(
+  parser: &mut JavascriptParser<'parser>,
+  member: MemberExpression,
+  expression: Expr,
+  info: Option<ExpressionExpressionInfo>,
+) -> Option<BasicEvaluatedExpression<'parser>> {
+  let result = if let Some(info) = info {
+    let span = member.span(parser.ast.ast);
+    let drive = parser.plugin_drive.clone();
     let is_created_require_member = parser.javascript_options.is_create_require_enabled()
       && matches!(
         info.root_info,

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_new_expr.rs
@@ -5,7 +5,7 @@ use super::BasicEvaluatedExpression;
 use crate::{
   parser_plugin::{evaluate_create_require_new_expression, is_create_require_specifier},
   utils::eval,
-  visitors::{CallHooksName, JavascriptParser},
+  visitors::JavascriptParser,
 };
 
 #[inline]
@@ -20,7 +20,7 @@ pub fn eval_new_expression<'parser>(
     if let Some(identifier) = identifier {
       let name = ast.get_utf8(identifier.name(ast));
       if is_create_require_specifier(parser, name) {
-        let evaluated = name.call_hooks_name(parser, |parser, for_name| {
+        let evaluated = parser.call_hooks_name(name, |parser, for_name| {
           evaluate_create_require_new_expression(parser, for_name, Some(callee), expression)
         });
         if evaluated.is_some() {

--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_unary_expr.rs
@@ -15,16 +15,16 @@ fn eval_typeof<'parser>(
   debug_assert_eq!(expression.operator(ast), UnaryOperator::Typeof);
   let argument = expression.argument(ast);
   let hook_result = match ast.expr_data(argument) {
-    ExprData::IdentifierReference(identifier) => ast
-      .get_utf8(identifier.name(ast))
-      .call_hooks_name(parser, |parser, name| {
+    ExprData::IdentifierReference(identifier) => {
+      parser.call_hooks_name(ast.get_utf8(identifier.name(ast)), |parser, name| {
         parser
           .plugin_drive
           .clone()
           .evaluate_typeof(parser, expression, name)
-      }),
+      })
+    }
     ExprData::MetaProperty(meta) => meta.get_root_name(ast).and_then(|name| {
-      name.call_hooks_name(parser, |parser, name| {
+      parser.call_hooks_name(name, |parser, name| {
         parser
           .plugin_drive
           .clone()

--- a/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
   eval_call_expr::eval_call_expression,
   eval_cond_expr::eval_cond_expression,
   eval_lit_expr::eval_lit_expr,
-  eval_member_expr::eval_member_expression,
+  eval_member_expr::{eval_member_expression, eval_member_expression_with_info},
   eval_new_expr::eval_new_expression,
   eval_source::eval_source,
   eval_tpl_expr::{TemplateStringKind, eval_tagged_tpl_expression, eval_tpl_expression},

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/call_hooks_name.rs
@@ -1,10 +1,8 @@
+use rspack_intern::AtomRef;
 use swc_next_ecma_ast::{ChainExpression, Expr, IdentifierReference, MemberExpression};
 
 use super::{AllowedMemberTypes, ExportedVariableInfo, JavascriptParser, MemberExpressionInfo};
-use crate::{
-  Atom,
-  visitors::{ExprRef, scope_info::BindingState},
-};
+use crate::visitors::{ExprRef, scope_info::BindingState};
 
 /// callHooksForName/callHooksForInfo in webpack
 /// webpack use HookMap and filter at callHooksForName/callHooksForInfo
@@ -45,58 +43,24 @@ impl CallHooksName for IdentifierReference {
   }
 }
 
-#[allow(unused_lifetimes)]
-impl CallHooksName for Atom {
-  fn call_hooks_name<'parser, F, T>(
-    &self,
-    parser: &mut JavascriptParser<'parser>,
+impl<'parser> JavascriptParser<'parser> {
+  pub fn call_hooks_name<'key, F, T>(
+    &mut self,
+    name: impl Into<AtomRef<'key>>,
     hook_call: F,
   ) -> Option<T>
   where
-    F: Fn(&mut JavascriptParser<'parser>, &str) -> Option<T>,
+    F: Fn(&mut Self, &str) -> Option<T>,
   {
-    if let Some(id) = parser.definitions_db.resolve(self) {
-      // resolved variable info
-      call_hooks_info(id, parser, hook_call)
+    let name = name.into();
+    if let Some(state) = self.definitions_db.resolve(name) {
+      call_hooks_info(state, self, hook_call)
     } else {
-      // unresolved free variable, for example the global `require` in commonjs.
-      hook_call(parser, self)
+      hook_call(self, name.as_str())
     }
   }
 }
 
-impl CallHooksName for &str {
-  fn call_hooks_name<'parser, F, T>(
-    &self,
-    parser: &mut JavascriptParser<'parser>,
-    hook_call: F,
-  ) -> Option<T>
-  where
-    F: Fn(&mut JavascriptParser<'parser>, &str) -> Option<T>,
-  {
-    if let Some(id) = parser.definitions_db.resolve(*self) {
-      // resolved variable info
-      call_hooks_info(id, parser, hook_call)
-    } else {
-      // unresolved free variable, for example the global `require` in commonjs.
-      hook_call(parser, self)
-    }
-  }
-}
-
-#[allow(unused_lifetimes)]
-impl CallHooksName for String {
-  fn call_hooks_name<'parser, F, T>(
-    &self,
-    parser: &mut JavascriptParser<'parser>,
-    hook_call: F,
-  ) -> Option<T>
-  where
-    F: Fn(&mut JavascriptParser<'parser>, &str) -> Option<T>,
-  {
-    self.as_str().call_hooks_name(parser, hook_call)
-  }
-}
 #[allow(unused_lifetimes)]
 impl CallHooksName for ExportedVariableInfo {
   fn call_hooks_name<'parser, F, T>(
@@ -108,7 +72,7 @@ impl CallHooksName for ExportedVariableInfo {
     F: Fn(&mut JavascriptParser<'parser>, &str) -> Option<T>,
   {
     match self {
-      ExportedVariableInfo::Name(n) => n.call_hooks_name(parser, hooks_call),
+      ExportedVariableInfo::Name(n) => parser.call_hooks_name(n, hooks_call),
       ExportedVariableInfo::VariableInfo(v) => call_hooks_info(*v, parser, hooks_call),
     }
   }
@@ -133,7 +97,7 @@ impl CallHooksName for MemberExpression {
     if members.is_empty() {
       expr_name.root_info.call_hooks_name(parser, hook_call)
     } else {
-      expr_name.name.call_hooks_name(parser, hook_call)
+      hook_call(parser, &expr_name.name)
     }
   }
 }
@@ -160,7 +124,7 @@ impl CallHooksName for ChainExpression {
     if members.is_empty() {
       expr_name.root_info.call_hooks_name(parser, hook_call)
     } else {
-      expr_name.name.call_hooks_name(parser, hook_call)
+      hook_call(parser, &expr_name.name)
     }
   }
 }

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -1760,6 +1760,9 @@ impl<'parser> JavascriptParser<'parser> {
           let state = self
             .definitions_db
             .resolve_identifier(self.ast, ident, resolution);
+          if matches!(state, Some(BindingState::Normal(_))) {
+            return None;
+          }
           let info = state.map(|state| self.definitions_db.expect_get_variable(state));
           if let Some(info) = info {
             if let Some(name) = info.name

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -485,7 +485,8 @@ pub struct JavascriptParser<'parser> {
   pub(crate) source: &'parser str,
   pub ast: &'parser ParsedJavaScriptAst<'parser>,
   synthetic_asts: Vec<(&'parser ParsedJavaScriptAst<'parser>, usize)>,
-  active_synthetic_ast: Option<usize>,
+  /// Active replacement AST index; `None` means the original module AST.
+  pub(crate) active_synthetic_ast: Option<usize>,
   pub parse_meta: ParseMeta,
   pub factory_meta: Option<&'parser FactoryMeta>,
   pub build_meta: &'parser mut BuildMeta,

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1,5 +1,5 @@
 use rspack_intern::AtomRef;
-use rspack_util::swc::AstSubRangeExt;
+use rspack_util::{SpanExt, swc::AstSubRangeExt};
 use smallvec::SmallVec;
 use swc_next_ecma_ast::*;
 
@@ -20,6 +20,7 @@ use crate::{
     CREATE_REQUIRE_EVALUATED_TAG, CREATE_REQUIRE_SPECIFIER_TAG, CREATED_REQUIRE_IDENTIFIER_TAG,
     CreatedRequireTagData, JavascriptParserPlugin, is_create_require_namespace_member,
   },
+  utils::eval::{BasicEvaluatedExpression, eval_member_expression_with_info},
   visitors::{
     AtomMembers, ExportedVariableInfo, ExprRef, Identifier, VariableDeclaration, VariableInfo,
     VariableInfoFlags, get_non_optional_part,
@@ -908,11 +909,14 @@ impl JavascriptParser<'_> {
         // we use `AllowedMemberTypes::Expression` above
         unreachable!();
       };
-      if expr_info
-        .name
-        .call_hooks_name(self, |this, for_name| drive.r#typeof(this, expr, for_name))
-        .unwrap_or_default()
-      {
+      let handled = if expr_info.members.is_empty() {
+        expr_info
+          .root_info
+          .call_hooks_name(self, |this, for_name| drive.r#typeof(this, expr, for_name))
+      } else {
+        drive.r#typeof(self, expr, &expr_info.name)
+      };
+      if handled.unwrap_or_default() {
         return;
       }
     };
@@ -922,7 +926,7 @@ impl JavascriptParser<'_> {
 
   fn walk_this_expression(&mut self, expr: ThisExpression) {
     let drive = self.plugin_drive.clone();
-    "this".call_hooks_name(self, |this, for_name| drive.this(this, expr, for_name));
+    self.call_hooks_name("this", |this, for_name| drive.this(this, expr, for_name));
   }
 
   pub(crate) fn walk_template_expression(&mut self, expr: TemplateLiteral) {
@@ -1087,11 +1091,8 @@ impl JavascriptParser<'_> {
       member_ranges,
     };
     let drive = self.plugin_drive.clone();
-    if expression_info
-      .name
-      .call_hooks_name(self, |this, for_name| {
-        drive.member(this, member.into(), for_name)
-      })
+    if drive
+      .member(self, member.into(), &expression_info.name)
       .unwrap_or_default()
     {
       return;
@@ -1117,10 +1118,8 @@ impl JavascriptParser<'_> {
     for index in (0..member_nodes.len().saturating_sub(1)).rev() {
       let removed_member = &expression_info.members[index + 1];
       prefix_name = &prefix_name[..prefix_name.len() - removed_member.len() - 1];
-      if prefix_name
-        .call_hooks_name(self, |this, for_name| {
-          drive.member(this, member_nodes[index].into(), for_name)
-        })
+      if drive
+        .member(self, member_nodes[index].into(), prefix_name)
         .unwrap_or_default()
       {
         return;
@@ -1199,12 +1198,10 @@ impl JavascriptParser<'_> {
             .new_expression(parser, expr, for_name)
         })
       } else {
-        info.name.call_hooks_name(self, |parser, for_name| {
-          parser
-            .plugin_drive
-            .clone()
-            .new_expression(parser, expr, for_name)
-        })
+        self
+          .plugin_drive
+          .clone()
+          .new_expression(self, expr, &info.name)
       };
       if result.unwrap_or_default() {
         return;
@@ -1294,16 +1291,12 @@ impl JavascriptParser<'_> {
   fn walk_member_expression(&mut self, expr: MemberExpression) {
     let ast = self.ast.ast;
     let drive = self.plugin_drive.clone();
-    if let Some(expr_info) =
-      self.get_member_expression_info(ExprRef::Member(expr), AllowedMemberTypes::all())
-    {
+    let (expr_info, await_import_member) = self.get_member_expression_info_and_await_import(expr);
+    if let Some(expr_info) = expr_info {
       match expr_info {
         MemberExpressionInfo::Expression(expr_info) => {
-          if expr_info
-            .name
-            .call_hooks_name(self, |this, for_name| {
-              drive.member(this, expr.into(), for_name)
-            })
+          if drive
+            .member(self, expr.into(), &expr_info.name)
             .unwrap_or_default()
           {
             return;
@@ -1377,7 +1370,7 @@ impl JavascriptParser<'_> {
     }
 
     // (await import(...)).a.b
-    if let Some((call, members, await_expr)) = self.extract_await_import_member(expr) {
+    if let Some((call, members, await_expr)) = await_import_member {
       if self.is_top_level_scope() {
         self
           .plugin_drive
@@ -1425,8 +1418,8 @@ impl JavascriptParser<'_> {
     {
       let origin = name.len();
       let name = &name[0..origin - 1 - property.len()];
-      if name
-        .call_hooks_name(self, |this, for_name| {
+      if self
+        .call_hooks_name(name, |this, for_name| {
           drive.member(this, member.into(), for_name)
         })
         .unwrap_or_default()
@@ -1553,12 +1546,16 @@ impl JavascriptParser<'_> {
     fn get_var_name(parser: &mut JavascriptParser, expr: Expr) -> Option<ExportedVariableInfo> {
       if let Some(rename_identifier) = parser.get_rename_identifier(expr)
         && let drive = parser.plugin_drive.clone()
-        && rename_identifier
-          .call_hooks_name(parser, |this, for_name| drive.can_rename(this, for_name))
+        && parser
+          .call_hooks_name(&rename_identifier, |this, for_name| {
+            drive.can_rename(this, for_name)
+          })
           .unwrap_or_default()
       {
-        if !rename_identifier
-          .call_hooks_name(parser, |this, for_name| drive.rename(this, expr, for_name))
+        if !parser
+          .call_hooks_name(&rename_identifier, |this, for_name| {
+            drive.rename(this, expr, for_name)
+          })
           .unwrap_or_default()
         {
           let variable = parser.get_variable_alias(rename_identifier);
@@ -1696,28 +1693,34 @@ impl JavascriptParser<'_> {
       return;
     }
 
+    let mut callee_expression_info = None;
     if let Some(member) = callee_member {
-      if let Some(MemberExpressionInfo::Call(expr_info)) =
-        self.get_member_expression_info(ExprRef::Member(member), AllowedMemberTypes::CallExpression)
-        && expr_info
-          .root_info
-          .call_hooks_name(self, |this, for_name| {
-            this
-              .plugin_drive
-              .clone()
-              .call_member_chain_of_call_member_chain(
-                this,
-                expr,
-                &expr_info.callee_members,
-                expr_info.call,
-                &expr_info.members,
-                &expr_info.member_ranges,
-                for_name,
-              )
-          })
-          .unwrap_or_default()
-      {
-        return;
+      let (member_info, await_import_member) =
+        self.get_member_expression_info_and_await_import(member);
+      match member_info {
+        Some(MemberExpressionInfo::Call(expr_info))
+          if expr_info
+            .root_info
+            .call_hooks_name(self, |this, for_name| {
+              this
+                .plugin_drive
+                .clone()
+                .call_member_chain_of_call_member_chain(
+                  this,
+                  expr,
+                  &expr_info.callee_members,
+                  expr_info.call,
+                  &expr_info.members,
+                  &expr_info.member_ranges,
+                  for_name,
+                )
+            })
+            .unwrap_or_default() =>
+        {
+          return;
+        }
+        Some(MemberExpressionInfo::Expression(info)) => callee_expression_info = Some(info),
+        _ => {}
       }
       // import(...).then(...)
       if let Some(import) = member.object(ast).as_import_expression(ast)
@@ -1731,7 +1734,7 @@ impl JavascriptParser<'_> {
         return;
       }
       // (await import(...)).a.b()
-      if let Some((call, members, await_expr)) = self.extract_await_import_member(member) {
+      if let Some((call, members, await_expr)) = await_import_member {
         if self.is_top_level_scope() {
           self
             .plugin_drive
@@ -1749,7 +1752,16 @@ impl JavascriptParser<'_> {
         }
       }
     }
-    let evaluated_callee = self.evaluate_expression(callee);
+    let evaluated_callee = if let Some(member) = callee_member {
+      eval_member_expression_with_info(self, member, callee, callee_expression_info)
+        .unwrap_or_else(|| {
+          let span = callee.span(ast);
+          BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi())
+        })
+        .with_expression_ast(Some(callee), self.active_synthetic_ast)
+    } else {
+      self.evaluate_expression(callee)
+    };
     if evaluated_callee.is_identifier() {
       let members = evaluated_callee.members().map_or(&[][..], Vec::as_slice);
       let owned_members_optionals;
@@ -1805,26 +1817,39 @@ impl JavascriptParser<'_> {
     self.walk_arguments(ast.nodes(arguments));
   }
 
-  fn extract_await_import_member(
-    &self,
+  fn get_member_expression_info_and_await_import(
+    &mut self,
     expr: MemberExpression,
-  ) -> Option<(ImportExpression, AtomMembers, AwaitExpression)> {
+  ) -> (
+    Option<MemberExpressionInfo>,
+    Option<(ImportExpression, AtomMembers, AwaitExpression)>,
+  ) {
     let ast = self.ast.ast;
     let super::RawExtractedMemberExpressionChainData {
       object,
       members,
       mut members_optionals,
-      ..
+      member_ranges,
     } = self.extract_member_expression_chain_raw(ExprRef::Member(expr));
-    let ExprRef::Await(await_expr) = object else {
-      return None;
-    };
-    let call = await_expr.argument(ast).as_import_expression(ast)?;
-    let mut members = super::materialize_member_atoms(ast, members);
-    members.reverse();
-    members_optionals.reverse();
-    let members = get_non_optional_part(&members, &members_optionals);
-    Some((call, members.into(), await_expr))
+    if let ExprRef::Await(await_expr) = object
+      && let Some(call) = await_expr.argument(ast).as_import_expression(ast)
+    {
+      let mut members = super::materialize_member_atoms(ast, members);
+      members.reverse();
+      members_optionals.reverse();
+      let members = get_non_optional_part(&members, &members_optionals);
+      return (None, Some((call, members.into(), await_expr)));
+    }
+    (
+      self._get_member_expression_info(
+        object,
+        members,
+        members_optionals,
+        member_ranges,
+        AllowedMemberTypes::all(),
+      ),
+      None,
+    )
   }
 
   pub fn walk_arguments<I>(&mut self, arguments: I)
@@ -1895,7 +1920,7 @@ impl JavascriptParser<'_> {
 
   fn walk_identifier_name(&mut self, name: &str, span: Span) {
     let drive = self.plugin_drive.clone();
-    name.call_hooks_name(self, |this, for_name| {
+    self.call_hooks_name(name, |this, for_name| {
       drive.identifier(this, &Identifier { span }, for_name)
     });
   }
@@ -1922,12 +1947,16 @@ impl JavascriptParser<'_> {
       }
       if expr.operator(ast) == AssignmentOperator::Assign
         && let Some(rename_identifier) = self.get_rename_identifier(right)
-        && rename_identifier
-          .call_hooks_name(self, |this, for_name| drive.can_rename(this, for_name))
+        && self
+          .call_hooks_name(&rename_identifier, |this, for_name| {
+            drive.can_rename(this, for_name)
+          })
           .unwrap_or_default()
       {
-        if !rename_identifier
-          .call_hooks_name(self, |this, for_name| drive.rename(this, right, for_name))
+        if !self
+          .call_hooks_name(&rename_identifier, |this, for_name| {
+            drive.rename(this, right, for_name)
+          })
           .unwrap_or_default()
         {
           let variable = self.get_variable_alias(rename_identifier);
@@ -1971,8 +2000,8 @@ impl JavascriptParser<'_> {
       }
       self.enter_array_pattern(array, |this, ident, name| {
         let ast = this.ast.ast;
-        if !name
-          .call_hooks_name(this, |this, for_name| {
+        if !this
+          .call_hooks_name(name, |this, for_name| {
             drive.assign(
               this,
               expr,
@@ -1995,8 +2024,8 @@ impl JavascriptParser<'_> {
       }
       self.enter_object_pattern(object, |this, ident, name| {
         let ast = this.ast.ast;
-        if !name
-          .call_hooks_name(this, |this, for_name| {
+        if !this
+          .call_hooks_name(name, |this, for_name| {
             drive.assign(
               this,
               expr,

--- a/tests/rspack-test/configCases/parsing/semantic-member-resolution/index.js
+++ b/tests/rspack-test/configCases/parsing/semantic-member-resolution/index.js
@@ -1,0 +1,17 @@
+it('reuses resolved member roots without losing aliases or computed keys', () => {
+  const alias = require;
+  expect(alias('./value').nested.call()).toBe('value');
+  expect(require.resolve('./value')).toBeDefined();
+  expect(DEFINED.branch.value).toBe('defined');
+  expect(typeof DEFINED.branch.value).toBe('string');
+  const local = { nested: { call() { return this.value; }, value: 'local' } };
+  expect(local['nested'].call()).toBe('local');
+  expect(local?.nested.call()).toBe('local');
+});
+
+it('shares await-import member analysis for reads and calls', async () => {
+  expect((await import('./value')).nested.value).toBe('value');
+  expect((await import('./value')).nested.call()).toBe('value');
+  expect((await import('./value')).nested?.call()).toBe('value');
+  expect((await import('./value')).missing?.call()).toBeUndefined();
+});

--- a/tests/rspack-test/configCases/parsing/semantic-member-resolution/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/semantic-member-resolution/rspack.config.js
@@ -1,0 +1,11 @@
+const { rspack } = require('@rspack/core');
+
+module.exports = {
+  target: 'node',
+  module: { parser: { javascript: { requireAlias: true } } },
+  plugins: [
+    new rspack.DefinePlugin({
+      'DEFINED.branch.value': JSON.stringify('defined'),
+    }),
+  ],
+};

--- a/tests/rspack-test/configCases/parsing/semantic-member-resolution/value.js
+++ b/tests/rspack-test/configCases/parsing/semantic-member-resolution/value.js
@@ -1,0 +1,4 @@
+export const nested = {
+  value: 'value',
+  call() { return this.value; },
+};

--- a/tests/rspack-test/configCases/side-effects/semantic-bindings/duplicate.cjs
+++ b/tests/rspack-test/configCases/side-effects/semantic-bindings/duplicate.cjs
@@ -1,0 +1,12 @@
+globalThis.__semantic_duplicate_calls__ = 0;
+
+function duplicate() {
+  return 1;
+}
+
+// Both declarations belong to one semantic symbol; the first body is not sufficient.
+function duplicate() {
+  globalThis.__semantic_duplicate_calls__++;
+}
+
+duplicate();

--- a/tests/rspack-test/configCases/side-effects/semantic-bindings/index.js
+++ b/tests/rspack-test/configCases/side-effects/semantic-bindings/index.js
@@ -1,0 +1,9 @@
+import './shadowed';
+import './duplicate.cjs';
+
+it('keeps shadowed callees and merged declarations conservative', () => {
+  expect(globalThis.__semantic_shadowed_calls__).toEqual(['parameter', 'block']);
+  expect(globalThis.__semantic_duplicate_calls__).toBe(1);
+  delete globalThis.__semantic_shadowed_calls__;
+  delete globalThis.__semantic_duplicate_calls__;
+});

--- a/tests/rspack-test/configCases/side-effects/semantic-bindings/rspack.config.js
+++ b/tests/rspack-test/configCases/side-effects/semantic-bindings/rspack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  mode: 'production',
+  experiments: { pureFunctions: true },
+  optimization: { minimize: false, concatenateModules: false },
+};

--- a/tests/rspack-test/configCases/side-effects/semantic-bindings/shadowed.js
+++ b/tests/rspack-test/configCases/side-effects/semantic-bindings/shadowed.js
@@ -1,0 +1,19 @@
+globalThis.__semantic_shadowed_calls__ = [];
+
+function selected() {
+  return 1;
+}
+
+function invoke(selected) {
+  selected();
+}
+
+// The callee inside invoke resolves to its parameter, not the pure top-level function.
+export const unused = invoke(() => globalThis.__semantic_shadowed_calls__.push('parameter'));
+
+{
+  const selected = () => globalThis.__semantic_shadowed_calls__.push('block');
+  selected();
+}
+
+export { selected };


### PR DESCRIPTION
## Summary

Reuse semantic and member-analysis results across side-effects analysis, the parser walker, and the evaluator. Stacked on #15595, ultimately targeting `release/2.3.0`.

- **Side effects:** use existing semantic bindings and declaration counts instead of collecting all top-level names and building a duplicate-name map/set. Retain export-alias/default-export handling and distinguish top-level pure functions from shadowing bindings using resolved callee symbols.
- **Identifier evaluation:** reuse immutable semantic resolution across the hook/fallback path. Mutable variable state is still read again after hooks, so alias/tag changes remain visible.
- **Member walking and evaluation:** extract member-chain information once, share the result with member-callee evaluation, and combine normal-member/await-import analysis. Preserve optional-chain handling, plugin evaluation, and synthetic AST identity/ranges.
- **Hook dispatch:** use already-resolved qualified member names directly, avoiding another variable-name lookup. Consolidate remaining Atom/string name queries in a parser helper, while keeping direct identifier semantic lookup.
- Add compatibility coverage for shadowed/duplicate declarations, require aliases, DefinePlugin qualified names, computed/optional members, and await-import reads/calls.

The two commits remain grouped by responsibility: side-effects declaration reuse, followed by walker/evaluator result reuse. The combined PR changes 18 files (362 insertions / 371 deletions). Existing test assertions and snapshots are unchanged. There is no persistent evaluator cache or caching of mutable binding state across hooks.

### Performance

Local Docker + Valgrind Callgrind, `rust@scan_dependencies@three_module`:

| Version | Instructions (IR) |
| --- | ---: |
| Parent #15595 (`0ca2c88dd2`) | 34,406,832 |
| Side-effects-only revision (`5d0562b8c3`) | 34,263,698 |
| Combined PR (`f8c8aa492b`) | 32,466,923 |

The combined PR reduces scan IR by **1,939,909 (-5.64%) versus #15595**. Adding walker/evaluator reuse reduces IR by a further **1,796,775 (-5.24%) versus the side-effects-only revision**, replacing the previous standalone -0.42% PR result.

The candidate was measured once; the two verified earlier measurements were reused. All use the same native Linux ARM64 image, nightly-2026-04-16, Valgrind 3.19.0, build flags, and Three.js fixture. This measures dependency scanning, excluding parsing and semantic construction; it is not a whole-build wall-time claim.

## Related links

- Parent: #15595
- Original migration/optimization work: #15331

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
