### PR TITLE
refactor(javascript): avoid redundant literal string decoding

### DIFF
--- a/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
+++ b/crates/rspack_plugin_javascript/src/utils/eval/eval_lit_expr.rs
@@ -9,12 +9,12 @@ pub fn eval_lit_expr<'a>(ast: &Ast<'_>, expr: Expr) -> Option<BasicEvaluatedExpr
   let mut result = BasicEvaluatedExpression::with_range(span.real_lo(), span.real_hi());
   match ast.expr_data(expr) {
     ExprData::StringLiteral(string) => {
-      result.set_string(
-        ast
-          .get_wtf8(string.value(ast))
-          .to_string_lossy()
-          .into_owned(),
-      );
+      let value = ast.get_wtf8(string.value(ast));
+      // Skip WTF-8's surrogate scan for valid UTF-8; preserve its lossy fallback otherwise.
+      result.set_string(match std::str::from_utf8(value.as_bytes()) {
+        Ok(value) => value.to_owned(),
+        Err(_) => value.to_string_lossy().into_owned(),
+      });
     }
     ExprData::RegExpLiteral(regexp) => result.set_regexp(
       ast.get_utf8(regexp.pattern(ast)).to_string(),


### PR DESCRIPTION
## Summary

Stacked on #15597, ultimately targeting `release/2.3.0`.

Complete the remaining string-literal fast path from `3d6ffc2`:

- Use standard-library UTF-8 validation to bypass WTF-8's scalar surrogate scan for ordinary literals.
- Preserve the exact WTF-8 lossy fallback for isolated surrogates and retain the evaluator's owned `String` payload.
- Keep the change at its single call site. No additional helper, dependency, cache, ownership redesign, or template changes.

The historical identifier/member-root lazy name reads are already implemented by the parent stack and are not duplicated here. This PR changes one file, with 6 additions and 6 deletions. Existing test assertions and snapshots are unchanged.

### Performance

Local native Linux ARM64 Docker + Valgrind, `rust@scan_dependencies@three_module`, one measurement per version:

| Version | Instructions (IR) |
| --- | ---: |
| Rebased parent #15597 (`34a38b5c58`) | 31,785,670 |
| This PR (`588ce4f22c`) | 30,468,212 |

**1,317,458 fewer instructions (-4.14%) versus the actual parent.** Both measurements use the same image, nightly-2026-04-16, Valgrind 3.19.0, build flags and Three.js fixture. This measures dependency scanning, excluding parsing and semantic construction; it is not a whole-build wall-time claim.

### Validation

- Development binding build, workspace/all-targets Clippy, Rust format and dependency checks passed.
- Full `test:unit` passed: 9,225 Rspack tests, CLI tests and binding type checks.
- 48 existing Rust tests passed.
- A standalone equivalence check matched the original conversion for 196,678 UTF-16 inputs, including isolated surrogates, surrogate pairs and mixed/boundary-length strings.

## Related links

- Parent: #15597
- Original migration/optimization work: #15331

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
