### PR TITLE
refactor(javascript): consolidate raw member chain buffers

### DIFF
--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -184,25 +184,45 @@ where
 pub type AtomMembers = SmallVec<[Atom; 2]>;
 pub type OptionalMembers = SmallVec<[bool; 2]>;
 pub type MemberRanges = SmallVec<[Span; 2]>;
-type RawAtomMembers = SmallVec<[PropertyKeyData; 2]>;
+type RawMembers = SmallVec<[RawMember; 2]>;
 
-struct RawExtractedMemberExpressionChainData {
-  object: ExprRef,
-  members: RawAtomMembers,
-  members_optionals: OptionalMembers,
-  member_ranges: MemberRanges,
+/// Keep each segment together until its root needs member hooks. Spans and
+/// owned names are only read when materializing the parallel hook arguments.
+struct RawMember {
+  property: PropertyKeyData,
+  object: Expr,
+  optional: bool,
 }
 
-fn materialize_member_atoms(ast: &Ast<'_>, members: RawAtomMembers) -> AtomMembers {
-  let mut atoms = AtomMembers::with_capacity(members.len());
-  for property in members {
-    atoms.push(match property {
+impl RawMember {
+  fn atom(&self, ast: &Ast<'_>) -> Atom {
+    match self.property {
       PropertyKeyData::IdentifierName(identifier) => Atom::from(ast.get_utf8(identifier.name(ast))),
       property => member_property_key_data_to_atom(ast, property)
         .expect("validated computed member property should convert to an atom"),
-    });
+    }
   }
-  atoms
+}
+
+struct RawExtractedMemberExpressionChainData {
+  object: ExprRef,
+  members: RawMembers,
+}
+
+/// Preserve extraction order (outermost first) for consumers that reverse it.
+fn materialize_members(
+  ast: &Ast<'_>,
+  members: RawMembers,
+) -> (AtomMembers, OptionalMembers, MemberRanges) {
+  let mut atoms = AtomMembers::with_capacity(members.len());
+  let mut optionals = OptionalMembers::with_capacity(members.len());
+  let mut ranges = MemberRanges::with_capacity(members.len());
+  for member in members {
+    atoms.push(member.atom(ast));
+    optionals.push(member.optional);
+    ranges.push(member.object.span(ast));
+  }
+  (atoms, optionals, ranges)
 }
 
 #[derive(Debug)]
@@ -1195,9 +1215,7 @@ impl<'parser> JavascriptParser<'parser> {
   fn _get_member_expression_info(
     &mut self,
     object: ExprRef,
-    members: RawAtomMembers,
-    mut members_optionals: OptionalMembers,
-    mut member_ranges: MemberRanges,
+    members: RawMembers,
     allowed_types: AllowedMemberTypes,
   ) -> Option<MemberExpressionInfo> {
     let ast = self.ast.ast;
@@ -1211,16 +1229,20 @@ impl<'parser> JavascriptParser<'parser> {
           let extracted = self.extract_member_expression_chain_raw(ExprRef::Member(member));
           (extracted.object, extracted.members)
         } else {
-          (ExprRef::from_expr(ast, callee), RawAtomMembers::new())
+          (ExprRef::from_expr(ast, callee), RawMembers::new())
         };
         let NameInfo {
           name: resolved_root,
           info: root_info,
         } = self.get_name_info_from_root(root)?;
 
-        let mut root_members = materialize_member_atoms(ast, root_members);
-        let mut members = materialize_member_atoms(ast, members);
-        root_members.reverse();
+        let root_members = root_members
+          .iter()
+          .rev()
+          .map(|member| member.atom(ast))
+          .collect();
+        let (mut members, mut members_optionals, mut member_ranges) =
+          materialize_members(ast, members);
         members.reverse();
         members_optionals.reverse();
         member_ranges.reverse();
@@ -1245,7 +1267,8 @@ impl<'parser> JavascriptParser<'parser> {
           info: root_info,
         } = self.get_name_info_from_root(object)?;
 
-        let mut members = materialize_member_atoms(ast, members);
+        let (mut members, mut members_optionals, mut member_ranges) =
+          materialize_members(ast, members);
         let name = object_and_members_to_name(resolved_root, &members);
         members.reverse();
         members_optionals.reverse();
@@ -1275,13 +1298,7 @@ impl<'parser> JavascriptParser<'parser> {
       ExprRef::Member(_) | ExprRef::OptChain(_) => {
         self.get_member_expression_info(expr_ref, allowed_types)
       }
-      _ => self._get_member_expression_info(
-        expr_ref,
-        RawAtomMembers::new(),
-        OptionalMembers::new(),
-        MemberRanges::new(),
-        allowed_types,
-      ),
+      _ => self._get_member_expression_info(expr_ref, RawMembers::new(), allowed_types),
     }
   }
 
@@ -1290,34 +1307,21 @@ impl<'parser> JavascriptParser<'parser> {
     expr: ExprRef,
     allowed_types: AllowedMemberTypes,
   ) -> Option<MemberExpressionInfo> {
-    let RawExtractedMemberExpressionChainData {
-      object,
-      members,
-      members_optionals,
-      member_ranges,
-    } = self.extract_member_expression_chain_raw(expr);
-    self._get_member_expression_info(
-      object,
-      members,
-      members_optionals,
-      member_ranges,
-      allowed_types,
-    )
+    let RawExtractedMemberExpressionChainData { object, members } =
+      self.extract_member_expression_chain_raw(expr);
+    self._get_member_expression_info(object, members, allowed_types)
   }
 
   pub fn extract_member_expression_chain(
     &self,
     expr: ExprRef,
   ) -> ExtractedMemberExpressionChainData {
-    let RawExtractedMemberExpressionChainData {
-      object,
-      members,
-      members_optionals,
-      member_ranges,
-    } = self.extract_member_expression_chain_raw(expr);
+    let RawExtractedMemberExpressionChainData { object, members } =
+      self.extract_member_expression_chain_raw(expr);
+    let (members, members_optionals, member_ranges) = materialize_members(self.ast.ast, members);
     ExtractedMemberExpressionChainData {
       object,
-      members: materialize_member_atoms(self.ast.ast, members),
+      members,
       members_optionals,
       member_ranges,
     }
@@ -1329,9 +1333,7 @@ impl<'parser> JavascriptParser<'parser> {
   ) -> RawExtractedMemberExpressionChainData {
     let ast = self.ast.ast;
     let mut object = expr;
-    let mut members = RawAtomMembers::new();
-    let mut members_optionals = OptionalMembers::new();
-    let mut member_ranges = MemberRanges::new();
+    let mut members = RawMembers::new();
     let mut in_optional_chain = self.member_expr_in_optional_chain;
     loop {
       match object {
@@ -1348,10 +1350,12 @@ impl<'parser> JavascriptParser<'parser> {
           } else {
             break;
           };
-          members.push(property_data);
           let member_object = expr.object(ast);
-          member_ranges.push(member_object.span(ast));
-          members_optionals.push(in_optional_chain || expr.optional(ast));
+          members.push(RawMember {
+            property: property_data,
+            object: member_object,
+            optional: in_optional_chain || expr.optional(ast),
+          });
           object = ExprRef::from_expr(ast, member_object);
           in_optional_chain = false;
         }
@@ -1367,12 +1371,7 @@ impl<'parser> JavascriptParser<'parser> {
         _ => break,
       }
     }
-    RawExtractedMemberExpressionChainData {
-      object,
-      members,
-      members_optionals,
-      member_ranges,
-    }
+    RawExtractedMemberExpressionChainData { object, members }
   }
 
   fn enter_ident<F>(&mut self, ident: BindingIdentifier, on_ident: F)

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/walk.rs
@@ -5,8 +5,7 @@ use swc_next_ecma_ast::*;
 
 use super::{
   AllowedMemberTypes, CallHooksName, ExpressionExpressionInfo, JavascriptParser,
-  MemberExpressionInfo, MemberRanges, OptionalMembers, PatRef, RootName, ScopeTerminated,
-  TopLevelScope,
+  MemberExpressionInfo, OptionalMembers, PatRef, RootName, ScopeTerminated, TopLevelScope,
   estree::{
     ClassDeclOrExpr, ExportDefaultDeclaration, MaybeNamedClassDecl, MaybeNamedFunctionDecl,
     Statement, formal_parameter_patterns, formal_parameters_are_simple_identifiers,
@@ -23,7 +22,7 @@ use crate::{
   utils::eval::{BasicEvaluatedExpression, eval_member_expression_with_info},
   visitors::{
     AtomMembers, ExportedVariableInfo, ExprRef, Identifier, VariableDeclaration, VariableInfo,
-    VariableInfoFlags, get_non_optional_part,
+    VariableInfoFlags,
   },
 };
 
@@ -1049,13 +1048,9 @@ impl JavascriptParser<'_> {
   fn walk_jsx_member_expr(&mut self, member: JsxMemberExpression) {
     let ast = self.ast.ast;
     let mut current = member;
-    let mut members_optionals = OptionalMembers::new();
-    let mut member_ranges = MemberRanges::new();
     let mut member_nodes = SmallVec::<[JsxMemberExpression; 2]>::new();
     let root = loop {
       let object = current.object(ast);
-      members_optionals.push(false);
-      member_ranges.push(object.span(ast));
       member_nodes.push(current);
       match ast.jsx_member_expression_object_data(object) {
         JsxMemberExpressionObjectData::JsxIdentifier(identifier) => break identifier,
@@ -1079,9 +1074,12 @@ impl JavascriptParser<'_> {
       .collect();
     let name = object_and_members_to_name(resolved_root, &members);
     members.reverse();
-    members_optionals.reverse();
-    member_ranges.reverse();
     member_nodes.reverse();
+    let members_optionals = std::iter::repeat_n(false, member_nodes.len()).collect();
+    let member_ranges = member_nodes
+      .iter()
+      .map(|member| member.object(ast).span(ast))
+      .collect();
 
     let expression_info = ExpressionExpressionInfo {
       name,
@@ -1825,29 +1823,21 @@ impl JavascriptParser<'_> {
     Option<(ImportExpression, AtomMembers, AwaitExpression)>,
   ) {
     let ast = self.ast.ast;
-    let super::RawExtractedMemberExpressionChainData {
-      object,
-      members,
-      mut members_optionals,
-      member_ranges,
-    } = self.extract_member_expression_chain_raw(ExprRef::Member(expr));
+    let super::RawExtractedMemberExpressionChainData { object, members } =
+      self.extract_member_expression_chain_raw(ExprRef::Member(expr));
     if let ExprRef::Await(await_expr) = object
       && let Some(call) = await_expr.argument(ast).as_import_expression(ast)
     {
-      let mut members = super::materialize_member_atoms(ast, members);
-      members.reverse();
-      members_optionals.reverse();
-      let members = get_non_optional_part(&members, &members_optionals);
-      return (None, Some((call, members.into(), await_expr)));
+      let members = members
+        .iter()
+        .rev()
+        .take_while(|member| !member.optional)
+        .map(|member| member.atom(ast))
+        .collect();
+      return (None, Some((call, members, await_expr)));
     }
     (
-      self._get_member_expression_info(
-        object,
-        members,
-        members_optionals,
-        member_ranges,
-        AllowedMemberTypes::all(),
-      ),
+      self._get_member_expression_info(object, members, AllowedMemberTypes::all()),
       None,
     )
   }

--- a/tests/rspack-test/normalCases/parsing/member-chain-buffers/index.js
+++ b/tests/rspack-test/normalCases/parsing/member-chain-buffers/index.js
@@ -1,0 +1,28 @@
+import * as ns from "./module";
+
+it("should preserve member order across inline and spilled chains", () => {
+	expect(ns.tree.a["b"].value).toBe(42);
+	expect(ns.tree.a.b.read()).toBe(42);
+	expect(ns.build().a.b.value).toBe(42);
+	expect(require("./module").tree.a.b.value).toBe(42);
+	expect(typeof ns.tree.a.b.value).toBe("number");
+});
+
+it("should stop at dynamic keys and preserve optional member boundaries", () => {
+	let calls = 0;
+	const key = () => {
+		calls++;
+		return "a";
+	};
+	expect(ns.tree[key()].b.value).toBe(42);
+	expect(calls).toBe(1);
+	expect(ns.tree?.a.b?.read()).toBe(42);
+	expect(ns.missing?.[key()].b.value).toBeUndefined();
+	expect(calls).toBe(1);
+});
+
+it("should preserve the non-optional prefix of awaited imports", async () => {
+	expect((await import("./module")).tree.a["b"].value).toBe(42);
+	expect((await import("./module")).tree?.a.b.read()).toBe(42);
+	expect((await import("./module")).missing?.a.b.value).toBeUndefined();
+});

--- a/tests/rspack-test/normalCases/parsing/member-chain-buffers/module.js
+++ b/tests/rspack-test/normalCases/parsing/member-chain-buffers/module.js
@@ -1,0 +1,12 @@
+export const tree = {
+	a: {
+		b: {
+			value: 42,
+			read() {
+				return this.value;
+			}
+		}
+	}
+};
+export const missing = null;
+export const build = () => tree;


### PR DESCRIPTION
## Summary

Stacked on #15624. Consolidate member-chain temporary storage without changing parser hooks or member-analysis semantics.

- Replace three parallel raw SmallVec buffers with one buffer of property/object handles and optional flags. Decode object spans and materialize the parallel hook arguments only after root resolution succeeds.
- Avoid constructing unused optional/range arrays for call-root names and awaited-import prefixes; preserve the existing non-optional-prefix rule.
- Apply the same deferred optional/range construction to JSX member chains.
- Preserve computed-key stopping conditions, member order, receiver behavior and hook interfaces. Add regression coverage for long chains, computed-key side effects, optional boundaries and awaited imports in the existing normal-case harness.

This does not change evaluator payload ownership, InnerGraph, semantic resolution or source-location indexing.

### Local performance

Native Linux ARM64 Docker + Valgrind 3.19.0, exact stage `rust@scan_dependencies@three_module`, Cargo target `benches` with the `codspeed` build profile.

| Version | Instructions |
| --- | ---: |
| Actual parent #15624 (`588ce4f22c`) | 30,468,212 |
| This PR (`0f051770a7`) | 29,446,715 |

**3.35% fewer scan instructions** (1,021,497 IR). One candidate run, compared with the existing single parent run after verifying the same source baseline, fixture, toolchain, Docker image and measurement environment. These are scan-stage instruction counts, not whole-build wall-clock gains or a comparison against main.

Image: `rspack-perf-valgrind:nightly-2026-04-16`, ID `sha256:ad4bf3d1931a328cfebd58092b5a9af81c2fcf9fb04b06c33882126246275b52`.

### Validation

- `pnpm run build:binding:dev` and `pnpm run build:js`
- `pnpm run test:unit`: main suite 9,229 passed / 4 skipped; CLI 90 passed / 1 skipped; binding type checks passed
- New member-chain case in normal, dev, prod and hot modes
- `cargo lint` (workspace / all targets, warnings denied)
- `cargo test -p rspack_plugin_javascript --lib`: 48 passed
- `cargo fmt --all --check`, `git diff --check`, and `cargo shear --locked --deny-warnings -p rspack_plugin_javascript`

The first full test attempt hit two existing CLI dev-server tests' fixed 8-second startup guards during concurrent validation. Both isolated checks and the complete rerun passed without changing test timeouts or assertions.

## Related links

- Parent: #15624
- Member-chain extraction reuse: #15597
- Original optimization backlog: #15331

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
