### PR TITLE
refactor(javascript): optimize inner graph analysis

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -606,20 +606,6 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           .inner_graph
           .decl_with_top_level_symbol
           .insert(decl.span(ast), v);
-
-        if !matches!(
-          ast.expr_data(init),
-          ExprData::Function(_)
-            | ExprData::ArrowFunctionExpression(_)
-            | ExprData::StringLiteral(_)
-            | ExprData::NumericLiteral(_)
-            | ExprData::BigIntLiteral(_)
-            | ExprData::BooleanLiteral(_)
-            | ExprData::NullLiteral(_)
-            | ExprData::RegExpLiteral(_)
-        ) {
-          parser.inner_graph.pure_declarators.insert(decl.span(ast));
-        }
       }
     }
 
@@ -844,43 +830,32 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
       parser.inner_graph.set_top_level_symbol(Some(*v));
 
       let ast = parser.ast.ast;
-      if parser
-        .inner_graph
-        .pure_declarators
-        .contains(&decl.span(ast))
-      {
-        // class Foo extends Bar {}
-        // if Foo is not used, we can ignore extends Bar
-        if let Some(init) = decl.init(ast)
-          && let Some(class) = init.as_class(ast)
-          && let Some(super_class) = class.super_class(ast)
-        {
-          let super_span = super_class.span(ast);
-          let dep = PureExpressionDependency::new(
-            DependencyRange::new(super_span.real_lo(), super_span.real_hi()),
-            *parser.module_identifier,
-          );
-          let dep_idx = parser.next_dependency_idx();
-          parser.add_dependency(BoxDependency::new(dep));
-          Self::on_usage(parser, InnerGraphUsageOperation::PureExpression(dep_idx));
-        } else if let Some(init) = decl.init(ast)
-          && !init.is_class(ast)
-        {
-          let init_span = init.span(ast);
-          let dep = PureExpressionDependency::new(
-            DependencyRange::new(init_span.real_lo(), init_span.real_hi()),
-            *parser.module_identifier,
-          );
-          let dep_idx = parser.next_dependency_idx();
-          parser.add_dependency(BoxDependency::new(dep));
-          InnerGraphParserPlugin::on_usage(
-            parser,
-            InnerGraphUsageOperation::PureExpression(dep_idx),
-          );
-        }
+      // Class initializers are tracked separately in class_with_top_level_symbol.
+      let init = decl
+        .init(ast)
+        .expect("inner graph declarator has an initializer");
+      if !matches!(
+        ast.expr_data(init),
+        ExprData::Function(_)
+          | ExprData::ArrowFunctionExpression(_)
+          | ExprData::StringLiteral(_)
+          | ExprData::NumericLiteral(_)
+          | ExprData::BigIntLiteral(_)
+          | ExprData::BooleanLiteral(_)
+          | ExprData::NullLiteral(_)
+          | ExprData::RegExpLiteral(_)
+      ) {
+        let init_span = init.span(ast);
+        let dep = PureExpressionDependency::new(
+          DependencyRange::new(init_span.real_lo(), init_span.real_hi()),
+          *parser.module_identifier,
+        );
+        let dep_idx = parser.next_dependency_idx();
+        parser.add_dependency(BoxDependency::new(dep));
+        Self::on_usage(parser, InnerGraphUsageOperation::PureExpression(dep_idx));
       }
 
-      parser.walk_expression(decl.init(ast).expect("should have initialization"));
+      parser.walk_expression(init);
       parser.inner_graph.set_top_level_symbol(None);
       return Some(true);
     } else if decl

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/plugin.rs
@@ -2,10 +2,11 @@ use rspack_core::{
   BoxDependency, Dependency, DependencyId, DependencyRange, UsedByExports,
   UsedByExportsDeferredPureCheck,
 };
+use rspack_intern::AtomRef;
 use rspack_util::SpanExt;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_next_ecma_ast::{
-  AssignmentExpression, AssignmentOperator, ClassElement, ClassElementData,
+  AssignmentExpression, AssignmentOperator, BindingIdentifier, ClassElement, ClassElementData,
   ExportDefaultDeclarationKindData, Expr, ExprData, GetSpan, Program, Span, Stmt, StmtData,
   ThisExpression, VariableDeclarator,
 };
@@ -59,7 +60,8 @@ impl InnerGraphParserPlugin {
 
     if let Some(tag_info) = parser.current_tag_info {
       let tag_info = parser.definitions_db.expect_get_tag_info(tag_info);
-      let symbol = TopLevelSymbol::downcast(tag_info.data.clone().expect("should have data"));
+      let symbol =
+        *TopLevelSymbol::downcast_ref(tag_info.data.as_deref().expect("should have data"));
       let usage = parser.inner_graph.get_top_level_symbol();
       parser.inner_graph.add_usage(
         symbol,
@@ -96,46 +98,52 @@ impl InnerGraphParserPlugin {
 
   pub fn infer_dependency_usage(
     state: &mut InnerGraphState,
-    deferred_pure_checks_by_symbol: &HashMap<TopLevelSymbol, Vec<UsedByExportsDeferredPureCheck>>,
+    deferred_pure_checks_by_symbol: &[Vec<UsedByExportsDeferredPureCheck>],
   ) -> Vec<(InnerGraphUsageOperation, UsedByExports)> {
-    let mut non_terminal = state.inner_graph.keys().copied().collect::<HashSet<_>>();
-    let mut processed: HashMap<TopLevelSymbol, HashSet<InnerGraphMapSetValue>> = HashMap::default();
+    let mut non_terminal = state
+      .symbols
+      .iter()
+      .enumerate()
+      .filter_map(|(index, symbol)| symbol.graph.is_some().then_some(index))
+      .collect::<Vec<_>>();
+    let mut processed = vec![HashSet::default(); state.symbols.len()];
+    // Reuse a drained source set as the next propagation buffer.
+    let mut new_set = HashSet::default();
 
     while !non_terminal.is_empty() {
-      let mut keys_to_remove = vec![];
-      for key in non_terminal.iter() {
-        let mut new_set = HashSet::default();
+      non_terminal.retain(|&key| {
         // Using enum to manipulate original is pretty hard, so I use an extra variable to
         // flagging the new set has changed to boolean `true`
         // you could refer https://github.com/webpack/webpack/blob/ac7e531436b0d47cd88451f497cdfd0dad41535d/lib/optimize/InnerGraph.js#L150
         let mut set_is_true = false;
         let mut is_terminal = true;
-        let already_processed = processed.entry(*key).or_default();
-        if matches!(state.inner_graph.get(key), Some(InnerGraphMapValue::Set(_))) {
-          let Some(InnerGraphMapValue::Set(names)) = state.inner_graph.remove(key) else {
+        let already_processed = &mut processed[key];
+        if matches!(state.symbols[key].graph, Some(InnerGraphMapValue::Set(_))) {
+          let Some(InnerGraphMapValue::Set(mut names)) = state.symbols[key].graph.take() else {
             unreachable!("checked Set value before removing inner graph entry")
           };
           already_processed.extend(names.iter().cloned());
-          for name in names {
+          for name in names.drain() {
             match name {
               InnerGraphMapSetValue::Str(v) => {
                 new_set.insert(InnerGraphMapSetValue::Str(v));
               }
               InnerGraphMapSetValue::TopLevel(dep_symbol) => {
-                if dep_symbol == *key {
+                if dep_symbol.index() == key {
                   continue;
                 }
-                if deferred_pure_checks_by_symbol.contains_key(&dep_symbol) {
+                if !deferred_pure_checks_by_symbol[dep_symbol.index()].is_empty() {
                   new_set.insert(InnerGraphMapSetValue::TopLevel(dep_symbol));
                 }
-                match state.inner_graph.get(&dep_symbol) {
+                match state.symbols[dep_symbol.index()].graph.as_ref() {
                   Some(InnerGraphMapValue::True) => {
                     set_is_true = true;
                     break;
                   }
                   Some(InnerGraphMapValue::Set(item_value)) => {
                     for i in item_value {
-                      if matches!(i, InnerGraphMapSetValue::TopLevel(value) if value == key) {
+                      if matches!(i, InnerGraphMapSetValue::TopLevel(value) if value.index() == key)
+                      {
                         continue;
                       }
                       if already_processed.contains(i) {
@@ -153,59 +161,55 @@ impl InnerGraphParserPlugin {
             }
           }
           if set_is_true {
-            state.inner_graph.insert(*key, InnerGraphMapValue::True);
+            new_set.clear();
+            state.symbols[key].graph = Some(InnerGraphMapValue::True);
           } else if new_set.is_empty() {
-            state.inner_graph.insert(*key, InnerGraphMapValue::Nil);
+            state.symbols[key].graph = Some(InnerGraphMapValue::Nil);
           } else {
-            state
-              .inner_graph
-              .insert(*key, InnerGraphMapValue::Set(new_set));
+            state.symbols[key].graph = Some(InnerGraphMapValue::Set(std::mem::replace(
+              &mut new_set,
+              names,
+            )));
           }
         }
 
-        if is_terminal {
-          keys_to_remove.push(*key);
-          // We use `""` to represent global_key
-          if key.is_global() {
-            let global_value = state.inner_graph.get(&TopLevelSymbol::global()).cloned();
-            if let Some(global_value) = global_value {
-              for (key, value) in state.inner_graph.iter_mut() {
-                if !key.is_global() && value != &InnerGraphMapValue::True {
-                  if global_value == InnerGraphMapValue::True {
-                    *value = InnerGraphMapValue::True;
-                  } else {
-                    let mut new_set = match value {
-                      InnerGraphMapValue::Set(set) => std::mem::take(set),
-                      InnerGraphMapValue::True => unreachable!(),
-                      InnerGraphMapValue::Nil => HashSet::default(),
-                    };
-                    let extend_value = match global_value.clone() {
-                      InnerGraphMapValue::Set(set) => set,
-                      InnerGraphMapValue::True => unreachable!(),
-                      InnerGraphMapValue::Nil => HashSet::default(),
-                    };
-                    new_set.extend(extend_value);
-                    *value = InnerGraphMapValue::Set(new_set);
+        // We use `""` to represent global_key.
+        if is_terminal && key == TopLevelSymbol::global().index() {
+          let (global, symbols) = state.symbols.split_first_mut().expect("global symbol");
+          if let Some(global_value) = &global.graph {
+            for symbol in symbols {
+              let Some(value) = symbol.graph.as_mut() else {
+                continue;
+              };
+              if !matches!(value, InnerGraphMapValue::True) {
+                if matches!(global_value, InnerGraphMapValue::True) {
+                  *value = InnerGraphMapValue::True;
+                } else {
+                  let mut merged_set = match value {
+                    InnerGraphMapValue::Set(set) => std::mem::take(set),
+                    InnerGraphMapValue::True => unreachable!(),
+                    InnerGraphMapValue::Nil => HashSet::default(),
+                  };
+                  if let InnerGraphMapValue::Set(global_set) = global_value {
+                    merged_set.extend(global_set.iter().cloned());
                   }
+                  *value = InnerGraphMapValue::Set(merged_set);
                 }
               }
             }
           }
         }
-      }
-      // Work around for rustc borrow rules
-      for k in keys_to_remove {
-        non_terminal.remove(&k);
-      }
+        !is_terminal
+      });
     }
 
     let mut finalized = vec![];
-    for (symbol, cbs) in state.usage_map.drain() {
-      let mut deferred_pure_checks = deferred_pure_checks_by_symbol
-        .get(&symbol)
-        .cloned()
-        .unwrap_or_default();
-      let usage = state.inner_graph.get(&symbol);
+    for (index, symbol) in state.symbols.iter_mut().enumerate() {
+      if symbol.usages.is_empty() {
+        continue;
+      }
+      let mut deferred_pure_checks = deferred_pure_checks_by_symbol[index].clone();
+      let usage = symbol.graph.as_ref();
       let used_by_exports = if let Some(usage) = usage {
         match usage {
           InnerGraphMapValue::Set(set) => {
@@ -213,9 +217,11 @@ impl InnerGraphParserPlugin {
             for item in set {
               match item {
                 InnerGraphMapSetValue::TopLevel(dep_symbol) => {
-                  if let Some(checks) = deferred_pure_checks_by_symbol.get(dep_symbol) {
-                    deferred_pure_checks.extend(checks.iter().cloned());
-                  }
+                  deferred_pure_checks.extend(
+                    deferred_pure_checks_by_symbol[dep_symbol.index()]
+                      .iter()
+                      .cloned(),
+                  );
                 }
                 InnerGraphMapSetValue::Str(export_name) => {
                   finalized_set.insert(export_name.clone());
@@ -231,7 +237,7 @@ impl InnerGraphParserPlugin {
         UsedByExports::bool(false)
       }
       .with_deferred_pure_checks(deferred_pure_checks);
-      for cb in cbs {
+      for cb in symbol.usages.drain(..) {
         finalized.push((cb, used_by_exports.clone()));
       }
     }
@@ -243,14 +249,14 @@ impl InnerGraphParserPlugin {
     state: &mut InnerGraphState,
     dependencies: &mut [BoxDependency],
   ) {
-    if !state.is_enabled() || state.usage_map.is_empty() {
+    if !state.is_enabled() || state.symbols.iter().all(|symbol| symbol.usages.is_empty()) {
       return;
     }
 
-    let mut deferred_pure_checks_by_symbol = HashMap::default();
+    let mut deferred_pure_checks_by_symbol = vec![Vec::new(); state.symbols.len()];
     if state
-      .symbol_map
-      .values()
+      .symbols
+      .iter()
       .any(|symbol_data| !symbol_data.depend_on_pure.is_empty())
     {
       let mut dep_by_span: HashMap<(u32, u32), (DependencyId, Atom)> = dependencies
@@ -267,13 +273,13 @@ impl InnerGraphParserPlugin {
 
       let mut always_used_symbols = Vec::new();
 
-      for (symbol, symbol_data) in &state.symbol_map {
+      for (symbol, symbol_data) in state.symbols.iter().enumerate() {
         // A single UsedByExports edge cannot safely describe a pure
         // expression whose purity depends on multiple imported callees. Keep
         // the expression conservative until the dependency model can encode
         // the combined condition.
         if symbol_data.depend_on_pure.len() > 1 {
-          always_used_symbols.push(*symbol);
+          always_used_symbols.push(symbol);
           continue;
         }
         let mut deferred_pure_checks = Vec::new();
@@ -285,20 +291,20 @@ impl InnerGraphParserPlugin {
               atom: import_name,
             });
           } else {
-            always_used_symbols.push(*symbol);
+            always_used_symbols.push(symbol);
             deferred_pure_checks.clear();
             break;
           }
         }
 
         if !deferred_pure_checks.is_empty() {
-          deferred_pure_checks_by_symbol.insert(*symbol, deferred_pure_checks);
+          deferred_pure_checks_by_symbol[symbol] = deferred_pure_checks;
         }
       }
 
       for symbol in always_used_symbols {
-        state.inner_graph.insert(symbol, InnerGraphMapValue::True);
-        deferred_pure_checks_by_symbol.remove(&symbol);
+        state.symbols[symbol].graph = Some(InnerGraphMapValue::True);
+        deferred_pure_checks_by_symbol[symbol].clear();
       }
     }
 
@@ -334,10 +340,7 @@ impl InnerGraphParserPlugin {
   }
 
   pub fn add_variable_usage(parser: &mut JavascriptParser, name: &Atom, usage: InnerGraphMapUsage) {
-    let symbol = parser
-      .get_tag_data::<TopLevelSymbol>(name, TOP_LEVEL_SYMBOL)
-      .copied()
-      .unwrap_or_else(|| Self::tag_top_level_symbol(parser, name));
+    let symbol = Self::tag_top_level_symbol(parser, name, None);
 
     parser.inner_graph.add_usage(symbol, usage);
   }
@@ -346,11 +349,8 @@ impl InnerGraphParserPlugin {
     if parser.inner_graph.is_enabled()
       && let Some(symbol) = parser.inner_graph.get_top_level_symbol()
     {
-      parser
-        .inner_graph
-        .usage_map
-        .entry(symbol)
-        .or_default()
+      parser.inner_graph.symbols[symbol.index()]
+        .usages
         .push(operation);
       // When inner graph is enabled but no top-level symbol, the expression is always used,
       // so we skip adding PureExpressionDependency (same as UsedByExports::Bool(true))
@@ -358,23 +358,36 @@ impl InnerGraphParserPlugin {
     // When inner graph is disabled, we skip adding PureExpressionDependency (same as None)
   }
 
-  pub fn tag_top_level_symbol(
+  /// Reuses semantic declaration identity; synthetic export names use the scoped name lookup.
+  pub fn tag_top_level_symbol<'key>(
     parser: &mut crate::visitors::JavascriptParser,
-    name: &Atom,
+    name: impl Into<AtomRef<'key>>,
+    identifier: Option<BindingIdentifier>,
   ) -> TopLevelSymbol {
-    if let Some(existing) = parser
-      .get_tag_data::<TopLevelSymbol>(name, TOP_LEVEL_SYMBOL)
-      .copied()
-    {
+    let name = name.into();
+    let resolution = if let Some(identifier) = identifier {
+      parser
+        .definitions_db
+        .resolve_binding(parser.ast, identifier)
+    } else {
+      parser.definitions_db.resolve_with_symbol(name)
+    };
+    if let Some(existing) = resolution.0.and_then(|state| {
+      parser
+        .get_variable_tag_data::<TopLevelSymbol>(state, TOP_LEVEL_SYMBOL)
+        .copied()
+    }) {
       return existing;
     }
 
+    let name = name.to_atom();
     let symbol = parser.inner_graph.new_top_level_symbol(name.clone());
-    parser.tag_variable_with_flags(
-      name.clone(),
+    parser.tag_variable_resolved(
+      name,
       TOP_LEVEL_SYMBOL,
-      Some(symbol),
+      Some(TagInfoData::into_any(symbol)),
       VariableInfoFlags::NORMAL,
+      resolution,
     );
     symbol
   }
@@ -409,11 +422,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
       && let Some(fn_decl) = stmt.as_function_decl()
     {
       let ast = parser.ast.ast;
-      let name = &fn_decl.ident(ast).map_or_else(
-        || DEFAULT_STAR_JS_WORD.clone(),
-        |ident| Atom::from(ast.get_utf8(ident.name(ast))),
+      let identifier = fn_decl.ident(ast);
+      let name = identifier.map_or_else(
+        || DEFAULT_STAR_JS_WORD.as_str(),
+        |ident| ast.get_utf8(ident.name(ast)),
       );
-      let fn_variable = Self::tag_top_level_symbol(parser, name);
+      let fn_variable = Self::tag_top_level_symbol(parser, name, identifier);
 
       parser
         .inner_graph
@@ -445,11 +459,12 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
       )
     {
       let ast = parser.ast.ast;
-      let name = &class_decl.ident(ast).map_or_else(
-        || DEFAULT_STAR_JS_WORD.clone(),
-        |ident| Atom::from(ast.get_utf8(ident.name(ast))),
+      let identifier = class_decl.ident(ast);
+      let name = identifier.map_or_else(
+        || DEFAULT_STAR_JS_WORD.as_str(),
+        |ident| ast.get_utf8(ident.name(ast)),
       );
-      let class_variable = Self::tag_top_level_symbol(parser, name);
+      let class_variable = Self::tag_top_level_symbol(parser, name, identifier);
       parser
         .inner_graph
         .class_with_top_level_symbol
@@ -483,7 +498,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           None,
         )
       {
-        let variable = Self::tag_top_level_symbol(parser, &DEFAULT_STAR_JS_WORD);
+        let variable = Self::tag_top_level_symbol(parser, &*DEFAULT_STAR_JS_WORD, None);
         parser
           .inner_graph
           .class_with_top_level_symbol
@@ -492,7 +507,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
         ast.export_default_declaration_kind_data(declaration)
         && is_pure_function(parser, function)
       {
-        let variable = Self::tag_top_level_symbol(parser, &DEFAULT_STAR_JS_WORD);
+        let variable = Self::tag_top_level_symbol(parser, &*DEFAULT_STAR_JS_WORD, None);
         parser
           .inner_graph
           .statement_with_top_level_symbol
@@ -509,7 +524,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           parser.ast.comments,
           Some(&mut callees),
         ) {
-          let variable = Self::tag_top_level_symbol(parser, &DEFAULT_STAR_JS_WORD);
+          let variable = Self::tag_top_level_symbol(parser, &*DEFAULT_STAR_JS_WORD, None);
           for (name, span) in callees {
             variable.add_depend_on(&mut parser.inner_graph, name, span);
           }
@@ -567,7 +582,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           None,
         )
       {
-        let v = Self::tag_top_level_symbol(parser, &Atom::from(name));
+        let v = Self::tag_top_level_symbol(parser, name, Some(identifier));
 
         parser
           .inner_graph
@@ -582,7 +597,7 @@ impl<'p, 'a> JavascriptParserPlugin<'p, 'a> for InnerGraphParserPlugin {
           Some(&mut callees),
         )
       {
-        let v = Self::tag_top_level_symbol(parser, &Atom::from(name));
+        let v = Self::tag_top_level_symbol(parser, name, Some(identifier));
         for (symbol, span) in callees {
           v.add_depend_on(&mut parser.inner_graph, symbol, span);
         }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
@@ -1,41 +1,30 @@
-use std::{
-  collections::hash_map::Entry,
-  sync::atomic::{AtomicUsize, Ordering},
-};
-
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use swc_next_ecma_ast::Span;
 
 use crate::Atom;
 
-static TOP_LEVEL_SYMBOL_ID: AtomicUsize = AtomicUsize::new(1);
-
+/// A module-local index allocated by InnerGraph, independent of semantic symbol IDs.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
-pub(crate) struct TopLevelSymbol(usize);
+pub(crate) struct TopLevelSymbol(u32);
 
 impl TopLevelSymbol {
-  pub fn is_global(&self) -> bool {
-    self.0 == 0
+  /// Allocates an index in this InnerGraph's append-only symbol vector.
+  pub(super) fn from_index(index: usize) -> Self {
+    Self(u32::try_from(index).expect("too many inner graph symbols"))
+  }
+
+  /// Addresses the symbol's data and mutable usage state.
+  pub(super) fn index(self) -> usize {
+    self.0 as usize
   }
 
   pub fn global() -> Self {
     Self(0)
   }
 
-  pub fn new() -> Self {
-    let id = TOP_LEVEL_SYMBOL_ID.fetch_add(1, Ordering::Relaxed);
-    Self(id)
-  }
-
   pub(crate) fn add_depend_on(self, state: &mut InnerGraphState, depend_on: Atom, span: Span) {
-    let symbol = state.symbol_map.get_mut(&self).expect("should have symbol");
+    let symbol = &mut state.symbols[self.index()];
     symbol.depend_on_pure.insert((depend_on, span));
-  }
-}
-
-impl Default for TopLevelSymbol {
-  fn default() -> Self {
-    Self::new()
   }
 }
 
@@ -43,6 +32,10 @@ impl Default for TopLevelSymbol {
 pub(super) struct TopLevelSymbolData {
   pub(super) name: Atom,
   pub(super) depend_on_pure: HashSet<(Atom, Span)>,
+  /// Dependency operations whose usage is determined by this symbol.
+  pub(super) usages: Vec<InnerGraphUsageOperation>,
+  /// None distinguishes a missing graph entry from an explicitly unused symbol.
+  pub(super) graph: Option<InnerGraphMapValue>,
 }
 
 #[derive(Default, Clone, PartialEq, Eq, Debug)]
@@ -78,9 +71,8 @@ impl From<InnerGraphMapUsage> for InnerGraphMapSetValue {
 
 #[derive(Default)]
 pub(crate) struct InnerGraphState {
-  pub(super) symbol_map: HashMap<TopLevelSymbol, TopLevelSymbolData>,
-  pub(super) usage_map: HashMap<TopLevelSymbol, Vec<InnerGraphUsageOperation>>,
-  pub(super) inner_graph: HashMap<TopLevelSymbol, InnerGraphMapValue>,
+  /// Dense symbol data and usage state; slot zero is the global symbol.
+  pub(super) symbols: Vec<TopLevelSymbolData>,
   current_top_level_symbol: Option<TopLevelSymbol>,
   enable: bool,
   pub(super) statement_with_top_level_symbol: HashMap<Span, TopLevelSymbol>,
@@ -92,32 +84,29 @@ pub(crate) struct InnerGraphState {
 
 impl InnerGraphState {
   pub(crate) fn new() -> Self {
-    let mut symbol_map = HashMap::<TopLevelSymbol, TopLevelSymbolData>::default();
-
-    symbol_map.insert(
-      TopLevelSymbol::global(),
-      TopLevelSymbolData {
+    Self {
+      symbols: vec![TopLevelSymbolData {
         name: Atom::new(""),
         depend_on_pure: Default::default(),
-      },
-    );
-    Self {
-      symbol_map,
+        usages: Vec::new(),
+        graph: None,
+      }],
       ..Default::default()
     }
   }
 
   pub(super) fn top_level_symbol(&self, name: &TopLevelSymbol) -> &TopLevelSymbolData {
-    &self.symbol_map[name]
+    &self.symbols[name.index()]
   }
 
   pub(crate) fn new_top_level_symbol(&mut self, name: Atom) -> TopLevelSymbol {
-    let symbol = TopLevelSymbol::new();
-    let data = TopLevelSymbolData {
+    let symbol = TopLevelSymbol::from_index(self.symbols.len());
+    self.symbols.push(TopLevelSymbolData {
       name,
       depend_on_pure: Default::default(),
-    };
-    self.symbol_map.insert(symbol, data);
+      usages: Vec::new(),
+      graph: None,
+    });
     symbol
   }
 
@@ -150,27 +139,20 @@ impl InnerGraphState {
       return;
     }
 
+    let graph = &mut self.symbols[symbol.index()].graph;
     match usage {
       InnerGraphMapUsage::True => {
-        self.inner_graph.insert(symbol, InnerGraphMapValue::True);
+        *graph = Some(InnerGraphMapValue::True);
       }
       InnerGraphMapUsage::Value(_) | InnerGraphMapUsage::TopLevel(_) => {
         let set_value: InnerGraphMapSetValue = usage.into();
-        match self.inner_graph.entry(symbol) {
-          Entry::Occupied(mut occ) => {
-            let val = occ.get_mut();
-            match val {
-              InnerGraphMapValue::Set(set) => {
-                set.insert(set_value);
-              }
-              InnerGraphMapValue::True => {}
-              InnerGraphMapValue::Nil => {
-                *val = InnerGraphMapValue::Set(HashSet::from_iter([set_value]));
-              }
-            }
+        match graph {
+          Some(InnerGraphMapValue::Set(set)) => {
+            set.insert(set_value);
           }
-          Entry::Vacant(vac) => {
-            vac.insert(InnerGraphMapValue::Set(HashSet::from_iter([set_value])));
+          Some(InnerGraphMapValue::True) => {}
+          None | Some(InnerGraphMapValue::Nil) => {
+            *graph = Some(InnerGraphMapValue::Set(HashSet::from_iter([set_value])));
           }
         }
       }

--- a/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/inner_graph/state.rs
@@ -79,7 +79,6 @@ pub(crate) struct InnerGraphState {
   pub(super) statement_pure_part: HashMap<Span, Span>,
   pub(super) class_with_top_level_symbol: HashMap<Span, TopLevelSymbol>,
   pub(super) decl_with_top_level_symbol: HashMap<Span, TopLevelSymbol>,
-  pub(super) pure_declarators: HashSet<Span>,
 }
 
 impl InnerGraphState {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/parser/mod.rs
@@ -53,7 +53,9 @@ use crate::{
   visitors::{
     ParsedJavaScriptAst, PatternIdentifier, ScanDependenciesResult,
     dependency::parser::{ast::ExprRef, location_advancer::DependencyLocationAdvancer},
-    scope_info::{BindingState, ScopeInfoDB, TagInfo, TagInfoId, VariableInfo, VariableInfoFlags},
+    scope_info::{
+      BindingState, ScopeInfoDB, SymbolBinding, TagInfo, TagInfoId, VariableInfo, VariableInfoFlags,
+    },
   },
 };
 
@@ -1166,8 +1168,20 @@ impl<'parser> JavascriptParser<'parser> {
     flags: Option<VariableInfoFlags>,
   ) {
     let flags = flags.unwrap_or(VariableInfoFlags::TAGGED);
+    let resolution = self.definitions_db.resolve_with_symbol(&name);
+    self.tag_variable_resolved(name, tag, data, flags, resolution);
+  }
+
+  /// Attaches a tag using an immediate binding lookup, preserving aliases and scope restoration.
+  pub(crate) fn tag_variable_resolved(
+    &mut self,
+    name: Atom,
+    tag: &'static str,
+    data: Option<Box<dyn anymap::CloneAny>>,
+    flags: VariableInfoFlags,
+    (state, symbol): (Option<BindingState>, Option<SymbolBinding>),
+  ) {
     let scope = self.definitions_db.current_scope();
-    let (state, symbol) = self.definitions_db.resolve_with_symbol(&name);
     let new_info =
       if let Some(old_info) = state.map(|state| self.definitions_db.expect_get_variable(state)) {
         if let Some(old_tag_info) = old_info.tag_info {

--- a/crates/rspack_plugin_javascript/src/visitors/scope_info/semantic.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/scope_info/semantic.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use swc_next_ecma_ast::{IdentifierReference, NodeId, ScopeId, SymbolId};
+use swc_next_ecma_ast::{BindingIdentifier, IdentifierReference, NodeId, ScopeId, SymbolId};
 use swc_next_ecma_semantic::{ReferenceSpace, Semantic, SymbolFlags, scope::ScopeKind};
 
 use super::{
@@ -434,6 +434,33 @@ impl<'ast> ScopeInfoDB<'ast> {
       // binding through the name-based overlay.
     }
     self.get(self.current_scope(), name)
+  }
+
+  /// Reuses a declaration's semantic symbol while still observing mutable tags and aliases.
+  pub(crate) fn resolve_binding(
+    &mut self,
+    parsed: &ParsedJavaScriptAst<'_>,
+    identifier: BindingIdentifier,
+  ) -> (Option<BindingState>, Option<SymbolBinding>) {
+    debug_assert!(
+      self
+        .semantic_context
+        .ast
+        .is_some_and(|ast| std::ptr::eq(ast, parsed))
+    );
+    if let Some(symbol) = parsed.semantic.symbol_of(identifier.node_id()) {
+      let symbol = symbol_binding(
+        parsed.semantic,
+        self.semantic_context.symbol_start,
+        self.semantic_context.scope_start,
+        symbol,
+      );
+      if let Some(state) = self.symbol_state(symbol) {
+        return (state.defined(), Some(symbol));
+      }
+    }
+    // Pre-walked block declarations may not have an active semantic owner yet.
+    self.resolve_with_symbol(parsed.ast.get_utf8(identifier.name(parsed.ast)))
   }
 
   /// Defines a normal binding in the current scope without replacing its existing plugin tags.


### PR DESCRIPTION
## Summary

- Allocate module-local, contiguous `TopLevelSymbol` IDs and store symbol data, usage operations and graph state in a single `Vec`. Keep slot zero for the global symbol; do not depend on SWC symbol IDs being dense.
- Resolve named declaration bindings through the existing Semantic data and reuse the immediate resolution when attaching tags. Preserve mutable aliases/tags, scope restoration and name-based fallback for synthetic names or inactive scope owners.
- Borrow and copy the symbol stored in a tag instead of cloning a temporary boxed payload.
- Reuse drained HashSet capacity during usage propagation and borrow the global edge set when extending other symbols. Keep HashSet throughout; no Small/Large collection variant or propagation-algorithm rewrite.

- Remove the separate `pure_declarators` HashSet and derive the pure-expression dependency gate from the initializer when processing a tracked declarator. Preserve the function/literal exclusions and the separate class-initializer path.

Evaluator payloads and dependency source locations are outside this PR. Existing test assertions and snapshots are unchanged.

## Performance

Local Docker + Valgrind, native Linux ARM64, Rust nightly 2026-04-16, Valgrind 3.19.0, fixed fixture and `rust@scan_dependencies@three_module`:

| Version | Instructions |
| --- | ---: |
| Release base / #15626 | 29,446,715 |
| Before pure-declarator cleanup (`6325d6427c`) | 28,646,837 |
| This PR, including pure-declarator cleanup | 28,636,993 |
| Total reduction vs release | **809,722 / 2.75%** |

The pure-declarator cleanup saves an additional **9,844 instructions / 0.034%** relative to the previous PR head: a small incremental improvement, not a substantial new speedup. It also removes 26 net lines of code.

Each implementation version was measured once. The previous measurements were reused after verifying source and environment equivalence: the release base (`0e963bc1af`) matches the measured #15626 tree, and the previous PR head (`6325d6427c`) matches all 23,148 tracked files in its measured snapshot. The new measurement uses the same image, tool versions, fixture and build settings, with only the two InnerGraph source files changed. This is scan instruction count, not full-build wall time.

## Validation

- Development binding build.
- Full `test:unit`: 9,229 Rspack tests and 90 CLI tests passed; existing skips unchanged; binding TypeScript checks passed.
- `cargo test -p rspack_plugin_javascript --lib --locked`: 48 passed.
- `cargo clippy -p rspack_plugin_javascript --all-targets --locked -- --deny warnings`.
- `cargo fmt --all --check` and `cargo shear --locked --deny-warnings -p rspack_plugin_javascript`.
- Standalone differential check of the before/after propagation function: 20,040 randomized and structured graph cases, including cycles, self-edges, dense fan-out, global states and deferred pure checks. Dependency outputs, deferred-check multisets and final graph states matched.

The pure-declarator follow-up was rebuilt and the full unit suite, Rust tests, Clippy, format and cargo shear passed again on the current source. The earlier 20,040-case differential check covers the propagation implementation, which this follow-up does not change.

## Related links

- Follow-up to #15331, #15595 and #15626.
- Base branch: `release/2.3.0`.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
