### PR TITLE
refactor: replace FreezeLock blocking locks with atomic borrows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4213,6 +4213,7 @@ dependencies = [
  "arc-swap",
  "async-recursion",
  "async-trait",
+ "atomic_refcell",
  "bitflags 2.13.1",
  "concat-string",
  "cow-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,7 +4236,6 @@ dependencies = [
  "napi",
  "num-bigint",
  "once_cell",
- "parking_lot",
  "paste",
  "pretty_assertions",
  "rayon",

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -34,7 +34,6 @@ mime_guess                 = { workspace = true }
 napi                       = { workspace = true, optional = true }
 num-bigint                 = { workspace = true }
 once_cell                  = { workspace = true }
-parking_lot                = { workspace = true }
 paste                      = { workspace = true }
 rayon                      = { workspace = true }
 regex                      = { workspace = true }

--- a/crates/rspack_core/Cargo.toml
+++ b/crates/rspack_core/Cargo.toml
@@ -11,6 +11,7 @@ anymap                     = { workspace = true }
 arc-swap                   = { workspace = true }
 async-recursion            = { workspace = true }
 async-trait                = { workspace = true }
+atomic_refcell             = { workspace = true }
 bitflags                   = { workspace = true }
 concat-string              = { workspace = true }
 cow-utils                  = { workspace = true }

--- a/crates/rspack_core/src/compilation/create_module_assets/mod.rs
+++ b/crates/rspack_core/src/compilation/create_module_assets/mod.rs
@@ -27,7 +27,7 @@ pub async fn create_module_assets(
   let mut module_assets = vec![];
   let mg = compilation.get_module_graph();
   for (identifier, module) in mg.modules() {
-    let assets = &module.build_info().assets;
+    let assets = &module.build_info_unchecked().assets;
     if assets.is_empty() {
       continue;
     }

--- a/crates/rspack_core/src/compilation/module_ids/mod.rs
+++ b/crates/rspack_core/src/compilation/module_ids/mod.rs
@@ -21,8 +21,8 @@ fn get_modules_needing_ids(
       m.need_id()
         && ChunkGraph::get_module_id(module_ids_artifact, m.identifier()).is_none()
         && (chunk_graph.get_number_of_module_chunks(m.identifier()) != 0
-          || m.build_meta().is_css_module()
-          || m.build_meta().need_id_in_concatenation())
+          || m.build_meta_unchecked().is_css_module()
+          || m.build_meta_unchecked().need_id_in_concatenation())
     })
     .map(|m| m.identifier())
     .collect()

--- a/crates/rspack_core/src/concatenated_module.rs
+++ b/crates/rspack_core/src/concatenated_module.rs
@@ -743,6 +743,10 @@ impl Module for ConcatenatedModule {
     self.build_info.read()
   }
 
+  fn build_info_unchecked(&self) -> &BuildInfo {
+    self.build_info.get_unchecked()
+  }
+
   fn freeze_build_info(&self) {
     self.build_info.freeze();
   }
@@ -757,6 +761,10 @@ impl Module for ConcatenatedModule {
 
   fn build_meta(&self) -> crate::FreezeReadGuard<'_, BuildMeta> {
     self.root_module_ctxt.build_meta.read()
+  }
+
+  fn build_meta_unchecked(&self) -> &BuildMeta {
+    self.root_module_ctxt.build_meta.get_unchecked()
   }
 
   fn freeze_build_meta(&self) -> &triomphe::Arc<BuildMeta> {
@@ -814,7 +822,7 @@ impl Module for ConcatenatedModule {
       .expect("should have root module");
 
     // populate root inline_exports
-    self.build_info.get_mut().inline_exports = root_module.build_info().inline_exports;
+    self.build_info.get_mut().inline_exports = root_module.build_info_unchecked().inline_exports;
 
     let dependency_parts = self
       .modules
@@ -846,7 +854,7 @@ impl Module for ConcatenatedModule {
       let module = module_graph
         .module_by_identifier(&m.id)
         .expect("should have module");
-      let cur_build_info = module.build_info();
+      let cur_build_info = module.build_info_unchecked();
 
       // populate cacheable
       if !cur_build_info.cacheable {
@@ -861,7 +869,7 @@ impl Module for ConcatenatedModule {
       self.diagnostics.extend(module.diagnostics().into_owned());
 
       // populate topLevelDeclarations
-      let module_build_info = module.build_info();
+      let module_build_info = module.build_info_unchecked();
       if let Some(decls) = &module_build_info.top_level_declarations
         && let Some(top_level_declarations) = &mut self.build_info.get_mut().top_level_declarations
       {
@@ -1203,7 +1211,7 @@ impl Module for ConcatenatedModule {
         let module = module_graph
           .module_by_identifier(&info.module)
           .expect("should have module");
-        let build_meta = module.build_meta();
+        let build_meta = module.build_meta_unchecked();
         let mut refs = vec![];
         for reference in info.global_scope_ident.iter() {
           let name = &reference.id.sym;
@@ -1298,7 +1306,7 @@ impl Module for ConcatenatedModule {
     let root_module = module_graph
       .module_by_identifier(&root_module_id)
       .expect("should have box module");
-    let strict_esm_module = root_module.build_meta().strict_esm_module();
+    let strict_esm_module = root_module.build_meta_unchecked().strict_esm_module();
 
     let exports_info = compilation
       .exports_info_artifact
@@ -1461,7 +1469,7 @@ impl Module for ConcatenatedModule {
         &compilation.module_static_cache,
         &context,
       );
-      let strict_esm_module = box_module.build_meta().strict_esm_module();
+      let strict_esm_module = box_module.build_meta_unchecked().strict_esm_module();
       let name_space_name = module_info.namespace_object_name.clone();
 
       if let Some(ref _namespace_export_symbol) = module_info.namespace_export_symbol {
@@ -1558,7 +1566,7 @@ impl Module for ConcatenatedModule {
             module_graph,
             &compilation.module_graph_cache_artifact,
             &compilation.exports_info_artifact,
-            root_module.build_meta().strict_esm_module(),
+            root_module.build_meta_unchecked().strict_esm_module(),
           ),
           &module_id,
           // an async module will opt-out of the concat module optimization.
@@ -1592,7 +1600,7 @@ impl Module for ConcatenatedModule {
               module_graph,
               &compilation.module_graph_cache_artifact,
               &compilation.exports_info_artifact,
-              root_module.build_meta().strict_esm_module(),
+              root_module.build_meta_unchecked().strict_esm_module(),
             )),
           )));
         }
@@ -2495,7 +2503,7 @@ impl ConcatenatedModule {
       .module_by_identifier(&info.id())
       .expect("should have module");
     let is_module_deferred = matches!(info, ModuleInfo::External(info) if info.deferred)
-      && !module.build_meta().has_top_level_await();
+      && !module.build_meta_unchecked().has_top_level_await();
     let is_deferred = reexport_deferred.unwrap_or(dep_deferred) && is_module_deferred;
 
     match target {

--- a/crates/rspack_core/src/concatenation_backend.rs
+++ b/crates/rspack_core/src/concatenation_backend.rs
@@ -399,7 +399,7 @@ impl<'a> ConcatenationBindingResolver<'a> {
               let mut plan = self.resolve_inner(
                 &ref_info.id(),
                 target_export_name,
-                module.build_meta().strict_esm_module(),
+                module.build_meta_unchecked().strict_esm_module(),
                 visited_exports,
               );
               plan.reexport_deferred.get_or_insert(reexport.defer);
@@ -521,7 +521,7 @@ impl ConcatenationNameAllocator {
       .module_graph
       .module_by_identifier(&module)
       .expect("should have module")
-      .build_meta();
+      .build_meta_unchecked();
     let exports_type: BuildMetaExportsType = build_meta.exports_type();
     let default_object: BuildMetaDefaultObject = build_meta.default_object();
     let module_identifier = context.module_identifier(&module);

--- a/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
+++ b/crates/rspack_core/src/legacy_cache/persistent/occasion/make/alternatives/module.rs
@@ -78,6 +78,10 @@ impl Module for TempModule {
     self.build_info.read()
   }
 
+  fn build_info_unchecked(&self) -> &BuildInfo {
+    self.build_info.get_unchecked()
+  }
+
   fn freeze_build_info(&self) {
     self.build_info.freeze();
   }
@@ -92,6 +96,10 @@ impl Module for TempModule {
 
   fn build_meta(&self) -> crate::FreezeReadGuard<'_, BuildMeta> {
     self.build_meta.read()
+  }
+
+  fn build_meta_unchecked(&self) -> &BuildMeta {
+    self.build_meta.get_unchecked()
   }
 
   fn freeze_build_meta(&self) -> &triomphe::Arc<BuildMeta> {

--- a/crates/rspack_core/src/module.rs
+++ b/crates/rspack_core/src/module.rs
@@ -754,7 +754,12 @@ pub trait Module:
   /// Refresh factory metadata and clear compilation-specific state on cache reuse.
   fn reset_for_compilation(&self, factory_meta: Option<Arc<FactoryMeta>>);
 
+  /// Read metadata during build or in codegen helpers also used by `importModule`.
   fn build_info(&self) -> crate::FreezeReadGuard<'_, BuildInfo>;
+
+  /// Read finalized metadata during seal without a build borrow guard.
+  /// Panics if the metadata has not been frozen yet.
+  fn build_info_unchecked(&self) -> &BuildInfo;
 
   /// Finalize build information after loader assets and the cache snapshot.
   fn freeze_build_info(&self);
@@ -764,7 +769,12 @@ pub trait Module:
 
   fn build_info_mut(&mut self) -> &mut BuildInfo;
 
+  /// Read metadata during build or in codegen helpers also used by `importModule`.
   fn build_meta(&self) -> crate::FreezeReadGuard<'_, BuildMeta>;
+
+  /// Read finalized metadata during seal without a build borrow guard.
+  /// Panics if the metadata has not been frozen yet.
+  fn build_meta_unchecked(&self) -> &BuildMeta;
 
   /// Publish build metadata after failed-rebuild recovery has finished.
   fn freeze_build_meta(&self) -> &triomphe::Arc<BuildMeta>;
@@ -1214,6 +1224,10 @@ macro_rules! impl_module_meta_info {
       self.build_info.read()
     }
 
+    fn build_info_unchecked(&self) -> &$crate::BuildInfo {
+      self.build_info.get_unchecked()
+    }
+
     fn freeze_build_info(&self) {
       self.build_info.freeze();
     }
@@ -1228,6 +1242,10 @@ macro_rules! impl_module_meta_info {
 
     fn build_meta(&self) -> $crate::FreezeReadGuard<'_, $crate::BuildMeta> {
       self.build_meta.read()
+    }
+
+    fn build_meta_unchecked(&self) -> &$crate::BuildMeta {
+      self.build_meta.get_unchecked()
     }
 
     fn freeze_build_meta(&self) -> &$crate::SharedBuildMeta {
@@ -1387,6 +1405,10 @@ mod test {
           unreachable!()
         }
 
+        fn build_info_unchecked(&self) -> &crate::BuildInfo {
+          unreachable!()
+        }
+
         fn freeze_build_info(&self) {
           unreachable!()
         }
@@ -1400,6 +1422,10 @@ mod test {
         }
 
         fn build_meta(&self) -> crate::FreezeReadGuard<'_, crate::BuildMeta> {
+          unreachable!()
+        }
+
+        fn build_meta_unchecked(&self) -> &crate::BuildMeta {
           unreachable!()
         }
 

--- a/crates/rspack_core/src/normal_module.rs
+++ b/crates/rspack_core/src/normal_module.rs
@@ -894,6 +894,10 @@ impl Module for NormalModule {
     self.build_info.read()
   }
 
+  fn build_info_unchecked(&self) -> &BuildInfo {
+    self.build_info.get_unchecked()
+  }
+
   fn freeze_build_info(&self) {
     self.build_info.freeze();
   }
@@ -908,6 +912,10 @@ impl Module for NormalModule {
 
   fn build_meta(&self) -> crate::FreezeReadGuard<'_, BuildMeta> {
     self.build_meta.read()
+  }
+
+  fn build_meta_unchecked(&self) -> &BuildMeta {
+    self.build_meta.get_unchecked()
   }
 
   fn freeze_build_meta(&self) -> &triomphe::Arc<BuildMeta> {

--- a/crates/rspack_core/src/utils/freeze_lock.rs
+++ b/crates/rspack_core/src/utils/freeze_lock.rs
@@ -71,6 +71,17 @@ impl<T> FreezeLock<T> {
     self.get()
   }
 
+  /// Read published metadata without a build borrow guard.
+  ///
+  /// Only build borrow checking is skipped: publication is checked in all builds.
+  /// Panics if the metadata has not been frozen yet.
+  #[inline]
+  pub fn get_unchecked(&self) -> &T {
+    self
+      .frozen()
+      .expect("metadata must be frozen before unchecked access")
+  }
+
   fn frozen_arc(&self) -> Option<&Arc<T>> {
     if !self.published.load(Ordering::Acquire) {
       return None;

--- a/crates/rspack_core/src/utils/freeze_lock.rs
+++ b/crates/rspack_core/src/utils/freeze_lock.rs
@@ -1,6 +1,11 @@
-use std::{fmt, ops::Deref, sync::OnceLock};
+use std::{
+  cell::UnsafeCell,
+  fmt,
+  ops::Deref,
+  sync::atomic::{AtomicBool, Ordering},
+};
 
-use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use atomic_refcell::{AtomicRef, AtomicRefCell};
 use rspack_cacheable::{
   Error,
   rkyv::{
@@ -13,44 +18,70 @@ use triomphe::{Arc, UniqueArc};
 
 /// Metadata with independent build and publication lifetimes.
 ///
-/// Inspired by [rustc's `FreezeLock`], adapted for shared, cacheable metadata.
+/// Like [Servo's shared lock], build access uses atomic borrow checking rather
+/// than a blocking lock: multiple readers or one writer, with conflicting access
+/// panicking. `get` retains the read guard internally; `get_mut` uses an exclusive
+/// Rust borrow, and field-specific updates retain a write guard internally.
 ///
-/// Building owns a `UniqueArc`; freezing converts it to an `Arc` without moving
-/// the value. Reads after publication do not acquire the build lock. Restored
-/// cache values are already frozen and cannot be made mutable again.
+/// Freezing requires exclusive build access and converts the `UniqueArc` to an
+/// `Arc` without moving the value. Published reads only acquire-load a flag and
+/// borrow the immutable value. Cached values are restored already frozen.
 ///
-/// [rustc's `FreezeLock`]: https://github.com/rust-lang/rust/blob/main/compiler/rustc_data_structures/src/sync/freeze.rs
+/// [Servo's shared lock]: https://github.com/mozilla-firefox/firefox/blob/main/servo/components/style/shared_lock.rs
 pub struct FreezeLock<T> {
-  frozen: OnceLock<Arc<T>>,
-  building: RwLock<Option<UniqueArc<T>>>,
+  published: AtomicBool,
+  frozen: UnsafeCell<Option<Arc<T>>>,
+  building: AtomicRefCell<Option<UniqueArc<T>>>,
 }
+
+// SAFETY: before publication, AtomicRefCell enforces exclusive writes and shared
+// reads. The frozen slot is written only while holding the exclusive build
+// borrow, and never changed after the release-store to `published`. Readers
+// acquire-load that flag before accessing the slot. Sharing also requires T to
+// be Send because publication and field-specific updates can occur on any thread.
+unsafe impl<T: Send + Sync> Sync for FreezeLock<T> {}
 
 impl<T> FreezeLock<T> {
   pub fn new(value: T) -> Self {
     Self {
-      frozen: OnceLock::new(),
-      building: RwLock::new(Some(UniqueArc::new(value))),
+      published: AtomicBool::new(false),
+      frozen: UnsafeCell::new(None),
+      building: AtomicRefCell::new(Some(UniqueArc::new(value))),
+    }
+  }
+
+  /// Read metadata, retaining a shared build borrow until the guard is dropped.
+  /// Panics if a build update or publication is in progress.
+  pub fn get(&self) -> FreezeReadGuard<'_, T> {
+    if let Some(value) = self.frozen_arc() {
+      return FreezeReadGuard(FreezeRead::Frozen(value));
+    }
+    let building = self.building.borrow();
+    // Publication may have completed before we acquired the build borrow.
+    if let Some(value) = self.frozen_arc() {
+      FreezeReadGuard(FreezeRead::Frozen(value))
+    } else {
+      FreezeReadGuard(FreezeRead::Building(AtomicRef::map(building, |value| {
+        &**value.as_ref().expect("metadata must be initialized")
+      })))
     }
   }
 
   pub fn read(&self) -> FreezeReadGuard<'_, T> {
-    if let Some(value) = self.frozen.get() {
-      return FreezeReadGuard(FreezeRead::Frozen(value));
+    self.get()
+  }
+
+  fn frozen_arc(&self) -> Option<&Arc<T>> {
+    if !self.published.load(Ordering::Acquire) {
+      return None;
     }
-    let building = self.building.read();
-    // Publication may have completed while we were waiting for the lock.
-    if let Some(value) = self.frozen.get() {
-      FreezeReadGuard(FreezeRead::Frozen(value))
-    } else {
-      FreezeReadGuard(FreezeRead::Building(RwLockReadGuard::map(
-        building,
-        |value| &**value.as_ref().expect("metadata must be initialized"),
-      )))
-    }
+    // SAFETY: the acquire-load observes initialization of the frozen slot, which
+    // is never modified again. Its value remains alive for the lifetime of self.
+    unsafe { &*self.frozen.get() }.as_ref()
   }
 
   pub fn frozen(&self) -> Option<&T> {
-    self.frozen.get().map(|value| &**value)
+    self.frozen_arc().map(|value| &**value)
   }
 
   /// Exclusive access while constructing the containing module.
@@ -63,28 +94,41 @@ impl<T> FreezeLock<T> {
   }
 
   /// Used only by field-specific APIs for metadata finalized after module build.
+  /// Panics on conflicting borrows or after publication.
   pub(crate) fn update(&self, update: impl FnOnce(&mut T)) {
-    let mut building = self.building.write();
+    let mut building = self.building.borrow_mut();
     update(building.as_mut().expect("metadata is already frozen"));
   }
 
+  /// Publish the value permanently. All build guards must have been dropped.
   pub fn freeze(&self) -> &Arc<T> {
-    if let Some(value) = self.frozen.get() {
+    if let Some(value) = self.frozen_arc() {
       return value;
     }
-    let mut building = self.building.write();
-    self.frozen.get_or_init(|| {
-      building
-        .take()
-        .expect("metadata must be initialized")
-        .shareable()
-    })
+    let mut building = self.building.borrow_mut();
+    // Another publisher may have finished before the exclusive borrow.
+    if let Some(value) = self.frozen_arc() {
+      return value;
+    }
+    let value = building
+      .take()
+      .expect("metadata must be initialized")
+      .shareable();
+    // SAFETY: the exclusive build borrow excludes other publishers, and the
+    // flag is still false, so no reader can access the frozen slot yet.
+    unsafe { *self.frozen.get() = Some(value) };
+    self.published.store(true, Ordering::Release);
+    self.frozen_arc().expect("metadata must be frozen")
   }
 
   /// Publish metadata retained from a successful build after a failed rebuild.
   pub(crate) fn freeze_with(&self, value: Arc<T>) {
-    let mut building = self.building.write();
-    assert!(self.frozen.set(value).is_ok(), "metadata is already frozen");
+    let mut building = self.building.borrow_mut();
+    assert!(self.frozen_arc().is_none(), "metadata is already frozen");
+    // SAFETY: as in freeze, the exclusive build borrow excludes publishers and
+    // the unpublished slot cannot yet be accessed by readers.
+    unsafe { *self.frozen.get() = Some(value) };
+    self.published.store(true, Ordering::Release);
     building.take();
   }
 }
@@ -104,8 +148,9 @@ impl<T> From<T> for FreezeLock<T> {
 impl<T> From<Arc<T>> for FreezeLock<T> {
   fn from(value: Arc<T>) -> Self {
     Self {
-      frozen: OnceLock::from(value),
-      building: RwLock::new(None),
+      published: AtomicBool::new(true),
+      frozen: UnsafeCell::new(Some(value)),
+      building: AtomicRefCell::new(None),
     }
   }
 }
@@ -119,14 +164,14 @@ impl<T: fmt::Debug> fmt::Debug for FreezeLock<T> {
 pub struct FreezeReadGuard<'a, T: ?Sized>(FreezeRead<'a, T>);
 
 enum FreezeRead<'a, T: ?Sized> {
-  Building(MappedRwLockReadGuard<'a, T>),
+  Building(AtomicRef<'a, T>),
   Frozen(&'a T),
 }
 
 impl<'a, T: ?Sized> FreezeReadGuard<'a, T> {
   pub fn map<U: ?Sized>(self, map: impl FnOnce(&T) -> &U) -> FreezeReadGuard<'a, U> {
     FreezeReadGuard(match self.0 {
-      FreezeRead::Building(value) => FreezeRead::Building(MappedRwLockReadGuard::map(value, map)),
+      FreezeRead::Building(value) => FreezeRead::Building(AtomicRef::map(value, map)),
       FreezeRead::Frozen(value) => FreezeRead::Frozen(map(value)),
     })
   }
@@ -136,9 +181,7 @@ impl<'a, T: ?Sized> FreezeReadGuard<'a, T> {
     map: impl FnOnce(&T) -> Option<&U>,
   ) -> Option<FreezeReadGuard<'a, U>> {
     Some(FreezeReadGuard(match self.0 {
-      FreezeRead::Building(value) => {
-        FreezeRead::Building(MappedRwLockReadGuard::try_map(value, map).ok()?)
-      }
+      FreezeRead::Building(value) => FreezeRead::Building(AtomicRef::filter_map(value, map)?),
       FreezeRead::Frozen(value) => FreezeRead::Frozen(map(value)?),
     }))
   }
@@ -167,8 +210,7 @@ impl<T: Archive> Archive for FreezeLock<T> {
 
   fn resolve(&self, resolver: Self::Resolver, out: Place<Self::Archived>) {
     self
-      .frozen
-      .get()
+      .frozen_arc()
       .expect("metadata must be frozen before caching")
       .resolve(resolver, out);
   }
@@ -181,8 +223,7 @@ where
 {
   fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
     self
-      .frozen
-      .get()
+      .frozen_arc()
       .ok_or(Error::MessageError(
         "metadata must be frozen before caching",
       ))?

--- a/crates/rspack_core/src/utils/mod.rs
+++ b/crates/rspack_core/src/utils/mod.rs
@@ -163,9 +163,12 @@ pub fn get_module_hashbang(
       let root_module_id = concatenated_module.get_root();
       module_graph
         .module_by_identifier(&root_module_id)
-        .map_or_else(|| module.build_info(), |m| m.build_info())
+        .map_or_else(
+          || module.build_info_unchecked(),
+          |m| m.build_info_unchecked(),
+        )
     } else {
-      module.build_info()
+      module.build_info_unchecked()
     };
 
   build_info
@@ -190,9 +193,12 @@ pub fn get_module_directives(
       let root_module_id = concatenated_module.get_root();
       module_graph
         .module_by_identifier(&root_module_id)
-        .map_or_else(|| module.build_info(), |m| m.build_info())
+        .map_or_else(
+          || module.build_info_unchecked(),
+          |m| m.build_info_unchecked(),
+        )
     } else {
-      module.build_info()
+      module.build_info_unchecked()
     };
 
   build_info

--- a/crates/rspack_ids/src/id_helpers.rs
+++ b/crates/rspack_ids/src/id_helpers.rs
@@ -29,7 +29,7 @@ pub type ModuleFilterFn =
   Arc<dyn for<'a> Fn(CompilerId, &'a dyn Module) -> BoxFuture<'a, Result<bool>> + Send + Sync>;
 
 pub(crate) fn should_assign_module_id_without_chunk(module: &dyn Module) -> bool {
-  let build_meta = module.build_meta();
+  let build_meta = module.build_meta_unchecked();
   build_meta.is_css_module() || build_meta.need_id_in_concatenation()
 }
 

--- a/crates/rspack_macros/src/runtime_module.rs
+++ b/crates/rspack_macros/src/runtime_module.rs
@@ -161,6 +161,10 @@ pub fn impl_runtime_module(
         unreachable!()
       }
 
+      fn build_info_unchecked(&self) -> &::rspack_core::BuildInfo {
+        unreachable!()
+      }
+
       fn freeze_build_info(&self) {
         unreachable!()
       }
@@ -174,6 +178,10 @@ pub fn impl_runtime_module(
       }
 
       fn build_meta(&self) -> ::rspack_core::FreezeReadGuard<'_, ::rspack_core::BuildMeta> {
+        unreachable!()
+      }
+
+      fn build_meta_unchecked(&self) -> &::rspack_core::BuildMeta {
         unreachable!()
       }
 

--- a/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_css/src/parser_and_generator/mod.rs
@@ -318,7 +318,7 @@ impl ParserAndGenerator for CssParserAndGenerator {
       Some("Module Concatenation is not implemented for CommonJS css exports".into())
     } else if self.effective_export_type(module) == Some(CssExportType::Style)
       && module
-        .build_info()
+        .build_info_unchecked()
         .css
         .as_deref()
         .is_some_and(|css_build_info| css_build_info.has_render_conditions())

--- a/crates/rspack_plugin_esm_library/src/link.rs
+++ b/crates/rspack_plugin_esm_library/src/link.rs
@@ -669,7 +669,7 @@ impl EsmLibraryPlugin {
             .expect("should have box module");
           let module_readable_identifier =
             box_module.readable_identifier(&compilation.options.context);
-          let strict_esm_module = box_module.build_meta().strict_esm_module();
+          let strict_esm_module = box_module.build_meta_unchecked().strict_esm_module();
 
           // scope hoisted module can only exist in only 1 chunk
           // so it's safe to use module_info.namespace_object_name, which is
@@ -824,7 +824,7 @@ impl EsmLibraryPlugin {
             let target_strict_esm_module = module_graph
               .module_by_identifier(&target_module)
               .expect("should have target module")
-              .build_meta()
+              .build_meta_unchecked()
               .strict_esm_module();
 
             self.get_binding(
@@ -1852,7 +1852,7 @@ var {} = {{}};
       module_graph,
       binding_resolver.context.module_graph_cache,
       binding_resolver.context.exports_info_artifact,
-      module.build_meta().strict_esm_module(),
+      module.build_meta_unchecked().strict_esm_module(),
     );
 
     if matches!(exports_type, ExportsType::DefaultOnly) {
@@ -1883,7 +1883,7 @@ var {} = {{}};
           needed_namespace_objects,
           false,
           false,
-          module.build_meta().strict_esm_module(),
+          module.build_meta_unchecked().strict_esm_module(),
           None,
           required,
           &mut chunk_link.name_allocator,
@@ -2637,7 +2637,7 @@ var {} = {{}};
               needed_namespace_objects,
               options.call,
               !options.direct_import,
-              module.build_meta().strict_esm_module(),
+              module.build_meta_unchecked().strict_esm_module(),
               options.asi_safe,
               required,
               &mut chunk_link.name_allocator,

--- a/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
+++ b/crates/rspack_plugin_esm_library/src/optimize_chunks.rs
@@ -41,7 +41,7 @@ pub(crate) fn extract_tla_shared_modules(compilation: &mut Compilation) -> bool 
   // at module top level" info which is not exposed on the block.
   let mut async_chunks_set: FxHashSet<ChunkUkey> = FxHashSet::default();
   for (module_id, module) in module_graph.modules() {
-    if !module.build_meta().has_top_level_await() {
+    if !module.build_meta_unchecked().has_top_level_await() {
       continue;
     }
     for block_id in module.get_blocks() {

--- a/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
+++ b/crates/rspack_plugin_javascript/src/parser_and_generator/mod.rs
@@ -476,7 +476,7 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
     _cg: &ChunkGraph,
   ) -> Option<Cow<'static, str>> {
     // Only ES modules are valid for optimization
-    if module.build_meta().exports_type() != BuildMetaExportsType::Namespace {
+    if module.build_meta_unchecked().exports_type() != BuildMetaExportsType::Namespace {
       return Some("Module is not an ECMAScript module".into());
     }
 
@@ -494,7 +494,11 @@ impl ParserAndGenerator for JavaScriptParserAndGenerator {
       return Some("Module is not an ECMAScript module".into());
     }
 
-    if let Some(bailout) = module.build_info().module_concatenation_bailout.as_deref() {
+    if let Some(bailout) = module
+      .build_info_unchecked()
+      .module_concatenation_bailout
+      .as_deref()
+    {
       return Some(format!("Module uses {bailout}").into());
     }
     None

--- a/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/flag_dependency_usage_plugin.rs
@@ -245,7 +245,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
               .module_by_identifier(&module_id)
               .expect("should have module");
             let is_exports_type_unset = matches!(
-              module.build_meta().exports_type(),
+              module.build_meta_unchecked().exports_type(),
               BuildMetaExportsType::Unset
             );
             let is_side_effect_free =
@@ -448,7 +448,7 @@ impl<'a> FlagDependencyUsagePluginProxy<'a> {
       .expect("should have module");
     if !used_exports.is_empty() {
       let need_insert = matches!(
-        module.build_meta().exports_type(),
+        module.build_meta_unchecked().exports_type(),
         BuildMetaExportsType::Unset
       );
 

--- a/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/mangle_exports_plugin.rs
@@ -151,7 +151,7 @@ async fn optimize_code_generation(
     .modules()
     .map(|(mid, module)| {
       let is_namespace = matches!(
-        module.build_meta().exports_type(),
+        module.build_meta_unchecked().exports_type(),
         BuildMetaExportsType::Namespace
       );
       (exports_info_artifact.get_exports_info(mid), is_namespace)

--- a/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/plugin/module_concatenation_plugin.rs
@@ -963,7 +963,7 @@ impl ModuleConcatenationPlugin {
           return (false, false, module_id, bailout_reason);
         }
 
-        if !m.build_info().strict {
+        if !m.build_info_unchecked().strict {
           bailout_reason.push("Module is not in strict mode".into());
           return (false, false, module_id, bailout_reason);
         }

--- a/crates/rspack_plugin_library/src/assign_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/assign_library_plugin.rs
@@ -394,12 +394,12 @@ async fn embed_in_runtime_bailout(
   let codegen = compilation
     .code_generation_results
     .get(&module.identifier(), Some(chunk.runtime()));
-  let build_info = module.build_info();
+  let build_info = module.build_info_unchecked();
   let top_level_decls = codegen
     .data()
     .get::<CodeGenerationDataTopLevelDeclarations>()
     .map(|d| d.inner())
-    .or_else(|| build_info.top_level_declarations.as_ref());
+    .or(build_info.top_level_declarations.as_ref());
   if let Some(top_level_decls) = top_level_decls {
     let full_name = self
       .get_resolved_full_name(&options, compilation, chunk)

--- a/crates/rspack_plugin_library/src/module_library_plugin.rs
+++ b/crates/rspack_plugin_library/src/module_library_plugin.rs
@@ -87,7 +87,7 @@ async fn render_startup(
     module_graph,
     &compilation.module_graph_cache_artifact,
     &compilation.exports_info_artifact,
-    boxed_module.build_info().strict,
+    boxed_module.build_info_unchecked().strict,
   );
   for export_info in exports_info.exports().values() {
     if matches!(export_info.provided(), Some(ExportProvided::NotProvided)) {

--- a/crates/rspack_plugin_rslib/src/dyn_import_external.rs
+++ b/crates/rspack_plugin_rslib/src/dyn_import_external.rs
@@ -90,7 +90,7 @@ pub fn cutout_star_re_export_externals(
       .module_by_identifier(&module_id)
       .expect("should have entry module");
 
-    if !module.build_meta().esm() {
+    if !module.build_meta_unchecked().esm() {
       continue;
     }
 

--- a/crates/rspack_plugin_rslib/src/plugin.rs
+++ b/crates/rspack_plugin_rslib/src/plugin.rs
@@ -375,7 +375,7 @@ async fn process_assets(&self, compilation: &mut Compilation) -> Result<()> {
   let module_graph = compilation.get_module_graph();
   for (_, module) in module_graph.modules() {
     let module = module.as_ref();
-    if let Some(isolated_dts) = module.build_info().isolated_dts.as_deref() {
+    if let Some(isolated_dts) = module.build_info_unchecked().isolated_dts.as_deref() {
       dts_outputs.push(isolated_dts.clone());
     }
     if let Some(normal_module) = module.as_normal_module()


### PR DESCRIPTION
## Motivation

Avoid blocking locks when accessing build metadata, following Servo's shared-lock approach.

## Changes

Use atomic borrow guards during construction and release/acquire publication after freezing. Add a safe `get_unchecked()` that asserts publication and returns a direct reference for seal-specific reads. Preserve metadata identity and existing freeze points.

## Open questions

`Module::build()` returns before metadata is final: `succeedModule` can emit assets, make completion merges `importModule` assets, cache preparation writes `BuildInfo.snapshot`, and failed rebuilds can restore `BuildMeta`. `importModule` also runs codegen during make, before freezing is guaranteed.

The implementation therefore still needs guarded reads and field-specific `&self` updates. We need to settle whether finalization can finish while the module is exclusively owned, before freezing and sharing it. Until that boundary is resolved, read/write separation relies on runtime borrow checks, with conflicts panicking instead of waiting.