### PR TITLE
fix: normalize HttpUriPlugin allowedUris before matching

### DIFF
--- a/crates/rspack_plugin_schemes/src/http_uri/mod.rs
+++ b/crates/rspack_plugin_schemes/src/http_uri/mod.rs
@@ -282,7 +282,22 @@ impl HttpUriOptionsAllowedUris {
   }
 
   pub fn is_allowed(&self, uri: &str) -> bool {
-    self.conditions.try_match(uri)
+    let Ok(parsed_uri) = Url::parse(uri) else {
+      return false;
+    };
+
+    // Normalize both URLs so a host-only rule includes the trailing slash and
+    // cannot match a different host through userinfo or a shared hostname prefix.
+    let matches = |condition: &AssetCondition| match condition {
+      AssetCondition::String(allowed) => Url::parse(allowed)
+        .is_ok_and(|parsed_allowed| parsed_uri.as_str().starts_with(parsed_allowed.as_str())),
+      AssetCondition::Regexp(regexp) => regexp.test(parsed_uri.as_str()),
+    };
+
+    match &self.conditions {
+      AssetConditions::Single(condition) => matches(condition),
+      AssetConditions::Multiple(conditions) => conditions.iter().any(matches),
+    }
   }
 
   pub fn get_allowed_uris_description(&self) -> String {

--- a/tests/rspack-test/configCases/build-http/allowed-uris-security/errors.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris-security/errors.js
@@ -1,0 +1,7 @@
+module.exports = [
+  /http:\/\/allowed\.example@blocked\.example\/userinfo\.js doesn't match the allowedUris policy/,
+  /http:\/\/allowed\.example\.blocked\.example\/host-prefix\.js doesn't match the allowedUris policy/,
+  /http:\/\/path\.example\/outside\.js doesn't match the allowedUris policy/,
+  /https:\/\/blocked\.example\/invalid-rule\.js doesn't match the allowedUris policy/,
+  /http:\/\/allowed\.example@blocked\.example\/redirected\.js doesn't match the allowedUris policy after redirect/,
+];

--- a/tests/rspack-test/configCases/build-http/allowed-uris-security/index.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris-security/index.js
@@ -1,0 +1,7 @@
+import 'http://allowed.example@blocked.example/userinfo.js';
+import 'http://allowed.example.blocked.example/host-prefix.js';
+import 'http://path.example/modules/../outside.js';
+import 'https://blocked.example/invalid-rule.js';
+import 'http://allowed.example/redirect';
+
+throw new Error('Compilation should reject disallowed URLs');

--- a/tests/rspack-test/configCases/build-http/allowed-uris-security/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris-security/rspack.config.js
@@ -1,0 +1,28 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  target: 'web',
+  experiments: {
+    buildHttp: {
+      allowedUris: [
+        'http://allowed.example',
+        'http://path.example/modules/',
+        'https://',
+      ],
+      cacheLocation: false,
+      httpClient: async (url) => {
+        if (url === 'http://allowed.example/redirect') {
+          return {
+            status: 302,
+            headers: {
+              location: 'http://allowed.example@blocked.example/redirected.js',
+              'cache-control': 'no-store',
+            },
+            body: Buffer.from(''),
+          };
+        }
+
+        throw new Error(`Disallowed URL reached the HTTP client: ${url}`);
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/build-http/allowed-uris-security/test.config.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris-security/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isolateSource: true,
+};

--- a/tests/rspack-test/configCases/build-http/allowed-uris/index.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris/index.js
@@ -1,0 +1,17 @@
+import host from 'http://allowed.example/module.js';
+import path from 'http://path.example/modules/module.js';
+import regex from 'http://REGEX.EXAMPLE:80/module.js';
+import redirected from 'http://allowed.example/redirect';
+
+it('should normalize string rules and skip invalid rules', () => {
+  expect(host).toBe('http://allowed.example/module.js');
+  expect(path).toBe('http://path.example/modules/module.js');
+});
+
+it('should match regular expressions against normalized URLs', () => {
+  expect(regex).toBe('http://regex.example/module.js');
+});
+
+it('should allow redirects that match a normalized rule', () => {
+  expect(redirected).toBe('http://allowed.example/redirected.js');
+});

--- a/tests/rspack-test/configCases/build-http/allowed-uris/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris/rspack.config.js
@@ -1,0 +1,36 @@
+/** @type {import('@rspack/core').Configuration} */
+module.exports = {
+  target: 'web',
+  experiments: {
+    buildHttp: {
+      allowedUris: [
+        'not a URL',
+        'HTTP://ALLOWED.EXAMPLE:80',
+        'http://path.example/old/../modules/',
+        /^http:\/\/regex\.example\/module\.js$/,
+      ],
+      cacheLocation: false,
+      httpClient: async (url) => {
+        if (url === 'http://allowed.example/redirect') {
+          return {
+            status: 302,
+            headers: {
+              location: './redirected.js',
+              'cache-control': 'no-store',
+            },
+            body: Buffer.from(''),
+          };
+        }
+
+        return {
+          status: 200,
+          headers: {
+            'content-type': 'application/javascript',
+            'cache-control': 'no-store',
+          },
+          body: Buffer.from(`export default ${JSON.stringify(url)};`),
+        };
+      },
+    },
+  },
+};

--- a/tests/rspack-test/configCases/build-http/allowed-uris/test.config.js
+++ b/tests/rspack-test/configCases/build-http/allowed-uris/test.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  isolateSource: true,
+};

--- a/tests/rspack-test/configCases/build-http/asset/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/asset/rspack.config.js
@@ -14,7 +14,7 @@ module.exports = {
   },
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://raw.githubusercontent.com/'],
       lockfileLocation: path.resolve(__dirname, './lock-files/lock.json'),
       cacheLocation: path.resolve(__dirname, './lock-files/test'),
     },

--- a/tests/rspack-test/configCases/build-http/css/rspack.config.js
+++ b/tests/rspack-test/configCases/build-http/css/rspack.config.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://raw.githubusercontent.com/'],
       lockfileLocation: path.resolve(__dirname, './lock-files/lock.json'),
       cacheLocation: path.resolve(__dirname, './lock-files/test'),
     },

--- a/website/docs/en/api/javascript-api/browser.mdx
+++ b/website/docs/en/api/javascript-api/browser.mdx
@@ -146,7 +146,7 @@ export default {
   plugins: [new BrowserHttpImportEsmPlugin({ domain: 'https://esm.sh' })],
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://esm.sh/'],
     },
   },
 };

--- a/website/docs/en/config/experiments.mdx
+++ b/website/docs/en/config/experiments.mdx
@@ -74,6 +74,8 @@ type HttpUriOptions = {
 
 After enabling this feature, Rspack can build remote resources that start with the `http(s):` protocol. Rspack will download the resources to the local machine and then bundle them.
 
+String entries in `allowedUris` must be valid absolute URLs. Rspack normalizes both the requested URL and each string entry before comparing their prefixes. For example, `'https://example.com'` is normalized to `'https://example.com/'`. Invalid string entries, such as `'https://'`, are ignored. Regular expressions are tested against the normalized URL; use `/^https:\/\//` if you intend to allow any HTTPS URL. Redirect targets must also match `allowedUris`.
+
 By default, Rspack will generate `rspack.lock` and `rspack.lock.data` in the [context](/config/context) folder as the locations of the Lockfile and the cache respectively. You can also configure them through `lockfileLocation` and `cacheLocation`.
 
 :::note
@@ -88,7 +90,7 @@ import path from 'node:path';
 export default {
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://example.com/'],
       lockfileLocation: path.join(import.meta.dirname, 'my_project.lock'),
       cacheLocation: path.join(import.meta.dirname, 'my_project.lock.data'),
     },

--- a/website/docs/zh/api/javascript-api/browser.mdx
+++ b/website/docs/zh/api/javascript-api/browser.mdx
@@ -147,7 +147,7 @@ export default {
   plugins: [new BrowserHttpImportEsmPlugin({ domain: 'https://esm.sh' })],
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://esm.sh/'],
     },
   },
 };

--- a/website/docs/zh/config/experiments.mdx
+++ b/website/docs/zh/config/experiments.mdx
@@ -75,6 +75,8 @@ type HttpUriOptions = {
 
 启用此功能后，Rspack 可以构建以 `http(s):` 协议开头的远程资源。Rspack 会将资源下载到本地，然后再进行打包。
 
+`allowedUris` 中的字符串必须是有效的绝对 URL。Rspack 会先规范化请求 URL 和各个字符串规则，再比较前缀。例如，`'https://example.com'` 会被规范化为 `'https://example.com/'`。无效字符串（如 `'https://'`）会被忽略。正则表达式匹配的是规范化后的 URL；如果你希望允许任意 HTTPS URL，可以使用 `/^https:\/\//`。重定向目标也必须匹配 `allowedUris`。
+
 默认情况下，Rspack 会在 [context](/config/context) 文件夹下生成 `rspack.lock` 和 `rspack.lock.data` 分别作为 Lockfile 和缓存的位置，你也可以通过 `lockfileLocation` 和 `cacheLocation` 进行配置。
 
 :::note
@@ -89,7 +91,7 @@ import path from 'node:path';
 export default {
   experiments: {
     buildHttp: {
-      allowedUris: ['https://'],
+      allowedUris: ['https://example.com/'],
       lockfileLocation: path.join(import.meta.dirname, 'my_project.lock'),
       cacheLocation: path.join(import.meta.dirname, 'my_project.lock.data'),
     },


### PR DESCRIPTION
## Motivation

`HttpUriPlugin` compares string `allowedUris` rules without normalizing them as URLs. A host-only rule can therefore match a URL with userinfo or a different hostname that shares the permitted hostname prefix, allowing requests outside the intended allowlist.

Align this behavior with [webpack’s fix](https://github.com/webpack/webpack/commit/c5100702335a9cdcb75558ccd80def2329bd4abf).

## Changes

- Parse and normalize requested URLs and string rules before prefix matching. Ignore invalid string rules and match regular expressions against the normalized URL. Initial requests and redirects continue to share the same policy check.
- Add regression cases for valid normalized rules, regex matching, allowed redirects, userinfo bypasses, hostname-prefix bypasses, path boundaries, invalid rules, and disallowed redirects. The security cases use a mock HTTP client and fail if a disallowed request reaches it.
- Update the English and Chinese documentation and existing HTTP fixtures. Scheme-only strings such as `'https://'` must be replaced with complete URLs or an intentional regular expression.

Validation:

- `pnpm run build:cli:dev`
- `pnpm --dir tests/rspack-test run test -t configCases/build-http` — 14 passed
- `pnpm --dir tests/rspack-test run test -t configCases/asset-modules/http-redirect-security` — 2 passed
- `cargo clippy -p rspack_plugin_schemes --lib -- --deny warnings`
- Rust formatting, configuration/documentation formatting, and `git diff --check`
