### PR TITLE
fix(javascript): do not terminate the enclosing scope after a do-while loop

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -1869,8 +1869,10 @@ impl JavascriptParser<'_> {
   }
 
   fn walk_do_while_statement(&mut self, stmt: &DoWhileStmt) {
-    self.walk_nested_statement(&stmt.body);
-    self.walk_expression(&stmt.test);
+    self.in_block_scope(false, |this| {
+      this.walk_nested_statement(&stmt.body);
+      this.walk_expression(&stmt.test);
+    });
   }
 
   fn walk_block_statement(&mut self, stmt: &BlockStmt) {

--- a/tests/rspack-test/configCases/parsing/dead-code-elimination/index.js
+++ b/tests/rspack-test/configCases/parsing/dead-code-elimination/index.js
@@ -134,6 +134,52 @@ it("Shouldn't hoist const/let from dead for-in branch", () => {
 	expect(key).toBe("start");
 });
 
+it("Shouldn't eliminate statements after a do-while loop whose body ends in throw (#15617)", () => {
+	let afterCalled = false;
+	const f = (x, c) => {
+		do {
+			if (x()) break;
+			throw new Error("e");
+		} while (c());
+		afterCalled = true;
+		return "done";
+	};
+	expect(
+		f(
+			() => true,
+			() => false
+		)
+	).toBe("done");
+	expect(afterCalled).toBe(true);
+
+	const g = (x, c) => {
+		let i = 0;
+		do {
+			if (x(i++)) continue;
+			throw new Error("e");
+		} while (c(i));
+		afterCalled = "g";
+		return "done";
+	};
+	expect(
+		g(
+			() => true,
+			i => i < 2
+		)
+	).toBe("done");
+	expect(afterCalled).toBe("g");
+
+	const h = x => {
+		do {
+			if (x()) break;
+			return 1;
+		} while (false);
+		return 2;
+	};
+	expect(h(() => true)).toBe(2);
+	expect(h(() => false)).toBe(1);
+});
+
 if (true) {
 	return;
 }


### PR DESCRIPTION
## Motivation

Fixes #15617.

Since 2.0.0 (#13147) the parser's dead-control-flow elimination removes every statement after a `do { … } while (cond);` loop whose body ends in `throw`/`return`, even when the body contains a `break`/`continue` that makes the following code reachable:

```js
do {
  if (x()) break;
  throw new Error('e');
} while (c());
after();       // removed by dead control flow
return 'done'; // removed by dead control flow
```

`while`, `for`, `for…in` and `for…of` walk their bodies inside `in_block_scope(false, …)`, which restores `terminated` on exit and only propagates it when the scope is on an always-executed path. `walk_do_while_statement` was the only loop that walked its body directly, so a terminating statement at the end of the body marked the *enclosing* scope as terminated. webpack's `walkDoWhileStatement` enters a block scope for `do…while` too.

## Changes

- `walk_do_while_statement` now walks the body and test inside `in_block_scope(false, …)`, matching `walk_while_statement` and webpack.
- Added cases to `configCases/parsing/dead-code-elimination` covering `break` + `throw`, `continue` + `throw`, and `break` + `return` bodies.

Verified locally with `pnpm --dir tests/rspack-test run test -t "configCases/parsing/dead-code-elimination"`; the new cases fail before the fix (the statements after the loop are replaced by `// removed by dead control flow`) and pass after.
