### PR TITLE
test: use native ESM configs in e2e tests

### DIFF
--- a/tests/e2e/cases/chunk/esm_split/rspack.config.js
+++ b/tests/e2e/cases/chunk/esm_split/rspack.config.js
@@ -1,8 +1,7 @@
-'use strict';
-let rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   mode: 'development',
   output: {
     module: true,

--- a/tests/e2e/cases/chunk/issue-4936/rspack.config.js
+++ b/tests/e2e/cases/chunk/issue-4936/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.js',
   stats: 'none',
   mode: 'development',

--- a/tests/e2e/cases/chunk/recover-error/rspack.config.js
+++ b/tests/e2e/cases/chunk/recover-error/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
-module.exports = {
+export default {
   mode: 'development',
-  context: __dirname,
+  context: import.meta.dirname,
   entry: {
     main: './src/main.jsx',
   },

--- a/tests/e2e/cases/css/chunk-loading-order/rspack.config.js
+++ b/tests/e2e/cases/css/chunk-loading-order/rspack.config.js
@@ -1,7 +1,7 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   devServer: {

--- a/tests/e2e/cases/css/css-filename/rspack.config.js
+++ b/tests/e2e/cases/css/css-filename/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   output: {

--- a/tests/e2e/cases/css/hmr-async-chunk-css/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-async-chunk-css/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-css-added/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-css-added/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-esm-async-css-added/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-esm-async-css-added/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-esm-css-only-update/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-esm-css-only-update/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-extract-css-modules/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-extract-css-modules/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-extract-css-readd/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-extract-css-readd/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-extract-no-runtime/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-extract-no-runtime/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-extract-unloaded-async-css/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-extract-unloaded-async-css/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-mixed-css-both-update/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-mixed-css-both-update/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-mixed-css-runtimes/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-mixed-css-runtimes/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-multi-css-chunks-update/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-multi-css-chunks-update/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-native-css-lifecycle/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-native-css-lifecycle/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-native-css-modules/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-native-css-modules/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-native-first-css/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-native-first-css/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-native-unloaded-async-css/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-native-unloaded-async-css/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-precise-css-updates/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-precise-css-updates/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/hmr-split-css-chunk/rspack.config.js
+++ b/tests/e2e/cases/css/hmr-split-css-chunk/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/css/import-double-css-files-with-empty/rspack.config.js
+++ b/tests/e2e/cases/css/import-double-css-files-with-empty/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   devServer: {

--- a/tests/e2e/cases/css/import-empty-css-file/rspack.config.js
+++ b/tests/e2e/cases/css/import-empty-css-file/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   devServer: {

--- a/tests/e2e/cases/css/render-to-body/rspack.config.js
+++ b/tests/e2e/cases/css/render-to-body/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   devServer: {

--- a/tests/e2e/cases/css/shared-stylesheet-dedup-link/rspack.config.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup-link/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type {import('@rspack/core').RspackOptions} */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: ['./src/index.css', './src/index.js'],

--- a/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
+++ b/tests/e2e/cases/css/shared-stylesheet-dedup/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: ['./src/index.css', './src/index.js'],

--- a/tests/e2e/cases/css/update-initial-chunks-after-hmr/rspack.config.js
+++ b/tests/e2e/cases/css/update-initial-chunks-after-hmr/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: ['./src/index.css', './src/index.js'],

--- a/tests/e2e/cases/css/update-initial-chunks/rspack.config.js
+++ b/tests/e2e/cases/css/update-initial-chunks/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: ['./src/index.css', './src/index.js'],

--- a/tests/e2e/cases/file/context-delete-file/rspack.config.js
+++ b/tests/e2e/cases/file/context-delete-file/rspack.config.js
@@ -1,7 +1,7 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/file/missing-files/rspack.config.js
+++ b/tests/e2e/cases/file/missing-files/rspack.config.js
@@ -1,7 +1,7 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/index.js',

--- a/tests/e2e/cases/hooks/asset-emitted/rspack.config.js
+++ b/tests/e2e/cases/hooks/asset-emitted/rspack.config.js
@@ -1,6 +1,6 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
-module.exports = {
+export default {
   entry: {
     main: './src/index.js',
   },

--- a/tests/e2e/cases/hooks/no-emit-on-errors-recover-consecutive/rspack.config.js
+++ b/tests/e2e/cases/hooks/no-emit-on-errors-recover-consecutive/rspack.config.js
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './src/index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [new rspack.HtmlRspackPlugin()],
   optimization: {

--- a/tests/e2e/cases/hooks/no-emit-on-errors-recover/rspack.config.js
+++ b/tests/e2e/cases/hooks/no-emit-on-errors-recover/rspack.config.js
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './src/index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [new rspack.HtmlRspackPlugin()],
   optimization: {

--- a/tests/e2e/cases/html/asset-tag-hooks/rspack.config.js
+++ b/tests/e2e/cases/html/asset-tag-hooks/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   stats: 'none',

--- a/tests/e2e/cases/html/cross-origin-loading/rspack.config.js
+++ b/tests/e2e/cases/html/cross-origin-loading/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.js',
   stats: 'none',

--- a/tests/e2e/cases/html/issue-4366/rspack.config.js
+++ b/tests/e2e/cases/html/issue-4366/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.js',
   stats: 'none',
   plugins: [new rspack.HtmlRspackPlugin({ template: './src/index.html' })],

--- a/tests/e2e/cases/incremental/remove-optimized-module/rspack.config.js
+++ b/tests/e2e/cases/incremental/remove-optimized-module/rspack.config.js
@@ -1,7 +1,7 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   mode: 'development',
   entry: './index.js',
   cache: true,

--- a/tests/e2e/cases/lazy-compilation/active-lots-modules/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/active-lots-modules/rspack.config.js
@@ -1,4 +1,4 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /*
 Construct a project with lots of virtual files with very long file names
@@ -24,8 +24,8 @@ lotsLongFileNameVirtualFiles['src/virtual_index.js'] = `
 `;
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/virtual_index.js',
   mode: 'development',
   lazyCompilation: true,

--- a/tests/e2e/cases/lazy-compilation/cross-origin/index.test.ts
+++ b/tests/e2e/cases/lazy-compilation/cross-origin/index.test.ts
@@ -4,12 +4,8 @@ import { test as base, expect } from '@playwright/test';
 import fs from 'fs-extra';
 import { type Compiler, type Configuration, rspack } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
-import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const tempDir = path.resolve(__dirname, '../../temp');
+import { pathToFileURL } from 'node:url';
+import { calcPathInfo } from '@/fixtures/pathInfo';
 
 // Create a separate lazy compilation server on a different port (cross-origin)
 function createLazyCompilationServer(
@@ -43,21 +39,7 @@ const test = base.extend<{
   crossOriginSetup: [
     async ({ page }, use, testInfo) => {
       const workerId = String(testInfo.workerIndex);
-      const testProjectDir = path.dirname(testInfo.file);
-      const tempProjectDir = path.join(tempDir, `cross-origin-${workerId}`);
-
-      // Copy test project to temp directory
-      if (await fs.exists(tempProjectDir)) {
-        await fs.remove(tempProjectDir);
-      }
-      await fs.copy(testProjectDir, tempProjectDir);
-
-      // Clear require cache for temp directory
-      for (const modulePath of Object.keys(require.cache)) {
-        if (modulePath.startsWith(tempProjectDir)) {
-          delete require.cache[modulePath];
-        }
-      }
+      const { tempProjectDir } = await calcPathInfo(testInfo.file, workerId);
 
       // Use different ports for frontend and lazy compilation server
       const basePort = 8500;
@@ -66,8 +48,9 @@ const test = base.extend<{
 
       // Load and modify config
       const configPath = path.resolve(tempProjectDir, 'rspack.config.js');
-      const config: Configuration = require(configPath);
-      delete require.cache[configPath];
+      const { default: config }: { default: Configuration } = await import(
+        pathToFileURL(configPath).href
+      );
 
       config.context = tempProjectDir;
       config.output = {

--- a/tests/e2e/cases/lazy-compilation/cross-origin/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/cross-origin/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },

--- a/tests/e2e/cases/lazy-compilation/css-update/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/css-update/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.js',
   mode: 'development',
   module: {

--- a/tests/e2e/cases/lazy-compilation/custom-prefix/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/custom-prefix/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },

--- a/tests/e2e/cases/lazy-compilation/default-prefix/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/default-prefix/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-import-shared/rspack.config.js
@@ -1,11 +1,11 @@
-const path = require('path');
-const fs = require('fs');
-const rspack = require('@rspack/core');
+import path from 'node:path';
+import fs from 'node:fs';
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: async () => {
-    const context = path.resolve(__dirname, 'src');
+    const context = path.resolve(import.meta.dirname, 'src');
     const files = await fs.promises.readdir(context);
     const result = {};
     for (const f of files) {
@@ -15,7 +15,7 @@ module.exports = {
     }
     return result;
   },
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [
     new rspack.HtmlRspackPlugin({ chunks: ['main'], filename: 'index.html' }),

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-remove/rspack.config.js
@@ -1,11 +1,11 @@
-const path = require('path');
-const fs = require('fs');
-const rspack = require('@rspack/core');
+import path from 'node:path';
+import fs from 'node:fs';
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: async () => {
-    const context = path.resolve(__dirname, 'src');
+    const context = path.resolve(import.meta.dirname, 'src');
     const files = await fs.promises.readdir(context);
     let entries = files.filter((f) => f.startsWith('index'));
     entries.sort();
@@ -14,7 +14,7 @@ module.exports = {
       return acc;
     }, {});
   },
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [
     new rspack.HtmlRspackPlugin({ chunks: ['index1'], filename: 'index.html' }),

--- a/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/dynamic-entry-removed-with-import-alive/rspack.config.js
@@ -1,11 +1,11 @@
-const path = require('path');
-const fs = require('fs');
-const rspack = require('@rspack/core');
+import path from 'node:path';
+import fs from 'node:fs';
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: async () => {
-    const context = path.resolve(__dirname, 'src');
+    const context = path.resolve(import.meta.dirname, 'src');
     const entries = { main: './src/main.js' };
     try {
       await fs.promises.stat(path.join(context, 'marker.js'));
@@ -13,7 +13,7 @@ module.exports = {
     } catch {}
     return entries;
   },
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [
     new rspack.HtmlRspackPlugin({ chunks: ['main'], filename: 'index.html' }),

--- a/tests/e2e/cases/lazy-compilation/ignore-entry/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/ignore-entry/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: [
       // Will trigger the issue.

--- a/tests/e2e/cases/lazy-compilation/module-federation/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/module-federation/rspack.config.js
@@ -1,9 +1,10 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { fileURLToPath } from 'node:url';
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.jsx',
   mode: 'development',
   devtool: false,
@@ -47,7 +48,9 @@ module.exports = {
         react: {},
         'react-dom': {},
       },
-      runtimePlugins: [require.resolve('./runtime-plugin.js')],
+      runtimePlugins: [
+        fileURLToPath(import.meta.resolve('./runtime-plugin.js')),
+      ],
     }),
     new ReactRefreshRspackPlugin(),
   ],

--- a/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
+++ b/tests/e2e/cases/lazy-compilation/persistent-cache/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: ['./src/component.js', './src/index.js'],
   },

--- a/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_builtin_loader/rspack.config.js
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './src/index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [new rspack.HtmlRspackPlugin()],
   module: {

--- a/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
+++ b/tests/e2e/cases/make/failed_module_by_js_loader/rspack.config.js
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './src/index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [new rspack.HtmlRspackPlugin()],
   module: {

--- a/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
+++ b/tests/e2e/cases/make/remove-dynamic-entry-with-loader/rspack.config.js
@@ -1,11 +1,11 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 const sharedObj = {
   useFullEntry: true,
 };
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: async () => {
     if (sharedObj.useFullEntry) {
       return {
@@ -24,7 +24,7 @@ module.exports = {
       };
     }
   },
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   optimization: {
     runtimeChunk: 'single',

--- a/tests/e2e/cases/make/remove-dynamic-entry/rspack.config.js
+++ b/tests/e2e/cases/make/remove-dynamic-entry/rspack.config.js
@@ -1,11 +1,11 @@
-const path = require('path');
-const fs = require('fs');
-const rspack = require('@rspack/core');
+import path from 'node:path';
+import fs from 'node:fs';
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: async () => {
-    const context = path.resolve(__dirname, 'src');
+    const context = path.resolve(import.meta.dirname, 'src');
     const files = await fs.promises.readdir(context);
     let entries = files.filter((f) => f.startsWith('index'));
     entries.sort();
@@ -14,7 +14,7 @@ module.exports = {
       return acc;
     }, {});
   },
-  context: __dirname,
+  context: import.meta.dirname,
   mode: 'development',
   plugins: [new rspack.HtmlRspackPlugin()],
   devServer: {

--- a/tests/e2e/cases/make/rewrite-factorize-provide-request/rspack.config.js
+++ b/tests/e2e/cases/make/rewrite-factorize-provide-request/rspack.config.js
@@ -1,13 +1,13 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 const sharedObj = {
   time: 1,
 };
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   cache: true,
   experiments: {
     cache: true,

--- a/tests/e2e/cases/make/rewrite-factorize-reexport-request/rspack.config.js
+++ b/tests/e2e/cases/make/rewrite-factorize-reexport-request/rspack.config.js
@@ -1,14 +1,14 @@
-const { rspack } = require('@rspack/core');
-const path = require('path');
+import { rspack } from '@rspack/core';
+import path from 'node:path';
 
 const sharedObj = {
   time: 1,
 };
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   cache: true,
   experiments: {
     cache: true,
@@ -17,7 +17,7 @@ module.exports = {
   module: {
     rules: [
       {
-        include: path.resolve(__dirname, 'reexport.js'),
+        include: path.resolve(import.meta.dirname, 'reexport.js'),
         sideEffects: true,
       },
     ],

--- a/tests/e2e/cases/make/rewrite-factorize-request/rspack.config.js
+++ b/tests/e2e/cases/make/rewrite-factorize-request/rspack.config.js
@@ -1,13 +1,13 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 const sharedObj = {
   time: 1,
 };
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   cache: true,
   experiments: {
     cache: true,

--- a/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
+++ b/tests/e2e/cases/module-federation/async-startup-self-remote-runtimechunk-single/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.js',
   mode: 'development',
   devtool: false,

--- a/tests/e2e/cases/module-federation/async-startup-self-remote/rspack.config.js
+++ b/tests/e2e/cases/module-federation/async-startup-self-remote/rspack.config.js
@@ -1,8 +1,8 @@
-const { rspack } = require('@rspack/core');
+import { rspack } from '@rspack/core';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.jsx',
   mode: 'development',
   devtool: false,

--- a/tests/e2e/cases/module-federation/container-entry-split-chunks-lazy/rspack.config.js
+++ b/tests/e2e/cases/module-federation/container-entry-split-chunks-lazy/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.jsx',
   mode: 'development',
   devtool: false,

--- a/tests/e2e/cases/module-federation/container-entry-split-chunks/rspack.config.js
+++ b/tests/e2e/cases/module-federation/container-entry-split-chunks/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: './src/index.jsx',
   mode: 'development',
   devtool: false,

--- a/tests/e2e/cases/persistent-cache/rename-file/rspack.config.js
+++ b/tests/e2e/cases/persistent-cache/rename-file/rspack.config.js
@@ -1,9 +1,9 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {import("@rspack/core").Configuration} */
-module.exports = {
+export default {
   entry: './index.js',
-  context: __dirname,
+  context: import.meta.dirname,
   // use production mod to make sure
   // the persistent cache will write to disk
   mode: 'production',

--- a/tests/e2e/cases/react/basic/rspack.config.js
+++ b/tests/e2e/cases/react/basic/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],

--- a/tests/e2e/cases/react/class-component/rspack.config.js
+++ b/tests/e2e/cases/react/class-component/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.jsx',
   resolve: {

--- a/tests/e2e/cases/react/tailwindcss-with-css-extract/rspack.config.js
+++ b/tests/e2e/cases/react/tailwindcss-with-css-extract/rspack.config.js
@@ -1,9 +1,9 @@
-const path = require('node:path');
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import path from 'node:path';
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/main.jsx',
@@ -51,7 +51,10 @@ module.exports = {
               postcssOptions: {
                 plugins: {
                   tailwindcss: {
-                    config: path.join(__dirname, './tailwind.config.js'),
+                    config: path.join(
+                      import.meta.dirname,
+                      './tailwind.config.js',
+                    ),
                   },
                 },
               },

--- a/tests/e2e/cases/react/tailwindcss/rspack.config.js
+++ b/tests/e2e/cases/react/tailwindcss/rspack.config.js
@@ -1,9 +1,9 @@
-const path = require('node:path');
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import path from 'node:path';
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: {
     main: './src/main.jsx',
@@ -44,7 +44,10 @@ module.exports = {
               postcssOptions: {
                 plugins: {
                   tailwindcss: {
-                    config: path.join(__dirname, './tailwind.config.js'),
+                    config: path.join(
+                      import.meta.dirname,
+                      './tailwind.config.js',
+                    ),
                   },
                 },
               },

--- a/tests/e2e/cases/react/with-babel/rspack.config.js
+++ b/tests/e2e/cases/react/with-babel/rspack.config.js
@@ -1,9 +1,10 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { fileURLToPath } from 'node:url';
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   resolve: {
     extensions: ['...', '.ts', '.tsx', '.jsx'],
@@ -37,7 +38,9 @@ module.exports = {
             loader: 'babel-loader',
             options: {
               presets: [['@babel/preset-react', { runtime: 'automatic' }]],
-              plugins: [require.resolve('react-refresh/babel')],
+              plugins: [
+                fileURLToPath(import.meta.resolve('react-refresh/babel')),
+              ],
             },
           },
         ],

--- a/tests/e2e/cases/react/worker/rspack.config.js
+++ b/tests/e2e/cases/react/worker/rspack.config.js
@@ -1,9 +1,9 @@
-const { rspack } = require('@rspack/core');
-const { ReactRefreshRspackPlugin } = require('@rspack/plugin-react-refresh');
+import { rspack } from '@rspack/core';
+import { ReactRefreshRspackPlugin } from '@rspack/plugin-react-refresh';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/index.jsx',
   resolve: {

--- a/tests/e2e/cases/vue3/rspack.config.js
+++ b/tests/e2e/cases/vue3/rspack.config.js
@@ -1,9 +1,9 @@
-const { DefinePlugin, HtmlRspackPlugin } = require('@rspack/core');
-const { VueLoaderPlugin } = require('rspack-vue-loader');
+import { DefinePlugin, HtmlRspackPlugin } from '@rspack/core';
+import { VueLoaderPlugin } from 'rspack-vue-loader';
 
 /** @type { import('@rspack/core').RspackOptions } */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   mode: 'development',
   entry: './src/main.js',
   devServer: {

--- a/tests/e2e/cases/worker/mf-worker/rspack.config.js
+++ b/tests/e2e/cases/worker/mf-worker/rspack.config.js
@@ -1,9 +1,9 @@
-const path = require('path');
-const rspack = require('@rspack/core');
+import path from 'node:path';
+import rspack from '@rspack/core';
 
 /** @type {rspack.Configuration} */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },
@@ -11,7 +11,7 @@ module.exports = {
   mode: 'development',
   resolve: {
     alias: {
-      'shared-lib': path.resolve(__dirname, 'src/shared-lib'),
+      'shared-lib': path.resolve(import.meta.dirname, 'src/shared-lib'),
     },
   },
   plugins: [

--- a/tests/e2e/cases/worker/worker-hmr/rspack.config.js
+++ b/tests/e2e/cases/worker/worker-hmr/rspack.config.js
@@ -1,8 +1,8 @@
-const rspack = require('@rspack/core');
+import rspack from '@rspack/core';
 
 /** @type {rspack.Configuration} */
-module.exports = {
-  context: __dirname,
+export default {
+  context: import.meta.dirname,
   entry: {
     main: './src/index.js',
   },

--- a/tests/e2e/fixtures/pathInfo.ts
+++ b/tests/e2e/fixtures/pathInfo.ts
@@ -1,9 +1,6 @@
 import path from 'node:path';
 import fs from 'fs-extra';
 import type { Fixtures } from '@playwright/test';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
 
 type PathInfo = {
   testFile: string;
@@ -16,7 +13,7 @@ export type PathInfoFixtures = {
 };
 
 const tempDir = path.resolve(import.meta.dirname, '../temp');
-async function calcPathInfo(
+export async function calcPathInfo(
   testFile: string,
   workerId: string,
 ): Promise<PathInfo> {
@@ -28,16 +25,10 @@ async function calcPathInfo(
     throw new Error(`rspack config not exist in ${testProjectDir}`);
   }
 
-  const tempProjectDir = path.join(tempDir, workerId);
-  if (await fs.exists(tempProjectDir)) {
-    await fs.remove(tempProjectDir);
-  }
+  // Native ESM modules are cached by URL. Give each test a fresh module graph.
+  await fs.ensureDir(tempDir);
+  const tempProjectDir = await fs.mkdtemp(path.join(tempDir, `${workerId}-`));
   await fs.copy(testProjectDir, tempProjectDir);
-  for (const modulePath of Object.keys(require.cache)) {
-    if (modulePath.startsWith(tempProjectDir)) {
-      delete require.cache[modulePath];
-    }
-  }
 
   return {
     testFile,

--- a/tests/e2e/fixtures/rspack.ts
+++ b/tests/e2e/fixtures/rspack.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { Fixtures, PlaywrightTestArgs } from '@playwright/test';
 import {
   type Compiler,
@@ -8,9 +9,6 @@ import {
 } from '@rspack/core';
 import { RspackDevServer } from '@rspack/dev-server';
 import type { PathInfoFixtures } from './pathInfo';
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
 
 class Rspack {
   private config: RspackConfig;
@@ -21,11 +19,10 @@ class Rspack {
   private onDone: Array<() => void> = [];
   constructor(
     projectDir: string,
+    config: Configuration,
     handleRspackConfig: (config: Configuration) => Configuration,
   ) {
-    const configPath = path.resolve(projectDir, 'rspack.config.js');
-    this.config = handleRspackConfig(require(configPath));
-    delete require.cache[configPath];
+    this.config = handleRspackConfig(config);
     this.projectDir = projectDir;
     this.outDir = this.config.output!.path!;
   }
@@ -113,7 +110,11 @@ export const rspackFixtures = (): RspackFixtures => {
       async ({ page, pathInfo, rspackConfig }, use, { workerIndex }) => {
         const { tempProjectDir } = pathInfo;
         const port = rspackConfig.basePort + workerIndex;
-        const rspack = new Rspack(tempProjectDir, (config) => {
+        const configPath = path.join(tempProjectDir, 'rspack.config.js');
+        const { default: config } = await import(
+          pathToFileURL(configPath).href
+        );
+        const rspack = new Rspack(tempProjectDir, config, (config) => {
           // rewrite port
           if (!config.devServer) {
             config.devServer = {};

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -17,6 +17,8 @@ export default defineConfig<RspackOptions>({
   build: {
     external: [
       '**/moduleFederationDefaultRuntime.js',
+      // Fixture configs are native ESM and do not need Playwright transforms.
+      '**/rspack.config.js',
       // E2E tests load @rspack/core through both import and require.
       // Skip Playwright transforms and let Node load its dist files natively.
       '**/packages/rspack/dist/**',


### PR DESCRIPTION
## Motivation

E2E fixture configs use CommonJS syntax inside a `type: module` package, relying on Playwright transforms to load them. Make these configs compatible with native Node.js ESM loading.

## Changes

Convert fixture configs to ESM and load them through dynamic `import()`, bypassing Playwright transforms. Use a unique temporary directory for each test to isolate ESM module caches.