### PR TITLE
docs: correct Lightning CSS unusedSymbols option type

### DIFF
--- a/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/en/guide/features/builtin-lightningcss-loader.mdx
@@ -117,7 +117,7 @@ type LightningcssLoaderOptions = {
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
-  unusedSymbols?: Set<String>;
+  unusedSymbols?: string[];
 };
 ```
 

--- a/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
+++ b/website/docs/en/plugins/lightning-css-minimizer-rspack-plugin.mdx
@@ -117,7 +117,7 @@ type LightningCssMinimizerOptions = {
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
-  unusedSymbols?: Set<String>;
+  unusedSymbols?: string[];
 };
 
 type LightningcssFeatureOptions = {

--- a/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
+++ b/website/docs/zh/guide/features/builtin-lightningcss-loader.mdx
@@ -117,7 +117,7 @@ type LightningcssLoaderOptions = {
   drafts?: Drafts;
   nonStandard?: NonStandard;
   pseudoClasses?: PseudoClasses;
-  unusedSymbols?: Set<String>;
+  unusedSymbols?: string[];
 };
 ```
 


### PR DESCRIPTION
## Motivation

The English Lightning CSS minimizer documentation declares `unusedSymbols` as `Set<String>`, but the public option accepts `string[]`. Copying the documented collection type produces an invalid configuration.

## Changes

Correct the declaration to `unusedSymbols?: string[]`, matching the public implementation and the existing Chinese documentation. This changes documentation only.

Validation: the website production build and affected-file formatting check pass. With `@rspack/core` 2.2.3, a public-API type check accepts an array and rejects a `Set`; a CSS build using `unusedSymbols: ['drop']` removes `.drop` and preserves `.keep`. The rendered page contains the corrected declaration.
