### PR TITLE
feat: share persistent cache cross child compilers

### DIFF
--- a/crates/node_binding/napi-binding.d.ts
+++ b/crates/node_binding/napi-binding.d.ts
@@ -276,6 +276,14 @@ export declare class ExternalModule {
   _emitFile(filename: string, source: JsSource, assetInfo?: AssetInfo | undefined | null): void
 }
 
+/** One shared cache, initialized from the first compiler that uses it. */
+export declare class JsCache {
+  constructor()
+  beginIdle(): void
+  endIdle(): void
+  shutdown(): Promise<void>
+}
+
 export declare class JsCompilation {
   updateAsset(filename: string, newSourceOrFunction: JsSource | ((source: JsSource) => JsSource), assetInfoUpdateOrFunction?: AssetInfo | ((assetInfo: AssetInfo) => AssetInfo | undefined)): void
   getAssets(): Readonly<JsAsset>[]
@@ -334,7 +342,7 @@ export declare class JsCompilation {
 }
 
 export declare class JsCompiler {
-  constructor(compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void)
+  constructor(compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void, cache: JsCache)
   setNonSkippableRegisters(kinds: Array<RegisterJsTapKind>): void
   /** Build with the given option passed to the constructor */
   build(callback: (err: null | Error) => void): void

--- a/crates/node_binding/rspack.wasi-browser.js
+++ b/crates/node_binding/rspack.wasi-browser.js
@@ -88,6 +88,7 @@ export const EntryDependency = __napiModule.exports.EntryDependency
 export const EntryOptionsDto = __napiModule.exports.EntryOptionsDto
 export const EntryOptionsDTO = __napiModule.exports.EntryOptionsDTO
 export const ExternalModule = __napiModule.exports.ExternalModule
+export const JsCache = __napiModule.exports.JsCache
 export const JsCompilation = __napiModule.exports.JsCompilation
 export const JsCompiler = __napiModule.exports.JsCompiler
 export const JsContextModuleFactoryAfterResolveData = __napiModule.exports.JsContextModuleFactoryAfterResolveData

--- a/crates/node_binding/rspack.wasi.cjs
+++ b/crates/node_binding/rspack.wasi.cjs
@@ -128,6 +128,7 @@ module.exports.EntryDependency = __napiModule.exports.EntryDependency
 module.exports.EntryOptionsDto = __napiModule.exports.EntryOptionsDto
 module.exports.EntryOptionsDTO = __napiModule.exports.EntryOptionsDTO
 module.exports.ExternalModule = __napiModule.exports.ExternalModule
+module.exports.JsCache = __napiModule.exports.JsCache
 module.exports.JsCompilation = __napiModule.exports.JsCompilation
 module.exports.JsCompiler = __napiModule.exports.JsCompiler
 module.exports.JsContextModuleFactoryAfterResolveData = __napiModule.exports.JsContextModuleFactoryAfterResolveData

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -53,9 +53,10 @@ use rspack_core::{
   MangleExportsOption, Mode, ModuleNoParseRules, ModuleOptions, ModuleRule, ModuleRuleEffect,
   ModuleType, NewCacheOptions, NodeDirnameOption, NodeFilenameOption, NodeGlobalOption, NodeOption,
   Optimization, OutputOptions, ParseOption, ParserOptions, ParserOptionsMap, PathInfo,
-  PrintlnInfrastructureLogSink, PublicPath, Resolve, RuleSetCondition, RuleSetLogicalConditions,
-  SideEffectOption, SnapshotOptions, StatsOptions, TrustedTypes, UsedExportsOption, WasmLoading,
-  WasmLoadingType, incremental::IncrementalOptions, runtime_mode::RuntimeMode,
+  PrintlnInfrastructureLogSink, PublicPath, Resolve, ResolverFactory, RuleSetCondition,
+  RuleSetLogicalConditions, SideEffectOption, SnapshotOptions, StatsOptions, TrustedTypes,
+  UsedExportsOption, WasmLoading, WasmLoadingType, create_cache, incremental::IncrementalOptions,
+  runtime_mode::RuntimeMode,
 };
 use rspack_error::{Error, Result};
 use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
@@ -454,23 +455,53 @@ impl CompilerBuilder {
     let platform = builder_context.take_platform();
     plugins.append(&mut self.plugins);
 
-    let input_filesystem = self.input_filesystem.take();
-    let intermediate_filesystem = self.intermediate_filesystem.take();
-    let output_filesystem = self.output_filesystem.take();
+    // pnp is only meaningful for input_filesystem, so disable it for intermediate_filesystem and output_filesystem
+    let pnp = compiler_options.resolve.pnp.unwrap_or(false);
+    let input_filesystem = self
+      .input_filesystem
+      .take()
+      .unwrap_or_else(|| Arc::new(NativeFileSystem::new(pnp)));
+    let intermediate_filesystem = self
+      .intermediate_filesystem
+      .take()
+      .unwrap_or_else(|| Arc::new(NativeFileSystem::new(false)));
+    let output_filesystem = self
+      .output_filesystem
+      .take()
+      .unwrap_or_else(|| Arc::new(NativeFileSystem::new(false)));
+
+    let resolver_factory = Arc::new(ResolverFactory::new(
+      compiler_options.resolve.clone(),
+      input_filesystem.clone(),
+    ));
+    let loader_resolver_factory = Arc::new(ResolverFactory::new(
+      compiler_options.resolve_loader.clone(),
+      input_filesystem.clone(),
+    ));
+
     let compiler_context = CURRENT_COMPILER_CONTEXT.try_with(|v| v.clone()).ok();
+
+    let infrastructure_log_sink = Arc::new(PrintlnInfrastructureLogSink);
+    let cache = Arc::new(create_cache(
+      &compiler_options,
+      input_filesystem,
+      infrastructure_log_sink.clone(),
+    ));
+
     Ok(Compiler::new(
       Arc::default(),
       compiler_options,
       plugins,
       vec![],
+      input_filesystem,
       output_filesystem,
       intermediate_filesystem,
-      input_filesystem,
-      None,
-      None,
+      resolver_factory,
+      loader_resolver_factory,
       compiler_context,
-      Arc::new(PrintlnInfrastructureLogSink),
+      infrastructure_log_sink,
       Arc::new(platform),
+      cache,
     ))
   }
 }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -459,7 +459,7 @@ impl CompilerBuilder {
     let output_filesystem = self.output_filesystem.take();
     let compiler_context = CURRENT_COMPILER_CONTEXT.try_with(|v| v.clone()).ok();
     Ok(Compiler::new(
-      String::new(),
+      Arc::default(),
       compiler_options,
       plugins,
       vec![],

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -499,9 +499,9 @@ impl CompilerBuilder {
       resolver_factory,
       loader_resolver_factory,
       compiler_context,
-      infrastructure_log_sink,
       Arc::new(platform),
       cache,
+      infrastructure_log_sink,
     ))
   }
 }

--- a/crates/rspack/src/builder/mod.rs
+++ b/crates/rspack/src/builder/mod.rs
@@ -59,7 +59,7 @@ use rspack_core::{
   runtime_mode::RuntimeMode,
 };
 use rspack_error::{Error, Result};
-use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
+use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hash::{HashDigest, HashFunction, HashSalt};
 use rspack_paths::{AssertUtf8, Utf8PathBuf};
 use rspack_regex::RspackRegex;
@@ -484,7 +484,7 @@ impl CompilerBuilder {
     let infrastructure_log_sink = Arc::new(PrintlnInfrastructureLogSink);
     let cache = Arc::new(create_cache(
       &compiler_options,
-      input_filesystem,
+      input_filesystem.clone(),
       infrastructure_log_sink.clone(),
     ));
 

--- a/crates/rspack_binding_api/src/cache.rs
+++ b/crates/rspack_binding_api/src/cache.rs
@@ -1,0 +1,75 @@
+use std::{
+  sync::{Arc, OnceLock},
+  time::{Duration, Instant},
+};
+
+use napi::bindgen_prelude::*;
+use napi_derive::napi;
+use rspack_core::{Cache, CompilerOptions, InfrastructureLogSink, create_cache};
+use rspack_fs::{NativeFileSystem, ReadableFileSystem};
+
+/// One shared cache, initialized from the first compiler that uses it.
+#[napi]
+pub struct JsCache {
+  cache: OnceLock<Arc<Cache>>,
+  build_start: Option<Instant>,
+}
+
+impl JsCache {
+  pub fn get_or_initialize(
+    &self,
+    options: &CompilerOptions,
+    input_filesystem: Arc<dyn ReadableFileSystem>,
+    infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
+  ) -> Arc<Cache> {
+    Arc::clone(self.cache.get_or_init(|| {
+      Arc::new(create_cache(
+        options,
+        input_filesystem,
+        infrastructure_log_sink,
+      ))
+    }))
+  }
+}
+
+#[napi]
+impl JsCache {
+  #[napi(constructor)]
+  pub fn new() -> Self {
+    Self {
+      cache: OnceLock::new(),
+      build_start: Some(Instant::now()),
+    }
+  }
+
+  #[napi]
+  pub fn begin_idle(&mut self) {
+    let build_time = self
+      .build_start
+      .take()
+      .map_or(Duration::ZERO, |start| start.elapsed());
+    if let Some(cache) = self.cache.get() {
+      cache.begin_idle(build_time);
+    }
+  }
+
+  #[napi]
+  pub fn end_idle(&mut self) {
+    if let Some(cache) = self.cache.get() {
+      cache.end_idle();
+    }
+    self.build_start = Some(Instant::now());
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn shutdown<'env>(&self, env: &'env Env) -> napi::Result<PromiseRaw<'env, ()>> {
+    // Own storage until shutdown completes, independently of the JS wrapper.
+    let cache = self.cache.get().cloned();
+    rspack_napi::runtime::promise_from_future(env, async move {
+      if let Some(cache) = cache {
+        cache.shutdown().await;
+      }
+      Ok(())
+    })
+  }
+}

--- a/crates/rspack_binding_api/src/cache.rs
+++ b/crates/rspack_binding_api/src/cache.rs
@@ -12,7 +12,7 @@ use rspack_fs::{NativeFileSystem, ReadableFileSystem};
 #[napi]
 pub struct JsCache {
   cache: OnceLock<Arc<Cache>>,
-  build_start: Option<Instant>,
+  build_start: Instant,
 }
 
 impl JsCache {
@@ -38,16 +38,13 @@ impl JsCache {
   pub fn new() -> Self {
     Self {
       cache: OnceLock::new(),
-      build_start: Some(Instant::now()),
+      build_start: Instant::now(),
     }
   }
 
   #[napi]
   pub fn begin_idle(&mut self) {
-    let build_time = self
-      .build_start
-      .take()
-      .map_or(Duration::ZERO, |start| start.elapsed());
+    let build_time = self.build_start.elapsed();
     if let Some(cache) = self.cache.get() {
       cache.begin_idle(build_time);
     }
@@ -58,7 +55,7 @@ impl JsCache {
     if let Some(cache) = self.cache.get() {
       cache.end_idle();
     }
-    self.build_start = Some(Instant::now());
+    self.build_start = Instant::now();
   }
 
   #[napi(ts_return_type = "Promise<void>")]

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -401,9 +401,9 @@ impl JsCompiler {
         resolver_factory,
         loader_resolver_factory,
         Some(compiler_context.clone()),
-        infrastructure_log_sink,
         platform,
         cache,
+        infrastructure_log_sink,
       );
 
       Ok(Self {

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -392,7 +392,7 @@ impl JsCompiler {
       let platform = Arc::new(CompilerPlatform::from(platform));
 
       let rspack = rspack_core::Compiler::new(
-        compiler_path,
+        compiler_path.into(),
         compiler_options,
         plugins,
         buildtime_plugins::buildtime_plugins(),

--- a/crates/rspack_binding_api/src/lib.rs
+++ b/crates/rspack_binding_api/src/lib.rs
@@ -55,6 +55,7 @@ mod asset_condition;
 mod async_dependency_block;
 mod browserslist;
 mod build_info;
+mod cache;
 mod chunk;
 mod chunk_graph;
 mod chunk_group;
@@ -123,6 +124,7 @@ use swc_core::common::util::take::Take;
 
 use crate::{
   async_dependency_block::AsyncDependenciesBlockWrapper,
+  cache::JsCache,
   chunk::ChunkWrapper,
   chunk_group::ChunkGroupWrapper,
   compilation::JsCompilationWrapper,
@@ -245,7 +247,7 @@ impl JsCompiler {
   #[allow(clippy::too_many_arguments)]
   #[napi(
     constructor,
-    ts_args_type = "compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void"
+    ts_args_type = "compilerPath: string, options: RawOptions, builtinPlugins: BuiltinPlugin[], registerJsTaps: RegisterJsTaps, outputFilesystem: ThreadsafeNodeFS, intermediateFilesystem: ThreadsafeNodeFS | undefined | null, inputFilesystem: ThreadsafeNodeFS | undefined | null, resolverFactoryReference: JsResolverFactory, unsafeFastDrop: boolean, platform: RawCompilerPlatform, infrastructureLogCallback: (logs: JsLog[]) => void, cache: JsCache"
   )]
   pub fn new(
     env: Env,
@@ -261,6 +263,7 @@ impl JsCompiler {
     unsafe_fast_drop: bool,
     platform: RawCompilerPlatform,
     raw_infrastructure_log_callback: Unknown<'static>,
+    cache: Reference<JsCache>,
   ) -> Result<Self> {
     tracing::info!(name:"rspack_version", version = rspack_workspace::rspack_pkg_version!());
 
@@ -323,8 +326,8 @@ impl JsCompiler {
 
       tracing::debug!(name:"normalized_options", options=?&compiler_options);
 
-      let mut input_file_system: Option<Arc<dyn ReadableFileSystem>> =
-        input_filesystem.and_then(|fs| {
+      let mut input_file_system: Arc<dyn ReadableFileSystem> = input_filesystem
+        .and_then(|fs| {
           use_input_fs.and_then(|use_input_file_system| {
             let node_fs = NodeFileSystem::new(fs).expect("Failed to create readable filesystem");
 
@@ -343,7 +346,8 @@ impl JsCompiler {
               }
             }
           })
-        });
+        })
+        .unwrap_or_else(|| Arc::new(NativeFileSystem::new(pnp)));
 
       let mut virtual_file_store: Option<Arc<RwLock<dyn VirtualFileStore>>> = None;
       if let Some(list) = virtual_files {
@@ -354,19 +358,7 @@ impl JsCompiler {
           }
           Arc::new(RwLock::new(store))
         };
-        input_file_system = input_file_system
-          .map(|real_fs| {
-            let binding: Arc<dyn ReadableFileSystem> =
-              Arc::new(VirtualFileSystem::new(real_fs, store.clone()));
-            binding
-          })
-          .or_else(|| {
-            let binding: Arc<dyn ReadableFileSystem> = Arc::new(VirtualFileSystem::new(
-              Arc::new(NativeFileSystem::new(pnp)),
-              store.clone(),
-            ));
-            Some(binding)
-          });
+        input_file_system = Arc::new(VirtualFileSystem::new(input_file_system, store.clone()));
         virtual_file_store = Some(store);
       }
 
@@ -378,36 +370,40 @@ impl JsCompiler {
       let resolver_factory = resolver_factory_reference.get_resolver_factory();
       let loader_resolver_factory = resolver_factory_reference.get_loader_resolver_factory();
 
-      let intermediate_filesystem: Option<Arc<dyn IntermediateFileSystem>> =
+      let intermediate_filesystem: Arc<dyn IntermediateFileSystem> =
         if let Some(fs) = intermediate_filesystem {
-          Some(Arc::new(
-            NodeFileSystem::new(fs).to_napi_result_with_message(|e| {
-              format!("Failed to create intermediate filesystem: {e}")
-            })?,
-          ))
+          Arc::new(NodeFileSystem::new(fs).to_napi_result_with_message(|e| {
+            format!("Failed to create intermediate filesystem: {e}")
+          })?)
         } else {
-          None
+          Arc::new(NativeFileSystem::new(false))
         };
 
       let platform = Arc::new(CompilerPlatform::from(platform));
+      let output_filesystem = Arc::new(
+        NodeFileSystem::new(output_filesystem)
+          .to_napi_result_with_message(|e| format!("Failed to create writable filesystem: {e}"))?,
+      );
+      let cache = cache.get_or_initialize(
+        &compiler_options,
+        input_file_system.clone(),
+        infrastructure_log_sink.clone(),
+      );
 
       let rspack = rspack_core::Compiler::new(
         compiler_path.into(),
         compiler_options,
         plugins,
         buildtime_plugins::buildtime_plugins(),
-        Some(Arc::new(
-          NodeFileSystem::new(output_filesystem).to_napi_result_with_message(|e| {
-            format!("Failed to create writable filesystem: {e}")
-          })?,
-        )),
-        intermediate_filesystem,
         input_file_system,
-        Some(resolver_factory),
-        Some(loader_resolver_factory),
+        output_filesystem,
+        intermediate_filesystem,
+        resolver_factory,
+        loader_resolver_factory,
         Some(compiler_context.clone()),
         infrastructure_log_sink,
         platform,
+        cache,
       );
 
       Ok(Self {

--- a/crates/rspack_binding_api/src/resolver_factory.rs
+++ b/crates/rspack_binding_api/src/resolver_factory.rs
@@ -59,20 +59,17 @@ impl JsResolverFactory {
 
   pub fn update_options(
     &mut self,
-    input_filesystem: Option<Arc<dyn ReadableFileSystem>>,
+    input_filesystem: Arc<dyn ReadableFileSystem>,
     resolve_options: Resolve,
     loader_resolve_options: Resolve,
   ) {
-    if input_filesystem.is_some()
-      || self.resolve_options != resolve_options
+    if self.resolve_options != resolve_options
       || self.loader_resolve_options != loader_resolve_options
     {
       self.resolver_factory = None;
       self.loader_resolver_factory = None;
     }
-    if let Some(input_filesystem) = input_filesystem {
-      self.input_filesystem = input_filesystem;
-    }
+    self.input_filesystem = input_filesystem;
     self.resolve_options = resolve_options;
     self.loader_resolve_options = loader_resolve_options;
   }

--- a/crates/rspack_binding_api/src/resolver_factory.rs
+++ b/crates/rspack_binding_api/src/resolver_factory.rs
@@ -63,7 +63,8 @@ impl JsResolverFactory {
     resolve_options: Resolve,
     loader_resolve_options: Resolve,
   ) {
-    if self.resolve_options != resolve_options
+    if !Arc::ptr_eq(&self.input_filesystem, &input_filesystem)
+      || self.resolve_options != resolve_options
       || self.loader_resolve_options != loader_resolve_options
     {
       self.resolver_factory = None;

--- a/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
+++ b/crates/rspack_core/src/compilation/build_module_graph/graph_updater/repair/context.rs
@@ -10,7 +10,7 @@ use crate::{
   DependencyTemplateType, DependencyType, ExportsInfoArtifact, FileSystemInfo, ModuleFactory,
   ResolverFactory, RuntimeTemplate, SharedPluginDriver, ValueCacheVersions,
   compilation::build_module_graph::module_build_cache::ModuleBuildCache, incremental::Incremental,
-  module_graph::ModuleGraph, new_cache::Cache,
+  module_graph::ModuleGraph, new_cache::CompilerCache,
 };
 
 #[derive(Debug)]
@@ -31,7 +31,7 @@ pub struct TaskContext {
   pub dependency_factories: HashMap<DependencyType, Arc<dyn ModuleFactory>>,
   pub dependency_templates: HashMap<DependencyTemplateType, Arc<dyn DependencyTemplate>>,
   pub runtime_template: RuntimeTemplate,
-  pub(crate) cache: Cache,
+  pub(crate) cache: CompilerCache,
   pub(crate) module_build_cache: Option<ModuleBuildCache>,
   pub value_cache_versions: ValueCacheVersions,
 

--- a/crates/rspack_core/src/compilation/mod.rs
+++ b/crates/rspack_core/src/compilation/mod.rs
@@ -98,7 +98,7 @@ use crate::{
   legacy_cache::persistent::occasion::{
     devtool::SourceMapDevToolPluginCache, minimize::MinimizePersistentCache,
   },
-  new_cache::{Cache, CacheFacade},
+  new_cache::{CacheFacade, CompilerCache},
   to_identifier,
 };
 
@@ -239,7 +239,7 @@ pub struct Compilation {
   pub emitted_assets: DashSet<String, BuildHasherDefault<FxHasher>>,
   diagnostics: Vec<Diagnostic>,
   logging: CompilationLogging,
-  cache: Cache,
+  cache: CompilerCache,
   pub(crate) module_build_cache: Option<ModuleBuildCache>,
   pub file_system_info: FileSystemInfo,
   pub plugin_driver: SharedPluginDriver,
@@ -352,7 +352,7 @@ impl Compilation {
     incremental: Incremental,
     module_executor: Option<ModuleExecutor>,
     logging: CompilationLogging,
-    cache: Cache,
+    cache: CompilerCache,
     modified_files: InternedPathSet,
     removed_files: InternedPathSet,
     input_filesystem: Arc<dyn ReadableFileSystem>,

--- a/crates/rspack_core/src/compiler/meta.rs
+++ b/crates/rspack_core/src/compiler/meta.rs
@@ -1,0 +1,8 @@
+use rspack_cacheable::cacheable;
+
+/// Compiler-owned state needed to reuse modules with stored dependency IDs.
+#[cacheable]
+#[derive(Debug)]
+pub(crate) struct Meta {
+  pub max_dependency_id: u32,
+}

--- a/crates/rspack_core/src/compiler/meta.rs
+++ b/crates/rspack_core/src/compiler/meta.rs
@@ -1,8 +1,0 @@
-use rspack_cacheable::cacheable;
-
-/// Compiler-owned state needed to reuse modules with stored dependency IDs.
-#[cacheable]
-#[derive(Debug)]
-pub(crate) struct Meta {
-  pub max_dependency_id: u32,
-}

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,9 +1,6 @@
 mod meta;
 mod rebuild;
-use std::{
-  sync::{Arc, atomic::AtomicU32},
-  time::{Duration, Instant},
-};
+use std::sync::{Arc, atomic::AtomicU32};
 
 use futures::future::join_all;
 use rspack_cacheable::cacheable;
@@ -30,7 +27,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{CacheFacade, CacheValue, CompilerCache, create_cache},
+  new_cache::{Cache, CacheFacade, CacheValue, CompilerCache, create_cache},
   trim_dir,
 };
 
@@ -126,16 +123,15 @@ impl Compiler {
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
     buildtime_plugins: Vec<BoxPlugin>,
-    output_filesystem: Option<Arc<dyn WritableFileSystem>>,
-    intermediate_filesystem: Option<Arc<dyn IntermediateFileSystem>>,
-    // only supports passing input_filesystem in rust api, no support for js api
-    input_filesystem: Option<Arc<dyn ReadableFileSystem>>,
-    // no need to pass resolve_factory in rust api
-    resolver_factory: Option<Arc<ResolverFactory>>,
-    loader_resolver_factory: Option<Arc<ResolverFactory>>,
+    input_filesystem: Arc<dyn ReadableFileSystem>,
+    output_filesystem: Arc<dyn WritableFileSystem>,
+    intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
+    resolver_factory: Arc<ResolverFactory>,
+    loader_resolver_factory: Arc<ResolverFactory>,
     compiler_context: Option<Arc<CompilerContext>>,
     infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
     platform: Arc<CompilerPlatform>,
+    cache: Arc<Cache>,
   ) -> Self {
     #[cfg(debug_assertions)]
     {
@@ -143,41 +139,13 @@ impl Compiler {
         debug_info.with_context(options.context.to_string());
       }
     }
-    let pnp = options.resolve.pnp.unwrap_or(false);
-    // pnp is only meaningful for input_filesystem, so disable it for intermediate_filesystem and output_filesystem
-    let input_filesystem = input_filesystem.unwrap_or_else(|| Arc::new(NativeFileSystem::new(pnp)));
-
-    let output_filesystem =
-      output_filesystem.unwrap_or_else(|| Arc::new(NativeFileSystem::new(false)));
-    let intermediate_filesystem =
-      intermediate_filesystem.unwrap_or_else(|| Arc::new(NativeFileSystem::new(false)));
-
-    let resolver_factory = resolver_factory.unwrap_or_else(|| {
-      Arc::new(ResolverFactory::new(
-        options.resolve.clone(),
-        input_filesystem.clone(),
-      ))
-    });
-    let loader_resolver_factory = loader_resolver_factory.unwrap_or_else(|| {
-      Arc::new(ResolverFactory::new(
-        options.resolve_loader.clone(),
-        input_filesystem.clone(),
-      ))
-    });
 
     let options = Arc::new(options);
     let compilation_logging: CompilationLogging = Default::default();
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
-    let new_cache = CompilerCache::new(
-      Arc::new(create_cache(
-        options.clone(),
-        input_filesystem.clone(),
-        infrastructure_log_sink,
-      )),
-      compiler_path.clone(),
-    );
+    let new_cache = CompilerCache::new(cache, compiler_path.clone());
     let cache = create_legacy_cache(
       &compiler_path,
       options.clone(),
@@ -240,12 +208,7 @@ impl Compiler {
     self.new_cache.facade(name)
   }
 
-  fn end_idle(&self) -> Instant {
-    self.new_cache.end_idle();
-    Instant::now()
-  }
-
-  fn begin_idle(&mut self, build_time: Duration) {
+  fn store_cache_metadata(&mut self) {
     if self.new_cache.has_file_cache() {
       if let CacheOptions::Persistent(options) = &self.options.cache {
         self.compilation.build_dependencies.extend(
@@ -267,7 +230,6 @@ impl Compiler {
         max_dependency_id: self.compiler_context.dependency_id(),
       }),
     );
-    self.new_cache.begin_idle(build_time);
   }
 
   pub async fn run(&mut self) -> Result<()> {
@@ -276,7 +238,6 @@ impl Compiler {
   }
 
   pub async fn build(&mut self) -> Result<()> {
-    let start = self.end_idle();
     let compiler_context = self.compiler_context.clone();
     let result = match within_compiler_context(compiler_context, self.build_inner()).await {
       Ok(_) => {
@@ -297,7 +258,7 @@ impl Compiler {
         failed.and(Err(e))
       }
     };
-    self.begin_idle(start.elapsed());
+    self.store_cache_metadata();
     result
   }
 
@@ -670,7 +631,6 @@ impl Compiler {
       .await?;
 
     self.cache.close().await;
-    self.new_cache.shutdown().await;
     Ok(())
   }
 }

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,4 +1,3 @@
-mod meta;
 mod rebuild;
 use std::sync::{Arc, atomic::AtomicU32};
 
@@ -15,7 +14,6 @@ use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::Semaphore;
 use tracing::instrument;
 
-use self::meta::Meta;
 pub use self::rebuild::CompilationRecords;
 use crate::{
   BoxPlugin, CacheOptions, CleanOptions, Compilation, CompilationAsset, CompilationLogging,
@@ -30,6 +28,12 @@ use crate::{
   new_cache::{Cache, CacheFacade, CacheValue, CompilerCache, create_cache},
   trim_dir,
 };
+
+#[cacheable]
+#[derive(Debug)]
+struct Meta {
+  pub max_dependency_id: u32,
+}
 
 // should be SyncHook, but rspack need call js hook
 define_hook!(CompilerThisCompilation: Series(compilation: &mut Compilation, params: &mut CompilationParams));
@@ -221,15 +225,15 @@ impl Compiler {
       let (build_dependencies, _, _, _) = self.compilation.build_dependencies();
       self
         .new_cache
-        .store_build_dependencies(build_dependencies.cloned().collect())
+        .store_build_dependencies(build_dependencies.cloned().collect());
+      self.get_cache("meta").store(
+        "state",
+        None,
+        CacheValue::new(Meta {
+          max_dependency_id: self.compiler_context.dependency_id(),
+        }),
+      );
     };
-    self.get_cache("meta").store(
-      "state",
-      None,
-      CacheValue::new(Meta {
-        max_dependency_id: self.compiler_context.dependency_id(),
-      }),
-    );
   }
 
   pub async fn run(&mut self) -> Result<()> {
@@ -264,7 +268,9 @@ impl Compiler {
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
-    if let Some(restored) = self.get_cache("meta").get::<Meta>("state", None) {
+    if self.new_cache.has_file_cache()
+      && let Some(restored) = self.get_cache("meta").get::<Meta>("state", None)
+    {
       let current = self.compiler_context.dependency_id();
       if current < restored.max_dependency_id {
         self

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -1,3 +1,4 @@
+mod meta;
 mod rebuild;
 use std::{
   sync::{Arc, atomic::AtomicU32},
@@ -17,6 +18,7 @@ use rustc_hash::FxHashMap as HashMap;
 use tokio::sync::Semaphore;
 use tracing::instrument;
 
+use self::meta::Meta;
 pub use self::rebuild::CompilationRecords;
 use crate::{
   BoxPlugin, CacheOptions, CleanOptions, Compilation, CompilationAsset, CompilationLogging,
@@ -28,7 +30,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{Cache, CacheFacade, Meta, create_cache},
+  new_cache::{CacheFacade, CacheValue, CompilerCache, create_cache},
   trim_dir,
 };
 
@@ -96,7 +98,7 @@ const EMIT_ASSETS_CONCURRENCY_LIMIT: usize = 15;
 #[derive(Debug)]
 pub struct Compiler {
   id: CompilerId,
-  pub compiler_path: String,
+  pub compiler_path: Arc<str>,
   pub options: Arc<CompilerOptions>,
   pub output_filesystem: Arc<dyn WritableFileSystem>,
   pub intermediate_filesystem: Arc<dyn IntermediateFileSystem>,
@@ -108,7 +110,7 @@ pub struct Compiler {
   pub loader_resolver_factory: Arc<ResolverFactory>,
   pub cache: Box<dyn LegacyCache>,
   incremental_artifacts: IncrementalArtifacts,
-  new_cache: Cache,
+  new_cache: CompilerCache,
   /// emitted asset versions
   /// the key of HashMap is filename, the value of HashMap is version
   pub emitted_asset_versions: HashMap<String, String>,
@@ -120,7 +122,7 @@ pub struct Compiler {
 impl Compiler {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
-    compiler_path: String,
+    compiler_path: Arc<str>,
     options: CompilerOptions,
     plugins: Vec<BoxPlugin>,
     buildtime_plugins: Vec<BoxPlugin>,
@@ -168,11 +170,13 @@ impl Compiler {
     let plugin_driver = PluginDriver::new(options.clone(), plugins, resolver_factory.clone());
     let buildtime_plugin_driver =
       PluginDriver::new(options.clone(), buildtime_plugins, resolver_factory.clone());
-    let new_cache = create_cache(
+    let new_cache = CompilerCache::new(
+      Arc::new(create_cache(
+        options.clone(),
+        input_filesystem.clone(),
+        infrastructure_log_sink,
+      )),
       compiler_path.clone(),
-      options.clone(),
-      input_filesystem.clone(),
-      infrastructure_log_sink,
     );
     let cache = create_legacy_cache(
       &compiler_path,
@@ -256,9 +260,13 @@ impl Compiler {
         .new_cache
         .store_build_dependencies(build_dependencies.cloned().collect())
     };
-    self.new_cache.store_meta(Meta {
-      max_dependency_id: self.compiler_context.dependency_id(),
-    });
+    self.get_cache("meta").store(
+      "state",
+      None,
+      CacheValue::new(Meta {
+        max_dependency_id: self.compiler_context.dependency_id(),
+      }),
+    );
     self.new_cache.begin_idle(build_time);
   }
 
@@ -295,7 +303,7 @@ impl Compiler {
 
   #[instrument("Compiler:build",target=TRACING_BENCH_TARGET, skip_all)]
   async fn build_inner(&mut self) -> Result<()> {
-    if let Some(restored) = self.new_cache.restore_meta()? {
+    if let Some(restored) = self.get_cache("meta").get::<Meta>("state", None) {
       let current = self.compiler_context.dependency_id();
       if current < restored.max_dependency_id {
         self

--- a/crates/rspack_core/src/compiler/mod.rs
+++ b/crates/rspack_core/src/compiler/mod.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, atomic::AtomicU32};
 use futures::future::join_all;
 use rspack_cacheable::cacheable;
 use rspack_error::Result;
-use rspack_fs::{IntermediateFileSystem, NativeFileSystem, ReadableFileSystem, WritableFileSystem};
+use rspack_fs::{IntermediateFileSystem, ReadableFileSystem, WritableFileSystem};
 use rspack_hook::define_hook;
 use rspack_paths::{InternedPath, Utf8Path, Utf8PathBuf};
 use rspack_sources::BoxSource;
@@ -25,7 +25,7 @@ use crate::{
   incremental::{Incremental, IncrementalPasses},
   legacy_cache::{Cache as LegacyCache, create_cache as create_legacy_cache},
   logger::Logger,
-  new_cache::{Cache, CacheFacade, CacheValue, CompilerCache, create_cache},
+  new_cache::{Cache, CacheFacade, CacheValue, CompilerCache},
   trim_dir,
 };
 
@@ -133,9 +133,9 @@ impl Compiler {
     resolver_factory: Arc<ResolverFactory>,
     loader_resolver_factory: Arc<ResolverFactory>,
     compiler_context: Option<Arc<CompilerContext>>,
-    infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
     platform: Arc<CompilerPlatform>,
     cache: Arc<Cache>,
+    _infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
   ) -> Self {
     #[cfg(debug_assertions)]
     {

--- a/crates/rspack_core/src/compiler/rebuild.rs
+++ b/crates/rspack_core/src/compiler/rebuild.rs
@@ -21,7 +21,6 @@ impl Compiler {
     changed_files: FxHashSet<String>,
     deleted_files: FxHashSet<String>,
   ) -> Result<()> {
-    let start = self.end_idle();
     let result = match within_compiler_context(
       self.compiler_context.clone(),
       self.rebuild_inner(changed_files, deleted_files),
@@ -46,7 +45,7 @@ impl Compiler {
         failed.and(Err(e))
       }
     };
-    self.begin_idle(start.elapsed());
+    self.store_cache_metadata();
     result
   }
 

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -17,7 +17,7 @@ pub use compilation::{
 pub use exports::*;
 pub use new_cache::{
   Cache, CacheFacade, CacheValue, CompilerCache, Etag, FileSystemInfo, ItemCacheFacade,
-  MultiItemCache, Snapshot, SnapshotValidationResult,
+  MultiItemCache, Snapshot, SnapshotValidationResult, create_cache,
 };
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;

--- a/crates/rspack_core/src/lib.rs
+++ b/crates/rspack_core/src/lib.rs
@@ -16,8 +16,8 @@ pub use compilation::{
 };
 pub use exports::*;
 pub use new_cache::{
-  Cache, CacheFacade, CacheValue, Etag, FileSystemInfo, ItemCacheFacade, MultiItemCache, Snapshot,
-  SnapshotValidationResult,
+  Cache, CacheFacade, CacheValue, CompilerCache, Etag, FileSystemInfo, ItemCacheFacade,
+  MultiItemCache, Snapshot, SnapshotValidationResult,
 };
 pub use transient_cache::*;
 pub use value_cache_versions::ValueCacheVersions;

--- a/crates/rspack_core/src/new_cache/cache.rs
+++ b/crates/rspack_core/src/new_cache/cache.rs
@@ -1,42 +1,32 @@
-use std::{sync::Arc, time::Duration};
+use std::{ops::Deref, sync::Arc, time::Duration};
 
-use rspack_error::Result;
 use rspack_paths::InternedPathSet;
 
 use super::{
-  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult, Meta,
+  CacheFacade, CacheKey, CacheValue, Etag, IdleFileCache, MemoryCache, MemoryCacheGetResult,
   cache_value::CacheValueData,
 };
 
-/// Cache entry point backed by memory and optional filesystem storage.
-///
-/// Reads follow webpack's cache stage order: memory is queried first and only
-/// an unknown key falls through to the filesystem cache. Filesystem results,
-/// including misses, are recorded in memory for subsequent reads.
+/// Storage shared by all compiler-scoped cache views.
 #[derive(Debug)]
 struct CacheStorage {
   memory_cache: Option<MemoryCache>,
   idle_file_cache: Option<IdleFileCache>,
 }
 
+/// Shared cache storage, independent of a compiler's namespace.
+///
+/// Reads follow webpack's cache stage order: memory is queried first and only
+/// an unknown key falls through to the filesystem cache. Filesystem results,
+/// including misses, are recorded in memory for subsequent reads.
 #[derive(Debug)]
-struct CacheInner {
-  compiler_path: String,
+pub struct Cache {
   storage: Option<CacheStorage>,
 }
 
-/// Cheaply cloneable handle to the shared cache state.
-#[derive(Debug, Clone)]
-pub struct Cache {
-  inner: Arc<CacheInner>,
-}
-
 impl Cache {
-  pub fn new(
-    compiler_path: String,
-    memory_cache: Option<MemoryCache>,
-    idle_file_cache: Option<IdleFileCache>,
-  ) -> Self {
+  /// Creates storage from the configured memory and filesystem caches.
+  pub fn new(memory_cache: Option<MemoryCache>, idle_file_cache: Option<IdleFileCache>) -> Self {
     let storage = if memory_cache.is_some() || idle_file_cache.is_some() {
       Some(CacheStorage {
         memory_cache,
@@ -45,32 +35,15 @@ impl Cache {
     } else {
       None
     };
-    Self {
-      inner: Arc::new(CacheInner {
-        compiler_path,
-        storage,
-      }),
-    }
+    Self { storage }
   }
 
-  pub fn new_disabled(compiler_path: String) -> Self {
-    Self {
-      inner: Arc::new(CacheInner {
-        compiler_path,
-        storage: None,
-      }),
-    }
-  }
-
-  pub(crate) fn facade(&self, name: &str) -> CacheFacade {
-    let mut cache_name = String::with_capacity(self.inner.compiler_path.len() + name.len());
-    cache_name.push_str(&self.inner.compiler_path);
-    cache_name.push_str(name);
-    CacheFacade::new(self.clone(), cache_name)
+  pub fn new_disabled() -> Self {
+    Self::new(None, None)
   }
 
   pub fn get<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>) -> Option<CacheValue<T>> {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return None;
     };
     if let Some(memory_cache) = &storage.memory_cache {
@@ -105,7 +78,7 @@ impl Cache {
   }
 
   pub fn store<T: CacheValueData>(&self, key: CacheKey, etag: Option<Etag>, value: CacheValue<T>) {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return;
     };
     if let Some(memory_cache) = &storage.memory_cache {
@@ -117,7 +90,7 @@ impl Cache {
   }
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return;
     };
     if let Some(file_cache) = &storage.idle_file_cache {
@@ -125,36 +98,15 @@ impl Cache {
     }
   }
 
-  pub fn store_meta(&self, meta: Meta) {
-    let Some(storage) = &self.inner.storage else {
-      return;
-    };
-    if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.store_meta(meta);
-    }
-  }
-
-  pub fn restore_meta(&self) -> Result<Option<Meta>> {
-    let Some(storage) = &self.inner.storage else {
-      return Ok(None);
-    };
-    if let Some(file_cache) = &storage.idle_file_cache {
-      file_cache.restore_meta()
-    } else {
-      Ok(None)
-    }
-  }
-
   pub fn has_file_cache(&self) -> bool {
     self
-      .inner
       .storage
       .as_ref()
       .is_some_and(|storage| storage.idle_file_cache.is_some())
   }
 
   pub fn begin_idle(&self, build_time: Duration) {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return;
     };
     if let Some(memory_cache) = &storage.memory_cache {
@@ -166,7 +118,7 @@ impl Cache {
   }
 
   pub fn end_idle(&self) {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return;
     };
     if let Some(file_cache) = &storage.idle_file_cache {
@@ -175,7 +127,7 @@ impl Cache {
   }
 
   pub async fn shutdown(&self) {
-    let Some(storage) = &self.inner.storage else {
+    let Some(storage) = &self.storage else {
       return;
     };
     if let Some(memory_cache) = &storage.memory_cache {
@@ -184,5 +136,34 @@ impl Cache {
     if let Some(file_cache) = &storage.idle_file_cache {
       file_cache.shutdown().await;
     }
+  }
+}
+
+/// A compiler's view of shared cache storage.
+#[derive(Debug, Clone)]
+pub struct CompilerCache {
+  cache: Arc<Cache>,
+  compiler_path: Arc<str>,
+}
+
+impl Deref for CompilerCache {
+  type Target = Cache;
+
+  fn deref(&self) -> &Self::Target {
+    &self.cache
+  }
+}
+
+impl CompilerCache {
+  pub fn new(cache: Arc<Cache>, compiler_path: Arc<str>) -> Self {
+    Self {
+      cache,
+      compiler_path,
+    }
+  }
+
+  pub fn facade(&self, name: &str) -> CacheFacade {
+    let cache_name = [self.compiler_path.as_ref(), name].join("|");
+    CacheFacade::new(Arc::clone(&self.cache), cache_name)
   }
 }

--- a/crates/rspack_core/src/new_cache/cache_facade.rs
+++ b/crates/rspack_core/src/new_cache/cache_facade.rs
@@ -5,26 +5,16 @@ use super::{Cache, CacheKey, CacheValue, Etag, cache_value::CacheValueData};
 /// A namespaced view of the shared cache.
 ///
 /// This is the minimal equivalent of webpack's `CacheFacade`: it prefixes
-/// identifiers with a fixed namespace and creates child or item facades.
+/// identifiers with a fixed namespace and creates item facades.
 #[derive(Debug, Clone)]
 pub struct CacheFacade {
-  cache: Cache,
-  name: Arc<str>,
+  cache: Arc<Cache>,
+  name: String,
 }
 
 impl CacheFacade {
-  pub(crate) fn new(cache: Cache, name: impl Into<Arc<str>>) -> Self {
-    Self {
-      cache,
-      name: name.into(),
-    }
-  }
-
-  pub fn get_child_cache(&self, name: &str) -> Self {
-    Self {
-      cache: self.cache.clone(),
-      name: join_name(&self.name, name, true),
-    }
+  pub(crate) fn new(cache: Arc<Cache>, name: String) -> Self {
+    Self { cache, name }
   }
 
   pub fn get_item_cache(&self, identifier: &str, etag: Option<Etag>) -> ItemCacheFacade {
@@ -53,14 +43,14 @@ impl CacheFacade {
   }
 
   fn key(&self, identifier: &str) -> CacheKey {
-    CacheKey::from(join_name(&self.name, identifier, true))
+    CacheKey::from([self.name.as_ref(), identifier].join("|"))
   }
 }
 
 /// A cache facade with a fixed identifier and etag.
 #[derive(Debug, Clone)]
 pub struct ItemCacheFacade {
-  cache: Cache,
+  cache: Arc<Cache>,
   key: CacheKey,
   etag: Option<Etag>,
 }
@@ -105,14 +95,4 @@ impl MultiItemCache {
       item.store(value.clone());
     }
   }
-}
-
-fn join_name(prefix: &str, name: &str, with_separator: bool) -> Arc<str> {
-  let mut result = String::with_capacity(prefix.len() + name.len() + usize::from(with_separator));
-  result.push_str(prefix);
-  if with_separator {
-    result.push('|');
-  }
-  result.push_str(name);
-  result.into()
 }

--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -11,17 +11,15 @@ use crate::new_cache::CacheKey;
 pub enum DatabaseFamily {
   Cache,
   Validator,
-  Meta,
 }
 
 impl DatabaseFamily {
-  pub const COUNT: usize = 3;
+  pub const COUNT: usize = 2;
 
   pub const fn index(self) -> usize {
     match self {
       Self::Cache => 0,
       Self::Validator => 1,
-      Self::Meta => 2,
     }
   }
 }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -330,10 +330,6 @@ fn database_config() -> DbConfig<{ DatabaseFamily::COUNT }> {
         name: "validator",
         kind: FamilyKind::SingleValue,
       },
-      FamilyConfig {
-        name: "meta",
-        kind: FamilyKind::SingleValue,
-      },
     ],
   }
 }

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -10,7 +10,7 @@ use rspack_util::fx_hash::FxDashMap;
 use tokio::sync::Notify;
 
 use super::{
-  CacheKey, Etag, Meta,
+  CacheKey, Etag,
   cache_value::{CacheEntry, CacheValueDecoder, CacheValueEncoder, ErasedCacheValue},
   db::{Database, DatabaseFamily},
   snapshot::FileSystemInfo,
@@ -19,13 +19,11 @@ use super::{
 use crate::{InfrastructureLogger, Logger, cache::CacheCodec, new_cache::db::TurboDatabase};
 
 const VALIDATOR_KEY: &str = "validator";
-const META_KEY: &str = "meta";
 
 #[derive(Debug, Default)]
 struct PendingWrites {
   entries: FxDashMap<CacheKey, PendingWrite>,
   new_build_dependencies: Mutex<Option<InternedPathSet>>,
-  meta: Mutex<Option<Meta>>,
 }
 
 #[derive(Debug)]
@@ -39,12 +37,8 @@ impl PendingWrites {
     self.new_build_dependencies.lock().expect("should lock")
   }
 
-  fn meta(&self) -> MutexGuard<'_, Option<Meta>> {
-    self.meta.lock().expect("should lock")
-  }
-
   fn is_empty(&self) -> bool {
-    self.entries.is_empty() && self.new_build_dependencies().is_none() && self.meta().is_none()
+    self.entries.is_empty() && self.new_build_dependencies().is_none()
   }
 }
 
@@ -272,34 +266,6 @@ impl FileCacheStrategy {
       .extend(dependencies);
   }
 
-  pub fn store_meta(&self, meta: Meta) {
-    if self.readonly {
-      return;
-    }
-    let state = self.read_state();
-    let Some(state) = state.as_ref() else {
-      return;
-    };
-    *state.pending_writes.meta() = Some(meta);
-  }
-
-  pub fn restore_meta(&self) -> Result<Option<Meta>> {
-    let state_guard = self.read_state();
-    let Some(state) = state_guard.as_ref() else {
-      return Ok(None);
-    };
-    if let Some(pending) = state.pending_writes.meta().as_ref() {
-      return Ok(Some(pending.clone()));
-    }
-
-    let result = state
-      .database
-      .get(DatabaseFamily::Meta, &CacheKey::new(META_KEY))
-      .and_then(|entry| entry.map(|entry| self.codec.decode(&entry)).transpose());
-    drop(state_guard);
-    result.inspect_err(|error| self.session_unavailable(Some(error)))
-  }
-
   pub(super) fn restore(
     &self,
     key: &CacheKey,
@@ -364,7 +330,6 @@ impl FileCacheStrategy {
       let codec = &self.codec;
       let mut writes;
       let new_build_dependencies;
-      let meta;
       {
         let mut state = self.write_state();
         let Some(state) = state.as_mut() else {
@@ -387,7 +352,6 @@ impl FileCacheStrategy {
           .collect::<Vec<_>>();
 
         new_build_dependencies = state.pending_writes.new_build_dependencies().take();
-        meta = state.pending_writes.meta().take();
       }
 
       if let Some(dependencies) = new_build_dependencies
@@ -398,11 +362,6 @@ impl FileCacheStrategy {
           CacheKey::from(VALIDATOR_KEY),
           validator,
         ));
-      }
-
-      if let Some(meta) = meta {
-        let meta = codec.encode(&meta)?;
-        writes.push((DatabaseFamily::Meta, CacheKey::from(META_KEY), meta));
       }
 
       let writes_len = writes.len();

--- a/crates/rspack_core/src/new_cache/idle_file_cache.rs
+++ b/crates/rspack_core/src/new_cache/idle_file_cache.rs
@@ -7,7 +7,6 @@ use std::{
   time::Duration,
 };
 
-use rspack_error::Result;
 use rspack_paths::{InternedPathSet, Utf8PathBuf};
 use tokio::{
   sync::mpsc,
@@ -15,7 +14,7 @@ use tokio::{
 };
 
 use super::{
-  CacheKey, CacheValue, Etag, FileCacheStrategy, Meta,
+  CacheKey, CacheValue, Etag, FileCacheStrategy,
   cache_value::{CacheValueData, ErasedCacheValue},
 };
 use crate::{InfrastructureLogger, Logger};
@@ -232,14 +231,6 @@ impl IdleFileCache {
 
   pub fn store_build_dependencies(&self, dependencies: InternedPathSet) {
     self.strategy.store_build_dependencies(dependencies);
-  }
-
-  pub fn store_meta(&self, meta: Meta) {
-    self.strategy.store_meta(meta);
-  }
-
-  pub fn restore_meta(&self) -> Result<Option<Meta>> {
-    self.strategy.restore_meta()
   }
 
   pub fn begin_idle(&self, build_time: Duration) {

--- a/crates/rspack_core/src/new_cache/meta.rs
+++ b/crates/rspack_core/src/new_cache/meta.rs
@@ -1,7 +1,0 @@
-use rspack_cacheable::cacheable;
-
-#[cacheable]
-#[derive(Debug, Clone)]
-pub struct Meta {
-  pub max_dependency_id: u32,
-}

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -30,7 +30,7 @@ use crate::{
 
 /// Creates cache storage independently of a compiler's namespace.
 pub fn create_cache(
-  compiler_options: Arc<CompilerOptions>,
+  compiler_options: &CompilerOptions,
   input_filesystem: Arc<dyn ReadableFileSystem>,
   infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
 ) -> Cache {

--- a/crates/rspack_core/src/new_cache/mod.rs
+++ b/crates/rspack_core/src/new_cache/mod.rs
@@ -7,13 +7,12 @@ mod etag;
 mod file_cache_strategy;
 mod idle_file_cache;
 mod memory_cache;
-mod meta;
 pub(crate) mod snapshot;
 mod validator;
 
 use std::sync::Arc;
 
-pub use cache::Cache;
+pub use cache::{Cache, CompilerCache};
 pub use cache_facade::{CacheFacade, ItemCacheFacade, MultiItemCache};
 pub use cache_key::CacheKey;
 pub use cache_value::CacheValue;
@@ -21,7 +20,6 @@ pub use etag::Etag;
 pub use file_cache_strategy::FileCacheStrategy;
 pub use idle_file_cache::IdleFileCache;
 pub use memory_cache::{MemoryCache, MemoryCacheGetResult};
-pub use meta::Meta;
 use rspack_fs::ReadableFileSystem;
 pub use snapshot::{FileSystemInfo, Snapshot, SnapshotValidationResult};
 
@@ -30,25 +28,25 @@ use crate::{
   cache::{CacheCodec, MaxMemoryGenerations},
 };
 
+/// Creates cache storage independently of a compiler's namespace.
 pub fn create_cache(
-  compiler_path: String,
   compiler_options: Arc<CompilerOptions>,
   input_filesystem: Arc<dyn ReadableFileSystem>,
   infrastructure_log_sink: Arc<dyn InfrastructureLogSink>,
 ) -> Cache {
   if !compiler_options.experiments.new_cache.is_enabled() {
-    return Cache::new_disabled(compiler_path);
+    return Cache::new_disabled();
   }
 
   let options = match &compiler_options.cache {
     crate::CacheOptions::Disabled => {
-      return Cache::new_disabled(compiler_path);
+      return Cache::new_disabled();
     }
     crate::CacheOptions::Memory {
       max_generations: _, /* TODO: old cache default to 1, change to 5 and pass to MemoryCache */
       ..
     } => {
-      return Cache::new(compiler_path, Some(MemoryCache::new(5)), None);
+      return Cache::new(Some(MemoryCache::new(5)), None);
     }
     crate::CacheOptions::Persistent(options) => options,
   };
@@ -99,5 +97,5 @@ pub fn create_cache(
     MaxMemoryGenerations::Finite(max_generations) => Some(MemoryCache::new(max_generations)),
   };
 
-  Cache::new(compiler_path, memory_cache, Some(idle_file_cache))
+  Cache::new(memory_cache, Some(idle_file_cache))
 }

--- a/packages/rspack/src/Compiler.ts
+++ b/packages/rspack/src/Compiler.ts
@@ -570,7 +570,6 @@ class Compiler {
     const finalCallback = (err: Error | null, stats?: Stats) => {
       this.idle = true;
       this.cache.beginIdle();
-      this.idle = true;
       this.running = false;
       if (err) {
         this.hooks.failed.call(err);
@@ -637,7 +636,7 @@ class Compiler {
 
     if (this.idle) {
       this.cache.endIdle((err) => {
-        if (err) return callback(err);
+        if (err) return finalCallback(err);
         this.idle = false;
         run();
       });
@@ -828,16 +827,21 @@ class Compiler {
       return;
     }
 
+    const instanceCallback = (error?: Error | null) => {
+      const close = this.#instance?.close();
+      if (close) {
+        close.then(
+          () => callback(error),
+          (closeError) => callback(error || closeError),
+        );
+      } else {
+        callback(error);
+      }
+    };
+
     this.hooks.shutdown.callAsync((err) => {
       if (err) return callback(err);
-      this.cache.shutdown(() => {
-        const closePromise = this.#instance?.close();
-        if (closePromise) {
-          closePromise.then(() => callback(), callback);
-        } else {
-          callback();
-        }
-      });
+      this.cache.shutdown(instanceCallback);
     });
   }
 
@@ -989,6 +993,7 @@ class Compiler {
             compiler.#logInfrastructureBatch(logs);
           }
         },
+        Cache.__to_binding(this.cache),
       );
 
       callback(null, this.#instance);

--- a/packages/rspack/src/Watching.ts
+++ b/packages/rspack/src/Watching.ts
@@ -311,41 +311,52 @@ export class Watching {
     this.compiler.removedFiles = this.#collectedRemovedFiles;
     this.#collectedChangedFiles = undefined;
     this.#collectedRemovedFiles = undefined;
-    this.invalid = false;
-    this.#invalidReported = false;
-    this.compiler.hooks.watchRun.callAsync(this.compiler, (err) => {
-      if (err) return this._done(err);
-
-      const onCompiled = (
-        err: Error | null,
-        _compilation: Compilation | undefined,
-      ) => {
+    const run = () => {
+      if (this.compiler.idle) {
+        return this.compiler.cache.endIdle((err) => {
+          if (err) return this._done(err);
+          this.compiler.idle = false;
+          run();
+        });
+      }
+      this.invalid = false;
+      this.#invalidReported = false;
+      this.compiler.hooks.watchRun.callAsync(this.compiler, (err) => {
         if (err) return this._done(err);
 
-        const compilation = _compilation!;
+        const onCompiled = (
+          err: Error | null,
+          _compilation: Compilation | undefined,
+        ) => {
+          if (err) return this._done(err);
 
-        const needAdditionalPass = compilation.hooks.needAdditionalPass.call();
-        if (needAdditionalPass) {
-          compilation.needAdditionalPass = true;
+          const compilation = _compilation!;
 
-          compilation.startTime = this.startTime;
-          compilation.endTime = Date.now();
-          const stats = new Stats(compilation);
-          this.compiler.hooks.done.callAsync(stats, (err) => {
-            if (err) return this._done(err, compilation);
+          const needAdditionalPass =
+            compilation.hooks.needAdditionalPass.call();
+          if (needAdditionalPass) {
+            compilation.needAdditionalPass = true;
 
-            this.compiler.hooks.additionalPass.callAsync((err) => {
+            compilation.startTime = this.startTime;
+            compilation.endTime = Date.now();
+            const stats = new Stats(compilation);
+            this.compiler.hooks.done.callAsync(stats, (err) => {
               if (err) return this._done(err, compilation);
-              this.compiler.compile(onCompiled);
-            });
-          });
-          return;
-        }
-        this._done(null, this.compiler._lastCompilation);
-      };
 
-      this.compiler.compile(onCompiled);
-    });
+              this.compiler.hooks.additionalPass.callAsync((err) => {
+                if (err) return this._done(err, compilation);
+                this.compiler.compile(onCompiled);
+              });
+            });
+            return;
+          }
+          this._done(null, this.compiler._lastCompilation);
+        };
+
+        this.compiler.compile(onCompiled);
+      });
+    };
+    run();
   }
 
   // Fold a finished compilation's file/context/missing deltas into the accumulator.
@@ -383,8 +394,8 @@ export class Watching {
 
     const handleError = (err: Error, cbs?: Callback<Error, void>[]) => {
       this.compiler.hooks.failed.call(err);
-      // this.compiler.cache.beginIdle();
-      // this.compiler.idle = true;
+      this.compiler.cache.beginIdle();
+      this.compiler.idle = true;
       this.handler(err, stats);
 
       const callbacksToExecute = cbs || this.callbacks.splice(0);
@@ -428,6 +439,8 @@ export class Watching {
       if (err) return handleError(err, cbs);
       this.handler(null, stats);
 
+      this.compiler.cache.beginIdle();
+      this.compiler.idle = true;
       process.nextTick(() => {
         if (!this.#closed) {
           // Deliver this build's deltas merged with any carried from skipped

--- a/packages/rspack/src/lib/Cache.ts
+++ b/packages/rspack/src/lib/Cache.ts
@@ -8,6 +8,8 @@
  * https://github.com/webpack/webpack/blob/main/LICENSE
  */
 
+import { createRequire } from 'node:module';
+import type binding from '@rspack/binding';
 import {
   AsyncParallelHook,
   AsyncSeriesBailHook,
@@ -16,6 +18,8 @@ import {
 
 import { makeWebpackError, makeWebpackErrorCallback } from './HookWebpackError';
 import type { WebpackError } from './WebpackError';
+
+const require = createRequire(import.meta.url);
 
 export interface Etag {
   toString(): string;
@@ -50,6 +54,8 @@ export class Cache {
   static STAGE_DEFAULT = 0;
   static STAGE_NETWORK = 20;
 
+  #binding: binding.JsCache;
+
   hooks: {
     get: AsyncSeriesBailHook<[string, Etag | null, GotHandler[]], any>;
     store: AsyncParallelHook<[string, Etag | null, any]>;
@@ -68,6 +74,12 @@ export class Cache {
       endIdle: new AsyncParallelHook([]),
       shutdown: new AsyncParallelHook([]),
     };
+    const { JsCache } = require('@rspack/binding') as typeof binding;
+    this.#binding = new JsCache();
+  }
+  
+  static __to_binding(cache: Cache): binding.JsCache {
+    return cache.#binding;
   }
 
   /**
@@ -142,6 +154,7 @@ export class Cache {
 
   beginIdle() {
     this.hooks.beginIdle.call();
+    this.#binding.beginIdle();
   }
 
   /**
@@ -149,6 +162,7 @@ export class Cache {
    * @returns
    */
   endIdle(callback: CallbackCache<void>) {
+    this.#binding.endIdle();
     this.hooks.endIdle.callAsync(
       makeWebpackErrorCallback(callback, 'Cache.hooks.endIdle'),
     );
@@ -159,9 +173,11 @@ export class Cache {
    * @returns
    */
   shutdown(callback: CallbackCache<void>) {
-    this.hooks.shutdown.callAsync(
-      makeWebpackErrorCallback(callback, 'Cache.hooks.shutdown'),
-    );
+    this.#binding.shutdown().then(() => {
+      this.hooks.shutdown.callAsync(
+        makeWebpackErrorCallback(callback, 'Cache.hooks.shutdown')
+      );
+    });
   }
 }
 

--- a/packages/rspack/src/lib/Cache.ts
+++ b/packages/rspack/src/lib/Cache.ts
@@ -77,7 +77,7 @@ export class Cache {
     const { JsCache } = require('@rspack/binding') as typeof binding;
     this.#binding = new JsCache();
   }
-  
+
   static __to_binding(cache: Cache): binding.JsCache {
     return cache.#binding;
   }
@@ -175,7 +175,7 @@ export class Cache {
   shutdown(callback: CallbackCache<void>) {
     this.#binding.shutdown().then(() => {
       this.hooks.shutdown.callAsync(
-        makeWebpackErrorCallback(callback, 'Cache.hooks.shutdown')
+        makeWebpackErrorCallback(callback, 'Cache.hooks.shutdown'),
       );
     });
   }

--- a/tests/rspack-test/compilerCases/persistent-cache-child-sst.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-child-sst.js
@@ -1,0 +1,78 @@
+const { promisify } = require("node:util");
+
+/** @type {import("@rspack/test-tools").TCompilerCaseConfig} */
+module.exports = {
+	description:
+		"should keep a live child's SST readable when another compiler opens the cache",
+	options(context) {
+		return {
+			experiments: { newCache: true },
+			incremental: false,
+			cache: {
+				type: "persistent",
+				maxMemoryGenerations: 0,
+				storage: { type: "filesystem", location: context.getDist("cache") }
+			},
+			infrastructureLogging: { level: "none" }
+		};
+	},
+	async build(context, compiler) {
+		const warnings = [];
+		let resolveStored;
+		const waitForStore = () => new Promise(resolve => (resolveStored = resolve));
+		compiler.hooks.infrastructureLog.tap("ChildSstTest", (name, type, args) => {
+			if (name !== "rspack.cache.IdleFileCache") return;
+			if (type === "warn") warnings.push(args[0]);
+			if (type === "log" && args[0].startsWith("Stored cache")) resolveStored?.();
+		});
+
+		const run = async target => {
+			const stats = await promisify(target.run.bind(target))();
+			expect(stats.hasErrors()).toBe(false);
+		};
+		const close = target => promisify(target.close.bind(target))();
+		const children = [];
+		let parentCompilation, child, parentStored;
+		const createChild = name => {
+			const target = parentCompilation.createChildCompiler(
+				name,
+				{ filename: `${name}.js` },
+				[
+					new compiler.rspack.EntryPlugin(compiler.context, "./a", { name: "main" })
+				]
+			);
+			children.push(target);
+			return target;
+		};
+
+		compiler.hooks.make.tapPromise("ChildSstTest", async compilation => {
+			parentCompilation = compilation;
+			// The parent has already opened the empty database. Seed advances CURRENT.
+			const seed = createChild("seed");
+			await run(seed);
+			await close(seed);
+			children.pop();
+
+			// Keep this child's newer SST on disk, but not in the memory cache.
+			child = createChild("child");
+			const childStored = waitForStore();
+			await run(child);
+			await childStored;
+			parentStored = waitForStore();
+		});
+
+		try {
+			await run(compiler);
+			// With a shared database, the stale parent's commit rolls CURRENT back.
+			await parentStored;
+			// Opening another child cleans files above CURRENT. No manual deletion.
+			await run(createChild("late"));
+			// The child must still be able to read its own SST after that open.
+			await run(child);
+		} finally {
+			for (const target of children) await close(target);
+			await context.closeCompiler();
+		}
+		expect(warnings, warnings.join("\n")).toEqual([]);
+	}
+};

--- a/tests/rspack-test/compilerCases/persistent-cache-child-sst.js
+++ b/tests/rspack-test/compilerCases/persistent-cache-child-sst.js
@@ -2,77 +2,46 @@ const { promisify } = require("node:util");
 
 /** @type {import("@rspack/test-tools").TCompilerCaseConfig} */
 module.exports = {
-	description:
-		"should keep a live child's SST readable when another compiler opens the cache",
+	description: "should persist parent and child compiler caches without storage conflicts",
 	options(context) {
 		return {
 			experiments: { newCache: true },
-			incremental: false,
 			cache: {
 				type: "persistent",
 				maxMemoryGenerations: 0,
 				storage: { type: "filesystem", location: context.getDist("cache") }
-			},
-			infrastructureLogging: { level: "none" }
+			}
 		};
 	},
 	async build(context, compiler) {
-		const warnings = [];
-		let resolveStored;
-		const waitForStore = () => new Promise(resolve => (resolveStored = resolve));
-		compiler.hooks.infrastructureLog.tap("ChildSstTest", (name, type, args) => {
-			if (name !== "rspack.cache.IdleFileCache") return;
-			if (type === "warn") warnings.push(args[0]);
-			if (type === "log" && args[0].startsWith("Stored cache")) resolveStored?.();
-		});
-
-		const run = async target => {
-			const stats = await promisify(target.run.bind(target))();
-			expect(stats.hasErrors()).toBe(false);
-		};
-		const close = target => promisify(target.close.bind(target))();
-		const children = [];
-		let parentCompilation, child, parentStored;
-		const createChild = name => {
-			const target = parentCompilation.createChildCompiler(
-				name,
-				{ filename: `${name}.js` },
-				[
-					new compiler.rspack.EntryPlugin(compiler.context, "./a", { name: "main" })
-				]
-			);
-			children.push(target);
-			return target;
+		const run = async parent => {
+			const built = { parent: 0, child: 0 };
+			const track = (target, name) => {
+				target.hooks.thisCompilation.tap("ChildSstTest", compilation => {
+					compilation.hooks.buildModule.tap("ChildSstTest", () => built[name]++);
+				});
+			};
+			track(parent, "parent");
+			parent.hooks.make.tapAsync("ChildSstTest", (compilation, callback) => {
+				const child = compilation.createChildCompiler("child", { filename: "child.js" }, [
+					new parent.rspack.EntryPlugin(parent.context, "./b", { name: "main" })
+				]);
+				track(child, "child");
+				child.runAsChild(callback);
+			});
+			try {
+				const stats = await promisify(parent.run.bind(parent))();
+				expect(stats.hasErrors()).toBe(false);
+				return built;
+			} finally {
+				await promisify(parent.close.bind(parent))();
+			}
 		};
 
-		compiler.hooks.make.tapPromise("ChildSstTest", async compilation => {
-			parentCompilation = compilation;
-			// The parent has already opened the empty database. Seed advances CURRENT.
-			const seed = createChild("seed");
-			await run(seed);
-			await close(seed);
-			children.pop();
-
-			// Keep this child's newer SST on disk, but not in the memory cache.
-			child = createChild("child");
-			const childStored = waitForStore();
-			await run(child);
-			await childStored;
-			parentStored = waitForStore();
-		});
-
-		try {
-			await run(compiler);
-			// With a shared database, the stale parent's commit rolls CURRENT back.
-			await parentStored;
-			// Opening another child cleans files above CURRENT. No manual deletion.
-			await run(createChild("late"));
-			// The child must still be able to read its own SST after that open.
-			await run(child);
-		} finally {
-			for (const target of children) await close(target);
-			await context.closeCompiler();
-		}
-		expect(warnings, warnings.join("\n")).toEqual([]);
+		expect(await run(compiler)).toEqual({ parent: 1, child: 1 });
+		// Reopening the same directory must recover both compilers' data from disk.
+		const reopened = context.getCompiler().createCompiler();
+		reopened.outputFileSystem = compiler.outputFileSystem;
+		expect(await run(reopened)).toEqual({ parent: 0, child: 0 });
 	}
 };

--- a/xtask/benchmark/benches/groups/build_chunk_graph.rs
+++ b/xtask/benchmark/benches/groups/build_chunk_graph.rs
@@ -5,8 +5,8 @@ use criterion::BatchSize;
 use rspack::builder::{Builder as _, CompilerBuilder};
 use rspack_benchmark::Criterion;
 use rspack_core::{
-  Cache, Compilation, Compiler, ModuleOptions, ModuleRule, ModuleRuleEffect, ModuleRuleUse,
-  ModuleRuleUseLoader, Optimization, RuleSetCondition, build_chunk_graph,
+  Cache, Compilation, Compiler, CompilerCache, ModuleOptions, ModuleRule, ModuleRuleEffect,
+  ModuleRuleUse, ModuleRuleUseLoader, Optimization, RuleSetCondition, build_chunk_graph,
   build_module_graph::{build_module_graph_pass, finish_build_module_graph},
   fast_set,
   incremental::{Incremental, IncrementalOptions},
@@ -368,7 +368,10 @@ fn reset_compilation_state(compiler: &mut Compiler) {
 
   let compiler_id = compiler.id();
   let compiler_context = CURRENT_COMPILER_CONTEXT.get();
-  let cache = Cache::new_disabled(compiler.compiler_path.clone());
+  let cache = CompilerCache::new(
+    Arc::new(Cache::new_disabled()),
+    compiler.compiler_path.clone(),
+  );
   fast_set(
     &mut compiler.compilation,
     Compilation::new(


### PR DESCRIPTION
## Motivation

With `experiments.newCache`, parent and child compilers inherit the same persistent cache directory but create separate native cache instances. Their database writes and cleanup can interfere with each other, losing cache entries or removing SST files that another compiler still needs. They need to coordinate access to the shared storage while keeping each compiler's cache entries and metadata separate.

## Changes

- Share one native `Cache` through the JavaScript `Cache` object, and use `CompilerCache` views to scope cache keys by compiler path.
- Drive idle work and shutdown through the JavaScript run/watch lifecycle so child compilations use the parent's shared cache. Continue recording build dependencies and compiler metadata at the end of each build/rebuild.
- Store compiler metadata as regular entries in each compiler's cache namespace, replacing the single global metadata record.
- Add a regression case that closes and recreates a parent compiler using the same persistent cache directory, then verifies that both the parent and its child compiler restore their modules from disk.
