### PR TITLE
fix: omit build-local paths from sourcemap content hash

### DIFF
--- a/crates/rspack_core/src/artifacts/code_generation_results.rs
+++ b/crates/rspack_core/src/artifacts/code_generation_results.rs
@@ -343,7 +343,9 @@ impl CodeGenerationResultBuilder {
     hash_salt: &HashSalt,
   ) {
     let mut hasher = RspackHasher::with_salt(hash_function, hash_salt);
-    for (source_type, source) in self.value.sources.as_ref() {
+    let mut entries = self.value.sources.as_ref().iter().collect::<Vec<_>>();
+    entries.sort_unstable_by_key(|(source_type, _)| **source_type);
+    for (source_type, source) in entries {
       source_type.hash(&mut hasher);
       std::hash::Hash::hash(source, &mut hasher);
     }
@@ -365,7 +367,9 @@ impl CodeGenerationResultBuilder {
   ) {
     let mut hasher = RspackHasher::with_salt(hash_function, hash_salt);
     runtime_hash.hash(&mut hasher);
-    for source_type in self.value.sources.as_ref().keys() {
+    let mut source_types = self.value.sources.as_ref().keys().collect::<Vec<_>>();
+    source_types.sort_unstable();
+    for source_type in source_types {
       source_type.hash(&mut hasher);
     }
     self.value.data.update_hash(&mut hasher);

--- a/crates/rspack_sources/src/source.rs
+++ b/crates/rspack_sources/src/source.rs
@@ -911,7 +911,7 @@ mod tests {
     RawBufferSource::from("a".as_bytes()).hash(&mut state);
     (&RawStringSource::from("h") as &dyn Source).hash(&mut state);
     ReplaceSource::new(RawStringSource::from("i").boxed()).hash(&mut state);
-    assert_eq!(format!("{:x}", state.finish()), "1f41150b3252c34b");
+    assert_eq!(format!("{:x}", state.finish()), "76b8c22688fd7506");
   }
 
   #[test]

--- a/crates/rspack_sources/src/source_map_source.rs
+++ b/crates/rspack_sources/src/source_map_source.rs
@@ -376,31 +376,6 @@ mod tests {
   }
 
   #[test]
-  fn should_hash_independently_of_source_map_paths() {
-    let source = |sandbox: &str| {
-      SourceMapSource::new(SourceMapSourceOptions {
-        value: "console.log(1);\n".to_string(),
-        name: "mod.js".to_string(),
-        source_map: SourceMap::from_json(format!(
-          r#"{{"version":3,"file":"{sandbox}/dist/mod.js","sources":["{sandbox}/app/src/mod.ts"],"sourceRoot":"{sandbox}","names":[],"sourcesContent":["console.log(1)"],"mappings":"AAAA"}}"#
-        ))
-        .unwrap(),
-        original_source: None,
-        inner_source_map: None,
-        remove_original_source: false,
-      })
-    };
-
-    let mut a = twox_hash::XxHash64::default();
-    source("/mnt/engflow/worker/work/0/exec").hash(&mut a);
-
-    let mut b = twox_hash::XxHash64::default();
-    source("/mnt/engflow/worker/work/7/exec").hash(&mut b);
-
-    assert_eq!(a.finish(), b.finish());
-  }
-
-  #[test]
   fn should_handle_null_sources_and_sources_content() {
     let a = SourceMapSource::new(WithoutOriginalOptions {
       value: "hello world\n",

--- a/crates/rspack_sources/src/source_map_source.rs
+++ b/crates/rspack_sources/src/source_map_source.rs
@@ -161,13 +161,30 @@ impl Source for SourceMapSource {
   }
 }
 
+/// Hash only the content-relevant source map fields. Path-like fields such as
+/// `sources`, `sourceRoot`, and `file` may include sandbox roots that differ
+/// across otherwise identical builds.
+fn hash_source_map_content<H: Hasher>(source_map: &SourceMap<'_>, state: &mut H) {
+  source_map.mappings().hash(state);
+  source_map.names().hash(state);
+  source_map.sources_content().hash(state);
+  source_map.ignore_list().hash(state);
+  source_map.get_debug_id().hash(state);
+}
+
 impl Hash for SourceMapSource {
   fn hash<H: Hasher>(&self, state: &mut H) {
     "SourceMapSource".hash(state);
     self.buffer().hash(state);
-    self.source_map.hash(state);
+    hash_source_map_content(&self.source_map, state);
     self.original_source.hash(state);
-    self.inner_source_map.hash(state);
+    match &self.inner_source_map {
+      Some(inner) => {
+        true.hash(state);
+        hash_source_map_content(inner, state);
+      }
+      None => false.hash(state),
+    }
     self.remove_original_source.hash(state);
   }
 }
@@ -355,7 +372,32 @@ mod tests {
 
     let mut hasher = twox_hash::XxHash64::default();
     sms1.hash(&mut hasher);
-    assert_eq!(format!("{:x}", hasher.finish()), "736934c6e249aa6e");
+    assert_eq!(format!("{:x}", hasher.finish()), "23217f6b1bca9508");
+  }
+
+  #[test]
+  fn should_hash_independently_of_source_map_paths() {
+    let source = |sandbox: &str| {
+      SourceMapSource::new(SourceMapSourceOptions {
+        value: "console.log(1);\n".to_string(),
+        name: "mod.js".to_string(),
+        source_map: SourceMap::from_json(format!(
+          r#"{{"version":3,"file":"{sandbox}/dist/mod.js","sources":["{sandbox}/app/src/mod.ts"],"sourceRoot":"{sandbox}","names":[],"sourcesContent":["console.log(1)"],"mappings":"AAAA"}}"#
+        ))
+        .unwrap(),
+        original_source: None,
+        inner_source_map: None,
+        remove_original_source: false,
+      })
+    };
+
+    let mut a = twox_hash::XxHash64::default();
+    source("/mnt/engflow/worker/work/0/exec").hash(&mut a);
+
+    let mut b = twox_hash::XxHash64::default();
+    source("/mnt/engflow/worker/work/7/exec").hash(&mut b);
+
+    assert_eq!(a.finish(), b.finish());
   }
 
   #[test]

--- a/tests/rspack-test/hashCases/source-map-path-independence/index.js
+++ b/tests/rspack-test/hashCases/source-map-path-independence/index.js
@@ -1,0 +1,1 @@
+console.log(1);

--- a/tests/rspack-test/hashCases/source-map-path-independence/loader.js
+++ b/tests/rspack-test/hashCases/source-map-path-independence/loader.js
@@ -1,0 +1,13 @@
+module.exports = function (source) {
+  const { sandbox, changeCode } = this.getOptions();
+  const code = changeCode ? source.replace('log(1)', 'log(2)') : source;
+  this.callback(null, code, {
+    version: 3,
+    file: `${sandbox}/dist/mod.js`,
+    sources: [`${sandbox}/app/src/mod.ts`],
+    sourceRoot: sandbox,
+    names: [],
+    sourcesContent: [code],
+    mappings: 'AAAA',
+  });
+};

--- a/tests/rspack-test/hashCases/source-map-path-independence/rspack.config.js
+++ b/tests/rspack-test/hashCases/source-map-path-independence/rspack.config.js
@@ -1,0 +1,38 @@
+const path = require('node:path');
+
+function config(name, sandbox, changeCode = false) {
+  return {
+    name,
+    mode: 'production',
+    devtool: 'hidden-source-map',
+    entry: './index.js',
+    output: {
+      path: path.resolve(__dirname, 'dist', name),
+      filename: '[name].[contenthash].js',
+    },
+    module: {
+      rules: [
+        {
+          test: /index\.js$/,
+          use: {
+            loader: path.resolve(__dirname, 'loader.js'),
+            // Keep module identity stable while varying the loader's source map.
+            ident: 'source-map-path-independence',
+            options: { sandbox, changeCode },
+          },
+        },
+      ],
+    },
+    optimization: {
+      minimize: false,
+      // Hashing final asset bytes would hide source-map contributions to codegen hashes.
+      realContentHash: false,
+    },
+  };
+}
+
+module.exports = [
+  config('worker-0', '/mnt/engflow/worker/work/0/exec'),
+  config('worker-7', '/mnt/engflow/worker/work/7/exec'),
+  config('changed-code', '/mnt/engflow/worker/work/7/exec', true),
+];

--- a/tests/rspack-test/hashCases/source-map-path-independence/test.config.js
+++ b/tests/rspack-test/hashCases/source-map-path-independence/test.config.js
@@ -1,0 +1,12 @@
+/** @type {import('@rspack/test-tools').THashCaseConfig} */
+module.exports = {
+  validate(stats) {
+    expect(stats.hasErrors()).toBe(false);
+    const [first, relocated, changed] = stats.stats.map((child) =>
+      child.toJson({ assets: true }),
+    );
+    expect(first.assetsByChunkName.main).toBeTruthy();
+    expect(relocated.assetsByChunkName.main).toEqual(first.assetsByChunkName.main);
+    expect(changed.assetsByChunkName.main).not.toEqual(first.assetsByChunkName.main);
+  },
+};


### PR DESCRIPTION
## Motivation

Rspack’s code generation hash currently hashes each generated `Source` structurally. For `SourceMapSource`, that structural hash includes the full source map, including path-like fields such as `sources`, `sourceRoot`, and `file`. In sandboxed or remote-execution CI environments, those fields can contain absolute worker paths like `/mnt/engflow/worker/work/N/exec/...`, where `N` varies between otherwise identical builds. Those path differences do not affect emitted JavaScript bytes, but they feed into per-module codegen hashes. The tainted module hashes then feed chunk content hashes, causing unstable asset filenames and reducing cross-build asset reuse.

## Changes

This change makes codegen hashing deterministic for that case by:
- sorting codegen `SourceType` entries before hashing, avoiding hash-map iteration-order instability
- hashing only content-relevant source-map fields for `SourceMapSource`
- deliberately excluding path-like source-map metadata from the source hash while preserving it in emitted source maps

This keeps debug/source-map output unchanged, while ensuring content hashes reflect emitted content and stable source-map content rather than ephemeral build-machine paths.

The added regression test confirms builds with identical emitted code and different sandbox source-map paths produce the same source hash.