### PR TITLE
perf(binding): share hook registration code across hook types

### DIFF
--- a/crates/rspack_binding_api/src/plugins/interceptor.rs
+++ b/crates/rspack_binding_api/src/plugins/interceptor.rs
@@ -288,7 +288,7 @@ impl RegisterJsTapsInner {
 
   pub async fn call_register(
     &self,
-    hook: &impl Hook,
+    used_stages: &[i32],
   ) -> rspack_error::Result<RegisterFunctionOutput> {
     if let RegisterJsTapsCache::Cache(rw) = &self.cache {
       let cache = {
@@ -298,7 +298,7 @@ impl RegisterJsTapsInner {
       Ok(match cache {
         Some(js_taps) => js_taps,
         None => {
-          let js_taps = self.call_register_impl(hook).await?;
+          let js_taps = self.call_register_impl(used_stages).await?;
           {
             #[allow(clippy::unwrap_used)]
             let mut cache = rw.write().unwrap();
@@ -308,17 +308,18 @@ impl RegisterJsTapsInner {
         }
       })
     } else {
-      let js_taps = self.call_register_impl(hook).await?;
+      let js_taps = self.call_register_impl(used_stages).await?;
       Ok(js_taps)
     }
   }
 
   async fn call_register_impl(
     &self,
-    hook: &impl Hook,
+    used_stages: &[i32],
   ) -> rspack_error::Result<RegisterFunctionOutput> {
-    let mut used_stages = Vec::from_iter(hook.used_stages());
+    let mut used_stages = used_stages.to_vec();
     used_stages.sort_unstable();
+    used_stages.dedup();
     self.register.call_with_sync(used_stages).await
   }
 
@@ -425,7 +426,7 @@ macro_rules! define_register {
         if let Some(non_skippable_registers) = &self.inner.non_skippable_registers && !non_skippable_registers.is_non_skippable(&$kind) {
           return Ok(Vec::new());
         }
-        let js_taps = self.inner.call_register(hook).await?;
+        let js_taps = self.inner.call_register(hook.tap_stages()).await?;
         let js_taps = js_taps
           .iter()
           .map(|t| Box::new($tap_name::new(t.clone())) as <$tap_hook as Hook>::Tap)

--- a/crates/rspack_macros/src/hook.rs
+++ b/crates/rspack_macros/src/hook.rs
@@ -209,6 +209,10 @@ impl DefineHookInput {
       impl #hook_name {
         pub #call_fn
 
+        pub fn tap_stages(&self) -> &[i32] {
+          self.common.tap_stages()
+        }
+
         pub fn tap(&mut self, tap: impl #trait_name + Send + Sync + 'static) {
           let stage = tap.stage();
           let index = self.common.tap_insert_position(stage);


### PR DESCRIPTION
## Motivation

Hook registration currently passes `&impl Hook` into async helpers, causing Rust to generate separate registration code for each hook type even though the helpers only need tap stages.

For example, compiler `make` and compilation `processAssets` use the same registration/cache logic, but the generic parameter produces distinct async implementations.

## Changes

- Pass borrowed stage slices (`&[i32]`) to `call_register` and `call_register_impl` so their registration code can be shared across hook types.
- Expose the existing common `tap_stages()` slice on generated hook types.

## Validation

- Development binding and JavaScript builds.
- Rust formatting and diff checks.
- `Hook.test.js`: 11 passed.
- `configCases/hooks` (normal and runtime modes, including stage ordering): 96 passed.

---
_by OpenAI Codex_