### PR TITLE
docs: add Extension.js to the ecosystem page

### DIFF
--- a/website/docs/en/guide/start/ecosystem.mdx
+++ b/website/docs/en/guide/start/ecosystem.mdx
@@ -65,6 +65,15 @@ Rspack is part of Rstack, the fast, unified JavaScript toolchain for developers 
 
 Docusaurus supports Rspack as the bundler since v3.6, see [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster) for details.
 
+### Extension.js
+
+<Tag color="geekblue">Build tool</Tag>
+<Tag color="purple">Browser extensions</Tag>
+
+[Extension.js](https://extension.js.org/) is a framework for creating, developing and building browser extensions for Chrome, Edge, Firefox and Safari from a single codebase.
+
+Extension.js builds with Rspack and resolves the entry points declared in `manifest.json` into the Rspack entry graph.
+
 ### Modern.js
 
 <Tag color="geekblue">Web framework</Tag>

--- a/website/docs/zh/guide/start/ecosystem.mdx
+++ b/website/docs/zh/guide/start/ecosystem.mdx
@@ -62,6 +62,14 @@ Rspack 是 Rstack 的一员。Rstack 是为开发者与 Agent 打造的高性能
 
 Docusaurus 从 v3.6 开始支持使用 Rspack 作为打包工具，详见 [Docusaurus Faster](https://docusaurus.io/blog/releases/3.6#docusaurus-faster)。
 
+### Extension.js
+
+<Tag color="geekblue">构建工具</Tag> <Tag color="purple">浏览器扩展</Tag>
+
+[Extension.js](https://extension.js.org/) 是一个用单一代码库为 Chrome、Edge、Firefox 和 Safari 构建浏览器扩展的框架。
+
+Extension.js 使用 Rspack 打包，并把 `manifest.json` 中声明的入口解析为 Rspack 的入口图。
+
 ### Modern.js
 
 <Tag color="geekblue">Web 框架</Tag> <Tag color="purple">React</Tag>


### PR DESCRIPTION
## Motivation

hey folks, I maintain Extension.js, a framework for building browser extensions built on Rspack

the Rspack 2.0 post already name-checks it in the ecosystem list:
https://rspack.rs/blog/announcing-2-0

14 of the other projects from the post are under Community integrations, but Extension.js never made it across. this PR adds it

## Changes

adds an Extension.js entry to the ecosystem page, English and Chinese. entry sits after Docusaurus so the existing order holds

what it actually does, in case it helps with the wording: Extension.js reads the entry points declared in a `manifest.json` (background, content scripts, popup, options, and so on) and feeds them into the Rspack entry graph, then emits one build per browser. one source tree, output for Chrome, Edge, Firefox and Safari. running on `@rspack/core` 2.x

- https://extension.js.org
- https://github.com/extension-js/extension.js

happy to trim the blurb or drop a tag if you'd rather keep entries shorter