### PR TITLE
refactor: stream new cache writes directly into database batches

### DIFF
--- a/crates/rspack_core/src/new_cache/db/mod.rs
+++ b/crates/rspack_core/src/new_cache/db/mod.rs
@@ -3,10 +3,6 @@ mod noop;
 #[cfg(not(target_family = "wasm"))]
 mod turbo;
 
-use rspack_error::Result;
-
-use crate::new_cache::CacheKey;
-
 #[derive(Debug, Clone, Copy)]
 pub enum DatabaseFamily {
   Cache,
@@ -27,26 +23,8 @@ impl DatabaseFamily {
 #[cfg(target_family = "wasm")]
 pub type DatabaseValue = std::sync::Arc<[u8]>;
 #[cfg(target_family = "wasm")]
-pub use noop::NoopDatabase as TurboDatabase;
+pub use noop::NoopDatabase as Database;
 #[cfg(not(target_family = "wasm"))]
 pub type DatabaseValue = turbo_persistence::ArcBytes;
 #[cfg(not(target_family = "wasm"))]
-pub use turbo::TurboDatabase;
-
-pub(crate) trait Database: Send + Sync {
-  fn get(&self, family: DatabaseFamily, key: &CacheKey) -> Result<Option<DatabaseValue>>;
-
-  fn is_empty(&self) -> bool;
-
-  fn write_batch(&self, writes: Vec<(DatabaseFamily, CacheKey, Vec<u8>)>) -> Result<()>;
-
-  fn compact(&self) -> Result<()>;
-
-  fn has_unrecoverable_write_error(&self) -> bool;
-
-  fn reset(&mut self) -> Result<()>;
-
-  fn cleanup_stale(&self) -> Result<()>;
-
-  fn shutdown(self: Box<Self>) -> Result<()>;
-}
+pub use turbo::TurboDatabase as Database;

--- a/crates/rspack_core/src/new_cache/db/noop.rs
+++ b/crates/rspack_core/src/new_cache/db/noop.rs
@@ -1,8 +1,9 @@
+use rayon::iter::ParallelIterator;
 use rspack_error::Result;
 
 use crate::new_cache::{
   CacheKey,
-  db::{Database, DatabaseFamily, DatabaseValue},
+  db::{DatabaseFamily, DatabaseValue},
 };
 
 pub struct NoopDatabase;
@@ -15,38 +16,39 @@ impl NoopDatabase {
   ) -> Result<Self> {
     Ok(Self)
   }
-}
 
-impl Database for NoopDatabase {
-  fn get(&self, _family: DatabaseFamily, _key: &CacheKey) -> Result<Option<DatabaseValue>> {
+  pub fn get(&self, _family: DatabaseFamily, _key: &CacheKey) -> Result<Option<DatabaseValue>> {
     Ok(None)
   }
 
-  fn is_empty(&self) -> bool {
+  pub fn is_empty(&self) -> bool {
     true
   }
 
-  fn write_batch(&self, _writes: Vec<(DatabaseFamily, CacheKey, Vec<u8>)>) -> Result<()> {
+  pub fn write_batch(
+    &self,
+    writes: impl ParallelIterator<Item = (DatabaseFamily, CacheKey, Vec<u8>)>,
+  ) -> Result<usize> {
+    Ok(writes.count())
+  }
+
+  pub fn compact(&self) -> Result<()> {
     Ok(())
   }
 
-  fn compact(&self) -> Result<()> {
-    Ok(())
-  }
-
-  fn has_unrecoverable_write_error(&self) -> bool {
+  pub fn has_unrecoverable_write_error(&self) -> bool {
     false
   }
 
-  fn reset(&mut self) -> Result<()> {
+  pub fn reset(&mut self) -> Result<()> {
     Ok(())
   }
 
-  fn cleanup_stale(&self) -> Result<()> {
+  pub fn cleanup_stale(&self) -> Result<()> {
     Ok(())
   }
 
-  fn shutdown(self: Box<Self>) -> Result<()> {
+  pub fn shutdown(self) -> Result<()> {
     Ok(())
   }
 }

--- a/crates/rspack_core/src/new_cache/db/turbo.rs
+++ b/crates/rspack_core/src/new_cache/db/turbo.rs
@@ -14,7 +14,7 @@ use turbo_persistence::{
 
 use crate::new_cache::{
   CacheKey,
-  db::{Database, DatabaseFamily, DatabaseValue},
+  db::{DatabaseFamily, DatabaseValue},
 };
 
 const STALE_DIRECTORY: &str = "_stale";
@@ -213,27 +213,36 @@ impl TurboDatabase {
       readonly,
     })
   }
-}
 
-impl Database for TurboDatabase {
-  fn get(&self, family: DatabaseFamily, key: &CacheKey) -> Result<Option<DatabaseValue>> {
+  pub fn get(&self, family: DatabaseFamily, key: &CacheKey) -> Result<Option<DatabaseValue>> {
     Ok(self.inner.get(family.index(), &key)?)
   }
 
-  fn is_empty(&self) -> bool {
+  pub fn is_empty(&self) -> bool {
     self.inner.is_empty()
   }
 
-  fn write_batch(&self, writes: Vec<(DatabaseFamily, CacheKey, Vec<u8>)>) -> Result<()> {
+  pub fn write_batch(
+    &self,
+    writes: impl ParallelIterator<Item = (DatabaseFamily, CacheKey, Vec<u8>)>,
+  ) -> Result<usize> {
     let batch = self.inner.write_batch::<CacheKey>()?;
-    writes
-      .into_par_iter()
-      .try_for_each(|(family, key, value)| batch.put(family.index() as u32, key, value.into()))?;
-    self.inner.commit_write_batch(batch)?;
-    Ok(())
+    let writes_len = writes
+      .try_fold(
+        || 0,
+        |count, (family, key, value)| -> Result<usize> {
+          batch.put(family.index() as u32, key, value.into())?;
+          Ok(count + 1)
+        },
+      )
+      .try_reduce(|| 0, |a, b| Ok(a + b))?;
+    if writes_len > 0 {
+      self.inner.commit_write_batch(batch)?;
+    }
+    Ok(writes_len)
   }
 
-  fn compact(&self) -> Result<()> {
+  pub fn compact(&self) -> Result<()> {
     if self.readonly || self.inner.is_empty() {
       return Ok(());
     }
@@ -241,11 +250,11 @@ impl Database for TurboDatabase {
     Ok(())
   }
 
-  fn has_unrecoverable_write_error(&self) -> bool {
+  pub fn has_unrecoverable_write_error(&self) -> bool {
     self.inner.has_unrecoverable_write_error()
   }
 
-  fn reset(&mut self) -> Result<()> {
+  pub fn reset(&mut self) -> Result<()> {
     let old_database = std::mem::replace(
       &mut self.inner,
       Inner::empty_in_memory_with_config(database_config()),
@@ -261,7 +270,7 @@ impl Database for TurboDatabase {
     Ok(())
   }
 
-  fn cleanup_stale(&self) -> Result<()> {
+  pub fn cleanup_stale(&self) -> Result<()> {
     let stale_directory = stale_directory(&self.base_path);
     match std::fs::remove_dir_all(stale_directory) {
       Ok(()) => Ok(()),
@@ -270,7 +279,7 @@ impl Database for TurboDatabase {
     }
   }
 
-  fn shutdown(self: Box<Self>) -> Result<()> {
+  pub fn shutdown(self) -> Result<()> {
     self.inner.clear_cache();
     self.inner.shutdown()?;
     Ok(())

--- a/crates/rspack_core/src/new_cache/file_cache_strategy.rs
+++ b/crates/rspack_core/src/new_cache/file_cache_strategy.rs
@@ -16,7 +16,7 @@ use super::{
   snapshot::FileSystemInfo,
   validator::{CacheValidator, CacheValidatorResult},
 };
-use crate::{InfrastructureLogger, Logger, cache::CacheCodec, new_cache::db::TurboDatabase};
+use crate::{InfrastructureLogger, Logger, cache::CacheCodec};
 
 const VALIDATOR_KEY: &str = "validator";
 
@@ -43,7 +43,7 @@ impl PendingWrites {
 }
 
 struct State {
-  database: Box<dyn Database>,
+  database: Database,
   pending_writes: PendingWrites,
 }
 
@@ -94,7 +94,7 @@ impl FileCacheStrategy {
   }
 
   pub async fn db_init(&self, (base_path, path): (Utf8PathBuf, Utf8PathBuf)) {
-    fn set_initialized(strategy: &FileCacheStrategy, database: Box<dyn Database>) {
+    fn set_initialized(strategy: &FileCacheStrategy, database: Database) {
       strategy
         .state
         .set(RwLock::new(Some(State {
@@ -105,8 +105,8 @@ impl FileCacheStrategy {
     }
 
     let start = self.logger.time("open cache database");
-    let mut database = match TurboDatabase::open(base_path, path, self.readonly) {
-      Ok(database) => Box::new(database) as Box<dyn Database>,
+    let mut database = match Database::open(base_path, path, self.readonly) {
+      Ok(database) => database,
       Err(error) => {
         self.session_unavailable(Some(&error));
         return;
@@ -120,7 +120,7 @@ impl FileCacheStrategy {
     }
 
     let start = self.logger.time("validate cache database");
-    if let Err(e) = self.db_validate(&mut *database).await {
+    if let Err(e) = self.db_validate(&mut database).await {
       self.shutdown_database(database);
       self.session_unavailable(Some(&e));
       return;
@@ -130,7 +130,7 @@ impl FileCacheStrategy {
     set_initialized(self, database);
   }
 
-  async fn db_validate(&self, database: &mut dyn Database) -> Result<()> {
+  async fn db_validate(&self, database: &mut Database) -> Result<()> {
     let data = database.get(DatabaseFamily::Validator, &CacheKey::new(VALIDATOR_KEY))?;
     let validation = self.validator.validate(data.as_deref()).await?;
     match validation {
@@ -220,7 +220,7 @@ impl FileCacheStrategy {
     self.unavailable.notify_one();
   }
 
-  fn shutdown_database(&self, database: Box<dyn Database>) {
+  fn shutdown_database(&self, database: Database) {
     if let Err(error) = database.shutdown() {
       self
         .logger
@@ -328,50 +328,52 @@ impl FileCacheStrategy {
       self.logger.log("Storing cache...");
       let start = self.logger.time("store cache");
       let codec = &self.codec;
-      let mut writes;
-      let new_build_dependencies;
-      {
+
+      let (entries, new_build_dependencies) = {
         let mut state = self.write_state();
         let Some(state) = state.as_mut() else {
           return Ok(());
         };
+        (
+          std::mem::take(&mut state.pending_writes.entries),
+          state.pending_writes.new_build_dependencies().take(),
+        )
+      };
 
-        writes = std::mem::take(&mut state.pending_writes.entries)
-          .into_par_iter()
-          .filter_map(
-            |(key, pending)| match (pending.encoder)(&pending.entry, codec) {
-              Ok(value) => Some((DatabaseFamily::Cache, key, value)),
-              Err(error) => {
-                self.logger.warn(format!(
-                  "Failed to encode cache entry for key {key}: {error}"
-                ));
-                None
-              }
-            },
+      let validator = if let Some(dependencies) = new_build_dependencies {
+        self.validator.update(dependencies).await?
+      } else {
+        None
+      };
+
+      let writes = entries
+        .into_par_iter()
+        .filter_map(
+          |(key, pending)| match (pending.encoder)(&pending.entry, codec) {
+            Ok(value) => Some((DatabaseFamily::Cache, key, value)),
+            Err(error) => {
+              self.logger.warn(format!(
+                "Failed to encode cache entry for key {key}: {error}"
+              ));
+              None
+            }
+          },
+        )
+        .chain(validator.into_par_iter().map(|validator| {
+          (
+            DatabaseFamily::Validator,
+            CacheKey::from(VALIDATOR_KEY),
+            validator,
           )
-          .collect::<Vec<_>>();
+        }));
 
-        new_build_dependencies = state.pending_writes.new_build_dependencies().take();
-      }
-
-      if let Some(dependencies) = new_build_dependencies
-        && let Some(validator) = self.validator.update(dependencies).await?
-      {
-        writes.push((
-          DatabaseFamily::Validator,
-          CacheKey::from(VALIDATOR_KEY),
-          validator,
-        ));
-      }
-
-      let writes_len = writes.len();
-      if writes_len > 0 {
+      let writes_len = {
         let state = self.read_state();
         let Some(state) = state.as_ref() else {
           return Ok(());
         };
-        state.database.write_batch(writes)?;
-      }
+        state.database.write_batch(writes)?
+      };
       self.logger.time_end(start);
 
       self


### PR DESCRIPTION
## Motivation

Flushing the new filesystem cache currently retains all serialized entries in a `Vec` before starting database writes. Large flushes therefore keep the entire encoded batch in memory, even though the database can flush its buffers as entries arrive.

## Changes

Stream parallel encoding results directly into a single database write batch, with validator data included in the same commit. Count entries as they are consumed and skip empty commits.

In my benchmark, cold-start peak native memory decreased by **1.10 GiB (16.5%)**, and memory footprint decreased by **8.5%**. Cold-cache write time fell from **2.935 s to 2.007 s (−31.6%)**.

Total RSS did not decrease, and warm starts showed no clear memory benefit.
