### PR TITLE
fix(mf): retain shared dependencies during selective cache cleanup

### DIFF
--- a/crates/rspack_plugin_mf/src/container/container_entry_module.rs
+++ b/crates/rspack_plugin_mf/src/container/container_entry_module.rs
@@ -2,10 +2,10 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use rspack_cacheable::{cacheable, cacheable_dyn};
-use rspack_collections::{Identifiable, Identifier};
+use rspack_collections::{Identifiable, Identifier, IdentifierSet};
 use rspack_core::{
   AsyncDependenciesBlock, AsyncDependenciesBlockIdentifier, BoxDependency, BoxModule, BuildContext,
-  BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, ChunkGroupOptions,
+  BuildInfo, BuildMeta, BuildMetaExportsType, BuildResult, ChunkGraph, ChunkGroupOptions,
   CodeGenerationDataItem, CodeGenerationResultBuilder, CodeGenerationRuntimeRequirementsWrite,
   Compilation, Context, DependenciesBlock, Dependency, DependencyId, DependencyType,
   ExportsArgument, FactoryMeta, GroupOptions, LibIdentOptions, Module, ModuleCodeGenerationContext,
@@ -236,6 +236,7 @@ impl Module for ContainerEntryModule {
           "get".into(),
           "init".into(),
           "__webpack_clear_cache__".into(),
+          "__webpack_clear_exposed_cache__".into(),
         ]),
         false,
       )));
@@ -369,19 +370,63 @@ for(var id in {module_cache}) {{
         ),
       );
 
+      // Preserve the dependency closure of all declared/consumed shared modules,
+      // including async dependencies which may execute after remote removal.
+      // Keeping all shares is conservative and avoids depending on framework state.
+      let module_graph = compilation.get_module_graph();
+      let mut pending = module_graph
+        .modules()
+        .filter_map(|(id, module)| {
+          matches!(
+            module.module_type(),
+            ModuleType::ProvideShared | ModuleType::ConsumeShared
+          )
+          .then_some(*id)
+        })
+        .collect::<Vec<_>>();
+      let mut visited = IdentifierSet::default();
+      while let Some(id) = pending.pop() {
+        if !visited.insert(id) {
+          continue;
+        }
+        for connection in module_graph.get_outgoing_connections(&id) {
+          pending.push(*connection.module_identifier());
+        }
+      }
+      let mut retained_ids = visited
+        .iter()
+        .filter_map(|id| ChunkGraph::get_module_id(&compilation.module_ids_artifact, *id).cloned())
+        .collect::<Vec<_>>();
+      retained_ids.sort_unstable();
+      retained_ids.dedup();
+      let retained_ids = json_stringify(&retained_ids);
+      let clear_exposed_cache = runtime_template.basic_function(
+        "",
+        &format!(
+          r#"
+var retained = new Set({retained_ids}.map(String));
+for(var id in {module_cache}) {{
+	if (!retained.has(id)) delete {module_cache}[id];
+}}"#
+        ),
+      );
+
       format!(
         r#"
+var clearExposedCache = {clear_exposed_cache};
 var clearCache = {clear_cache};
 {}({}, {{
 	get: {},
 	init: {},
-	__webpack_clear_cache__: {}
+	__webpack_clear_cache__: {},
+	__webpack_clear_exposed_cache__: {}
 }});"#,
         define_property_getters,
         runtime_template.render_exports_argument(ExportsArgument::Exports),
         runtime_template.returning_function(&get_container, ""),
         runtime_template.returning_function(&init_container, ""),
         runtime_template.returning_function("clearCache", ""),
+        runtime_template.returning_function("clearExposedCache", ""),
       )
     } else {
       let current_remote_get_scope =

--- a/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
+++ b/crates/rspack_plugin_mf/src/container/remote_runtime_module.rs
@@ -1,6 +1,6 @@
 use std::sync::LazyLock;
 
-use rspack_collections::Identifiable;
+use rspack_collections::{Identifiable, IdentifierSet};
 use rspack_core::{
   ChunkGraph, Compilation, DependenciesBlock, ModuleGraph, ModuleId, ModuleIdentifier,
   RuntimeGlobals, RuntimeModule, RuntimeModuleGenerateContext, RuntimeModuleRuntimeRequirements,
@@ -119,12 +119,19 @@ impl RuntimeModule for RemoteRuntimeModule {
           .iter()
           .map(|(_, module_id)| module_id.clone())
           .collect::<Vec<_>>();
-        for (consumer_module_identifier, consumer_module_id) in &consumer_modules {
+        let mut pending_consumers = consumer_modules.clone();
+        let mut visited_consumers = IdentifierSet::default();
+        while let Some((consumer_identifier, consumer_id)) = pending_consumers.pop() {
+          if !visited_consumers.insert(consumer_identifier) {
+            continue;
+          }
+          let parents = get_consumer_modules(compilation, module_graph, &consumer_identifier);
           add_to_mapping(
             &mut consumer_module_id_to_parent_module_ids,
-            consumer_module_id.clone(),
-            get_parent_module_ids(compilation, module_graph, consumer_module_identifier),
+            consumer_id,
+            parents.iter().map(|(_, id)| id.clone()).collect(),
           );
+          pending_consumers.extend(parents);
         }
         add_to_mapping(
           &mut remote_key_to_remote_module_ids,
@@ -244,18 +251,6 @@ fn get_consumer_modules(
       let module_id = get_module_id(compilation, module_identifier)?;
       Some((*module_identifier, module_id))
     })
-    .collect()
-}
-
-fn get_parent_module_ids(
-  compilation: &Compilation,
-  module_graph: &ModuleGraph,
-  consumer_module_identifier: &ModuleIdentifier,
-) -> Vec<ModuleId> {
-  module_graph
-    .get_incoming_connections(consumer_module_identifier)
-    .filter_map(|connection| connection.original_module_identifier.as_ref())
-    .filter_map(|module_identifier| get_module_id(compilation, module_identifier))
     .collect()
 }
 

--- a/docs/design/mf-ssr-clear-cache.md
+++ b/docs/design/mf-ssr-clear-cache.md
@@ -660,3 +660,15 @@ Node SSR 下分别覆盖：
 MF runtime 负责定义语义和清理顺序；bundler runtime 负责清 remote module 和受影响消费者；SDK Node loader 负责清 remoteEntry 加载缓存；Node runtime plugin 负责清 SSR Node 侧 chunk 与模块缓存。
 
 这次方案的关键变化是：`clearCache` 只清缓存并保留 remote 注册；remote 更新不是只清生产者缓存，还必须让已经缓存的消费者链路在下一次 SSR 请求中重新执行。shared 第一版必须保守：未加载可清，已加载保留。这样能解决 remote 更新后的旧缓存残留问题，同时避免破坏 SSR 进程内的 shared 单例稳定性。
+
+## 2026-09-10：选择性 provider 清理与完整静态父链
+
+增强 container 新增可选导出 `__webpack_clear_exposed_cache__()`。它删除模块执行缓存中不属于 shared 依赖闭包的条目；旧的 `__webpack_clear_cache__()` 继续完整删除执行缓存。
+
+编译期从 `ProvideShared` 和 `ConsumeShared` 模块出发，遍历出向依赖（包含异步依赖），生成需要保留的模块 ID 集合。所有声明的 shared 都保守保留，不依赖 Modern 路由或运行时框架状态。因此已加载的 shared 及之后首次执行的 lazy 依赖可以继续使用，独立的非 shared exports 可以释放。如果业务模块同时也是 shared 的依赖，它会保留；模块工厂、业务已持有的 exports 和任意全局副作用不在清理范围内。
+
+MF runtime 在仍有 shared 使用或加载时检测此能力。旧 provider 没有该方法时保留执行缓存，不能退回完整清理。此方法不意味着 provider 整体可 GC，也不提供请求排空、框架资源发布或 shared 版本替换。
+
+`consumerModuleIdToParentModuleIds` 从直接 consumer 开始继续遍历到全部可表示的静态父节点，用 visited 集合终止循环，并保留多父节点。它是编译器模块图元数据，不是路由图：动态消费、框架入口映射及完整性判断仍由 MF/Modern JS 层负责，不能凭此承诺任意动态变量可分析。
+
+原生回归位于 `configCases/container/mf-clear-cache-metadata` 和 `configCases/container/mf-selective-provider-cache`。覆盖多层/多父节点/循环父链，以及拼接开关、数字 ID、压缩、更新后首次 lazy 加载和再次清理后的严格身份保持。外部 MF 基线另有 WeakRef/GC 和真实 Modern antd consumer 验证。当前完整 Modern CI 仍存在独立的 runtime capture 断言失败，不代表整个生产生命周期已经验收。

--- a/tests/rspack-test/configCases/container/mf-clear-cache-metadata/index.js
+++ b/tests/rspack-test/configCases/container/mf-clear-cache-metadata/index.js
@@ -1,32 +1,48 @@
 it("should expose clear cache metadata for remotes", () => {
-	const loadConsumer = () => import("./consumer");
-	expect(typeof loadConsumer).toBe("function");
+  const loadConsumer = () =>
+    Promise.all([import("./page"), import("./sibling")]);
+  expect(typeof loadConsumer).toBe("function");
 
-	const data = __webpack_require__.remotesLoadingData;
-	expect(data).toBeTruthy();
+  const data = __webpack_require__.remotesLoadingData;
+  expect(data).toBeTruthy();
 
-	const remoteModuleId = Object.entries(data.moduleIdToRemoteDataMapping).find(
-		([, remoteData]) =>
-			remoteData.remoteName === "remoteA" && remoteData.name === "./A"
-	)?.[0];
-	expect(remoteModuleId).toBeTruthy();
+  const remoteModuleId = Object.entries(data.moduleIdToRemoteDataMapping).find(
+    ([, remoteData]) =>
+      remoteData.remoteName === "remoteA" && remoteData.name === "./A",
+  )?.[0];
+  expect(remoteModuleId).toBeTruthy();
 
-	const remoteData = data.moduleIdToRemoteDataMapping[remoteModuleId];
-	expect(data.remoteKeyToRemoteModuleIds.remoteA).toContain(remoteModuleId);
-	expect(data.remoteKeyToExternalModuleIds.remoteA).toContain(
-		remoteData.externalModuleId
-	);
+  const remoteData = data.moduleIdToRemoteDataMapping[remoteModuleId];
+  expect(data.remoteKeyToRemoteModuleIds.remoteA).toContain(remoteModuleId);
+  expect(data.remoteKeyToExternalModuleIds.remoteA).toContain(
+    remoteData.externalModuleId,
+  );
 
-	const consumerModuleIds =
-		data.remoteModuleIdToConsumerModuleIds[remoteModuleId];
-	expect(consumerModuleIds).toEqual(expect.arrayContaining(["./consumer.js"]));
-	expect(data.consumerModuleIdToParentModuleIds["./consumer.js"]).toEqual(
-		expect.arrayContaining(["./index.js"])
-	);
+  const consumerModuleIds =
+    data.remoteModuleIdToConsumerModuleIds[remoteModuleId];
+  expect(consumerModuleIds).toEqual(expect.arrayContaining(["./consumer.js"]));
+  expect(data.consumerModuleIdToParentModuleIds["./consumer.js"]).toEqual(
+    expect.arrayContaining(["./middle.js"]),
+  );
 
-	const remoteChunkIds = data.remoteKeyToChunkIds.remoteA;
-	expect(remoteChunkIds.length).toBeGreaterThan(0);
-	for (const chunkId of remoteChunkIds) {
-		expect(data.chunkMapping[chunkId]).toContain(remoteModuleId);
-	}
+  expect(data.consumerModuleIdToParentModuleIds["./middle.js"]).toContain(
+    "./page.js",
+  );
+  expect(data.consumerModuleIdToParentModuleIds["./page.js"]).toContain(
+    "./index.js",
+  );
+  expect(data.consumerModuleIdToParentModuleIds["./consumer.js"]).toContain(
+    "./sibling.js",
+  );
+  expect(data.consumerModuleIdToParentModuleIds["./sibling.js"]).toContain(
+    "./index.js",
+  );
+  expect(data.consumerModuleIdToParentModuleIds["./page.js"]).toContain(
+    "./middle.js",
+  );
+  const remoteChunkIds = data.remoteKeyToChunkIds.remoteA;
+  expect(remoteChunkIds.length).toBeGreaterThan(0);
+  for (const chunkId of remoteChunkIds) {
+    expect(data.chunkMapping[chunkId]).toContain(remoteModuleId);
+  }
 });

--- a/tests/rspack-test/configCases/container/mf-clear-cache-metadata/middle.js
+++ b/tests/rspack-test/configCases/container/mf-clear-cache-metadata/middle.js
@@ -1,0 +1,3 @@
+import value from "./consumer";
+import page from "./page";
+export default () => [value, page];

--- a/tests/rspack-test/configCases/container/mf-clear-cache-metadata/page.js
+++ b/tests/rspack-test/configCases/container/mf-clear-cache-metadata/page.js
@@ -1,0 +1,2 @@
+import middle from "./middle";
+export default () => middle();

--- a/tests/rspack-test/configCases/container/mf-clear-cache-metadata/rspack.config.js
+++ b/tests/rspack-test/configCases/container/mf-clear-cache-metadata/rspack.config.js
@@ -1,22 +1,23 @@
-const { ModuleFederationPlugin } = require('@rspack/core').container;
+const { ModuleFederationPlugin } = require("@rspack/core").container;
 
 /** @type {import("@rspack/core").Configuration} */
 module.exports = {
-  target: 'node',
-  entry: './index.js',
+  target: "node",
+  entry: "./index.js",
   output: {
-    filename: 'bundle.js',
-    uniqueName: 'mf-clear-cache-metadata',
+    filename: "bundle.js",
+    uniqueName: "mf-clear-cache-metadata",
   },
   optimization: {
-    chunkIds: 'named',
-    moduleIds: 'named',
+    concatenateModules: false,
+    chunkIds: "named",
+    moduleIds: "named",
   },
   plugins: [
     new ModuleFederationPlugin({
-      name: 'host',
+      name: "host",
       remotes: {
-        remoteA: 'promise Promise.resolve({ init() {}, get() {} })',
+        remoteA: "promise Promise.resolve({ init() {}, get() {} })",
       },
     }),
   ],

--- a/tests/rspack-test/configCases/container/mf-clear-cache-metadata/sibling.js
+++ b/tests/rspack-test/configCases/container/mf-clear-cache-metadata/sibling.js
@@ -1,0 +1,2 @@
+import value from "./consumer";
+export default () => value;

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/consumer.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/consumer.js
@@ -1,0 +1,2 @@
+import shared from "shared-lib";
+export default shared;

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/index.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/index.js
@@ -1,0 +1,15 @@
+it("should clear unshared exports but keep shared and async dependency identity", async () => {
+  const container = require("./container.js");
+  await container.init({});
+  const load = async (key) => (await container.get(key))().default;
+  const shared = await load("./Shared");
+  // First lazy execution happens after clearing the provider cache.
+  const payload = await load("./Payload");
+  expect(typeof container.__webpack_clear_exposed_cache__).toBe("function");
+  container.__webpack_clear_exposed_cache__();
+  expect(await load("./Payload")).not.toBe(payload);
+  expect(await load("./Shared")).toBe(shared);
+  const lazy = await shared.lazy();
+  container.__webpack_clear_exposed_cache__();
+  expect(await shared.lazy()).toBe(lazy);
+});

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/lazy.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/lazy.js
@@ -1,0 +1,1 @@
+export default { value: "lazy" };

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/payload.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/payload.js
@@ -1,0 +1,1 @@
+export default { value: "payload" };

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/rspack.config.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/rspack.config.js
@@ -1,0 +1,26 @@
+const { ModuleFederationPlugin } = require("@rspack/core").container;
+module.exports = [false, true].map((concatenateModules) => ({
+  target: "node",
+  externals: { "./container.js": "commonjs ./container.js" },
+  optimization: {
+    concatenateModules,
+    moduleIds: "deterministic",
+    minimize: true,
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "selective_provider",
+      filename: "container.js",
+      library: { type: "commonjs-module" },
+      exposes: { "./Shared": "./consumer.js", "./Payload": "./payload.js" },
+      shared: {
+        "shared-lib": {
+          import: "./shared.js",
+          version: "1.0.0",
+          requiredVersion: false,
+          singleton: true,
+        },
+      },
+    }),
+  ],
+}));

--- a/tests/rspack-test/configCases/container/mf-selective-provider-cache/shared.js
+++ b/tests/rspack-test/configCases/container/mf-selective-provider-cache/shared.js
@@ -1,0 +1,1 @@
+export default { lazy: () => import("./lazy").then((m) => m.default) };


### PR DESCRIPTION
## Summary

Add enhanced-container `__webpack_clear_exposed_cache__` to clear execution-cache entries outside declared/consumed shared dependency closures, including async dependencies. The existing full-clear method is unchanged. Emit transitive static consumer-parent edges with cycle protection and multiple-parent coverage.

The cache implementation is unreleased: host and provider use matching builds, with no legacy-provider fallback. Shared closures remain conservatively retained; arbitrary business references and framework lifecycle are outside this primitive.

Validation: `pnpm run build:binding:dev`; from tests/rspack-test, `pnpm run test:base -- -t configCases/container/mf-clear-cache-metadata` and `pnpm run test:base -- -t configCases/container/mf-selective-provider-cache` pass. Modified Rust passes rustfmt and git diff whitespace checks. Full compiler suites were not run; targeted cases cover cycles, multiple parents, concatenation, numeric IDs, minification and first lazy use after clearing. The latest follow-up changes documentation only.

Companion MF artifact/Modern HTTP matrix: 19 passes and 3 existing stale-adapter TODOs. Latest full Modern SSR rerun passes both remote-cache and shared-cache/GC specs. An earlier intermittent capture failure remains recorded and is not claimed fixed. R1 adapter lifecycle remains incomplete.

## Related links

Companion MF PR: https://github.com/module-federation/core/pull/5051

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).