### PR TITLE
fix: drop trailing comma when rewriting require.resolve calls

### DIFF
--- a/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/common_js_imports_parse_plugin.rs
@@ -38,6 +38,7 @@ use crate::{
     CallHooksName, ExportedVariableInfo, JavascriptParser, StatementPath, TagInfoData,
     VariableDeclaration, VariableDeclarationKind, VariableInfo, VariableInfoFlags, context_reg_exp,
     create_context_dependency, create_traceable_error, expr_name, get_non_optional_part,
+    resolve_call_trailing_comma_range,
   },
 };
 
@@ -1565,6 +1566,10 @@ impl CommonJsImportsParserPlugin {
     let loc = parser.to_dependency_location(range);
     let require_resolve_header_dependency =
       BoxDependency::new(RequireResolveHeaderDependency::new(range, loc));
+
+    if let Some(range) = resolve_call_trailing_comma_range(parser, call_expr) {
+      parser.add_presentational_dependency(Arc::new(ConstDependency::new(range, ")".into())));
+    }
 
     if param.is_conditional() {
       for option in param.options() {

--- a/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
+++ b/crates/rspack_plugin_javascript/src/parser_plugin/import_meta_plugin.rs
@@ -39,6 +39,7 @@ use crate::{
     AllowedMemberTypes, ExportedVariableInfo, ExprRef, JavascriptParser, MemberExpressionInfo,
     RootName, context_reg_exp, create_context_dependency, create_traceable_error, expr_name,
     get_non_optional_member_chain_from_expr, member_property_to_atom,
+    resolve_call_trailing_comma_range,
   },
 };
 
@@ -393,6 +394,10 @@ impl ImportMetaPlugin {
     let import_meta_resolve_header_dependency = BoxDependency::new(
       ImportMetaResolveHeaderDependency::new(callee_span.into(), loc),
     );
+
+    if let Some(range) = resolve_call_trailing_comma_range(parser, call_expr) {
+      parser.add_presentational_dependency(Arc::new(ConstDependency::new(range, ")".into())));
+    }
 
     if param.is_conditional() {
       for option in param.options() {

--- a/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
+++ b/crates/rspack_plugin_javascript/src/visitors/dependency/util.rs
@@ -3,7 +3,8 @@ use std::sync::LazyLock;
 use rspack_core::DependencyRange;
 use rspack_error::{Diagnostic, Error, Severity};
 use rspack_regex::RspackRegex;
-use swc_experimental_ecma_ast::{Expr, Lit, MemberExpr, OptChainBase};
+use rspack_util::SpanExt;
+use swc_experimental_ecma_ast::{CallExpr, Expr, GetSpan, Lit, MemberExpr, OptChainBase};
 
 use super::JavascriptParser;
 use crate::Atom;
@@ -63,6 +64,23 @@ pub fn static_string_from_expr(expr: &Expr) -> Option<String> {
       }
       None
     })
+}
+
+/// Range from the end of the sole argument to the end of the call, to be
+/// replaced by a bare `)`. Replacing a `resolve` callee with a comment turns the
+/// argument list into a parenthesized expression, where a trailing comma is a
+/// syntax error.
+pub fn resolve_call_trailing_comma_range(
+  parser: &JavascriptParser,
+  call_expr: &CallExpr,
+) -> Option<DependencyRange> {
+  let start = call_expr.args.last()?.span().real_hi();
+  let end = call_expr.span().real_hi();
+  let tail = parser.source().get(start as usize..end as usize)?;
+
+  // There is exactly one argument, so any comma here is the trailing one or
+  // sits inside a comment that is fine to drop along with it.
+  tail.contains(',').then(|| DependencyRange::new(start, end))
 }
 
 pub fn create_traceable_error(

--- a/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/bar.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/bar.js
@@ -1,0 +1,1 @@
+module.exports = "bar";

--- a/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/dir/foo.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/dir/foo.js
@@ -1,0 +1,1 @@
+module.exports = "dir-foo";

--- a/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/foo.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/foo.js
@@ -1,0 +1,1 @@
+module.exports = "foo";

--- a/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/index.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/index.js
@@ -1,0 +1,38 @@
+// Prettier and biome add a trailing comma to multi-line calls by default, so
+// published packages ship `require.resolve` calls that look like this.
+it("should handle require.resolve with a trailing comma", function () {
+	const id = require.resolve(
+		"./foo.js",
+	);
+	expect(id).toBe(require.resolve("./foo.js"));
+});
+
+it("should handle require.resolve with a trailing comma and a comment", function () {
+	const id = require.resolve("./bar.js" /* a, b */,);
+	expect(id).toBe(require.resolve("./bar.js"));
+});
+
+it("should handle require.resolveWeak with a trailing comma", function () {
+	const id = require.resolveWeak(
+		"./foo.js",
+	);
+	expect(id).toBe(require.resolveWeak("./foo.js"));
+});
+
+it("should handle a context require.resolve with a trailing comma", function () {
+	function getFile() {
+		return "foo";
+	}
+
+	const id = require.resolve(
+		"./dir/" + getFile() + ".js",
+	);
+	expect(id).toBe(require.resolve("./dir/" + getFile() + ".js"));
+});
+
+it("should handle import.meta.resolve with a trailing comma", function () {
+	const id = import.meta.resolve(
+		"./foo.js",
+	);
+	expect(id).toBe(require.resolve("./foo.js"));
+});

--- a/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/rspack.config.js
+++ b/tests/rspack-test/configCases/parsing/require-resolve-trailing-comma/rspack.config.js
@@ -1,0 +1,10 @@
+/** @type {import("@rspack/core").Configuration} */
+module.exports = {
+  module: {
+    parser: {
+      javascript: {
+        importMetaResolve: true,
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

`require.resolve(...)` is compiled by replacing only the callee with a `/*require.resolve*/` comment and the argument with the resolved module id. That leaves the original argument list behind as a parenthesized expression:

```js
// in
const id = require.resolve(
  "./foo.js",
);

// out (before this PR)
const id = /*require.resolve*/(
  "./src/foo.js",
);
```

A trailing comma is valid in a call argument list but a syntax error inside a parenthesized expression, so the emitted bundle fails to parse with `SyntaxError: Unexpected token ')'` — taking down the whole chunk, not just that module. Prettier and biome both add that trailing comma to multi-line calls by default, so published packages hit it; the reporter ran into it via `mocha@11`'s `lib/nodejs/parallel-buffered-runner.js`.

This PR rewrites everything between the end of the argument and the end of the call to a bare `)` whenever that span contains a comma:

```js
// out (after this PR)
const id = /*require.resolve*/(
  "./src/foo.js");
```

The call has exactly one argument by the time this runs, so any comma in that span is either the trailing comma or inside a comment that is fine to drop along with it.

`import.meta.resolve` goes through the same callee-to-comment rewrite and had the identical defect, so it is fixed in the same place via a shared helper in `visitors::dependency::util`. `require()` and `import()` are unaffected — the former keeps call syntax (`__webpack_require__(...)`), the latter replaces the whole expression.

### On webpack parity

This is a deliberate divergence from webpack, which has the same defect (reproduced on webpack 5.105.0 and 5.110.3). The issue's original "as webpack does" expectation was retracted in a [follow-up comment](https://github.com/web-infra-dev/rspack/issues/15655#issuecomment-5644639304). The output otherwise keeps webpack's `/*require.resolve*/(<id>)` shape — only the trailing comma goes away.

## Testing

New config case `tests/rspack-test/configCases/parsing/require-resolve-trailing-comma` covering `require.resolve`, `require.resolveWeak`, `import.meta.resolve`, a context (non-static) request, and a trailing comma preceded by a comment.

Verified it fails before the fix with the reported `SyntaxError: Unexpected token ')'` and passes after, and that the issue's own repro now runs instead of throwing. The full `base` project suite passes.

## Related links

- Closes #15655

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
