### PR TITLE
test: remove duplicate incremental e2e project

### DIFF
--- a/tests/e2e/fixtures/index.ts
+++ b/tests/e2e/fixtures/index.ts
@@ -1,12 +1,11 @@
 import { test as base, expect } from './base';
 import { pathInfoFixtures } from './pathInfo';
-import { rspackFixtures, type RspackOptions } from './rspack';
+import { rspackFixtures } from './rspack';
 import { fileActionFixtures } from './fileAction';
 
 const test = base
   .extend(pathInfoFixtures)
-  .extend(rspackFixtures())
+  .extend(rspackFixtures)
   .extend(fileActionFixtures);
 
-export type { RspackOptions };
 export { test, expect };

--- a/tests/e2e/fixtures/rspack.ts
+++ b/tests/e2e/fixtures/rspack.ts
@@ -27,12 +27,8 @@ class Rspack {
   compiler!: FixtureCompiler;
   devServer!: RspackDevServer;
   private onDone: Array<() => void> = [];
-  constructor(
-    projectDir: string,
-    config: Configuration,
-    handleRspackConfig: (config: Configuration) => Configuration,
-  ) {
-    this.config = handleRspackConfig(config);
+  constructor(projectDir: string, config: Configuration) {
+    this.config = config;
     this.projectDir = projectDir;
     this.outDir = this.config.output!.path!;
   }
@@ -71,7 +67,6 @@ class Rspack {
         item();
       }
     });
-    const DevServerConstructor = RspackDevServer;
     if (compiler.options.lazyCompilation) {
       const middleware = rspack.lazyCompilationMiddleware(compiler);
       const devServerOptions = compiler.options.devServer || {};
@@ -84,7 +79,7 @@ class Rspack {
         return [middleware, ...old];
       };
     }
-    this.devServer = new DevServerConstructor(
+    this.devServer = new RspackDevServer(
       compiler.options.devServer ?? ({} as any),
       compiler,
     );
@@ -98,82 +93,51 @@ class Rspack {
   }
 }
 
-export type RspackOptions = {
-  rspackConfig: {
-    handleConfig(config: Configuration): Configuration;
-    basePort: number;
-  };
-};
+export type RspackFixtures = { rspack: Rspack };
 
-export type RspackFixtures = RspackOptions & { rspack: Rspack };
-
-export const rspackFixtures = (): Fixtures<
+export const rspackFixtures: Fixtures<
   RspackFixtures,
   PlaywrightFixture & PathInfoFixtures
-> => {
-  return {
-    rspackConfig: {
-      basePort: process.env.RSPACK_E2E_INCREMENTAL === 'true' ? 8200 : 8000,
-      handleConfig(config) {
-        if (process.env.RSPACK_E2E_INCREMENTAL === 'true') {
-          if (config.incremental == undefined) {
-            config.incremental = true;
-          }
-          const cache = config.cache;
-          if (typeof cache === 'object' && cache.type === 'persistent') {
-            cache.storage = {
-              type: 'filesystem',
-              ...cache.storage,
-              location: 'node_modules/.cache/incremental',
-            };
-          }
-        }
-        return config;
-      },
+> = {
+  rspack: [
+    async ({ page, pathInfo }, use) => {
+      const { tempProjectDir } = pathInfo;
+      const port = 8000 + Number(process.env.RSTEST_WORKER_ID);
+      const configPath = path.join(tempProjectDir, 'rspack.config.js');
+      const { default: config }: { default: Configuration } = await import(
+        /* webpackIgnore: true */ pathToFileURL(configPath).href
+      );
+      // rewrite port
+      if (!config.devServer) {
+        config.devServer = {};
+      }
+      config.devServer.port = port;
+
+      // set default context
+      if (!config.context) {
+        config.context = tempProjectDir;
+      }
+
+      // set default output path
+      if (!config.output) {
+        config.output = {};
+      }
+      config.output.path = path.resolve(tempProjectDir, 'dist');
+
+      const rspack = new Rspack(tempProjectDir, config);
+      await rspack.start();
+
+      await page.goto(`http://localhost:${port}`);
+      // Initial HTML can render before the client connects. Wait before tests
+      // edit files, otherwise the browser can miss the first HMR notification.
+      await expect
+        .poll(() => rspack.devServer.webSocketServer?.clients.length ?? 0)
+        .toBeGreaterThan(0);
+
+      await use(rspack);
+
+      await rspack.stop();
     },
-    rspack: [
-      async ({ page, pathInfo, rspackConfig }, use) => {
-        const { tempProjectDir } = pathInfo;
-        const port =
-          rspackConfig.basePort + Number(process.env.RSTEST_WORKER_ID);
-        const configPath = path.join(tempProjectDir, 'rspack.config.js');
-        const { default: config } = await import(
-          /* webpackIgnore: true */ pathToFileURL(configPath).href
-        );
-        const rspack = new Rspack(tempProjectDir, config, (config) => {
-          // rewrite port
-          if (!config.devServer) {
-            config.devServer = {};
-          }
-          config.devServer.port = port;
-
-          // set default context
-          if (!config.context) {
-            config.context = tempProjectDir;
-          }
-
-          // set default output path
-          if (!config.output) {
-            config.output = {};
-          }
-          config.output.path = path.resolve(tempProjectDir, 'dist');
-
-          return rspackConfig.handleConfig(config);
-        });
-        await rspack.start();
-
-        await page.goto(`http://localhost:${port}`);
-        // Initial HTML can render before the client connects. Wait before tests
-        // edit files, otherwise the browser can miss the first HMR notification.
-        await expect
-          .poll(() => rspack.devServer.webSocketServer?.clients.length ?? 0)
-          .toBeGreaterThan(0);
-
-        await use(rspack);
-
-        await rspack.stop();
-      },
-      { auto: true },
-    ],
-  };
+    { auto: true },
+  ],
 };

--- a/tests/e2e/rstack.config.ts
+++ b/tests/e2e/rstack.config.ts
@@ -1,25 +1,15 @@
 import { define } from 'rstack';
-import { defineInlineProject } from 'rstack/test';
 import { e2eConfig } from './config.ts';
 
-const { pool, reporters, ...projectConfig } = e2eConfig(60_000, 4);
-
 define.test({
-  pool,
-  reporters,
-  projects: [false, true].map((incremental) =>
-    defineInlineProject({
-      ...projectConfig,
-      name: incremental ? 'chromium-incremental' : 'chromium',
-      env: {
-        // Rstest defaults to "test", but react-refresh/babel requires development.
-        NODE_ENV: 'development',
-        RSPACK_E2E_INCREMENTAL: String(incremental),
-      },
-      output: {
-        // Native ESM configs and bundled tests must share one native core instance.
-        externals: { '@rspack/core': 'commonjs @rspack/core' },
-      },
-    }),
-  ),
+  ...e2eConfig(60_000, 4),
+  name: 'chromium',
+  env: {
+    // Rstest defaults to "test", but react-refresh/babel requires development.
+    NODE_ENV: 'development',
+  },
+  output: {
+    // Native ESM configs and bundled tests must share one native core instance.
+    externals: { '@rspack/core': 'commonjs @rspack/core' },
+  },
 });


### PR DESCRIPTION
## Motivation

Rspack enables incremental builds by default, so `chromium-incremental` repeats the same E2E coverage as `chromium`.

## Changes

Keep a single `chromium` project with all 88 existing tests and remove the duplicate project's environment flag, port selection, and cache overrides. Simplify the Rspack fixture by removing its configuration callback, factory wrapper, and dev-server constructor alias.

## Validation

Both Linux E2E runs passed using the same Ubuntu runner type and Playwright Docker image. Comparing the final CI run of #15606 with this PR:

| Metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Tests | 176 | 88 | 50% |
| Rstest duration | 100 s | 49.1 s | 51% |
| `Run e2e` step, including builds | 148 s | 98 s | 34% |
| Entire E2E job | 185 s | 127 s | 31% |

CI logs: [before](https://github.com/web-infra-dev/rspack/actions/runs/34463330785/job/102827543160), [after](https://github.com/web-infra-dev/rspack/actions/runs/34468104766/job/102843842879). These figures compare one run per revision and include normal CI variability.