### PR TITLE
chore(ci): enable Corepack for resolver PnP fixtures

### DIFF
--- a/.github/workflows/ci-resolver.yml
+++ b/.github/workflows/ci-resolver.yml
@@ -76,13 +76,24 @@ jobs:
       - name: Setup Node.js and Pnpm
         uses: ./.github/actions/pnpm/setup
 
+      - name: Enable Corepack for Yarn
+        shell: bash
+        run: corepack enable yarn
+
+      - name: Install PnP fixtures
+        shell: bash
+        working-directory: crates/rspack_resolver/fixtures/pnp
+        run: yarn install --immutable
+
+      - name: Install PnP global cache fixtures
+        shell: bash
+        working-directory: crates/rspack_resolver/fixtures/pnp-global-cache-enabled
+        run: yarn install --immutable
+
       - name: Install fixtures
         shell: bash
         working-directory: crates/rspack_resolver/fixtures
-        run: |
-          pushd pnp && yarn install && popd
-          pushd pnp-global-cache-enabled && yarn install && popd
-          pnpm install
+        run: pnpm install
 
       # Compile test without debug info for reducing the CI cache size
       - name: Change profile.test


### PR DESCRIPTION
## Motivation

After #15634 removed Corepack initialization, Resolver CI cannot install its Yarn 4.3.1 fixtures because Yarn is missing on Linux or resolves to Yarn 1 on macOS and Windows.
The `pushd && yarn install && popd` chains hide installation failures, causing six PnP tests to fail on each platform.

## Changes

Enable Yarn through the Corepack bundled with the workflow's Node.js 22 so each fixture uses its declared `packageManager` version.
Install each PnP fixture in a separate step with `--immutable`, ensuring installation failures stop the job immediately.

## Related Links

- #15634
- [Yarn Corepack installation guide](https://yarnpkg.com/corepack#installation)
- [Failing Resolver CI](https://github.com/web-infra-dev/rspack/actions/runs/34581476839)