### PR TITLE
docs: correct default for module.parser["css/auto"].dashedIdents

### DIFF
--- a/website/docs/en/config/module-parser.mdx
+++ b/website/docs/en/config/module-parser.mdx
@@ -1331,7 +1331,7 @@ export default {
 ### ["css/auto"].dashedIdents
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
 Enable or disable renaming dashed identifiers, such as CSS custom properties and `@property` declarations.
 

--- a/website/docs/zh/config/module-parser.mdx
+++ b/website/docs/zh/config/module-parser.mdx
@@ -1330,7 +1330,7 @@ export default {
 ### ["css/auto"].dashedIdents
 
 - **类型：** `boolean`
-- **默认值：** `false`
+- **默认值：** `true`
 
 启用或禁用对 dashed identifiers 的重命名，例如 CSS 自定义属性和 `@property` 声明。
 


### PR DESCRIPTION
### What

`module.parser["css/auto"].dashedIdents` is documented as `Default: false`, but it has defaulted to `true` since v2.0.7.

### Why

The default was flipped in #14261, which updated the JSDoc in `packages/rspack/src/config/types.ts` but not the website:

```diff
// packages/rspack/src/config/defaults.ts
+  D(parserOptions, 'dashedIdents', true);

// packages/rspack/src/config/types.ts
-   * @default false
+   * @default true
```

Verified against the published package — `applyCssModuleParserOptionsDefaults` in `@rspack/core@2.2.3` sets it to `true`:

```js
applyCssParserOptionsDefaults(parserOptions),
  D(parserOptions, 'animation', !0),
  D(parserOptions, 'container', !0),
  D(parserOptions, 'customIdents', !0),
  D(parserOptions, 'dashedIdents', !0),
  D(parserOptions, 'function', !0),
  D(parserOptions, 'grid', !0);
```

The four options added in #14189 (`container`, `function`, `grid`, `pure`) were documented correctly at the time, because that PR updated `module-parser.mdx`. #14261 landed separately and didn't, so `dashedIdents` is the only one left stating the wrong default.

This is worth correcting because the page currently reads as though renaming is opt-in, and the example shows how to opt *in* to behaviour that is already on. Anyone who relies on custom property names surviving a build — reading them from another stylesheet, from JS, or across packages — will find them renamed despite the documentation saying otherwise.

### Checked

I diffed every documented default on the page against `applyCssParserOptionsDefaults`, `applyCssModuleParserOptionsDefaults` and `applyCssAutoOrModuleParserOptionsDefaults` in 2.2.3. `dashedIdents` is the only mismatch; `pure` is correctly documented as `false` and is unchanged here. The `css/global` and `css/module` sections inherit via their existing "Same as" cross-references, so they need no edit.

`exportType` and `resolveImport` have no JS-side default and I have not touched them.
