### PR TITLE
chore(ci): replace Corepack with pnpm action

### DIFF
--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -1,6 +1,6 @@
 name: nodejs and pnpm setup
 
-description: Install Node.js with pnpm global cache
+description: Install Node.js and pnpm
 
 inputs:
   node-version:
@@ -25,14 +25,4 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     - name: Install pnpm
-      shell: bash
-      run: |
-        if [[ "${{runner.os}}" == "Windows" ]]; then
-          # add the npm prefix to PATH to ensure the installed corepack work properly
-          NPM_PREFIX=$(cygpath -u "$(npm config get prefix)")
-          export PATH="$NPM_PREFIX:$PATH"
-        fi
-        npm install -g corepack@0.31.0 --force
-        echo "Corepack version: $(corepack --version)"
-        corepack enable
-        pnpm --version
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10

--- a/.github/actions/pnpm/setup/action.yml
+++ b/.github/actions/pnpm/setup/action.yml
@@ -26,3 +26,6 @@ runs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      with:
+        # E2E containers mount the tool cache to access Node.js and pnpm.
+        dest: ${{ runner.tool_cache }}/pnpm

--- a/.github/workflows/reusable-build-test.yml
+++ b/.github/workflows/reusable-build-test.yml
@@ -52,11 +52,11 @@ jobs:
       - name: Pnpm Install
         run: pnpm i
 
-      - name: Calculate Node Bin Path
-        id: calculate-node-bin-path
+      - name: Calculate Node.js and pnpm Bin Paths
+        id: calculate-bin-paths
         run: |
-          NODE_BIN_PATH=$(dirname $(which node))
-          echo "path=$NODE_BIN_PATH" >> $GITHUB_OUTPUT
+          echo "node=$(dirname "$(command -v node)")" >> "$GITHUB_OUTPUT"
+          echo "pnpm=$(dirname "$(command -v pnpm)")" >> "$GITHUB_OUTPUT"
 
       - name: Run e2e
         uses: ./.github/actions/docker/run
@@ -66,10 +66,10 @@ jobs:
           # If this is to change, make sure to upgrade the ubuntu version in GitHub Actions
           image: mcr.microsoft.com/playwright:v1.62.1-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker/run
-          # .tool_cache is required by pnpm
+          # The tool cache contains both Node.js and pnpm.
           options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
-            export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
+            export PATH="${{ steps.calculate-bin-paths.outputs.node }}:${{ steps.calculate-bin-paths.outputs.pnpm }}:$PATH"
             pnpm run build:js
             pnpm run test:e2e
 
@@ -81,10 +81,10 @@ jobs:
           # If this is to change, make sure to upgrade the ubuntu version in GitHub Actions
           image: mcr.microsoft.com/playwright:v1.62.1-jammy
           # .cache is required by download artifact, and mount in ./.github/actions/docker/run
-          # .tool_cache is required by pnpm
+          # The tool cache contains both Node.js and pnpm.
           options: -v ${{ runner.tool_cache }}:${{runner.tool_cache}}
           script: |
-            export PATH=${{ steps.calculate-node-bin-path.outputs.path }}:$PATH
+            export PATH="${{ steps.calculate-bin-paths.outputs.node }}:${{ steps.calculate-bin-paths.outputs.pnpm }}:$PATH"
             export WASM=1
             pnpm run build:js
             pnpm run test:e2e-browser


### PR DESCRIPTION
## Motivation

The pnpm 12 upgrade in #15631 fails during CI setup because Corepack 0.31.0 expects the removed `bin/pnpm.cjs` entry point.

## Changes

Replace Corepack with `pnpm/action-setup@v6.0.10`, matching Rsbuild's setup and reading the pnpm version from `package.json`. Keep the existing Node.js setup and self-hosted macOS registry configuration.
